### PR TITLE
Fixed incorrect skipping of 'test_correct_visa_kwarg' test

### DIFF
--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -29,7 +29,7 @@ from pytest import approx
 from pymeasure.adapters import VISAAdapter
 from pymeasure.instruments import Instrument
 
-pyvisa_sim_installed = bool(importlib.util.find_spec('pyvisa-sim'))
+pyvisa_sim_installed = bool(importlib.util.find_spec('pyvisa_sim'))
 
 
 def test_visa_version():


### PR DESCRIPTION
Came accross the test "test_correct_visa_kwarg", which was skipped even though the pyvisa-test was actually installed. It seems that, as pyvisa-sim provides a library for the pyvisa package rather than an importable module, it is not recognisable by `importlib.util.find_spec('pyvisa-sim')`.