### PR TITLE
Fix bug in Keithley 6517B Electrometer

### DIFF
--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -66,6 +66,7 @@ class Keithley6517B(Instrument, KeithleyBuffer):
         cast=bool
     )
 
+    @staticmethod
     def extract_value(self, result):
         """ extracts the physical value from a result object returned
             by the instrument """

--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -67,7 +67,7 @@ class Keithley6517B(Instrument, KeithleyBuffer):
     )
 
     @staticmethod
-    def extract_value(self, result):
+    def extract_value(result):
         """ extracts the physical value from a result object returned
             by the instrument """
         m = re.fullmatch(r'([+\-0-9E.]+)[A-Z]{4}', result[0])


### PR DESCRIPTION
Fixes #442 by changing the `extract_values` method into a staticmethod.