### PR TITLE
actually call should_stop in wait for trigger

### DIFF
--- a/pymeasure/instruments/agilent/agilent33220A.py
+++ b/pymeasure/instruments/agilent/agilent33220A.py
@@ -278,7 +278,7 @@ class Agilent33220A(Instrument):
                     " to finish the triggering."
                 )
 
-            if should_stop:
+            if should_stop():
                 return
 
     trigger_source = Instrument.control(


### PR DESCRIPTION
`should_stop` is passed as a function and should actually be called in the loop breaking conditional of `wait_for_trigger`