### PR TITLE
Fix for keyboard interrupt

### DIFF
--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -301,6 +301,9 @@ class ManagedWindow(QtGui.QMainWindow):
         self.resize(1000, 800)
 
     def quit(self, evt=None):
+        if self.manager.is_running():
+            self.abort()
+
         self.close()
 
     def browser_item_changed(self, item, column):
@@ -679,6 +682,9 @@ class ManagedImageWindow(QtGui.QMainWindow):
         self.resize(1000, 800)
 
     def quit(self, evt=None):
+        if self.manager.is_running():
+            self.abort()
+
         self.close()
 
     def browser_item_changed(self, item, column):

--- a/pymeasure/thread.py
+++ b/pymeasure/thread.py
@@ -25,9 +25,21 @@
 import logging
 
 from threading import Thread, Event
+from time import time
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+
+class InterruptableEvent(Event):
+    def wait(self, timeout=None):
+        if timeout is None:
+            while not super().wait(0.01):
+                pass
+        else:
+            timeout_start = time()
+            while not super().wait(0.01) and time() <= timeout_start + timeout:
+                pass
 
 
 class StoppableThread(Thread):
@@ -37,7 +49,7 @@ class StoppableThread(Thread):
 
     def __init__(self):
         super().__init__()
-        self._should_stop = Event()
+        self._should_stop = InterruptableEvent()
         self._should_stop.clear()
 
     def join(self, timeout=0):

--- a/pymeasure/thread.py
+++ b/pymeasure/thread.py
@@ -32,6 +32,12 @@ log.addHandler(logging.NullHandler())
 
 
 class InterruptableEvent(Event):
+    """
+    This subclass solves the problem indicated in bug
+    https://bugs.python.org/issue35935 that prevents the
+    wait of an Event to be interrupted by a KeyboardInterrupt.
+    """
+
     def wait(self, timeout=None):
         if timeout is None:
             while not super().wait(0.01):

--- a/pymeasure/thread.py
+++ b/pymeasure/thread.py
@@ -40,11 +40,11 @@ class InterruptableEvent(Event):
 
     def wait(self, timeout=None):
         if timeout is None:
-            while not super().wait(0.01):
+            while not super().wait(0.1):
                 pass
         else:
             timeout_start = time()
-            while not super().wait(0.01) and time() <= timeout_start + timeout:
+            while not super().wait(0.1) and time() <= timeout_start + timeout:
                 pass
 
 


### PR DESCRIPTION
Propose a fix for the KeyboardInterrupt (i.e. ctrl + C) that is not working on some systems when running a measurement script (issue #84).

It seems to be related to a python bug that causes the `wait` function of an event to be uninterruptable (https://bugs.python.org/issue35935).

I proposed a fix (/workaround) by introducing an `InterruptableEvent` where the `wait` function is divided in many shorter waits.
Note that this fix only works when running a measurement script (e.g. the script.py in examples); it is not possible to interrupt the GUI with ctrl+C (though I also think that that would not be required, as there is an abort button in the software).
However, since closing the GUI using the close-button can still leave the measurement running when it is not finished yet, I here also propose to issue an abort when the GUI window is closed.