### PR TITLE
Keithley2600 | Fixed error when retrieving error code

### DIFF
--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -54,7 +54,7 @@ class Keithley2600(Instrument):
         # if tab delimitated message is greater than one, grab first two as code, message
         # otherwise, assign code & message to returned error
         if len(err) > 1:
-            err = (int(err[0]), err[1])
+            err = (int(float(err[0])), err[1])
             code = err[0]
             message = err[1].replace('"', '')
         else:


### PR DESCRIPTION
In Keithley2600.error the error code is sometimes printed in scientific notation which raises an error when converted to an integer. This commit allows scientific notation to be used.