### PR TITLE
Added Superconducting Magnet Controller from ScientificMagnetics / Twickenham

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -32,3 +32,4 @@ Mathieu Plante
 Michele Sardo
 Steven Siegl
 Benjamin Klebel-Knobloch
+Alfons Schuck

--- a/docs/api/instruments/scientificmagnetics/index.rst
+++ b/docs/api/instruments/scientificmagnetics/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.scientificmagnetics
+
+###################
+ScientificMagnetics
+###################
+
+This section contains specific documentation on the Razorbill instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   scimag

--- a/docs/api/instruments/scientificmagnetics/scimag.rst
+++ b/docs/api/instruments/scientificmagnetics/scimag.rst
@@ -1,0 +1,8 @@
+#######################################################################
+ScientificMagnetics SciMag s-11-52-13 superconducting magnet controller
+#######################################################################
+
+.. autoclass:: pymeasure.instruments.scientificmagnetics.scimag
+    :members:
+    :show-inheritance:
+

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -89,18 +89,21 @@ class Adapter(object):
             results = preprocess_reply(results)
         elif callable(self.preprocess_reply):
             results = self.preprocess_reply(results)
-        results = results.split(separator)
-        for i, result in enumerate(results):
-            try:
-                if cast == bool:
-                    # Need to cast to float first since results are usually
-                    # strings and bool of a non-empty string is always True
-                    results[i] = bool(float(result))
-                else:
-                    results[i] = cast(result)
-            except Exception:
-                pass  # Keep as string
-        return results
+        if isinstance(results, dict):
+            return results
+        else:
+            results = results.split(separator)
+            for i, result in enumerate(results):
+                try:
+                    if cast == bool:
+                        # Need to cast to float first since results are usually
+                        # strings and bool of a non-empty string is always True
+                        results[i] = bool(float(result))
+                    else:
+                        results[i] = cast(result)
+                except Exception:
+                    pass  # Keep as string
+            return results
 
     def binary_values(self, command, header_bytes=0, dtype=np.float32):
         """ Returns a numpy array from a query for binary data 

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -121,7 +121,7 @@ class Instrument(object):
                 **kwargs):
         """Returns a property for the class based on the supplied
         commands. This property may be set and read from the
-        instrument.
+         instrument.
 
         :param get_command: A string command that asks for the value
         :param set_command: A string command that writes the value

--- a/pymeasure/instruments/scientificmagnetics/__init__.py
+++ b/pymeasure/instruments/scientificmagnetics/__init__.py
@@ -22,4 +22,4 @@
 # THE SOFTWARE.
 #
 
-from .smc import SMC
+from .scimag import SciMag

--- a/pymeasure/instruments/scientificmagnetics/__init__.py
+++ b/pymeasure/instruments/scientificmagnetics/__init__.py
@@ -22,34 +22,4 @@
 # THE SOFTWARE.
 #
 
-from ..errors import RangeError, RangeException
-from .instrument import Instrument
-from .mock import Mock
-from .resources import list_resources
-from .validators import discreteTruncate
-
-from . import advantest
-from . import agilent
-from . import ametek
-from . import ami
-from . import anapico
-from . import anritsu
-from . import attocube
-from . import danfysik
-from . import deltaelektronika
-from . import fwbell
-from . import hp
-from . import keithley
-from . import keysight
-from . import lakeshore
-from . import newport
-from . import ni
-from . import oxfordinstruments
-from . import parker
-from . import razorbill
-from . import signalrecovery
-from . import scientificmagnetics
-from . import srs
-from . import tektronix
-from . import thorlabs
-from . import yokogawa
+from .smc import SMC

--- a/pymeasure/instruments/scientificmagnetics/scimag.py
+++ b/pymeasure/instruments/scientificmagnetics/scimag.py
@@ -31,15 +31,16 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 # Define RegExpressions to match the responses of the instrument
-_reG = re.compile(r'^I([\s+-]\d{3}.\d{3})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
-_reJF = re.compile(r'^F([\s+-]\d{2}.\d{4})H(\d)\r\n$')
-_reJI = re.compile(r'^I([\s+-]\d{3}.\d{3})H(\d)\r\n$')
-_reKF = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{2}.\d{4})\r\n$')
-_reKI = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{3}.\d{3})\r\n$')
-_reN = re.compile(r'^F([\s+-]\d{2}.\d{4})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
-_reO = re.compile(r'^A(\d{2}.\d{5})D(\d)T(\d)B(\d)W(\d{3}.)C(0.\d{6})\r\n$')
-_reSF = re.compile(r'^T(\d)U(\d{2}.\d{4})L(\d{2}.\d{4})Y(\d{2}.\d)\r\n$')
-_reSI = re.compile(r'^T(\d)U(\d{3}.\d{3})L(\d{3}.\d{3})Y(\d{2}.\d)\r\n$')
+_reG = re.compile(r'^I([\s+-]\d{3}.\d{3})V([\s+-]\d{2}.\d)R(\d[AV])$')
+_reJF = re.compile(r'^F([\s+-]\d{2}.\d{4})H(\d)$')
+_reJI = re.compile(r'^I([\s+-]\d{3}.\d{3})H(\d)$')
+_reKF = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{2}.\d{4})$')
+_reKI = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{3}.\d{3})$')
+_reN = re.compile(r'^F([\s+-]\d{2}.\d{4})V([\s+-]\d{2}.\d)R(\d[AV])$')
+_reO = re.compile(r'^A(\d{2}.\d{5})D(\d)T(\d)B(\d)W(\d{3}.)C(0.\d{6})$')
+_reSF = re.compile(r'^T(\d)U(\d{2}.\d{4})L(\d{2}.\d{4})Y(\d{2}.\d)$')
+_reSI = re.compile(r'^T(\d)U(\d{3}.\d{3})L(\d{3}.\d{3})Y(\d{2}.\d)$')
+
 
 
 def extract_value_output_parameters_amps(reply) -> dict:
@@ -403,12 +404,7 @@ class SciMag(Instrument):
         """
         self.unit = "T"
         value = self.output_parameters_tesla["field"]
-        if self.operating_parameters["switch_direction"] == 0:
-            sign = +1
-            return float(sign * value)
-        elif self.operating_parameters["switch_direction"] == 1:
-            sign = -1
-            return float(sign * value)
+        return value
 
     @tesla.setter
     def tesla(self, value: float):
@@ -426,7 +422,7 @@ class SciMag(Instrument):
 
             # 2. Check, if value and sign are both positive or both negative
             if value * sign > 0:
-                self.upper_setpoint(abs(value))
+                self.upper_setpoint = abs(value)
             elif value * sign < 0:
                 self.ramp_target = "Z"
                 # At zero-field: switch direction.
@@ -436,7 +432,7 @@ class SciMag(Instrument):
                     self.reverse_switch_on = False
                 elif value < 0:
                     self.reverse_switch_on = True
-                self.upper_setpoint(abs(value))
+                self.upper_setpoint = abs(value)
             self.ramp_target = "U"
         else:
             log.warning("Intended field was: %08.4f T.\nAllowed maximum field is: %08.4f T" % (value, self._T_MAX))

--- a/pymeasure/instruments/scientificmagnetics/smc.py
+++ b/pymeasure/instruments/scientificmagnetics/smc.py
@@ -51,7 +51,7 @@ def extract_value_output_parameters_amps(reply) -> dict:
             Could not match regex to reply of output_parameters_amps.
             Reply received: 
             %s
-            """ %reply
+            """ % reply
         )
     else:
         i = float(match.group(1))
@@ -69,7 +69,7 @@ def extract_value_output_parameters_tesla(reply) -> dict:
             Could not match regex to reply of output_parameters_tesla.
             Reply received: 
             %s
-            """ %reply
+            """ % reply
         )
     else:
         f = float(match.group(1))
@@ -80,21 +80,18 @@ def extract_value_output_parameters_tesla(reply) -> dict:
 
 
 def extract_value_magnet_status(reply) -> dict:
-    matchF = _reJF.match(reply)
-    matchI = _reJI.match(reply)
+    match_f = _reJF.match(reply)
+    match_i = _reJI.match(reply)
 
-    if matchF:
-        return dict(heater=int(matchF.group(2)),
-                    value=float(matchF.group(1)),
+    if match_f:
+        return dict(heater=int(match_f.group(2)),
+                    value=float(match_f.group(1)),
                     units=1)
-    elif matchI:
-        return dict(heater=int(matchI.group(2)),
-                    value=float(matchI.group(1)),
+    elif match_i:
+        return dict(heater=int(match_i.group(2)),
+                    value=float(match_i.group(1)),
                     units=0)
     else:
-        return dict(heater=None,
-                    value=None,
-                    units=None)
         log.warning(
             """
             Could not match regex to reply of magnet_status.
@@ -102,35 +99,45 @@ def extract_value_magnet_status(reply) -> dict:
             %s
             """ % reply
         )
+        return dict(heater=None,
+                    value=None,
+                    units=None)
 
 
 def extract_value_current_status(reply) -> dict:
-    matchF = _reKF.match(reply)
-    matchI = _reKI.match(reply)
+    match_f = _reKF.match(reply)
+    match_i = _reKI.match(reply)
 
-    if matchF:
+    if match_f:
         return dict(
-            ramp_target=int(matchF.group(1)),
-            ramp_status=int(matchF.group(2)),
-            pause=int(matchF.group(3)),
-            external_trip=int(matchF.group(4)),
-            heater_mode=int(matchF.group(5)),
-            error_code=int(matchF.group(6)),
-            quench_value=float(matchF.group(7)),
+            ramp_target=int(match_f.group(1)),
+            ramp_status=int(match_f.group(2)),
+            pause=int(match_f.group(3)),
+            external_trip=int(match_f.group(4)),
+            heater_mode=int(match_f.group(5)),
+            error_code=int(match_f.group(6)),
+            quench_value=float(match_f.group(7)),
             units=1
         )
-    elif matchI:
+    elif match_i:
         return dict(
-            ramp_target=int(matchI.group(1)),
-            ramp_status=int(matchI.group(2)),
-            pause=int(matchI.group(3)),
-            external_trip=int(matchI.group(4)),
-            heater_mode=int(matchI.group(5)),
-            error_code=int(matchI.group(6)),
-            quench_value=float(matchI.group(7)),
+            ramp_target=int(match_i.group(1)),
+            ramp_status=int(match_i.group(2)),
+            pause=int(match_i.group(3)),
+            external_trip=int(match_i.group(4)),
+            heater_mode=int(match_i.group(5)),
+            error_code=int(match_i.group(6)),
+            quench_value=float(match_i.group(7)),
             units=0
         )
     else:
+        log.warning(
+            """
+            Could not match regex to reply of current_status.
+            Reply received: 
+            %s
+            """ % reply
+        )
         return dict(
             ramp_target=None,
             ramp_status=None,
@@ -141,14 +148,6 @@ def extract_value_current_status(reply) -> dict:
             quench_value=None,
             units=None
         )
-        log.warning(
-            """
-            Could not match regex to reply of current_status.
-            Reply received: 
-            %s
-            """ % reply
-        )
-
 
 
 def extract_value_operating_parameters(reply) -> dict:
@@ -164,6 +163,13 @@ def extract_value_operating_parameters(reply) -> dict:
             telsa_per_amps=float(match.group(6))
         )
     else:
+        log.warning(
+            """
+            Could not match regex to reply of operating_parameters.
+            Reply received: 
+            %s
+            """ % reply
+        )
         return dict(
             ramp_rate=None,
             switch_direction=None,
@@ -172,46 +178,41 @@ def extract_value_operating_parameters(reply) -> dict:
             heater_current_mA=None,
             telsa_per_amps=None
         )
-        log.warning(
-            """
-            Could not match regex to reply of operating_parameters.
-            Reply received: 
-            %s
-            """ % reply
-        )
+
 
 
 def extract_value_set_point_status(reply) -> dict:
-    matchF = _reSF.match(reply)
-    matchI = _reSI.match(reply)
+    match_f = _reSF.match(reply)
+    match_i = _reSI.match(reply)
 
-    if matchF:
+    if match_f:
         return dict(
-            units=int(matchF.group(1)),
-            upper_set_point=float(matchF.group(2)),
-            lower_set_point=float(matchF.group(3)),
-            terminal_voltage=float(matchF.group(4))
+            units=int(match_f.group(1)),
+            upper_set_point=float(match_f.group(2)),
+            lower_set_point=float(match_f.group(3)),
+            terminal_voltage=float(match_f.group(4))
         )
-    elif matchI:
+    elif match_i:
         return dict(
-            units=int(matchI.group(1)),
-            upper_set_point=float(matchI.group(2)),
-            lower_set_point=float(matchI.group(3)),
-            terminal_voltage=float(matchI.group(4))
+            units=int(match_i.group(1)),
+            upper_set_point=float(match_i.group(2)),
+            lower_set_point=float(match_i.group(3)),
+            terminal_voltage=float(match_i.group(4))
         )
     else:
-        return dict(
-            units=None,
-            upper_set_point=None,
-            lower_set_point=None,
-            terminal_voltage=None
-        )
         log.warning(
             """
             Could not match regex to reply of set_point_status.
             Reply received: 
             %s
             """ % reply
+        )
+        return dict(
+            units=None,
+            upper_set_point=None,
+            lower_set_point=None,
+            terminal_voltage=None
+        )
 
 
 class SMC(Instrument, includeSCPI=False):
@@ -245,13 +246,14 @@ class SMC(Instrument, includeSCPI=False):
         map_values=True
     )
 
-    direction = Instrument.setting(
+    reverse_switch_on = Instrument.setting(
         "D%d",
         """Sets the direction of the reversing switch, if installed.
-         Can take the values "F"orward or "R"everse.
-         WARNING: Change only if Magnet has been ramped to Zero!""",
+        Forward if switch is off; Reverse if switch is on.
+        Takes boolean value. True = Switch is on, Field is reverse.
+        WARNING: Change only if Magnet has been ramped to Zero!""",
         validator=strict_discrete_set,
-        values={"F": 0, "R": 1},
+        values={False: 0, True: 1},
         map_values=True
     )
 
@@ -313,6 +315,43 @@ class SMC(Instrument, includeSCPI=False):
         validator=strict_range,
         values=[0.01, 0.5],
     )
+
+    output_parameters_amps = Instrument.measurement(
+        "G",
+        """Returns dict of output parameters.""",
+        preprocess_reply=extract_value_output_parameters_amps
+    )
+
+    output_parameters_tesla = Instrument.measurement(
+        "N",
+        """Returns dict of output parameters.""",
+        preprocess_reply=extract_value_output_parameters_tesla
+    )
+
+    magnet_status = Instrument.measurement(
+        "J",
+        "Returns dict of magnet status.",
+        preprocess_reply=extract_value_magnet_status
+    )
+
+    current_status = Instrument.measurement(
+        "K",
+        "Returns dict of current status.",
+        preprocess_reply=extract_value_current_status
+    )
+
+    operating_parameters = Instrument.measurement(
+        "O",
+        "Returns dict of operation parameters",
+        preprocess_reply=extract_value_operating_parameters
+    )
+
+    set_point_status = Instrument.measurement(
+        "S",
+        "Returns dict of set point status.",
+        preprocess_reply=extract_value_set_point_status
+    )
+
 
     def __init__(self, resourceName,
                  ramp_rate_max=5,

--- a/pymeasure/instruments/scientificmagnetics/smc.py
+++ b/pymeasure/instruments/scientificmagnetics/smc.py
@@ -218,6 +218,10 @@ class SMC(Instrument, includeSCPI=False):
     """ Represents the Scientific Magnetics (Twickenham Scientific Instruments)
     Superconducting Magnet Controller and provides a high-level interface for
     interacting with the instrument.
+
+    WARNING: Use at your own risk!
+    Faulty operation of a superconducting magnet can lead to severe damage or injury!
+    Read the manual: https://www.twicksci.co.uk/manuals/pdf/smc552+.pdf
     """
 
     _RAMP_RATE_MAX = 5

--- a/pymeasure/instruments/scientificmagnetics/smc.py
+++ b/pymeasure/instruments/scientificmagnetics/smc.py
@@ -1,0 +1,276 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import re
+import time
+from pymeasure.instruments import Instrument
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class SMC(Instrument, includeSCPI=False):
+    """ Represents the Scientific Magnetics (Twickenham Scientific Instruments)
+    Superconducting Magnet Controller and provides a high-level interface for
+    interacting with the instrument.
+    """
+
+    def __init__(self, resourceName, **kwargs):
+        super().__init__(
+            resourceName,
+            "Scientific Magnetics SMC",
+            **kwargs
+        )
+
+        # Define RegExpressions to match the responses of the instrument
+        self._reG = re.compile(r'^I([\s+-]\d{3}.\d{3})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
+        self._reJF = re.compile(r'^F([\s+-]\d{2}.\d{4})H(\d)\r\n$')
+        self._reJI = re.compile(r'^I([\s+-]\d{3}.\d{3})H(\d)\r\n$')
+        self._reKF = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{2}.\d{4})\r\n$')
+        self._reKI = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{3}.\d{3})\r\n$')
+        self._reN = re.compile(r'^F([\s+-]\d{2}.\d{4})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
+        self._reO = re.compile(r'^A(\d{2}.\d{5})D(\d)T(\d)B(\d)W(\d{3}.)C(0.\d{6})\r\n$')
+        self._reSF = re.compile(r'^T(\d)U(\d{2}.\d{4})L(\d{2}.\d{4})Y(\d{2}.\d)\r\n$')
+        self._reSI = re.compile(r'^T(\d)U(\d{3}.\d{3})L(\d{3}.\d{3})Y(\d{2}.\d)\r\n$')
+
+    def pause_off(self):
+        self.write('P0')
+
+    def pause_on(self):
+        self.write('P1')
+
+    def unit_amps(self):
+        self.write('T0')
+
+    def unit_tesla(self):
+        self.write('T1')
+
+    def upper_setpoint_tesla(self, tesla):
+        self.unit_tesla()
+        self.write('U{tesla:07.4f}'.format(tesla=tesla))
+
+    def lower_setpoint_tesla(self, tesla):
+        self.unit_tesla()
+        self.write('L{tesla:07.4f}'.format(tesla=tesla))
+
+    def switch_forward(self):
+        self.write('D0')
+
+    def switch_reversed(self):
+        self.write('D1')
+
+    def ramp_zero(self):
+        self.write('R0')
+
+    def ramp_lower(self):
+        self.write('R1')
+
+    def ramp_upper(self):
+        self.write('R2')
+
+    def heater_off(self):
+        self.write('H0')
+
+    def heater_conditional_on(self):
+        """ Standard function to be used when turning on switch heater """
+        self.write('H1')
+
+    def heater_unconditional_on(self):
+        """ Warning this will turn on the heater without any interlocks.
+            Usage at own risk!
+        """
+        self.write('H2')
+
+    def heater_reset_persistent_mode_current_record_to_zero(self):
+        self.write('H9')
+
+    @property
+    def output_parameters_amps(self):
+        self.unit_amps()
+        self.write('G')
+        message = self.read()
+        match = self._reG.match(message)
+
+        if not match:
+            return None
+
+        I = float(match.group(1))
+        U = float(match.group(2))
+        R = match.group(3)
+
+        return dict(current=I, voltage=U, ramp=R)
+
+    @property
+    def output_parameters_tesla(self):
+        self.unit_tesla()
+        self.write('N')
+        message = self.read()
+        match = self._reN.match(message)
+
+        if not match:
+            print('DEBUG', self._reN, match, message)
+            return None
+
+        F = float(match.group(1))
+        U = float(match.group(2))
+        R = match.group(3)
+
+        return dict(field=F, voltage=U, ramp=R)
+
+    @property
+    def magnet_status(self):
+        self.write('J')
+        message = self.read()
+
+        matchF = self._reJF.match(message)
+        matchI = self._reJI.match(message)
+
+        if matchF:
+            return dict(heater=int(matchF.group(2)),
+                        value=float(matchF.group(1)),
+                        units=1)
+        elif matchI:
+            return dict(heater=int(matchI.group(2)),
+                        value=float(matchI.group(1)),
+                        units=0)
+        else:
+            return None
+
+    @property
+    def current_status(self):
+        self.write('K')
+        message = self.read()
+
+        matchF = self._reKF.match(message)
+        matchI = self._reKI.match(message)
+
+        if matchF:
+            return dict(
+                ramp_target=int(matchF.group(1)),
+                ramp_status=int(matchF.group(2)),
+                pause=int(matchF.group(3)),
+                external_trip=int(matchF.group(4)),
+                heater_mode=int(matchF.group(5)),
+                error_code=int(matchF.group(6)),
+                quench_value=float(matchF.group(7)),
+                units=1
+            )
+        elif matchI:
+            return dict(
+                ramp_target=int(matchI.group(1)),
+                ramp_status=int(matchI.group(2)),
+                pause=int(matchI.group(3)),
+                external_trip=int(matchI.group(4)),
+                heater_mode=int(matchI.group(5)),
+                error_code=int(matchI.group(6)),
+                quench_value=float(matchI.group(7)),
+                units=0
+            )
+        else:
+            return None
+
+    @property
+    def operating_parameters(self):
+        self.write('O')
+        message = self.read()
+
+        match = self._reO.match(message)
+
+        if match:
+            return dict(
+                ramp_rate=float(match.group(1)),
+                switch_direction=int(match.group(2)),
+                units=int(match.group(3)),
+                front_panel_lock=int(match.group(4)),
+                heater_current_mA=float(match.group(5)),
+                telsa_per_amps=float(match.group(6))
+            )
+        else:
+            return None
+
+    @property
+    def set_point_status(self):
+        self.write('S')
+        message = self.read()
+
+        matchF = self._reSF.match(message)
+        matchI = self._reSI.match(message)
+
+        if matchF:
+            return dict(
+                units=int(matchF.group(1)),
+                upper_set_point=float(matchF.group(2)),
+                lower_set_point=float(matchF.group(3)),
+                terminal_voltage=float(matchF.group(4))
+            )
+        elif matchI:
+            return dict(
+                units=int(matchI.group(1)),
+                upper_set_point=float(matchI.group(2)),
+                lower_set_point=float(matchI.group(3)),
+                terminal_voltage=float(matchI.group(4))
+            )
+        else:
+            return None
+
+    @property
+    def tesla(self) -> float:
+        value = self.output_parameters_tesla["field"]
+        if self.operating_parameters["switch_direction"] == 0:
+            sign = +1
+            return float(sign * value)
+        elif self.operating_parameters["switch_direction"] == 1:
+            sign = -1
+            return float(sign * value)
+
+
+    @tesla.setter
+    def tesla(self, value: float):
+        if value == 0:
+            self.ramp_zero()
+        else:
+            # 1. Get actual direction
+            if self.operating_parameters["switch_direction"] == 0:
+                sign = +1
+            elif self.operating_parameters["switch_direction"] == 1:
+                sign = -1
+            else:
+                sign = 0
+
+            # 2. Check, if value and sign are both positive or both negative
+            if value * sign > 0:
+                self.upper_setpoint_tesla(abs(value))
+            elif value * sign < 0:
+                self.ramp_zero()
+
+                # At zero-field: switch direction.
+                while not (self.current_status["ramp_status"] == 1):
+                    time.sleep(1)
+                if value > 0:
+                    self.switch_forward()
+                elif value < 0:
+                    self.switch_reversed()
+
+                self.upper_setpoint_tesla(abs(value))
+            self.ramp_upper()
+

--- a/pymeasure/instruments/scientificmagnetics/smc.py
+++ b/pymeasure/instruments/scientificmagnetics/smc.py
@@ -24,9 +24,32 @@
 import re
 import time
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+# Define RegExpressions to match the responses of the instrument
+_reG = re.compile(r'^I([\s+-]\d{3}.\d{3})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
+_reJF = re.compile(r'^F([\s+-]\d{2}.\d{4})H(\d)\r\n$')
+_reJI = re.compile(r'^I([\s+-]\d{3}.\d{3})H(\d)\r\n$')
+_reKF = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{2}.\d{4})\r\n$')
+_reKI = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{3}.\d{3})\r\n$')
+_reN = re.compile(r'^F([\s+-]\d{2}.\d{4})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
+_reO = re.compile(r'^A(\d{2}.\d{5})D(\d)T(\d)B(\d)W(\d{3}.)C(0.\d{6})\r\n$')
+_reSF = re.compile(r'^T(\d)U(\d{2}.\d{4})L(\d{2}.\d{4})Y(\d{2}.\d)\r\n$')
+_reSI = re.compile(r'^T(\d)U(\d{3}.\d{3})L(\d{3}.\d{3})Y(\d{2}.\d)\r\n$')
+
+def extract_value_output_parameters_amps(reply) -> dict:
+    match = _reG.match(reply)
+    if not match:
+        return None
+    i = float(match.group(1))
+    u = float(match.group(2))
+    r = match.group(3)
+    return dict(current=i, voltage=u, ramp=r)
+
+
 
 
 class SMC(Instrument, includeSCPI=False):
@@ -35,74 +58,110 @@ class SMC(Instrument, includeSCPI=False):
     interacting with the instrument.
     """
 
-    def __init__(self, resourceName, **kwargs):
+    _RAMP_RATE_MAX = 5
+    _VOLTAGE_LIMIT_MAX = 1
+
+    pause = Instrument.setting(
+        "P%d",
+        """A boolean property that controls the pause-status,
+         which takes the values True (pause) and False (continue)""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True
+    )
+
+    unit = Instrument.setting(
+        "T%d",
+        """Sets the units displayed and can take the values
+         "A"mpere or "T"esla""",
+        validator=strict_discrete_set,
+        values={"A": 0, "T": 1},
+        map_values=True
+    )
+
+    direction = Instrument.setting(
+        "D%d",
+        """Sets the direction of the reversing switch, if installed.
+         Can take the values "F"orward or "R"everse.
+         WARNING: Change only if Magnet has been ramped to Zero!""",
+        validator=strict_discrete_set,
+        values={"F": 0, "R": 1},
+        map_values=True
+    )
+
+    ramp_target = Instrument.setting(
+        "R%d",
+        """Sets Ramp Target. Can take the values "Z"ero, "L"ower, "U"pper.""",
+        validator=strict_discrete_set,
+        values={"Z": 0, "L": 1, "U": 2},
+        map_values=True
+    )
+
+    persistent_mode_heater = Instrument.setting(
+        "H%d",
+        """Sets the persistent mode.
+        Can take the values "O"ff, "C"onditional on, "U"nconditional on, "R"eset persistent current mode to zero.
+        WARNING: Unconditional on will turn on the heater without any interlocks! Use at own risk.
+        Standard mode to switch heater on is Conditional.
+        Simplified Commands are "True" (Conditional on) and "False" (Off).""",
+        validator=strict_discrete_set,
+        values={"O": 0, "C": 1, "U": 2, "R": 9, False: 0, True: 1},
+        map_values=True
+    )
+
+    ramp_rate = Instrument.setting(
+        "A%08.5f",
+        "Sets the Ramp rate in A/s.",
+        validator=strict_range,
+        values=[0, _RAMP_RATE_MAX],
+    )
+
+    external_trip = Instrument.setting(
+        "X%d",
+        """Sets the External trip:
+         False = Off, True = Simple trip On, "Auto" = Auto-rampdown On.""",
+        validator=strict_discrete_set,
+        values={False: 0, True: 1, "Auto": 4},
+        map_values=True
+    )
+
+    terminal_voltage_limit = Instrument.setting(
+        "Y%04.1f",
+        """Sets the terminal voltage limit to nn.n V.""",
+        validator=strict_range,
+        values=[0, _VOLTAGE_LIMIT_MAX]
+    )
+
+    heater_current_output = Instrument.setting(
+        "W%03d",
+        """Sets the Heater current output to nnn mA.""",
+        validator=strict_range,
+        values=[0, 255]
+    )
+
+    calibrate_tesla_per_amp = Instrument.setting(
+        "C%08.6f",
+        """Calibrate the output to Tesla per Amp value of the superconducting magnet.
+         The Value is assumed to lie between 0.01 and 0.5 T/A
+         and will be set to zero if a number outside this range is entered.""",
+        validator=strict_range,
+        values=[0.01, 0.5],
+    )
+
+
+
+    def __init__(self, resourceName,
+                 ramp_rate_max=5,
+                 voltage_limit_max=1,
+                 **kwargs):
         super().__init__(
             resourceName,
             "Scientific Magnetics SMC",
             **kwargs
         )
+        self._RAMP_RATE_MAX = ramp_rate_max  # A/s
+        self._VOLTAGE_LIMIT_MAX = voltage_limit_max  # V
 
-        # Define RegExpressions to match the responses of the instrument
-        self._reG = re.compile(r'^I([\s+-]\d{3}.\d{3})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
-        self._reJF = re.compile(r'^F([\s+-]\d{2}.\d{4})H(\d)\r\n$')
-        self._reJI = re.compile(r'^I([\s+-]\d{3}.\d{3})H(\d)\r\n$')
-        self._reKF = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{2}.\d{4})\r\n$')
-        self._reKI = re.compile(r'^R(\d)M(\d)P(\d)X(\d)H(\d)Z0.00E(\d{2})Q([\s+-]\d{3}.\d{3})\r\n$')
-        self._reN = re.compile(r'^F([\s+-]\d{2}.\d{4})V([\s+-]\d{2}.\d)R(\d[AV])\r\n$')
-        self._reO = re.compile(r'^A(\d{2}.\d{5})D(\d)T(\d)B(\d)W(\d{3}.)C(0.\d{6})\r\n$')
-        self._reSF = re.compile(r'^T(\d)U(\d{2}.\d{4})L(\d{2}.\d{4})Y(\d{2}.\d)\r\n$')
-        self._reSI = re.compile(r'^T(\d)U(\d{3}.\d{3})L(\d{3}.\d{3})Y(\d{2}.\d)\r\n$')
-
-    def pause_off(self):
-        self.write('P0')
-
-    def pause_on(self):
-        self.write('P1')
-
-    def unit_amps(self):
-        self.write('T0')
-
-    def unit_tesla(self):
-        self.write('T1')
-
-    def upper_setpoint_tesla(self, tesla):
-        self.unit_tesla()
-        self.write('U{tesla:07.4f}'.format(tesla=tesla))
-
-    def lower_setpoint_tesla(self, tesla):
-        self.unit_tesla()
-        self.write('L{tesla:07.4f}'.format(tesla=tesla))
-
-    def switch_forward(self):
-        self.write('D0')
-
-    def switch_reversed(self):
-        self.write('D1')
-
-    def ramp_zero(self):
-        self.write('R0')
-
-    def ramp_lower(self):
-        self.write('R1')
-
-    def ramp_upper(self):
-        self.write('R2')
-
-    def heater_off(self):
-        self.write('H0')
-
-    def heater_conditional_on(self):
-        """ Standard function to be used when turning on switch heater """
-        self.write('H1')
-
-    def heater_unconditional_on(self):
-        """ Warning this will turn on the heater without any interlocks.
-            Usage at own risk!
-        """
-        self.write('H2')
-
-    def heater_reset_persistent_mode_current_record_to_zero(self):
-        self.write('H9')
 
     @property
     def output_parameters_amps(self):
@@ -122,7 +181,7 @@ class SMC(Instrument, includeSCPI=False):
 
     @property
     def output_parameters_tesla(self):
-        self.unit_tesla()
+        self.unit = "T"
         self.write('N')
         message = self.read()
         match = self._reN.match(message)
@@ -243,7 +302,6 @@ class SMC(Instrument, includeSCPI=False):
             sign = -1
             return float(sign * value)
 
-
     @tesla.setter
     def tesla(self, value: float):
         if value == 0:
@@ -273,4 +331,9 @@ class SMC(Instrument, includeSCPI=False):
 
                 self.upper_setpoint_tesla(abs(value))
             self.ramp_upper()
+
+    def shutdown(self):
+        self.persistent_mode_heater = True
+        self.ramp_target = "Z"
+        self.pause = False
 


### PR DESCRIPTION
 I've added the Superconducting Magnet Controller from Twickenham Scientific (which was also distributed by ScientificMagnetics) to the Instruments-Library. Therefore, I had to slightly change the adapter-module to accept Dict-Values, as the SMU is a non-SCPI Device and, in my opinion, the communication protocol is kind of a "Bastard Protocol From Hell"; which can be checked here: https://www.twicksci.co.uk/manuals/pdf/smc552+.pdf

I hope that this work will be useful for other scientists - but be  careful: mixing up the solenoid can lead to a quench and thus, depending on  your setup, to serious damage or injury! I've only tested the setter- and getter functions for the magnetic field and also the shutdown routine as I don't need other functions by the moment.