### PR TITLE
Fix for warning by pyvisa on using deprecated API (get_instrument)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -28,3 +28,4 @@ Dominik Kriegner
 Jonathan Larochelle
 Dominic Caron
 Mathieu Plante
+Michele Sardo

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -28,3 +28,4 @@ The following developers have contributed to the PyMeasure package:
 | Jonathan Larochelle
 | Dominic Caron
 | Mathieu Plante
+| Michele Sardo

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -64,7 +64,7 @@ class VISAAdapter(Adapter):
         for key in kwargsCopy:
             if key not in safeKeywords:
                 kwargs.pop(key)
-        self.connection = self.manager.get_instrument(
+        self.connection = self.manager.open_resource(
             resourceName,
             **kwargs
         )


### PR DESCRIPTION
Minor fix on pyvisa deprecated API