### PR TITLE
Fixes for Agilent B1500 instrument

### DIFF
--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -427,8 +427,8 @@ class AgilentB1500(Instrument):
     class _data_formatting_FMT1(_data_formatting_generic):
         """ Data formatting for FMT1 format
         """
-        def __init__(self, smu_names={}):
-            super().__init__("FMT1", smu_names)
+        def __init__(self, output_format_string="FMT1", smu_names={}):
+            super().__init__(output_format_string, smu_names=smu_names)
 
         def format_single(self, element):
             """ Format single measurement value
@@ -454,7 +454,8 @@ class AgilentB1500(Instrument):
         """ Data formatting for FMT11 format
         """
         def __init__(self, smu_names={}):
-            super().__init__("FMT11", smu_names)
+            super().__init__(
+                output_format_string="FMT11", smu_names=smu_names)
 
     class _data_formatting_FMT21(_data_formatting_generic):
         """ Data formatting for FMT21 format


### PR DESCRIPTION
Hi,

these are two fixes for the Agilent B1500 instrument:

- fixing the ability to select fixed measurement ranges (negative indizes), addressing #366 
- (code cleanup and restructuring of ranging classes)
- fixing FMT11 formatting