### PR TITLE
Add Rohde&Schwarz FSL spectrum analyzer.

### DIFF
--- a/docs/api/instruments/rohdeschwarz/fsl.rst
+++ b/docs/api/instruments/rohdeschwarz/fsl.rst
@@ -1,0 +1,138 @@
+######################################
+R&S FSL spectrum analyzer
+######################################
+
+Connecting to the instrument via network
+----------------------------------------
+Once connected to the network, the instrument's IP address can be found by
+clicking the "Setup" button and navigating to "General Settings" -> "Network
+Address".  
+
+It can then be connected like this:
+
+.. code:: python
+    from pymeasure.instruments.rohdeschwarz import FSL
+    fsl = FSL("TCPIP::192.168.1.123::INSTR")
+
+Getting and setting parameters
+------------------------------
+
+Most parameters are implemented as properties, which means they can be read and
+written (getting and setting) in a consistent and dimple way. If numerical
+values are provided, base units are used (seconds, hertz, decibel, ...). 
+Alternatively, the values can also be provided with a unit, e.g. :code:"1.5 GHz" or
+:code:"1.5GHz". Return values are always numerical.
+
+.. code:: python
+
+    # Getting the current center frequency
+    fsl.freq_center
+
+    9000000000.0
+
+.. code:: python
+
+
+    # Changing it to 10 MHz by providing the numerical value 
+    fsl.freq_center = 10e6
+
+.. code:: python
+
+    # Verifying:
+    fsl.freq_center
+
+    10000000.0
+
+.. code:: python
+
+    # Changing it to 9 GHz by providing a string and verifying the result
+    fsl.freq_center = '9GHz'
+    fsl.freq_center
+
+    9000000000.0
+
+.. code:: python
+
+    # Setting the span to maximum
+    fsl.freq_span = '7 GHz'
+
+Reading a trace
+---------------
+
+We will read the current trace
+
+.. code:: python
+
+    x, y = fsl.read_trace()
+
+Markers
+-------
+
+Markers are implemented as their own class. You can create them like
+this:
+
+.. code:: python
+
+    m1 = fsl.create_marker()
+
+Set peak exursion:
+
+.. code:: python
+
+    m1.peak_excursion = 3
+
+Set marker to a specific position:
+
+.. code:: python
+
+    m1.x = 10e9
+
+Find the next peak to the left and get the level:
+
+.. code:: python
+
+    m1.to_next_peak('left')
+    m1.y
+
+    -34.9349060059
+
+Delta markers
+~~~~~~~~~~~~~
+
+Delta markers can be created by setting the appropriate keyword.
+
+.. code:: python
+
+    d2 = fsl.create_marker(is_delta_marker=True)
+    d2.name
+
+    'DELT2'
+
+Example program
+---------------
+
+Here is an example of a simple script for recording the peak of a signal.
+
+.. code:: python
+
+    m1 = fsl.create_marker() # create marker 1
+
+    # Set standard settings, set to full span
+    fsl.continuous_sweep = False
+    fsl.freq_span = '18 GHz'
+    fsl.rbw = "AUTO"
+    fsl.vbw = "AUTO"
+    fsl.sweep_time = "AUTO"
+
+    # Perform a sweep on full span, set the marker to the peak and some to that marker
+    fsl.single_sweep()
+    m1.to_peak()
+    m1.zoom('20 MHz')
+
+    # take data from the zoomed-in region
+    fsl.single_sweep()
+    x, y = fsl.read_trace()
+
+.. autoclass:: pymeasure.instruments.rohdeschwarz.fsl.FSL
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/rohdeschwarz/fsl.rst
+++ b/docs/api/instruments/rohdeschwarz/fsl.rst
@@ -19,7 +19,7 @@ Getting and setting parameters
 ------------------------------
 
 Most parameters are implemented as properties, which means they can be read and
-written (getting and setting) in a consistent and dimple way. If numerical
+written (getting and setting) in a consistent and simple way. If numerical
 values are provided, base units are used (s, Hz, dB, ...). 
 Alternatively, the values can also be provided with a unit, e.g. ``"1.5 GHz"``
 or ``"1.5GHz"``. Return values are always numerical.
@@ -32,8 +32,6 @@ or ``"1.5GHz"``. Return values are always numerical.
     9000000000.0
 
 .. code:: python
-
-
     # Changing it to 10 MHz by providing the numerical value 
     fsl.freq_center = 10e6
 

--- a/docs/api/instruments/rohdeschwarz/fsl.rst
+++ b/docs/api/instruments/rohdeschwarz/fsl.rst
@@ -11,6 +11,7 @@ Address".
 It can then be connected like this:
 
 .. code:: python
+
     from pymeasure.instruments.rohdeschwarz import FSL
     fsl = FSL("TCPIP::192.168.1.123::INSTR")
 
@@ -19,9 +20,9 @@ Getting and setting parameters
 
 Most parameters are implemented as properties, which means they can be read and
 written (getting and setting) in a consistent and dimple way. If numerical
-values are provided, base units are used (seconds, hertz, decibel, ...). 
-Alternatively, the values can also be provided with a unit, e.g. :code:"1.5 GHz" or
-:code:"1.5GHz". Return values are always numerical.
+values are provided, base units are used (s, Hz, dB, ...). 
+Alternatively, the values can also be provided with a unit, e.g. ``"1.5 GHz"``
+or ``"1.5GHz"``. Return values are always numerical.
 
 .. code:: python
 

--- a/docs/api/instruments/rohdeschwarz/fsl.rst
+++ b/docs/api/instruments/rohdeschwarz/fsl.rst
@@ -119,8 +119,8 @@ Here is an example of a simple script for recording the peak of a signal.
     # Set standard settings, set to full span
     fsl.continuous_sweep = False
     fsl.freq_span = '18 GHz'
-    fsl.rbw = "AUTO"
-    fsl.vbw = "AUTO"
+    fsl.res_bandwidth = "AUTO"
+    fsl.video_bandwidth = "AUTO"
     fsl.sweep_time = "AUTO"
 
     # Perform a sweep on full span, set the marker to the peak and some to that marker

--- a/docs/api/instruments/rohdeschwarz/fsl.rst
+++ b/docs/api/instruments/rohdeschwarz/fsl.rst
@@ -32,6 +32,7 @@ or ``"1.5GHz"``. Return values are always numerical.
     9000000000.0
 
 .. code:: python
+
     # Changing it to 10 MHz by providing the numerical value 
     fsl.freq_center = 10e6
 

--- a/docs/api/instruments/rohdeschwarz/index.rst
+++ b/docs/api/instruments/rohdeschwarz/index.rst
@@ -10,3 +10,4 @@ This section contains specific documentation on the Rohde & Schwarz instruments 
    :maxdepth: 2
 
    sfm
+   fsl

--- a/pymeasure/instruments/rohdeschwarz/__init__.py
+++ b/pymeasure/instruments/rohdeschwarz/__init__.py
@@ -23,3 +23,4 @@
 #
 
 from .sfm import SFM
+from .fsl import FSL

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -78,29 +78,28 @@ class FSL(Instrument):
         "Attenuation in dB.",
     )
 
-    @property
-    def res_bandwidth(self):
-        """Resolution bandwidth in Hz. Can be set to 'AUTO'."""
-        return float(self.ask("BAND:RES?"))
-
-    @res_bandwidth.setter
-    def res_bandwidth(self, value):
-        if type(value) is str and value.upper() == "AUTO":
-            self.write("BAND:RES:AUTO ON")
+    @staticmethod
+    def _number_or_auto(value):
+        # helper for the bandwidth setting
+        if isinstance(value, str) and value.upper() == "AUTO":
+            return ":AUTO ON"
         else:
-            self.write(f"BAND:RES {value}")
+            # There is no space in the set commands, so we have to add it
+            return " " + str(value)
 
-    @property
-    def video_bandwidth(self):
-        """Video bandwidth in Hz. Can be set to 'AUTO'."""
-        return float(self.ask("BAND:VID?"))
+    res_bandwidth = Instrument.control(
+        "BAND:RES?",
+        "BAND:RES%s",
+        "Resolution bandwidth in Hz. Can be set to 'AUTO'",
+        set_process=_number_or_auto,
+    )
 
-    @video_bandwidth.setter
-    def video_bandwidth(self, value):
-        if type(value) is str and value.upper() == "AUTO":
-            self.write("BAND:VID:AUTO ON")
-        else:
-            self.write(f"BAND:VID {value}")
+    video_bandwidth = Instrument.control(
+        "BAND:VID?",
+        "BAND:VID%s",
+        "Video bandwidth in Hz. Can be set to 'AUTO'",
+        set_process=_number_or_auto,
+    )
 
     # Sweeping ----------------------------------------------------------------
 

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -141,11 +141,11 @@ class FSL(Instrument):
         Read trace data.
 
         :param n_trace: The trace number (1-6). Default is 1.
-        :return: Nnumpy arrays of the trace data (frequency and amplitude).
+        :return: 2d numpy array of the trace data, [[frequency], [amplitude]].
         """
-        y = np.array(self.values("TRAC{n_trace}? TRACE{n_trace}"))
+        y = np.array(self.values(f"TRAC{n_trace}? TRACE{n_trace}"))
         x = np.linspace(self.freq_start, self.freq_stop, len(y))
-        return x, y
+        return np.array([x, y])
 
     trace_mode = Instrument.control(
         "DISP:TRAC:MODE?",

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -77,25 +77,43 @@ class FSL(Instrument):
         "Attenuation in dB.",
     )
 
-    rbw = Instrument.control(
-        "BAND:RES?",
-        "BAND:RES? %s",
-        "Resolution bandwidth in Hz. Can be set to 'AUTO'.",
-    )
+    @property
+    def rbw(self):
+        """Resolution bandwidth in Hz. Can be set to 'AUTO'."""
+        return self.values("BAND:RES?")[0]
 
-    vbw = Instrument.control(
-        "BAND:RES",
-        "BAND:RES %s",
-        "Video bandwidth in Hz. Can be set to 'AUTO'.",
-    )
+    @rbw.setter
+    def rbw(self, value):
+        if type(value) is str and value.upper() == "AUTO":
+            self.write("BAND:RES:AUTO ON")
+        else:
+            self.write(f"BAND:RES {value}")
+
+    @property
+    def vbw(self):
+        """Video bandwidth in Hz. Can be set to 'AUTO'."""
+        return self.values("BAND:VID?")[0]
+
+    @vbw.setter
+    def vbw(self, value):
+        if type(value) is str and value.upper() == "AUTO":
+            self.write("BAND:VID:AUTO ON")
+        else:
+            self.write(f"BAND:VID {value}")
 
     # Sweeping ----------------------------------------------------------------
 
-    sweep_time = Instrument.control(
-        "SWE:TIME",
-        "SWE:TIME %s",
-        "Sweep time in s. Can be set to 'AUTO'.",
-    )
+    @property
+    def sweep_time(self):
+        """Sweep time in s. Can be set to 'AUTO'."""
+        return self.values("SWE:TIME?")[0]
+
+    @sweep_time.setter
+    def sweep_time(self, value):
+        if type(value) is str and value.upper() == "AUTO":
+            self.write("SWE:TIME:AUTO ON")
+        else:
+            self.write(f"SWE:TIME {value}")
 
     continuous_sweep = Instrument.control(
         "INIT:CONT?",

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -79,24 +79,24 @@ class FSL(Instrument):
     )
 
     @property
-    def rbw(self):
+    def res_bandwidth(self):
         """Resolution bandwidth in Hz. Can be set to 'AUTO'."""
         return self.values("BAND:RES?")[0]
 
-    @rbw.setter
-    def rbw(self, value):
+    @res_bandwidth.setter
+    def res_bandwidth(self, value):
         if type(value) is str and value.upper() == "AUTO":
             self.write("BAND:RES:AUTO ON")
         else:
             self.write(f"BAND:RES {value}")
 
     @property
-    def vbw(self):
+    def video_bandwidth(self):
         """Video bandwidth in Hz. Can be set to 'AUTO'."""
         return self.values("BAND:VID?")[0]
 
-    @vbw.setter
-    def vbw(self, value):
+    @video_bandwidth.setter
+    def video_bandwidth(self, value):
         if type(value) is str and value.upper() == "AUTO":
             self.write("BAND:VID:AUTO ON")
         else:

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -192,15 +192,23 @@ class FSL(Instrument):
 
             self.activate()
 
+        def read(self):
+            return self.instrument.read()
+
         def write(self, command):
             self.instrument.write(f"CALC:{self.name}:{command}")
+
+        def ask(self, command):
+            return self.instrument.ask(f"CALC:{self.name}:{command}")
 
         def values(self, command, **kwargs):
             """
             Reads a set of values from the instrument through the adapter,
             passing on any keyword arguments.
             """
-            return self.values(f"CALC:{self.name}:{command}", **kwargs)
+            return self.instrument.values(
+                f"CALC:{self.name}:{command}", **kwargs
+            )
 
         def activate(self):
             """Activate a marker."""

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -1,0 +1,234 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+import numpy as np
+from pymeasure.instruments.validators import strict_discrete_set
+from pymeasure.instruments import Instrument
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class FSL(Instrument):
+    """
+    Represents a Rohde&Schwarz FSL spectrum analyzer.
+    All physical values that can be set can either be as a string of a value
+    and a unit (e.g. "1.2 GHz") or as a float value in the base units (Hz,
+    dBm, etc.).
+    """
+
+    def __init__(self, resourceName, **kwargs):
+        super(FSL, self).__init__(
+            resourceName, "Rohde&Schwarz FSL", includeSCPI=True, **kwargs
+        )
+
+    # Frequency settings ------------------------------------------------------
+
+    freq_span = Instrument.control(
+        "FREQ:SPAN?",
+        "FREQ:SPAN %s",
+        "Frequency span in Hz.",
+    )
+
+    freq_center = Instrument.control(
+        "FREQ:CENT?",
+        "FREQ:CENT %s",
+        "Center frequency in Hz.",
+    )
+
+    freq_start = Instrument.control(
+        "FREQ:STAR?",
+        "FREQ:STAR %s",
+        "Start frequency in Hz.",
+    )
+
+    freq_stop = Instrument.control(
+        "FREQ:STOP?",
+        "FREQ:STOP %s",
+        "Stop frequency in Hz.",
+    )
+
+    attenuation = Instrument.control(
+        "INP:ATT?",
+        "INP:ATT %s",
+        "Attenuation in dB.",
+    )
+
+    rbw = Instrument.control(
+        "BAND:RES?",
+        "BAND:RES? %s",
+        "Resolution bandwidth in Hz. Can be set to 'AUTO'.",
+    )
+
+    vbw = Instrument.control(
+        "BAND:RES",
+        "BAND:RES %s",
+        "Video bandwidth in Hz. Can be set to 'AUTO'.",
+    )
+
+    # Sweeping ----------------------------------------------------------------
+
+    sweep_time = Instrument.control(
+        "SWE:TIME",
+        "SWE:TIME %s",
+        "Sweep time in s. Can be set to 'AUTO'.",
+    )
+
+    continuous_sweep = Instrument.control(
+        "INIT:CONT?",
+        "INIT:CONT %s",
+        "Continuous (True) or single sweep (False)",
+        validator=strict_discrete_set,
+        values=[True, False],
+        set_process=lambda x: "ON" if x else "OFF",
+        get_process=lambda x: bool(x),
+    )
+
+    def single_sweep(self):
+        """Perform a single sweep with synchronization."""
+        self.write("INIT; *WAI")
+
+    def continue_single_sweep(self):
+        """Continue with single sweep with synchronization."""
+        self.write("INIT:CONM; *WAI")
+
+    # Traces ------------------------------------------------------------------
+
+    def read_trace(self, n_trace=1):
+        """
+        Read trace data.
+        :param n_trace: The trace number (1-6). Default is 1.
+        :return: Nnumpy arrays of the trace data (frequency and amplitude).
+        """
+        y = np.array(self.values("TRAC{n_trace}? TRACE{n_trace}"))
+        x = np.linspace(self.freq_start, self.freq_stop, len(y))
+        return x, y
+
+    trace_mode = Instrument.control(
+        "DISP:TRAC:MODE?",
+        "DISP:TRAC:MODE %s",
+        "Trace mode ('WRIT', 'MAXH', 'MINH', 'AVER' or 'VIEW'",
+        validator=strict_discrete_set,
+        values=["WRIT", "MAXH", "MINH", "AVER", "VIEW"],
+    )
+
+    # Markers --------------------------------------------------------------------
+
+    def create_marker(self, num=1, is_delta_marker=False):
+        """
+        Create a marker.
+        :param num: The marker number (1-4)
+        :param is_delta_marker: True if the marker is a delta marker, default
+                            is False.
+        :return: The marker object.
+        """
+        return self.Marker(self, num, is_delta_marker)
+
+    class Marker:
+        def __init__(self, instrument, num, is_delta_marker):
+            """
+            Marker and Delte Marker class.
+            :param instrument: The FSL instrument.
+            :param num: The marker number (1-4)
+            :param is_delta_marker: True if the marker is a delta marker,
+                                defaults to False.
+            """
+            self.instr = instrument
+            self.is_delta_marker = is_delta_marker
+            # Building the marker name for the commands.
+            if self.is_delta_marker:
+                # Smallest delta marker number is 2.
+                self.name = "DELT" + str(max(2, num))
+            else:
+                self.name = "MARK"
+                if num > 1:
+                    # Marker 1 doesn't get a number.
+                    self.name = self.name + str(num)
+
+            self.activate()
+
+        def activate(self):
+            """Activate a marker."""
+            self.instr.write(f"CALC:{self.name}:STAT ON")
+
+        def disable(self):
+            """Disable a marker."""
+            self.instr.write(f"CALC:{self.name}:STAT OFF")
+
+        def to_trace(self, n_trace=1):
+            """
+            Set marker to trace.
+            :param n_trace: The trace number (1-6). Default is 1.
+            """
+            self.instr.write(f"CALC:{self.name}:TRAC {n_trace}")
+
+        @property
+        def peak_excursion(self):
+            """Peak excursion in dB."""
+            return self.instr.values(f"CALC:{self.name}:PEXC?")
+
+        @peak_excursion.setter
+        def peak_excursion(self, value):
+            self.instr.write(f"CALC:{self.name}:PEXC {value}")
+
+        def to_peak(self):
+            """Set marker to highest peak within the span."""
+            self.instr.write(f"CALC:{self.name}:MAX")
+
+        def to_next_peak(self, direction="right"):
+            """
+            Set marker to next peak.
+            :param direction: Direction of the next peak ('left' or 'right' of
+                            the current position).
+            """
+            self.instr.write(f"CALC:{self.name}:MAX:{direction}")
+
+        @property
+        def x(self):
+            """Position of marker on the frequency axis in Hz."""
+            return self.instr.values(f"CALC:{self.name}:X?")
+
+        @x.setter
+        def x(self, value):
+            self.instr.write(f"CALC:{self.name}:X {value}")
+
+        @property
+        def y(self):
+            """Amplitude of the marker position."""
+            return self.instr.values(f"CALC:{self.name}:Y?")
+
+        @y.setter
+        def y(self, value):
+            self.instr.write(f"CALC:{self.name}:Y {value}")
+
+        def zoom(self, value):
+            """
+            Zoom in to a frequency span or by a factor.
+            :param value: The value to zoom in by. If a number is passed it is
+                        interpreted as a factor. If a string (number with
+                        unit) is passed it is interpreted as a frequency span.
+            """
+            self.instr.write(f"CALC:{self.name}:FUNC:ZOOM {value}; *WAI")

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -35,6 +35,7 @@ log.addHandler(logging.NullHandler())
 class FSL(Instrument):
     """
     Represents a Rohde&Schwarz FSL spectrum analyzer.
+
     All physical values that can be set can either be as a string of a value
     and a unit (e.g. "1.2 GHz") or as a float value in the base units (Hz,
     dBm, etc.).
@@ -138,6 +139,7 @@ class FSL(Instrument):
     def read_trace(self, n_trace=1):
         """
         Read trace data.
+
         :param n_trace: The trace number (1-6). Default is 1.
         :return: Nnumpy arrays of the trace data (frequency and amplitude).
         """
@@ -153,14 +155,15 @@ class FSL(Instrument):
         values=["WRIT", "MAXH", "MINH", "AVER", "VIEW"],
     )
 
-    # Markers --------------------------------------------------------------------
+    # Markers -----------------------------------------------------------------
 
     def create_marker(self, num=1, is_delta_marker=False):
         """
         Create a marker.
+
         :param num: The marker number (1-4)
         :param is_delta_marker: True if the marker is a delta marker, default
-                            is False.
+            is False.
         :return: The marker object.
         """
         return self.Marker(self, num, is_delta_marker)
@@ -169,10 +172,11 @@ class FSL(Instrument):
         def __init__(self, instrument, num, is_delta_marker):
             """
             Marker and Delte Marker class.
+
             :param instrument: The FSL instrument.
             :param num: The marker number (1-4)
             :param is_delta_marker: True if the marker is a delta marker,
-                                defaults to False.
+                defaults to False.
             """
             self.instr = instrument
             self.is_delta_marker = is_delta_marker
@@ -199,6 +203,7 @@ class FSL(Instrument):
         def to_trace(self, n_trace=1):
             """
             Set marker to trace.
+
             :param n_trace: The trace number (1-6). Default is 1.
             """
             self.instr.write(f"CALC:{self.name}:TRAC {n_trace}")
@@ -219,8 +224,9 @@ class FSL(Instrument):
         def to_next_peak(self, direction="right"):
             """
             Set marker to next peak.
+
             :param direction: Direction of the next peak ('left' or 'right' of
-                            the current position).
+                the current position).
             """
             self.instr.write(f"CALC:{self.name}:MAX:{direction}")
 
@@ -245,8 +251,9 @@ class FSL(Instrument):
         def zoom(self, value):
             """
             Zoom in to a frequency span or by a factor.
+
             :param value: The value to zoom in by. If a number is passed it is
-                        interpreted as a factor. If a string (number with
-                        unit) is passed it is interpreted as a frequency span.
+                interpreted as a factor. If a string (number with unit) is
+                passed it is interpreted as a frequency span.
             """
             self.instr.write(f"CALC:{self.name}:FUNC:ZOOM {value}; *WAI")

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -81,7 +81,7 @@ class FSL(Instrument):
     @property
     def res_bandwidth(self):
         """Resolution bandwidth in Hz. Can be set to 'AUTO'."""
-        return self.values("BAND:RES?")[0]
+        return float(self.ask("BAND:RES?"))
 
     @res_bandwidth.setter
     def res_bandwidth(self, value):
@@ -93,7 +93,7 @@ class FSL(Instrument):
     @property
     def video_bandwidth(self):
         """Video bandwidth in Hz. Can be set to 'AUTO'."""
-        return self.values("BAND:VID?")[0]
+        return float(self.ask("BAND:VID?"))
 
     @video_bandwidth.setter
     def video_bandwidth(self, value):

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -32,6 +32,15 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+def _number_or_auto(value):
+    # helper for the bandwidth setting
+    if isinstance(value, str) and value.upper() == "AUTO":
+        return ":AUTO ON"
+    else:
+        # There is no space in the set commands, so we have to add it
+        return " " + str(value)
+
+
 class FSL(Instrument):
     """
     Represents a Rohde&Schwarz FSL spectrum analyzer.
@@ -78,15 +87,7 @@ class FSL(Instrument):
         "Attenuation in dB.",
     )
 
-    @staticmethod
-    def _number_or_auto(value):
-        # helper for the bandwidth setting
-        if isinstance(value, str) and value.upper() == "AUTO":
-            return ":AUTO ON"
-        else:
-            # There is no space in the set commands, so we have to add it
-            return " " + str(value)
-
+    # There is no space between RES and %s on purpose, see _number_or_auto.
     res_bandwidth = Instrument.control(
         "BAND:RES?",
         "BAND:RES%s",

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -87,9 +87,9 @@ class FSL(Instrument):
         "Attenuation in dB.",
     )
 
-    # There is no space between RES and %s on purpose, see _number_or_auto.
     res_bandwidth = Instrument.control(
         "BAND:RES?",
+        # There is no space between RES and %s on purpose, see _number_or_auto.
         "BAND:RES%s",
         "Resolution bandwidth in Hz. Can be set to 'AUTO'",
         set_process=_number_or_auto,
@@ -104,17 +104,13 @@ class FSL(Instrument):
 
     # Sweeping ----------------------------------------------------------------
 
-    @property
-    def sweep_time(self):
-        """Sweep time in s. Can be set to 'AUTO'."""
-        return self.values("SWE:TIME?")[0]
-
-    @sweep_time.setter
-    def sweep_time(self, value):
-        if type(value) is str and value.upper() == "AUTO":
-            self.write("SWE:TIME:AUTO ON")
-        else:
-            self.write(f"SWE:TIME {value}")
+    sweep_time = Instrument.control(
+        "SWE:TIME?",
+        # No space between TIME and %s on purpose, see _number_or_auto.
+        "SWE:TIME%s",
+        "Sweep time in s. Can be set to 'AUTO'.",
+        set_process=_number_or_auto,
+    )
 
     continuous_sweep = Instrument.control(
         "INIT:CONT?",

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -150,7 +150,7 @@ class FSL(Instrument):
     trace_mode = Instrument.control(
         "DISP:TRAC:MODE?",
         "DISP:TRAC:MODE %s",
-        "Trace mode ('WRIT', 'MAXH', 'MINH', 'AVER' or 'VIEW'",
+        "Trace mode ('WRIT', 'MAXH', 'MINH', 'AVER' or 'VIEW')",
         validator=strict_discrete_set,
         values=["WRIT", "MAXH", "MINH", "AVER", "VIEW"],
     )
@@ -171,7 +171,7 @@ class FSL(Instrument):
     class Marker:
         def __init__(self, instrument, num, is_delta_marker):
             """
-            Marker and Delte Marker class.
+            Marker and Delta Marker class.
 
             :param instrument: The FSL instrument.
             :param num: The marker number (1-4)

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -121,9 +121,8 @@ class FSL(Instrument):
         "INIT:CONT %s",
         "Continuous (True) or single sweep (False)",
         validator=strict_discrete_set,
-        values=[True, False],
-        set_process=lambda x: "ON" if x else "OFF",
-        get_process=lambda x: bool(x),
+        values={True: 1, False: 0},
+        map_values=True,
     )
 
     def single_sweep(self):


### PR DESCRIPTION
I added the Rohde&Schwarz FSL spectrum analyzer, including the most common commands and a dedicated `Marker` class. 

The FSL handles both numerical value as well as physical quantities like "1.5 GHz". The latter feature is implemented by the device itself. It also automatically chooses the closest available value for some settings or ignores them if they are out of range (like setting the span wider than the maximum value). I thus do not perform validation in the interface itself in these cases to not change the behaviour compared to pure SCPI commands.

I also added documenation including an example above the API documentation.

I tested the commands with an FSL-18.