### PR TITLE
implement shutdown function for Keithley 2260B

### DIFF
--- a/pymeasure/instruments/keithley/keithley2260B.py
+++ b/pymeasure/instruments/keithley/keithley2260B.py
@@ -112,3 +112,8 @@ class Keithley2260B(Instrument):
             code, message = self.error
             if (time.time() - t) > 10:
                 log.warning("Timed out for Keithley 2260B error retrieval.")
+
+    def shutdown(self):
+        """ Disable output, call parent function"""
+        self.enabled = False
+        super().shutdown()


### PR DESCRIPTION
As was noted in #426, this instrument lacked a proper implementation of the shutdown function. 
Here it is. 