### PR TITLE
Add phase control for Agilent 33500

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -34,3 +34,4 @@ Michele Sardo
 Steven Siegl
 Benjamin Klebel-Knobloch
 Hud Wahab
+Nicola Corna

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -33,3 +33,4 @@ The following developers have contributed to the PyMeasure package:
 | Steven Siegl
 | Benjamin Klebel-Knobloch
 | Hud Wahab
+| Nicola Corna

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -151,6 +151,15 @@ class Agilent33500(Instrument):
         values=[-5, 4.99],
     )
 
+    phase = Instrument.control(
+        "PHAS?", "PHAS %f",
+        """ A floating point property that controls the phase of the output
+        waveform in degrees, from -360 degrees to 360 degrees. Not available
+        for arbitrary waveforms or noise. Can be set. """,
+        validator=strict_range,
+        values=[-360, 360],
+    )
+
     square_dutycycle = Instrument.control(
         "FUNC:SQU:DCYC?", "FUNC:SQU:DCYC %f",
         """ A floating point property that controls the duty cycle of a square


### PR DESCRIPTION
Tested on an Agilent 33521A but, from the "Agilent 33500 Series Waveform Generator Operating and Service Guide", it should be supported by the whole 33500 family.