### PR TITLE
Bump pytqtgraph minimum version, avoid implicit conversion warnings.

### DIFF
--- a/requirements/pymeasure.yml
+++ b/requirements/pymeasure.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy=1.19.2
   - pandas=1.1.3
   - pyqt=5.12.3
-  - pyqtgraph=0.11.0
+  - pyqtgraph=0.12.3
   - pyserial=3.4
   - pyvisa=1.10.1
   - pyzmq=22.0.3

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "pandas >= 0.14",
         "pyvisa >= 1.8",
         "pyserial >= 2.7",
-        "pyqtgraph >= 0.9.10"
+        "pyqtgraph >= 0.12.0"
     ],
     extras_require={
         'matplotlib': ['matplotlib >= 2.0.2'],


### PR DESCRIPTION
This avoids a deprecation warning "DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python. c.setHsv(h, sat, v)"