### PR TITLE
fix Attocube ANC300 with new SCPI Instrument properties

### DIFF
--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -227,19 +227,20 @@ class ANC300Controller(Instrument):
             includeSCPI = False,
             **kwargs
         )
+        self._axisnames = axisnames
         for i, axis in enumerate(axisnames):
             setattr(self, axis, Axis(self, i+1))
 
     def ground_all(self):
         """ Grounds all axis of the controller. """
-        for attr in dir(self):
+        for attr in self._axisnames:
             attribute = getattr(self, attr)
             if isinstance(attribute, Axis):
                 attribute.mode = 'gnd'
 
     def stop_all(self):
         """ Stop all movements of the axis. """
-        for attr in dir(self):
+        for attr in self._axisnames:
             attribute = getattr(self, attr)
             if isinstance(attribute, Axis):
                 attribute.stop()


### PR DESCRIPTION
in commit bbc0354 the not implemented SCPI properties were changed to emit an error. The properties of an instrument can therefore not be browsed anymore as before which made a code change in the Attocube code necessary.

Likely this iterating over all attributes (`for attr in dir(self)`) was never good as it was implemented before.