### PR TITLE
Add procedure flag for start and end of sequence

### DIFF
--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -899,14 +899,12 @@ class SequencerWidget(QtGui.QWidget):
 
                 procedure = self._parent.make_procedure()
                 procedure.set_parameters(parameters)
-                
                 procedure.first_in_sequence = False
                 procedure.last_in_sequence = False
                 if i == 0:
-                    procedure.last_in_sequence = True
+                    procedure.first_in_sequence = True
                 if i == len(sequence)-1:
                     procedure.last_in_sequence = True
-                
                 self._parent.queue(procedure=procedure)
 
         finally:

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -893,12 +893,20 @@ class SequencerWidget(QtGui.QWidget):
                 "Queuing %d measurements based on the entered sequences." % len(sequence)
             )
 
-            for entry in sequence:
+            for i, entry in enumerate(sequence):
                 QtGui.QApplication.processEvents()
                 parameters = dict(ChainMap(*entry[::-1]))
 
                 procedure = self._parent.make_procedure()
                 procedure.set_parameters(parameters)
+                
+                procedure.first_in_sequence = False
+                procedure.last_in_sequence = False
+                if i == 0:
+                    procedure.last_in_sequence = True
+                if i == len(sequence)-1:
+                    procedure.last_in_sequence = True
+                
                 self._parent.queue(procedure=procedure)
 
         finally:


### PR DESCRIPTION
Hi,

This is a minor change to the process of queuing a sequence which adds a flag to the created `procedure` which tells the procedure whether it is the first or last procedure in a sequence. 

I had independently created the same functionality (although in a much cruder way) that was added with the sequencers, and found that often there is either special setup needed for the instruments at the beginning of a sequence or some shutdown steps which only need to be done at the end of a sequence. As I don't believe there is a way to tell from within a `procedure` whether there are more queued, adding this flag is an easy workaround.

I suppose there is the risk of a name conflict with a user-defined `Parameter`, but the names `first_in_sequence` and `last_in_sequence` seem like unlikely `Parameter` names.

Please let me know if there is an existing way to do this or if there is a possibly better way.