### PR TITLE
Fix open file externally

### DIFF
--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -389,6 +389,10 @@ class ManagedWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
+        """ Method to open the datafile using an external editor or viewer. Uses the default
+        application to open a datafile of this filetype, but can be overridden by the child
+        class in order to open the file in another application of choice.
+        """
         system = platform.system()
         if (system == 'Windows'):
             # The empty argument after the start is needed to be able to cope correctly with filenames with spaces
@@ -764,6 +768,10 @@ class ManagedImageWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
+        """ Method to open the datafile using an external editor or viewer. Uses the default
+        application to open a datafile of this filetype, but can be overridden by the child
+        class in order to open the file in another application of choice.
+        """
         system = platform.system()
         if (system == 'Windows'):
             # The empty argument after the start is needed to be able to cope correctly with filenames with spaces

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -25,6 +25,9 @@
 import logging
 
 import os
+import subprocess, platform
+
+
 import pyqtgraph as pg
 
 from .browser import BrowserItem
@@ -148,7 +151,6 @@ class ManagedWindow(QtGui.QMainWindow):
 
 
     """
-    EDITOR = 'gedit'
 
     def __init__(self, procedure_class, inputs=(), displays=(), x_axis=None, y_axis=None,
                  log_channel='', log_level=logging.INFO, parent=None, sequencer=False,
@@ -387,13 +389,16 @@ class ManagedWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
-        import subprocess, platform
-
         system = platform.system()
         if (system == 'Windows'):
+            # The empty argument after the start is needed to be able to cope correctly with filenames with spaces
             proc = subprocess.Popen(['start', '', filename], shell=True)
         elif (system == 'Linux'):
-            proc = subprocess.Popen([self.EDITOR, filename])
+            proc = subprocess.Popen(['xdg-open', filename])
+        elif (system == 'Darwin'):
+            proc = subprocess.Popen(['open', filename])
+        else:
+            raise Exception("{cls} method open_file_externally does not support {system} OS".format(cls=type(self).__name__,system=system))
 
     def make_procedure(self):
         if not isinstance(self.inputs, InputsWidget):
@@ -539,8 +544,6 @@ class ManagedImageWindow(QtGui.QMainWindow):
 
 
     """
-
-    EDITOR = 'gedit'
 
     def __init__(self, procedure_class, x_axis, y_axis, z_axis=None, inputs=(), displays=(),
                  log_channel='', log_level=logging.INFO, parent=None):
@@ -761,13 +764,16 @@ class ManagedImageWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
-        import subprocess, platform
-
         system = platform.system()
         if (system == 'Windows'):
+            # The empty argument after the start is needed to be able to cope correctly with filenames with spaces
             proc = subprocess.Popen(['start', '', filename], shell=True)
         elif (system == 'Linux'):
-            proc = subprocess.Popen([self.EDITOR, filename])
+            proc = subprocess.Popen(['xdg-open', filename])
+        elif (system == 'Darwin'):
+            proc = subprocess.Popen(['open', filename])
+        else:
+            raise Exception("{cls} method open_file_externally does not support {system} OS".format(cls=type(self).__name__,system=system))
 
     def make_procedure(self):
         if not isinstance(self.inputs, InputsWidget):

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -387,9 +387,13 @@ class ManagedWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
-        # TODO: Make this function OS-agnostic
-        import subprocess
-        proc = subprocess.Popen([self.EDITOR, filename])
+        import subprocess, platform
+
+        system = platform.system()
+        if (system == 'Windows'):
+            proc = subprocess.Popen(['start',  '', filename], shell=True)
+        elif (platform.system() == 'Linux'):
+            proc = subprocess.Popen([self.EDITOR, filename])
 
     def make_procedure(self):
         if not isinstance(self.inputs, InputsWidget):
@@ -757,9 +761,13 @@ class ManagedImageWindow(QtGui.QMainWindow):
             experiment.curve.setPen(pg.mkPen(color=color, width=2))
 
     def open_file_externally(self, filename):
-        # TODO: Make this function OS-agnostic
-        import subprocess
-        proc = subprocess.Popen([self.EDITOR, filename])
+        import subprocess, platform
+
+        system = platform.system()
+        if (system == 'Windows'):
+            proc = subprocess.Popen(['start', '', filename], shell=True)
+        elif (platform.system() == 'Linux'):
+            proc = subprocess.Popen([self.EDITOR, filename])
 
     def make_procedure(self):
         if not isinstance(self.inputs, InputsWidget):

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -391,8 +391,8 @@ class ManagedWindow(QtGui.QMainWindow):
 
         system = platform.system()
         if (system == 'Windows'):
-            proc = subprocess.Popen(['start',  '', filename], shell=True)
-        elif (platform.system() == 'Linux'):
+            proc = subprocess.Popen(['start', '', filename], shell=True)
+        elif (system == 'Linux'):
             proc = subprocess.Popen([self.EDITOR, filename])
 
     def make_procedure(self):
@@ -766,7 +766,7 @@ class ManagedImageWindow(QtGui.QMainWindow):
         system = platform.system()
         if (system == 'Windows'):
             proc = subprocess.Popen(['start', '', filename], shell=True)
-        elif (platform.system() == 'Linux'):
+        elif (system == 'Linux'):
             proc = subprocess.Popen([self.EDITOR, filename])
 
     def make_procedure(self):


### PR DESCRIPTION
Added support for Windows in open_file_externally

This is done using start from a shell which is equivalent to 'double click' on the file.
Linux behavior (unchanged) is to unconditionally call gedit with file.