### PR TITLE
Documentation bugfix

### DIFF
--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -11,6 +11,11 @@ Using the Plotter
 
 While it lacks the nice features of the ManagedWindow, the Plotter object is the simplest way of getting live-plotting. The Plotter takes a Results object and plots the data at a regular interval, grabbing the latest data each time from the file.
 
+.. warning::
+   The example in this section is known to raise issues when executed on recent versions of macOS (10.12 Sierra and later): a `QApplication was not created in the main thread` / `nextEventMatchingMask should only be called from the Main Thread` warning is raised.
+   macOS users are hence adviced to skip this example and continue with the `Using the ManagedWindow`_ section.
+
+
 Let's extend our SimpleProcedure with a RandomProcedure, which generates random numbers during our loop. This example does not include instruments to provide a simpler example. ::
 
     import logging

--- a/requirements/pymeasure.yml
+++ b/requirements/pymeasure.yml
@@ -16,8 +16,8 @@ dependencies:
   - pytest-runner=5.2
   - pytest=6.1.1
   - flake8=3.8.4
-  - sphinx=3.2.1
-  - sphinx_rtd_theme=0.4.3
+  - sphinx=4.0.2
+  - sphinx_rtd_theme=0.5.2
   - pip  # don't pin, to gain newest conda compatibility fixes
   - pip:
     - pyvisa-sim==0.4.0


### PR DESCRIPTION
Fixes a bug which causes the documentation-pages of all Qt-derived classes to not show in the documentation. Is fixed by updating the sphinx version to a version >3.4.2. Thanks to @msmttchr for reporting and finding the cause of the issue.

Also adds a warning to the `Using the Plotter` tutorial for macOS users (see issue #422).