### PR TITLE
Fix missing return statements in Tektronix AFG3152C.

### DIFF
--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -135,13 +135,13 @@ class Channel(object):
             return self.instrument.values("source%d:%s" % (
                                           self.number, command), **kwargs)
         def ask(self, command):
-            self.instrument.ask("source%d:%s" % (self.number, command))
+            return self.instrument.ask("source%d:%s" % (self.number, command))
 
         def write(self, command):
             self.instrument.write("source%d:%s" % (self.number, command))
 
         def read(self):
-            self.instrument.read()
+            return self.instrument.read()
 
         def enable(self):
             self.instrument.write("output%d:state on" % self.number)

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 from math import sqrt, log10
-from pymeasure.instruments import Instrument, RangeException
+from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -21,147 +21,167 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from math import sqrt,log10
+from math import sqrt, log10
 from pymeasure.instruments import Instrument, RangeException
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
+
 class Channel(object):
-        SHAPES = {
-            'sinusoidal': 'SIN',
-            'square': 'SQU',
-            'pulse': 'PULS',
-            'ramp': 'RAMP',
-            'prnoise': 'PRN',
-            'dc': 'DC',
-            'sinc': 'SINC',
-            'gaussian': 'GAUS',
-            'lorentz': 'LOR',
-            'erise': 'ERIS',
-            'edecay': 'EDEC',
-            'haversine': 'HAV'
-        }
-        FREQ_LIMIT = [1e-6, 150e6] #Frequeny limit for sinusoidal function
-        DUTY_LIMIT = [0.001, 99.999]
-        AMPLITUDE_LIMIT = {
-            'VPP': [20e-3, 10],
-            'VRMS': list(map(lambda x: round(x/2/sqrt(2), 3), [20e-3, 10])),
-            'DBM': list(map(lambda x: round(20*log10(x/2/sqrt(0.1)), 2),
-                        [20e-3, 10]))
-            } #Vpp, Vrms and dBm limits
-        UNIT_LIMIT = ['VPP', 'VRMS', 'DBM']
-        IMP_LIMIT = [1, 1e4]
+    SHAPES = {
+        "sinusoidal": "SIN",
+        "square": "SQU",
+        "pulse": "PULS",
+        "ramp": "RAMP",
+        "prnoise": "PRN",
+        "dc": "DC",
+        "sinc": "SINC",
+        "gaussian": "GAUS",
+        "lorentz": "LOR",
+        "erise": "ERIS",
+        "edecay": "EDEC",
+        "haversine": "HAV",
+    }
+    FREQ_LIMIT = [1e-6, 150e6]  # Frequeny limit for sinusoidal function
+    DUTY_LIMIT = [0.001, 99.999]
+    AMPLITUDE_LIMIT = {
+        "VPP": [20e-3, 10],
+        "VRMS": list(map(lambda x: round(x / 2 / sqrt(2), 3), [20e-3, 10])),
+        "DBM": list(
+            map(lambda x: round(20 * log10(x / 2 / sqrt(0.1)), 2), [20e-3, 10])
+        ),
+    }  # Vpp, Vrms and dBm limits
+    UNIT_LIMIT = ["VPP", "VRMS", "DBM"]
+    IMP_LIMIT = [1, 1e4]
 
-        shape = Instrument.control(
-            "function:shape?","function:shape %s",
-            """ A string property that controls the shape of the output.
+    shape = Instrument.control(
+        "function:shape?",
+        "function:shape %s",
+        """ A string property that controls the shape of the output.
             This property can be set.""",
-            validator=strict_discrete_set,
-            values=SHAPES,
-            map_values=True
-        )
+        validator=strict_discrete_set,
+        values=SHAPES,
+        map_values=True,
+    )
 
-        unit = Instrument.control(
-            "voltage:unit?","voltage:unit %s",
-            """ A string property that controls the amplitude unit.
+    unit = Instrument.control(
+        "voltage:unit?",
+        "voltage:unit %s",
+        """ A string property that controls the amplitude unit.
             This property can be set.""",
-            validator=strict_discrete_set,
-            values=UNIT_LIMIT
-        )
+        validator=strict_discrete_set,
+        values=UNIT_LIMIT,
+    )
 
-        amp_vpp = Instrument.control(
-            "voltage:amplitude?","voltage:amplitude %eVPP",
-            """ A floating point property that controls the output amplitude
+    amp_vpp = Instrument.control(
+        "voltage:amplitude?",
+        "voltage:amplitude %eVPP",
+        """ A floating point property that controls the output amplitude
             in Vpp. This property can be set.""",
-            validator=strict_range,
-            values=AMPLITUDE_LIMIT['VPP']
-        )
+        validator=strict_range,
+        values=AMPLITUDE_LIMIT["VPP"],
+    )
 
-        amp_dbm = Instrument.control(
-            "voltage:amplitude?","voltage:amplitude %eDBM",
-            """ A floating point property that controls the output amplitude
+    amp_dbm = Instrument.control(
+        "voltage:amplitude?",
+        "voltage:amplitude %eDBM",
+        """ A floating point property that controls the output amplitude
             in dBm. This property can be set.""",
-            validator=strict_range,
-            values=AMPLITUDE_LIMIT['DBM']
-        )
+        validator=strict_range,
+        values=AMPLITUDE_LIMIT["DBM"],
+    )
 
-        amp_vrms = Instrument.control(
-            "voltage:amplitude?","voltage:amplitude %eVRMS",
-            """ A floating point property that controls the output amplitude
+    amp_vrms = Instrument.control(
+        "voltage:amplitude?",
+        "voltage:amplitude %eVRMS",
+        """ A floating point property that controls the output amplitude
             in Vrms. This property can be set.""",
-            validator=strict_range,
-            values=AMPLITUDE_LIMIT['VRMS']
-        )
+        validator=strict_range,
+        values=AMPLITUDE_LIMIT["VRMS"],
+    )
 
-        offset = Instrument.control(
-            "voltage:offset?","voltage:offset %e",
-            """ A floating point property that controls the amplitude
-            offset. It is always in Volt. This property can be set."""
-        )
+    offset = Instrument.control(
+        "voltage:offset?",
+        "voltage:offset %e",
+        """ A floating point property that controls the amplitude
+            offset. It is always in Volt. This property can be set.""",
+    )
 
-        frequency = Instrument.control(
-            "frequency:fixed?","frequency:fixed %e",
-            """ A floating point property that controls the frequency.
+    frequency = Instrument.control(
+        "frequency:fixed?",
+        "frequency:fixed %e",
+        """ A floating point property that controls the frequency.
             This property can be set.""",
-            validator=strict_range,
-            values=FREQ_LIMIT
-        )
+        validator=strict_range,
+        values=FREQ_LIMIT,
+    )
 
-        duty = Instrument.control(
-            "pulse:dcycle?","pulse:dcycle %.3f",
-            """ A floating point property that controls the duty
+    duty = Instrument.control(
+        "pulse:dcycle?",
+        "pulse:dcycle %.3f",
+        """ A floating point property that controls the duty
             cycle of pulse. This property can be set.""",
-            validator=strict_range,
-            values=DUTY_LIMIT
-        )
+        validator=strict_range,
+        values=DUTY_LIMIT,
+    )
 
-        impedance = Instrument.control(
-            "output:impedance?","output:impedance %d",
-            """ A floating point property that controls the output
+    impedance = Instrument.control(
+        "output:impedance?",
+        "output:impedance %d",
+        """ A floating point property that controls the output
             impedance of the channel. Be careful with this.
             This property can be set.""",
-            validator=strict_range,
-            values=IMP_LIMIT,
-            cast=int
+        validator=strict_range,
+        values=IMP_LIMIT,
+        cast=int,
+    )
+
+    def __init__(self, instrument, number):
+        self.instrument = instrument
+        self.number = number
+
+    def values(self, command, **kwargs):
+        """Reads a set of values from the instrument through the adapter,
+        passing on any key-word arguments.
+        """
+        return self.instrument.values(
+            "source%d:%s" % (self.number, command), **kwargs
         )
 
-        def __init__(self, instrument, number):
-            self.instrument = instrument
-            self.number = number
+    def ask(self, command):
+        return self.instrument.ask("source%d:%s" % (self.number, command))
 
-        def values(self, command, **kwargs):
-            """ Reads a set of values from the instrument through the adapter,
-            passing on any key-word arguments.
-            """
-            return self.instrument.values("source%d:%s" % (
-                                          self.number, command), **kwargs)
-        def ask(self, command):
-            return self.instrument.ask("source%d:%s" % (self.number, command))
+    def write(self, command):
+        self.instrument.write("source%d:%s" % (self.number, command))
 
-        def write(self, command):
-            self.instrument.write("source%d:%s" % (self.number, command))
+    def read(self):
+        return self.instrument.read()
 
-        def read(self):
-            return self.instrument.read()
+    def enable(self):
+        self.instrument.write("output%d:state on" % self.number)
 
-        def enable(self):
-            self.instrument.write("output%d:state on" % self.number)
+    def disable(self):
+        self.instrument.write("output%d:state off" % self.number)
 
-        def disable(self):
-            self.instrument.write("output%d:state off" % self.number)
+    def waveform(
+        self, shape="SIN", frequency=1e6, units="VPP", amplitude=1, offset=0
+    ):
+        """General setting method for a complete wavefunction"""
+        self.instrument.write(
+            "source%d:function:shape %s" % (self.number, shape)
+        )
+        self.instrument.write(
+            "source%d:frequency:fixed %e" % (self.number, frequency)
+        )
+        self.instrument.write(
+            "source%d:voltage:unit %s" % (self.number, units)
+        )
+        self.instrument.write(
+            "source%d:voltage:amplitude %e%s" % (self.number, amplitude, units)
+        )
+        self.instrument.write(
+            "source%d:voltage:offset %eV" % (self.number, offset)
+        )
 
-        def waveform(self, shape='SIN', frequency=1e6, units='VPP',
-                     amplitude=1, offset=0):
-            """General setting method for a complete wavefunction"""
-            self.instrument.write("source%d:function:shape %s" % (
-                                  self.number, shape))
-            self.instrument.write("source%d:frequency:fixed %e" % (
-                                  self.number, frequency))
-            self.instrument.write("source%d:voltage:unit %s" % (
-                                  self.number, units))
-            self.instrument.write("source%d:voltage:amplitude %e%s" %(
-                                  self.number, amplitude,units))
-            self.instrument.write("source%d:voltage:offset %eV" %(
-                                  self.number, offset))
 
 class AFG3152C(Instrument):
     """Represents the Tektronix AFG 3000 series (one or two channels)


### PR DESCRIPTION
As noticed in https://github.com/pymeasure/pymeasure/pull/511#discussion_r746893753, the implementation of the instrument was missing two `return` statements. This has been fixed here.

In addition I also fixed the code formatting by applying black (with 79 character line length). Before, flake8 was complaining about missing blank lines. Also removed an unused import.