### PR TITLE
Fix for use these values

### DIFF
--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -55,7 +55,9 @@ class Input(object):
         """
         self._parameter = parameter
 
-        if parameter.default is not None:
+        if parameter is not None:
+            self.setValue(parameter.value)
+        elif parameter.default is not None:
             self.setValue(parameter.default)
 
         if hasattr(parameter, 'units') and parameter.units:


### PR DESCRIPTION
### Work in progress

When using the option "Use these values" on an entry in the BrowserWidget, the default values for an input are inserted into the input, rather than the actual values used in that entry.

- [x] Fix the general behavior
- [ ] check if all types of inputs work as intended (at this moment a string seems not correctly escaped whenever it is filled back into the input widget)