### PR TITLE
Add write binary values serial adapter

### DIFF
--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -32,7 +32,8 @@ Serial adapter
     :members:
     :undoc-members:
     :inherited-members:
-    :show-inheritance: 
+    :show-inheritance:
+    :private-members: _format_binary_values
 
 ================
 Prologix adapter
@@ -42,7 +43,8 @@ Prologix adapter
     :members:
     :undoc-members:
     :inherited-members:
-    :show-inheritance: 
+    :show-inheritance:
+    :private-members: _format_binary_values
 
 ============
 VISA adapter

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -104,7 +104,7 @@ class PrologixAdapter(SerialAdapter):
         self.connection.write(command.encode())
 
     def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt = "ieee"):
-        """Format values in binary format in order to be used with instrument commands.
+        """Format values in binary format, used internally in :meth:`.write_binary_values`.
 
         :param values: data to be writen to the device.
         :param datatype: the format string for a single element. See struct module.
@@ -138,7 +138,7 @@ class PrologixAdapter(SerialAdapter):
 
         :param command: SCPI command to be sent to the instrument
         :param values: iterable representing the binary values
-        :param kwargs: Key-word arguments to pass onto :meth:`~._format_binary_values`
+        :param kwargs: Key-word arguments to pass onto :meth:`._format_binary_values`
         :returns: number of bytes written
         """
         if self.address is not None:

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -103,7 +103,7 @@ class PrologixAdapter(SerialAdapter):
         command += "\n"
         self.connection.write(command.encode())
 
-    def format_binary_values(self, values, datatype='f', is_big_endian=False):
+    def _format_binary_values(self, values, datatype='f', is_big_endian=False):
         """Format values in binary format in order to be used with instrument commands.
 
         :param values: data to be writen to the device.
@@ -113,7 +113,7 @@ class PrologixAdapter(SerialAdapter):
         :rtype: bytes
         """
 
-        block = super().format_binary_values(values, datatype, is_big_endian)
+        block = super()._format_binary_values(values, datatype, is_big_endian)
         # Prologix needs certian characters to be escaped.
         # Special care must be taken when sending binary data to instruments. If any of the
         # following characters occur in the binary data -- CR (ASCII 13), LF (ASCII 10), ESC
@@ -130,10 +130,15 @@ class PrologixAdapter(SerialAdapter):
         return new_block
 
     def write_binary_values(self, command, values, **kwargs):
-        """ Writes the command to the GPIB address stored in the
-        :attr:`.address`
+        """ Write binary data to the instrument, e.g. waveform for signal generators.
 
-        :param command: SCPI command string to be sent to the instrument
+        values are encoded in a binary format according to
+        IEEE 488.2 Definite Length Arbitrary Block Response Data block.
+
+        :param command: SCPI command to be sent to the instrument
+        :param values: iterable representing the binary values
+        :param kwargs: Key-word arguments to pass onto `_format_binary_values`
+        :returns: number of bytes written
         """
         if self.address is not None:
             address_command = "++addr %d\n" % self.address

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -103,17 +103,18 @@ class PrologixAdapter(SerialAdapter):
         command += "\n"
         self.connection.write(command.encode())
 
-    def _format_binary_values(self, values, datatype='f', is_big_endian=False):
+    def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt = "ieee"):
         """Format values in binary format in order to be used with instrument commands.
 
         :param values: data to be writen to the device.
         :param datatype: the format string for a single element. See struct module.
         :param is_big_endian: boolean indicating endianess.
+        :param header_fmt: Format of the header prefixing the data ("ieee", "hp", "empty").
         :return: binary string.
         :rtype: bytes
         """
 
-        block = super()._format_binary_values(values, datatype, is_big_endian)
+        block = super()._format_binary_values(values, datatype, is_big_endian, header_fmt)
         # Prologix needs certian characters to be escaped.
         # Special care must be taken when sending binary data to instruments. If any of the
         # following characters occur in the binary data -- CR (ASCII 13), LF (ASCII 10), ESC
@@ -137,7 +138,7 @@ class PrologixAdapter(SerialAdapter):
 
         :param command: SCPI command to be sent to the instrument
         :param values: iterable representing the binary values
-        :param kwargs: Key-word arguments to pass onto `_format_binary_values`
+        :param kwargs: Key-word arguments to pass onto :meth:`~._format_binary_values`
         :returns: number of bytes written
         """
         if self.address is not None:

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -78,7 +78,7 @@ class SerialAdapter(Adapter):
         header, data = binary[:header_bytes], binary[header_bytes:]
         return np.fromstring(data, dtype=dtype)
 
-    def _format_binary_values(self, values, datatype='f', is_big_endian=False):
+    def format_binary_values(self, values, datatype='f', is_big_endian=False):
         """Format values in binary format in order to be used with instrument commands.
 
         :param values: data to be writen to the device.
@@ -101,7 +101,7 @@ class SerialAdapter(Adapter):
         :returns: number of bytes written
         """
 
-        block = self._format_binary_values(values, **kwargs)
+        block = self.format_binary_values(values, **kwargs)
         return self.connection.write(command.encode() + block) 
 
     def __repr__(self):

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -45,7 +45,7 @@ class SerialAdapter(Adapter):
 
     def __init__(self, port, preprocess_reply=None, **kwargs):
         super().__init__(preprocess_reply=preprocess_reply)
-        if isinstance(port, serial.Serial):
+        if isinstance(port, serial.SerialBase):
             self.connection = port
         else:
             self.connection = serial.Serial(port, **kwargs)
@@ -78,10 +78,10 @@ class SerialAdapter(Adapter):
         header, data = binary[:header_bytes], binary[header_bytes:]
         return np.fromstring(data, dtype=dtype)
 
-    def format_binary_values(self, values, datatype='f', is_big_endian=False):
+    def _format_binary_values(self, values, datatype='f', is_big_endian=False):
         """Format values in binary format in order to be used with instrument commands.
 
-        :param values: data to be writen to the device.
+        :param values: data to be written to the device.
         :param datatype: the format string for a single element. See struct module.
         :param is_big_endian: boolean indicating endianess.
         :return: binary string.
@@ -97,11 +97,11 @@ class SerialAdapter(Adapter):
 
         :param command: SCPI command to be sent to the instrument
         :param values: iterable representing the binary values
-        :param kwargs: Key-word arguments to pass onto `write_binary_values`
+        :param kwargs: Key-word arguments to pass onto `_format_binary_values`
         :returns: number of bytes written
         """
 
-        block = self.format_binary_values(values, **kwargs)
+        block = self._format_binary_values(values, **kwargs)
         return self.connection.write(command.encode() + block) 
 
     def __repr__(self):

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -79,7 +79,7 @@ class SerialAdapter(Adapter):
         return np.fromstring(data, dtype=dtype)
 
     def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt = "ieee"):
-        """Format values in binary format in order to be used with instrument commands.
+        """Format values in binary format, used internally in :meth:`.write_binary_values`.
 
         :param values: data to be written to the device.
         :param datatype: the format string for a single element. See struct module.
@@ -105,7 +105,7 @@ class SerialAdapter(Adapter):
 
         :param command: SCPI command to be sent to the instrument
         :param values: iterable representing the binary values
-        :param kwargs: Key-word arguments to pass onto :meth:`~._format_binary_values`
+        :param kwargs: Key-word arguments to pass onto :meth:`._format_binary_values`
         :returns: number of bytes written
         """
 

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -34,7 +34,7 @@ def make_adapter(**kwargs):
 
 
 @pytest.mark.parametrize("test_input,expected", [("OUTP", prefix + "OUTP\n"),
-                                                 ("POWER 22 dBm", prefix+ "POWER 22 dBm\n")])
+                                                 ("POWER 22 dBm", prefix + "POWER 22 dBm\n")])
 def test_adapter_write(test_input, expected):
     adapter = make_adapter(timeout=0.2)
     adapter.write(test_input)

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -1,0 +1,49 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import serial
+
+from pymeasure.adapters import PrologixAdapter
+
+prefix="\n".join(["++auto 0", "++eoi 1", "++eos 2"])+"\n"
+
+def make_adapter(**kwargs):
+    return PrologixAdapter(serial.serial_for_url("loop://", **kwargs))
+
+
+@pytest.mark.parametrize("test_input,expected", [("OUTP", prefix + "OUTP\n"),
+                                                 ("POWER 22 dBm", prefix+ "POWER 22 dBm\n")])
+def test_adapter_write(test_input, expected):
+    adapter = make_adapter(timeout=0.2)
+    adapter.write(test_input)
+    assert(adapter.connection.read(len(expected)+10) == expected.encode())
+
+@pytest.mark.parametrize("test_input,expected", [([1,2,3], prefix.encode() + b'OUTP#13\x01\x02\x03' + "\n".encode()),
+                                                 ([43, 27, 10,13, 97, 98, 99], prefix.encode() + b'OUTP#17\x1b\x2b\x1b\x1b\x1b\x0a\x1b\x0dabc'+ "\n".encode())])
+def test_adapter_write_binary_values(test_input, expected):
+    adapter = make_adapter(timeout=0.2)
+    adapter.write_binary_values("OUTP", test_input, datatype='B')
+    # Add 10 bytes more, just to check that no extra bytes are present
+    assert(adapter.connection.read(len(expected)+10) == expected)

--- a/tests/adapters/test_serial.py
+++ b/tests/adapters/test_serial.py
@@ -1,0 +1,47 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import serial
+
+from pymeasure.adapters import SerialAdapter
+
+def make_adapter(**kwargs):
+    return SerialAdapter(serial.serial_for_url("loop://", **kwargs))
+
+
+@pytest.mark.parametrize("msg", ["OUTP\n", "POWER 22 dBm\n"])
+def test_adapter_write(msg):
+    adapter = make_adapter(timeout=0.2)
+    adapter.write(msg)
+    assert(adapter.read() == msg)
+
+@pytest.mark.parametrize("test_input,expected", [([1,2,3], b'OUTP#13\x01\x02\x03'),
+                                                 (range(100), b'OUTP#3100'+bytes(range(100)))])
+def test_adapter_write_binary_values(test_input, expected):
+    adapter = make_adapter(timeout=0.2)
+    adapter.write_binary_values("OUTP", test_input, datatype='B')
+    # Add 10 bytes more, just to check that no extra bytes are present
+    assert(adapter.connection.read(len(expected)+10) == expected)
+


### PR DESCRIPTION
This PR add the method `write_binary_values `in `SerialAdapter `and `PrologixAdapter` with same behavior of the version provided in `VISAAdapter`