### PR TITLE
Placeholder logic

### DIFF
--- a/pymeasure/experiment/__init__.py
+++ b/pymeasure/experiment/__init__.py
@@ -25,7 +25,7 @@
 from .parameters import (Parameter, IntegerParameter, FloatParameter,
                         VectorParameter, ListParameter, BooleanParameter, Measurable)
 from .procedure import Procedure, UnknownProcedure
-from .results import Results, unique_filename
+from .results import Results, unique_filename, replace_placeholders
 from .workers import Worker
 from .listeners import Listener, Recorder
 from .config import get_config

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -45,6 +45,9 @@ def replace_placeholders(string, procedure):
     parameters = procedure.parameter_objects()
     placeholders = {param.name: param.value for param in parameters.values()}
 
+    placeholders["date"] = now.strftime(date_format)
+    placeholders["time"] = now.strftime(time_format)
+
     # Check keys against available parameters
     invalid_keys = [i[1] for i in Formatter().parse(string)
                     if i[1] is not None and i[1] not in placeholders]

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -41,7 +41,31 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def replace_placeholders(string, procedure):
+def replace_placeholders(string, procedure, date_format="%Y-%m-%d", time_format="%H:%M:%S"):
+    """ Replaces the placeholders in the provided strings with the values of the
+    associated parameters, as provided by the procedure. This uses the standard
+    python string.format syntax. Apart from the parameter in the procedure (which
+    should be called by their full names) "date" and "time" are also added as optional
+    placeholders.
+
+    :param string:
+        The string in which the placeholders are to be replaced. Python string.format
+        syntax is used, e.g. "{Parameter Name}" to insert a FloatParameter called
+        "Parameter Name", or "{Parameter Name:.2f}" to also specifically format the
+        parameter.
+
+    :param procedure:
+        The procedure from which to get the parameter values.
+
+    :param date_format:
+        A string to represent how the additional placeholder "date" will be formatted.
+
+    :param time_format:
+        A string to represent how the additional placeholder "time" will be formatted.
+
+    """
+    now = datetime.now()
+
     parameters = procedure.parameter_objects()
     placeholders = {param.name: param.value for param in parameters.values()}
 

--- a/tests/experiment/test_replace_placeholders.py
+++ b/tests/experiment/test_replace_placeholders.py
@@ -1,0 +1,55 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+import os
+
+from pymeasure.experiment.results import replace_placeholders
+from pymeasure.experiment.procedure import Procedure
+from pymeasure.experiment import Parameter, BooleanParameter, FloatParameter
+
+
+def test_replace_placeholders():
+    class FakeProcedure(Procedure):
+        str_param = Parameter("String Parameter")
+        bool_param = BooleanParameter("Boolean Parameter")
+        float_param = FloatParameter("Float Parameter")
+
+    fake = FakeProcedure()
+    fake.set_parameters({
+        "str_param": "test",
+        "bool_param": False,
+        "float_param": 1.252
+    })
+
+    assert replace_placeholders("{String Parameter}", fake) == "test"
+    assert replace_placeholders("{Boolean Parameter}", fake) == "False"
+    assert replace_placeholders("{Float Parameter:.2f}", fake) == "1.25"
+    assert replace_placeholders("{String Parameter}_{Float Parameter}_{Boolean Parameter}", fake) == "test_1.252_False"
+
+    with pytest.raises(KeyError):
+        replace_placeholders("{Unknown Parameter}", fake)
+
+

--- a/tests/experiment/test_replace_placeholders.py
+++ b/tests/experiment/test_replace_placeholders.py
@@ -25,6 +25,7 @@
 import pytest
 
 import os
+from datetime import datetime
 
 from pymeasure.experiment.results import replace_placeholders
 from pymeasure.experiment.procedure import Procedure
@@ -52,4 +53,10 @@ def test_replace_placeholders():
     with pytest.raises(KeyError):
         replace_placeholders("{Unknown Parameter}", fake)
 
-
+    date_format = "%Y-%m"
+    time_format = "%H:%M"
+    now = datetime.now()
+    date = now.strftime(date_format)
+    time = now.strftime(time_format)
+    assert replace_placeholders("{date}--{time}", fake,
+                                date_format=date_format, time_format=time_format) == date + '--' + time


### PR DESCRIPTION
An alternative implementation for replacing placeholders to #423. Credits to @paulgoulain for the idea.

This replacer uses `str.format` to replace placeholders with the name (as given via the `name` argument) of any `Parameter` of the `Procedure`. It also adds to other placeholders: date and time (both with a keyword-argument to choose the format).

An example of usage would be `filename = replace_placeholders("Measurement_{Parameter Name:.2f}", procedure)`.

It can also be called via `unique_filename` by passing the `procedure` keyword-argument.