### PR TITLE
Adapters: Adding __close__ magic where it is still missing (VISA, vxi11)

### DIFF
--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -39,6 +39,11 @@ class Adapter(object):
     """
     def __init__(self, preprocess_reply=None, **kwargs):
         self.preprocess_reply = preprocess_reply
+        self.connection = None
+
+    def __del__(self):
+        """close connection upon garbage collection of the device"""
+        self.connection.close()
 
     def write(self, command):
         """ Writes a command to the instrument

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -50,11 +50,6 @@ class SerialAdapter(Adapter):
         else:
             self.connection = serial.Serial(port, **kwargs)
 
-    def __del__(self):
-        """ Ensures the connection is closed upon deletion
-        """
-        self.connection.close()
-
     def write(self, command):
         """ Writes a command to the instrument
 

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -54,11 +54,6 @@ class TelnetAdapter(Adapter):
                     f"allowed are: {str(safe_keywords)}")
         self.connection = telnetlib.Telnet(host, port, **kwargs)
 
-    def __del__(self):
-        """ Ensures the connection is closed upon deletion
-        """
-        self.connection.close()
-
     def write(self, command):
         """ Writes a command to the instrument
 
@@ -89,3 +84,7 @@ class TelnetAdapter(Adapter):
     def __repr__(self):
         return "<TelnetAdapter(host=%s, port=%d)>" % (self.connection.host, self.connection.port)
 
+    def __del__(self):
+        """ Ensures the connection is closed upon deletion
+        """
+        self.connection.close()

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -83,8 +83,3 @@ class TelnetAdapter(Adapter):
 
     def __repr__(self):
         return "<TelnetAdapter(host=%s, port=%d)>" % (self.connection.host, self.connection.port)
-
-    def __del__(self):
-        """ Ensures the connection is closed upon deletion
-        """
-        self.connection.close()

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -162,7 +162,3 @@ class VISAAdapter(Adapter):
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resourceName
-
-    def __del__(self):
-        """close connection upon device deletion"""
-        self.connection.close()

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -69,10 +69,6 @@ class VISAAdapter(Adapter):
             **kwargs
         )
 
-    def __del__(self):
-        """close connection upon device deletion"""
-        self.connection.close()
-
     @staticmethod
     def has_supported_version():
         """ Returns True if the PyVISA version is greater than 1.8 """
@@ -80,9 +76,6 @@ class VISAAdapter(Adapter):
             return parse_version(pyvisa.__version__) >= parse_version('1.8')
         else:
             return False
-
-    def __repr__(self):
-        return "<VISAAdapter(resource='%s')>" % self.connection.resourceName
 
     def write(self, command):
         """ Writes a command to the instrument
@@ -166,3 +159,10 @@ class VISAAdapter(Adapter):
         :param delay: Time delay between checking SRQ in seconds
         """
         self.connection.wait_for_srq(timeout * 1000)
+
+    def __repr__(self):
+        return "<VISAAdapter(resource='%s')>" % self.connection.resourceName
+
+    def __del__(self):
+        """close connection upon device deletion"""
+        self.connection.close()

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -69,6 +69,10 @@ class VISAAdapter(Adapter):
             **kwargs
         )
 
+    def __del__(self):
+        """close connection upon device deletion"""
+        self.connection.close()
+
     @staticmethod
     def has_supported_version():
         """ Returns True if the PyVISA version is greater than 1.8 """

--- a/pymeasure/adapters/vxi11.py
+++ b/pymeasure/adapters/vxi11.py
@@ -114,7 +114,3 @@ class VXI11Adapter(Adapter):
 
     def __repr__(self):
         return '<VXI11Adapter(host={})>'.format(self.connection.host)
-
-    def __del__(self):
-        """close connection upon device deletion"""
-        self.connection.close()

--- a/pymeasure/adapters/vxi11.py
+++ b/pymeasure/adapters/vxi11.py
@@ -59,6 +59,10 @@ class VXI11Adapter(Adapter):
     def __repr__(self):
         return '<VXI11Adapter(host={})>'.format(self.connection.host)
 
+    def __del__(self):
+        """close connection upon device deletion"""
+        self.connection.close()
+
     def write(self, command):
         """ Wrapper function for the write command using the
         vxi11 interface.

--- a/pymeasure/adapters/vxi11.py
+++ b/pymeasure/adapters/vxi11.py
@@ -56,13 +56,6 @@ class VXI11Adapter(Adapter):
 
         self.connection = vxi11.Instrument(host, **self.conn_kwargs)
 
-    def __repr__(self):
-        return '<VXI11Adapter(host={})>'.format(self.connection.host)
-
-    def __del__(self):
-        """close connection upon device deletion"""
-        self.connection.close()
-
     def write(self, command):
         """ Wrapper function for the write command using the
         vxi11 interface.
@@ -118,3 +111,10 @@ class VXI11Adapter(Adapter):
         :returns binary string containing the response from the device.
         """
         return self.connection.ask_raw(command)
+
+    def __repr__(self):
+        return '<VXI11Adapter(host={})>'.format(self.connection.host)
+
+    def __del__(self):
+        """close connection upon device deletion"""
+        self.connection.close()


### PR DESCRIPTION
Some instruments allow only a limited number of connections at once - while some connections might be broken (without consciously closing them) in a way the instrument can notice, others might not be. 
Communication via VISA over a TCP-IP connection is such a case. For example, the sr860 LockIn only allows a certain number of active tcp connection - if this is exceeded because of repeatedly connecting and, without closing, breaking the connection, at some point a new connection cannot be established. 

This PR introduces the `__del__` method for those adapters where it was not yet included (i.e. visa, and vxi11), on the basis of the corresponding frameworks.  
Additionally, just for the looks, it groups the "magic" methods of the adapter classes to the bottom, as is most common across pymeasure (currently), while I could not find a mention of importance of such an order in the PEP8 style guide. 