### PR TITLE
keithley2000 remove deprecated call to visa.config

### DIFF
--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -430,11 +430,6 @@ class Keithley2000(Instrument, KeithleyBuffer):
         values=[0, 999999.999]
     )
 
-    def __init__(self, adapter, **kwargs):
-        super(Keithley2000, self).__init__(
-            adapter, "Keithley 2000 Multimeter", **kwargs
-        )
-
     # TODO: Clean up error checking
     def check_errors(self):
         """ Read all errors from the instrument."""

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -434,14 +434,6 @@ class Keithley2000(Instrument, KeithleyBuffer):
         super(Keithley2000, self).__init__(
             adapter, "Keithley 2000 Multimeter", **kwargs
         )
-        # Set up data transfer format
-        if isinstance(self.adapter, VISAAdapter):
-            self.adapter.config(
-                is_binary=False,
-                datatype='float32',
-                converter='f',
-                separator=','
-            )
 
     # TODO: Clean up error checking
     def check_errors(self):

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -430,6 +430,11 @@ class Keithley2000(Instrument, KeithleyBuffer):
         values=[0, 999999.999]
     )
 
+    def __init__(self, adapter, **kwargs):
+        super(Keithley2000, self).__init__(
+            adapter, "Keithley 2000 Multimeter", **kwargs
+        )
+
     # TODO: Clean up error checking
     def check_errors(self):
         """ Read all errors from the instrument."""


### PR DESCRIPTION
Removing the deprecated function call to `self.adapter.config()` in the `keithley2000` multimeter. 
Refer to #440 and [commit where this function was removed from pymeasure](https://github.com/pymeasure/pymeasure/commit/21e659988fcb3a960bbce6143bb5dc806bf53a1b)

I am not 100% sure this would break something in the instrument functions, but it does not seem to, and the functionality of preprocessing output from the instrument is well integrated in pymeasure