### PR TITLE
Flexible API for defining connection configuration

### DIFF
--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -15,14 +15,14 @@ Adapter base class
     :undoc-members:
 
 ============
-Fake adapter
+VISA adapter
 ============
 
-.. autoclass:: pymeasure.adapters.FakeAdapter
+.. autoclass:: pymeasure.adapters.VISAAdapter
     :members:
     :undoc-members:
     :inherited-members:
-    :show-inheritance: 
+    :show-inheritance:
 
 ==============
 Serial adapter
@@ -46,16 +46,6 @@ Prologix adapter
     :show-inheritance:
     :private-members: _format_binary_values
 
-============
-VISA adapter
-============
-
-.. autoclass:: pymeasure.adapters.VISAAdapter
-    :members:
-    :undoc-members:
-    :inherited-members:
-    :show-inheritance: 
-
 ==============
 VXI-11 adapter
 ==============
@@ -71,6 +61,16 @@ Telnet adapter
 ==============
 
 .. autoclass:: pymeasure.adapters.TelnetAdapter
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
+============
+Fake adapter
+============
+
+.. autoclass:: pymeasure.adapters.FakeAdapter
     :members:
     :undoc-members:
     :inherited-members:

--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -66,4 +66,26 @@ To use this type equipment the python-vxi11 library has to be installed which is
    adapter = VXI11Adapter("TCPIP::192.168.0.100::inst0::INSTR")
    instr = Instrument(adapter, "my_instrument")
 
+.. _connection_settings:
+
+Modifying connection settings
+=============================
+
+Sometimes you want to tweak the connection settings when talking to a device.
+This might be because you have a non-standard device or connection, or are troubleshooting why a device does not reply.
+
+When using a string or integer to connect to an instrument, a :py:class:`~pymeasure.adapters.VISAAdapter` is used internally.
+Additional settings need to be passed in as keyword arguments.
+For example, to use a fast baud rate on a quick connection when connecting to the Keithely2400 as above, do ::
+
+    sourcemeter = Keithley2400("ASRL2", timeout=500, baud_rate=115200)
+
+This overrides any defaults that may be defined for the instrument, either generally valid ones like ``timeout`` or interface-specific ones like ``baud_rate``.
+
+If you use an invalid argument, either misspelled or not valid for the chosen interface, an exception will be raised.
+
+When using a separately-created Adapter instance, you define any custom settings when creating the adapter. Any keyword arguments passed in are discarded.
+
+----
+
 The above examples illustrate different methods for communicating with instruments, using adapters to keep instrument code independent from the communication protocols. Next we present the methods for setting up measurements.

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -36,15 +36,40 @@ log.addHandler(logging.NullHandler())
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
-    """ Adapter class for the VISA library using PyVISA to communicate
-    with instruments.
+    """ Adapter class for the VISA library, using PyVISA to communicate with instruments.
 
-    :param resource: VISA resource name that identifies the address
-    :param visa_library: VisaLibrary Instance, path of the VISA library or VisaLibrary spec
-        string (@py or @ni). If not given, the default for the platform will be used.
+    The workhorse of our library, used by most instruments.
+
+    :param resource_name: A
+        `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
+        or GPIB address integer that identifies the target of the connection
+    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library or VisaLibrary spec
+        string (``@py`` or ``@ivi``). If not given, the default for the platform will be used.
     :param preprocess_reply: optional callable used to preprocess strings
         received from the instrument. The callable returns the processed string.
-    :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
+    :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
+
+    :Kwargs:
+        Keyword arguments are used to configure the connection created by PyVISA. This is
+        complicated by the fact that *which* arguments are valid depends on the interface (e.g.
+        serial, GPIB, TCPI/IP, USB) determined by the current ``resource_name``.
+
+        A flexible process is used to easily define reasonable *default values* for
+        different instrument interfaces, but also enable the instrument user to *override any
+        setting* if their situation demands it.
+
+        A kwarg that names a pyVISA interface type (most commonly ``asrl``, ``gpib``, ``tcpip`` or
+        ``usb``) is a dictionary with keyword arguments defining defaults specific to that
+        interface. Example: ``asrl={'baud_rate': 4200}``.
+
+        All other kwargs are either generally valid (e.g. ``timeout=500``) or override any default
+        settings from the interface-specific entries above. For example, passing
+        ``baud_rate=115200`` when connecting via a resource name ``ASRL1`` would override a
+        default of 4200 defined as above.
+
+        See :ref:`connection_settings` for how to tweak settings when *connecting* to an instrument.
+        See :ref:`default_connection_settings` for how to best define default settings when
+        *implementing an instrument*.
     """
 
     def __init__(self, resource_name, visa_library='', preprocess_reply=None, **kwargs):

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -84,7 +84,7 @@ class VISAAdapter(Adapter):
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type
-        for key in list(kwargs):
+        for key in list(kwargs.keys()):  # iterate over a copy of the keys as we modify kwargs
             # Remove all interface-specific kwargs:
             if key in pyvisa.constants.InterfaceType.__members__:
                 if getattr(pyvisa.constants.InterfaceType, key) is if_type:

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -23,7 +23,6 @@
 #
 
 from pymeasure.instruments import Instrument
-from pymeasure.adapters import VISAAdapter
 from time import sleep, time
 
 import logging
@@ -59,9 +58,9 @@ class AMI430(Instrument):
     """
 
     def __init__(self, resourceName, **kwargs):
-        adapter = VISAAdapter(resourceName, read_termination='\n')
+        kwargs.setdefault('read_termination', '\n')
         super(AMI430, self).__init__(
-            adapter,
+            resourceName,
             "AMI superconducting magnet power supply.",
             includeSCPI=True,
             **kwargs

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -25,7 +25,6 @@
 import logging
 from time import sleep
 from enum import IntFlag
-from pymeasure.adapters import VISAAdapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_range, truncated_range, strict_discrete_set
 
@@ -196,19 +195,17 @@ class DPSeriesMotorController(Instrument):
         """
         self._address = address
         self._encoder_enabled = encoder_enabled
+        kwargs.setdefault('write_termination', '\r')
+        kwargs.setdefault('read_termination', '\r')
+        kwargs.setdefault('timeout', 2000)
 
         super().__init__(
             resourceName,
             "Anaheim Automation Stepper Motor Controller",
             includeSCPI=False,
-            write_termination="\r",
-            read_termination="\r",
-            timeout=2000,
+            asrl={'baud_rate': 38400},
             **kwargs
         )
-
-        if isinstance(self.adapter, VISAAdapter):
-            self.adapter.connection.baud_rate = 38400
 
     @property
     def encoder_enabled(self):

--- a/pymeasure/instruments/fluke/fluke7341.py
+++ b/pymeasure/instruments/fluke/fluke7341.py
@@ -24,7 +24,6 @@
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
-from pymeasure.adapters import VISAAdapter
 
 
 class Fluke7341(Instrument):

--- a/pymeasure/instruments/fluke/fluke7341.py
+++ b/pymeasure/instruments/fluke/fluke7341.py
@@ -60,15 +60,13 @@ class Fluke7341(Instrument):
                                 )
 
     def __init__(self, resource_name, **kwargs):
+        kwargs.setdefault('timeout', 2000)
+        kwargs.setdefault('write_termination', '\r\n')
         super().__init__(
             resource_name,
             "Fluke 7341",
-            timeout=2000,
-            write_termination='\r\n',
             preprocess_reply=lambda x: x.split()[1],
             includeSCPI=False,
+            asrl={'baud_rate': 2400},
             **kwargs
         )
-
-        if isinstance(self.adapter, VISAAdapter):
-            self.adapter.connection.baud_rate = 2400

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -46,5 +46,6 @@ class HP34401A(Instrument):
         super(HP34401A, self).__init__(
             resourceName,
             "HP 34401A",
+            asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},
             **kwargs
         )

--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -150,12 +150,12 @@ class HP3478A(Instrument):
     """
 
     def __init__(self, resourceName, **kwargs):
+        kwargs.setdefault('read_termination', '\r\n')
+        kwargs.setdefault('send_end', True)
         super(HP3478A, self).__init__(
             resourceName,
             "Hewlett-Packard HP3478A",
             includeSCPI=False,
-            send_end=True,
-            read_termination="\r\n",
             **kwargs
         )
 

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -35,14 +35,35 @@ log.addHandler(logging.NullHandler())
 
 
 class Instrument(object):
-    """ This provides the base class for all Instruments, which is
-    independent of the particular Adapter used to connect for
-    communication to the instrument. It provides basic SCPI commands
-    by default, but can be toggled with :code:`includeSCPI`.
+    """ The base class for all Instrument definitions.
 
-    :param adapter: An :class:`Adapter<pymeasure.adapters.Adapter>` object
-    :param name: A string name
+    It makes use of an array of :py:class:`~pymeasure.adapters.Adapter` classes for communication
+    with the connected hardware device. This decouples the instrument/command definition from the
+    specific communication interface used.
+
+    When ``adapter`` is a string, this is taken as an appropriate resource name. Depending on your
+    installed VISA library, this can be something simple like ``COM1`` or ``ASRL2``, or a more
+    complicated
+    `VISA resource name <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
+    defining the target of your connection.
+
+    When ``adapter`` is an integer, a GPIB resource name is created based on that.
+    In either case a :py:class:`~pymeasure.adapters.VISAAdapter` is constructed based on that
+    resource name.
+    Keyword arguments can be used to further configure the connection.
+
+    Otherwise, the passed :py:class:`~pymeasure.adapters.Adapter` object is used and any keyword
+    arguments are discarded.
+
+    This class defines basic SCPI commands by default. This can be disabled with
+    :code:`includeSCPI` for instruments not compatible with the standard SCPI commands.
+
+    :param adapter: A string, integer, or :py:class:`~pymeasure.adapters.Adapter` subclass object
+    :param string name: The name of the instrument. Often the model designation by default.
     :param includeSCPI: A boolean, which toggles the inclusion of standard SCPI commands
+    :param \\**kwargs: In case ``adapter`` is a string or
+        integer, additional arguments passed on to
+        :py:class:`~pymeasure.adapters.VISAAdapter` (check there for details). Discarded otherwise.
     """
 
     # noinspection PyPep8Naming

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -37,7 +37,7 @@ log.addHandler(logging.NullHandler())
 class Instrument(object):
     """ The base class for all Instrument definitions.
 
-    It makes use of an array of :py:class:`~pymeasure.adapters.Adapter` classes for communication
+    It makes use of one of the :py:class:`~pymeasure.adapters.Adapter` classes for communication
     with the connected hardware device. This decouples the instrument/command definition from the
     specific communication interface used.
 

--- a/pymeasure/instruments/oxfordinstruments/itc503.py
+++ b/pymeasure/instruments/oxfordinstruments/itc503.py
@@ -193,12 +193,12 @@ class ITC503(Instrument):
 
     def __init__(self, resourceName, clear_buffer=True,
                  max_temperature=301, min_temperature=0, **kwargs):
+        kwargs.setdefault('read_termination', '\r')
+        kwargs.setdefault('send_end', True)
         super(ITC503, self).__init__(
             resourceName,
             "Oxford ITC503",
             includeSCPI=False,
-            send_end=True,
-            read_termination="\r",
             **kwargs
         )
 

--- a/pymeasure/instruments/pendulum/cnt91.py
+++ b/pymeasure/instruments/pendulum/cnt91.py
@@ -47,11 +47,11 @@ class CNT91(Instrument):
     MAX_BUFFER_SIZE = 32000  # User Manual 8-38
 
     def __init__(self, resourceName, **kwargs):
+        kwargs.setdefault('timeout', 120000)
+        kwargs.setdefault('read_termination', '\n')
         super().__init__(
             resourceName,
             "Pendulum CNT-91",
-            timeout=120000,
-            read_termination="\n",
             **kwargs,
         )
 

--- a/pymeasure/instruments/srs/sr510.py
+++ b/pymeasure/instruments/srs/sr510.py
@@ -78,10 +78,10 @@ class SR510(Instrument):
                                     )
 
     def __init__(self, resourceName, **kwargs):
+        kwargs.setdefault('write_termination', '\r')
         super(SR510, self).__init__(
             resourceName,
             "Stanford Research Systems SR510 Lock-in amplifier",
             includeSCPI=False,
-            write_termination="\r",
             **kwargs,
         )

--- a/tests/instruments/test_connection_configuration.py
+++ b/tests/instruments/test_connection_configuration.py
@@ -1,0 +1,173 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2021 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import serial
+
+from pymeasure.adapters import SerialAdapter, VISAAdapter
+from pymeasure.instruments import Instrument
+
+
+# As an instrument contributor, I want to define default connection settings for my
+# instrument with a minimum of boiler-plate. These settings should be easily
+# user-overridable if appropriate without having to change the code/implementation
+# of my instrument.
+class MultiprotocolInstrument(Instrument):
+    """Test instrument for testing the configuration and use of multiple connection methods.
+
+    The instrument support multiple transports methods(serial, TCP/IP, GPIB).
+    In case of serial connections, the default baud rate is low (2400), but configurable in
+    the device, so it can use faster communication if desired.
+    Two examples in our instruments are AMI430, Keithley2260B (for TCP/IP, there are more
+    with GPIB capability)
+
+    It also has an attribute to configure a non-serial (gpib) connection. This demonstrates
+    that there may be attributes that are not valid for a serial connection, only others.
+    """
+    def __init__(self, adapter, name="Instrument with multiple connection methods",
+                 baud_rate=2400, **kwargs):
+        # - baud_rate is placed in the signature if it's expected to be modified by the user
+        # - baud_rate is only valid for the asrl protocol
+        # - enable_repeat_addressing is only for gpib and always False for this device
+        # - timeout is the same for all pyvisa protocols, using setdefault it is user-modifiable
+        # without cluttering the signature:
+        kwargs.setdefault('timeout', 1500)
+
+        super().__init__(adapter,
+                         name=name,
+                         gpib=dict(enable_repeat_addressing=False,
+                                   read_termination='\r'),
+                         asrl={'baud_rate': baud_rate,
+                               'read_termination': '\r\n'},
+                         **kwargs,  # all others/generally valid kwargs
+                         )
+
+# The defined tests use the pyvisa-sim simulated connections to avoid the need for a connected
+# instrument. The argument handling and connection creation happens in pyvisa just like for a
+# real instrument, through.
+
+
+def test_serial_default_settings():
+    """As a user, I want to simply connect to an instrument using default settings"""
+    instr = MultiprotocolInstrument(adapter='ASRL1::INSTR', visa_library='@sim')
+    assert instr.adapter.connection.baud_rate == 2400
+
+
+def test_serial_custom_baud_rate_is_set():
+    """As a user, I want to easily override default settings to fit my needs"""
+    instr = MultiprotocolInstrument(adapter='ASRL1::INSTR', baud_rate=115200, visa_library='@sim')
+    assert instr.adapter.connection.baud_rate == 115200
+
+
+def test_connections_use_tcpip():
+    """As a user, I want to be free to choose which connection to use (e.g. serial-over RS-232,
+    USB, TCP/IP) should an instrument support more than one
+    """
+    # here, baud_rate is invalid for pyvisa, but is a default kwarg anyway
+    instr = MultiprotocolInstrument(adapter='TCPIP::localhost:1111::INSTR', visa_library='@sim')
+    # method specific to pyvisa TCPIPInstrument
+    assert hasattr(instr.adapter.connection, 'control_ren')
+
+
+def test_connections_use_gpib():
+    """As a user, I want to be free to choose which connection to use (e.g. serial-over RS-232,
+    USB, TCP/IP) should an instrument support more than one
+    """
+    # here, baud_rate is invalid for pyvisa, but is a default kwarg anyway
+    instr = MultiprotocolInstrument(adapter='GPIB::8::INSTR', visa_library='@sim')
+    # attribute specific to pyvisa GPIBInstrument
+    assert instr.adapter.connection.enable_repeat_addressing is False
+
+
+def test_use_separate_SerialAdapter():
+    """As a user, I want to be able to supply a self-generated Adapter instance
+    (e.g. to enable serial connection sharing over RS-485/-422)
+    """
+    # note: baudrate, not baud_rate, as this goes to pyserial
+    ser = SerialAdapter(serial.serial_for_url("loop://", baudrate=4800))
+    instr = MultiprotocolInstrument(ser)
+    # don't need visa_library here as this does not go to pyvisa, kwargs are ignored if provided
+    assert instr.adapter.connection.baudrate == 4800
+
+
+def test_separate_adapter_discards_additional_args():
+    """When passing in a separate Adapter instance, all connection-specific args and settings
+    are ignored.
+    """
+    ser = SerialAdapter(serial.serial_for_url("loop://"))
+    instr = MultiprotocolInstrument(ser, baud_rate=1234, wrong_kwarg='fizzbuzz')
+    assert instr.adapter.connection.baudrate == 9600  # default of serial
+
+
+def test_use_separate_VISAAdapter():
+    """As a user, I want to be able to supply my own VISAAdpter with my settings
+    """
+    # User can use their own VISAAdapter
+    ser = VISAAdapter('ASRL1::INSTR', baud_rate=1200, visa_library='@sim')
+    instr = MultiprotocolInstrument(ser)
+    # don't need visa_library here as this does not go to pyvisa, kwargs are ignored if provided
+    assert instr.adapter.connection.baud_rate == 1200
+
+
+def test_incorrect_arg_is_flagged():
+    """As a user or instrument contributor that used an incorrect/invalid (kw)arg,
+    I want to be alerted to that fact.
+    """
+    with pytest.raises(ValueError, match='bitrate'):
+        _ = MultiprotocolInstrument(adapter='ASRL1::INSTR', bitrate=1234, visa_library='@sim')
+
+
+def test_common_kwargs_are_retained():
+    instr1 = MultiprotocolInstrument(adapter='ASRL1::INSTR', visa_library='@sim')
+    assert instr1.adapter.connection.timeout == 1500
+    instr2 = MultiprotocolInstrument(adapter='GPIB::8::INSTR', visa_library='@sim')
+    assert instr2.adapter.connection.timeout == 1500
+
+
+def test_distinct_interface_specific_defaults():
+    """As an instrument implementor, I can easily prescribe default settings
+    that are different between interfaces.
+    """
+    instr1 = MultiprotocolInstrument(adapter='ASRL1::INSTR', visa_library='@sim')
+    assert instr1.adapter.connection.read_termination == '\r\n'
+    instr2 = MultiprotocolInstrument(adapter='GPIB::8::INSTR', visa_library='@sim')
+    assert instr2.adapter.connection.read_termination == '\r'
+
+
+def test_modified_non_signature_kwargs_are_retained():
+    instr1 = MultiprotocolInstrument(adapter='ASRL1::INSTR', timeout=3000, visa_library='@sim')
+    assert instr1.adapter.connection.timeout == 3000
+    instr2 = MultiprotocolInstrument(adapter='GPIB::8::INSTR', timeout=3000, visa_library='@sim')
+    assert instr2.adapter.connection.timeout == 3000
+
+
+def test_override_interface_specific_defaults():
+    """As as user, I want to be able to override interface-specific hardcoded defaults.
+    """
+    instr1 = MultiprotocolInstrument(adapter='ASRL1::INSTR', read_termination='\r',
+                                     visa_library='@sim')
+    assert instr1.adapter.connection.read_termination == '\r'
+    instr2 = MultiprotocolInstrument(adapter='GPIB::8::INSTR', enable_repeat_addressing=True,
+                                     visa_library='@sim')
+    assert instr2.adapter.connection.enable_repeat_addressing is True

--- a/tests/instruments/test_connection_configuration.py
+++ b/tests/instruments/test_connection_configuration.py
@@ -138,6 +138,21 @@ def test_incorrect_arg_is_flagged():
         _ = MultiprotocolInstrument(adapter='ASRL1::INSTR', bitrate=1234, visa_library='@sim')
 
 
+def test_incorrect_interface_type_is_flagged():
+    """As a user or instrument contributor that used an incorrect/invalid interface type,
+    I want to be alerted to that fact.
+    """
+    class WrongInterfaceInstrument(Instrument):
+        def __init__(self, adapter, name="Instrument with incorrect interface name", **kwargs):
+            super().__init__(adapter,
+                             name=name,
+                             arsl={'read_termination': '\r\n'},  # typo here
+                             **kwargs,
+                             )
+    with pytest.raises(ValueError, match='arsl'):
+        _ = WrongInterfaceInstrument(adapter='ASRL1::INSTR', visa_library='@sim')
+
+
 def test_improper_arg_is_flagged():
     """As a user or instrument contributor that used a kwarg that is inappropriate for the present
     connection, I want to be alerted to that fact.

--- a/tests/instruments/test_connection_configuration.py
+++ b/tests/instruments/test_connection_configuration.py
@@ -138,6 +138,15 @@ def test_incorrect_arg_is_flagged():
         _ = MultiprotocolInstrument(adapter='ASRL1::INSTR', bitrate=1234, visa_library='@sim')
 
 
+def test_improper_arg_is_flagged():
+    """As a user or instrument contributor that used a kwarg that is inappropriate for the present
+    connection, I want to be alerted to that fact.
+    """
+    with pytest.raises(ValueError, match='enable_repeat_addressing'):
+        _ = MultiprotocolInstrument(adapter='ASRL1::INSTR', enable_repeat_addressing=True,
+                                    visa_library='@sim')
+
+
 def test_common_kwargs_are_retained():
     instr1 = MultiprotocolInstrument(adapter='ASRL1::INSTR', visa_library='@sim')
     assert instr1.adapter.connection.timeout == 1500


### PR DESCRIPTION
Flexible API for defining connection configuration as per comment https://github.com/pymeasure/pymeasure/pull/536#discussion_r763372161

Connection configuration is now passed fully as kwargs to Instrument.init, and sorted out within VISAAdapter.
Rebased from an earlier iteration, will be completed and documented before review.