### PR TITLE
Fix bug in the Keithley 2700

### DIFF
--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -248,8 +248,8 @@ class Keithley2700(Instrument, KeithleyBuffer):
             columns = new_columns
 
         # Determine channel number from rows and columns number.
-        rows = np.array(rows)
-        columns = np.array(columns)
+        rows = np.array(rows, ndmin=1)
+        columns = np.array(columns, ndmin=1)
 
         channels = (rows - 1) * 8 + columns
 


### PR DESCRIPTION
Fixes a bug where the `channels_from_rows_columns` method returns an `np.int32` rather than an `np.array` when both the `rows` and `columns` arguments are ints. This subsequently causes trouble with the validator when the output of this method is used for opening or closing channels.