### PR TITLE
Fixed setSizePolicy bug with PySide2

### DIFF
--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -256,7 +256,7 @@ class ManagedWindow(QtGui.QMainWindow):
             inputs_scroll.setWidgetResizable(True)
             inputs_scroll.setFrameStyle(QtGui.QScrollArea.NoFrame)
 
-            self.inputs.setSizePolicy(1, 0)
+            self.inputs.setSizePolicy(QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Fixed)
             inputs_scroll.setWidget(self.inputs)
             inputs_vbox.addWidget(inputs_scroll, 1)
 


### PR DESCRIPTION
There is a call to `setSizePolicy ` in `windows.py` which have two integer parameters 1 and 0.
`PySide2` does not like them and it throws the following error:
```
    self.inputs.setSizePolicy(1, 0)
TypeError: 'PySide2.QtWidgets.QWidget.setSizePolicy' called with wrong argument types:
  PySide2.QtWidgets.QWidget.setSizePolicy(int, int)
Supported signatures:
  PySide2.QtWidgets.QWidget.setSizePolicy(PySide2.QtWidgets.QSizePolicy)
  PySide2.QtWidgets.QWidget.setSizePolicy(PySide2.QtWidgets.QSizePolicy.Policy, PySide2.QtWidgets.QSizePolicy.Policy)

```
The fix is to replace the integer parameter with equivalent `QtGui.QSizePolicy` values.
The problem does not happen with `PyQt5`.

In general, I believe the change is extremely low risk and the final result is better code style.
