### PR TITLE
Limit size of results file, automatically creating a new file when needed.

### DIFF
--- a/pymeasure/experiment/listeners.py
+++ b/pymeasure/experiment/listeners.py
@@ -24,6 +24,7 @@
 
 import logging
 from logging import StreamHandler, FileHandler
+from logging.handlers import RotatingFileHandler
 
 from ..log import QueueListener
 from ..thread import StoppableThread
@@ -105,7 +106,7 @@ class Recorder(QueueListener):
         """
         handlers = []
         for filename in results.data_filenames:
-            fh = FileHandler(filename=filename, **kwargs)
+            fh = RotatingFileHandler(filename=filename, **kwargs)
             fh.setFormatter(results.formatter)
             fh.setLevel(logging.NOTSET)
             handlers.append(fh)

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -151,12 +151,16 @@ class Results(object):
 
     :cvar COMMENT: The character used to identify a comment (default: #)
     :cvar DELIMITER: The character used to delimit the data (default: ,)
-    :cvar LINE_BREAK: The character used for line breaks (default \\n)
+    :cvar LINE_BREAK: The character used for line breaks (default: \\n)
     :cvar CHUNK_SIZE: The length of the data chuck that is read
 
     :param procedure: Procedure object
     :param data_filename: The data filename where the data is or should be
                           stored
+    :param recorder_args: Dictionary of `maxBytes` and `backupCount`
+                          to limit results file size, or an empty 
+                          dictionary to write all files to a single file
+                          (default: {}) 
     """
 
     COMMENT = '#'
@@ -164,7 +168,7 @@ class Results(object):
     LINE_BREAK = "\n"
     CHUNK_SIZE = 1000
 
-    def __init__(self, procedure, data_filename):
+    def __init__(self, procedure, data_filename, recorder_args={}):
         if not isinstance(procedure, Procedure):
             raise ValueError("Results require a Procedure object")
         self.procedure = procedure
@@ -192,6 +196,14 @@ class Results(object):
                     f.write(self.header())
                     f.write(self.labels())
             self._data = None
+
+        if (
+            recorder_args != {} and
+            ('maxBytes' not in recorder_args or 'backupCount' not in recorder_args)
+        ):
+            raise ValueError('Must include both `maxBytes` and `backupCount` in `recorder_args`.')
+        
+        self.recorder_args = recorder_args
 
     def __getstate__(self):
         # Get all information needed to reconstruct procedure

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -406,7 +406,11 @@ class Results(object):
         """
         # get data files
         data_files = [ self.data_filename ]
-        if backupCount > 0:
+        if backupCount is None:
+            # needed to avoid comparison between None and integer
+            pass
+
+        elif backupCount > 0:
             for i in range(backupCount):
                 filename = f'{self.data_filename}.{i+1}'
                 if os.path.isfile(filename):
@@ -420,7 +424,7 @@ class Results(object):
                 i += 1
                 file_name = f'{self.data_filename}.{i}'
 
-        data_files = data_files.reverse()  # oldest data has highest count
+        data_files.reverse()  # oldest data has highest count
 
         # load data
         df = []

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -395,11 +395,11 @@ class Results(object):
         return self._data
 
     def reload(self, backupCount=None):
-        """ Preforms a full reloading of the file data, neglecting
+        """ Performs a full reloading of the file data, neglecting
         any changes in the comments
 
         :param backupCount: If a rotating file handler is used,
-                            how many backupfiles to load.
+                            how many backup files to load.
                             If None, only load active file.
                             If -1, load all. (Only loads consecutively numbered files.)
                             (default: None)
@@ -424,17 +424,18 @@ class Results(object):
                 i += 1
                 file_name = f'{self.data_filename}.{i}'
 
-        data_files.reverse()  # oldest data has highest count
+        data_files.reverse()  # oldest data has highest count name, but should be first in data
 
         # load data
         df = []
         for file in data_files:
             chunks = pd.read_csv(
-                self.data_filename,
+                file,
                 comment=Results.COMMENT,
                 chunksize=Results.CHUNK_SIZE,
                 iterator=True
             )
+
             try:
                 data = pd.concat(chunks, ignore_index=True)
             except Exception:

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -159,7 +159,7 @@ class Worker(StoppableThread):
 
         self.procedure = self.results.procedure
 
-        self.recorder = Recorder(self.results, self.recorder_queue)
+        self.recorder = Recorder(self.results, self.recorder_queue, **self.results.recorder_args)
         self.recorder.start()
 
         #locals()[self.procedures_file] = __import__(self.procedures_file)

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -159,7 +159,12 @@ class Worker(StoppableThread):
 
         self.procedure = self.results.procedure
 
-        self.recorder = Recorder(self.results, self.recorder_queue, **self.results.recorder_args)
+        self.recorder = Recorder(
+            self.results,
+            self.recorder_queue,
+            rollover=self.results.rollover,
+            recorder_args=self.results.recorder_args
+        )
         self.recorder.start()
 
         #locals()[self.procedures_file] = __import__(self.procedures_file)


### PR DESCRIPTION
For long running measurements a single reuslts file can get too long for comfort. If something happens to the file everything is lost. Another issue could be having to transfer all the data at once. By splitting the results into multiple files one does not have to worry about these issues.

To do this I utilized the [`RotatingFileHandler`](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler) and introduced a `recorder_args` argument to the `Results` class. This allows one to specifiy the maximum desired size of a single file, and create a new one if necessary.