### PR TITLE
Add pendulum CNT-91 frequency counter.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -41,3 +41,4 @@ Nicola Corna
 Robert Eckelmann
 Sam Condon
 Andreas Maeder
+Bastian Leykauf

--- a/docs/api/instruments/pendulum/cnt91.rst
+++ b/docs/api/instruments/pendulum/cnt91.rst
@@ -1,0 +1,7 @@
+################################
+Pendulum CNT91 frequency counter
+################################
+
+.. autoclass:: pymeasure.instruments.pendulum.cnt91.CNT91
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/pendulum/index.rst
+++ b/docs/api/instruments/pendulum/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.rohdeschwarz
+
+########
+Pendulum
+########
+
+This section contains specific documentation on the Pendulum hwarz instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   cnt91

--- a/pymeasure/instruments/pendulum/__init__.py
+++ b/pymeasure/instruments/pendulum/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .cnt91 import CNT91

--- a/pymeasure/instruments/pendulum/cnt91.py
+++ b/pymeasure/instruments/pendulum/cnt91.py
@@ -1,0 +1,191 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from time import sleep
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import (
+    strict_discrete_set,
+    strict_range,
+    truncated_range,
+)
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class CNT91(Instrument):
+    """Represents a Pendulum CNT-91 frequency counter."""
+
+    CHANNELS = {"A": 1, "B": 2, "C": 3, "E": 4, "INTREF": 6}
+    MAX_BUFFER_SIZE = 32000  # User Manual 8-38
+
+    def __init__(self, resourceName, **kwargs):
+        super().__init__(resourceName, "Pendulum CNT-91", **kwargs)
+        self.adapter.connection.timeout = 120000
+
+    def ask(self, command):
+        """
+        Writes the command to the instrument through the adapter
+        and returns the read response.
+
+        :param command: command string to be sent to the instrument
+        """
+        # Infinite loop occures if not redefined.
+        return super().ask(command).rstrip("\n")
+
+    @property
+    def operation_complete(self):
+        """Is True if operation is complete."""
+        return self.ask("*OPC?") == "1"
+
+    @property
+    def batch_size(self):
+        """Maximum number of buffer entries that can be transmitted at once."""
+        if not hasattr(self, "_batch_size"):
+            self._batch_size = int(self.ask("FORM:SMAX?"))
+        return self._batch_size
+
+    def read_buffer(self):
+        """
+        Read out the entire buffer.
+
+        :return : Frequency values from the buffer.
+        """
+        while not self.operation_complete:
+            # Wait until the buffer is filled.
+            sleep(0.01)
+        data = []
+        # Loop until the buffer is completely read out.
+        while True:
+            # Get maximum number of buffer values.
+            new = self.values(":FETC:ARR? MAX")
+            data += new
+            # Last values have been read from buffer.
+            if len(new) < self.batch_size:
+                break
+        return data
+
+    external_start_arming_source = Instrument.control(
+        "ARM:SOUR?",
+        "ARM:SOUR %s",
+        (
+            "Select arming input or switch off the start arming function."
+            "Options are 'A', 'B' and 'E' (rear). 'IMM' turns trigger off."
+        ),
+        validator=strict_discrete_set,
+        values={"A": "EXT1", "B": "EXT2", "E": "EXT4", "IMM": "IMM"},
+        map_values=True,
+    )
+
+    external_arming_start_slope = Instrument.control(
+        "ARM:SLOP?",
+        "ARM:SLOP %s",
+        "Set slope for the start arming condition.",
+        validator=strict_discrete_set,
+        values=["POS", "NEG"],
+    )
+
+    continuous = Instrument.control(
+        "INIT:CONT?",
+        "INIT:CONT %s",
+        "Turn continious measurement 'ON' or 'OFF'",
+        strict_discrete_set,
+        values=["ON", "OFF"],
+    )
+
+    measurement_time = Instrument.control(
+        ":ACQ:APER?",
+        ":ACQ:APER %f",
+        "Gate time for one measurement.",
+        validator=strict_range,
+        values=[2e-9, 1000],  # Programmer's guide 8-92
+    )
+
+    format = Instrument.control(
+        "FORM?",
+        "FORM %s",
+        "Reponse format (ASCII or REAL).",
+        validator=strict_discrete_set,
+        values=["ASCII", "REAL"],
+    )
+
+    interpolator_calibration = Instrument.control(
+        ":CAL:INT:AUTO?",
+        "CAL:INT:AUTO %s",
+        "Controls if interpolators should be calibrated automatically.",
+        strict_discrete_set,
+        values=["ON", "OFF"],
+        get_process=lambda v: "ON" if v else "OFF",
+    )
+
+    def configure_frequency_array_measurement(self, n_samples, channel):
+        """
+        Configure the counter for an array of measurements.
+
+        :param n_samples : The number of samples
+        :param channel : Measurment channel (A, B, C, E, INTREF)
+        """
+        n_samples = truncated_range(n_samples, [1, self.MAX_BUFFER_SIZE])
+        channel = strict_discrete_set(channel, self.CHANNELS)
+        channel = self.CHANNELS[channel]
+        self.write(f":CONF:ARR:FREQ {n_samples},(@{channel})")
+
+    def buffer_frequency_time_series(
+        self, channel, n_samples, sample_rate, trigger_source=None
+    ):
+        """
+        Record a time series to the buffer and read it out after completion.
+
+        :param channel: Channel that should be used.
+        :param n_samples : The number of samples
+        :param sample_rate : Sample rate in Hz.
+        :param trigger_source: Optionally specify a trigger source to start the
+                               measurement.
+        """
+        if self.interpolator_calibration:
+            max_sample_rate = 125e3
+        else:
+            max_sample_rate = 250e3
+        log.info(
+            "Calibration of interpolation is {}".format(
+                self.interpolator_calibration
+            )
+        )
+        sample_rate = strict_range(sample_rate, [0, max_sample_rate])
+        log.info("sample rate is {}".format(sample_rate))
+        measurement_time = 1 / sample_rate
+
+        self.clear()
+        self.format = "ASCII"
+        self.configure_frequency_array_measurement(n_samples, channel)
+        self.continuous = "OFF"
+        self.measurement_time = measurement_time
+
+        if trigger_source:
+            self.external_start_arming_source = trigger_source
+
+        # start the measurement (or wait for trigger)
+        self.write(":INIT")


### PR DESCRIPTION
I added some functionality for a new device: the pendulum CNT-91 frequency counter.

There is only a small fraction of commands implemented so far. It has a convenience function for taking time series of frequency data (that's what I use the device for). Validators and value mapping are implemented for the commands.