### PR TITLE
Fix incorrect columns on showing data

### DIFF
--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -287,6 +287,9 @@ class PlotWidget(TabWidget, QtGui.QWidget):
         self.plot_frame.change_y_axis(axis)
 
     def load(self, curve):
+        curve.x = self.columns_x.currentText()
+        curve.y = self.columns_y.currentText()
+        curve.update_data()
         self.plot.addItem(curve)
 
     def remove(self, curve):
@@ -368,6 +371,8 @@ class ImageWidget(TabWidget, QtGui.QWidget):
         self.image_frame.change_z_axis(axis)
 
     def load(self, curve):
+        curve.z = self.columns_z.currentText()
+        curve.update_data()
         self.plot.addItem(curve)
 
     def remove(self, curve):


### PR DESCRIPTION
I stumbled on a bug where a dataset shows the wrong columns when that data is un-hidden.
It can be reproduced by unchecking a dataset (i.e. hiding that dataset), changing the shown column of the plotter (e.g. changing the x-column), and checking (i.e. showing) the dataset again.

Here I propose to fix this issue by re-setting the x and y columns (or z for an image) upon adding a curve to the plotframe. 