### PR TITLE
Modernise the code base to use Python 3.7 features

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # PyMeasure documentation build configuration file, created by
 # sphinx-quickstart on Mon Apr  6 13:06:00 2015.
@@ -55,8 +54,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'PyMeasure'
-copyright = u'2013-2022, PyMeasure Developers'
+project = 'PyMeasure'
+copyright = '2013-2022, PyMeasure Developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -208,8 +207,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'PyMeasure.tex', u'PyMeasure Documentation',
-   u'PyMeasure Developers', 'manual'),
+  ('index', 'PyMeasure.tex', 'PyMeasure Documentation',
+   'PyMeasure Developers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -238,8 +237,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'pymeasure', u'PyMeasure Documentation',
-     [u'PyMeasure Developers'], 1)
+    ('index', 'pymeasure', 'PyMeasure Documentation',
+     ['PyMeasure Developers'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -252,8 +251,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'PyMeasure', u'PyMeasure Documentation',
-   u'PyMeasure Developers', 'PyMeasure', 'One line description of project.',
+  ('index', 'PyMeasure', 'PyMeasure Documentation',
+   'PyMeasure Developers', 'PyMeasure', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -149,7 +149,7 @@ Below we adapt our previous example to use a ManagedWindow. ::
     class MainWindow(ManagedWindow):
 
         def __init__(self):
-            super(MainWindow, self).__init__(
+            super().__init__(
                 procedure_class=RandomProcedure,
                 inputs=['iterations', 'delay', 'seed'],
                 displays=['iterations', 'delay', 'seed'],
@@ -254,7 +254,7 @@ In order to implement the sequencer into the previous example, only the :class:`
     class MainWindow(ManagedWindow):
 
         def __init__(self):
-            super(MainWindow, self).__init__(
+            super().__init__(
                 procedure_class=TestProcedure,
                 inputs=['iterations', 'delay', 'seed'],
                 displays=['iterations', 'delay', 'seed'],
@@ -304,7 +304,7 @@ An example of such a sequence file is given below, resulting in the sequence sho
 
 .. literalinclude:: gui_sequencer_example_sequence.txt
 
-This file can also be automatically loaded at the start of the program by adding the key-word argument :code:`sequence_file="filename.txt"` to the :code:`super(MainWindow, self).__init__` call, as was done in the example.
+This file can also be automatically loaded at the start of the program by adding the key-word argument :code:`sequence_file="filename.txt"` to the :code:`super().__init__` call, as was done in the example.
 
 Using the directory input
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -319,7 +319,7 @@ Only the MainWindow needs to be modified in order to use this option (modified l
     class MainWindow(ManagedWindow):
 
         def __init__(self):
-            super(MainWindow, self).__init__(
+            super().__init__(
                 procedure_class=TestProcedure,
                 inputs=['iterations', 'delay', 'seed'],
                 displays=['iterations', 'delay', 'seed'],

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -58,7 +58,7 @@ class TestProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=TestProcedure,
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -59,7 +59,7 @@ class TestProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=TestProcedure,
             displays=['iterations', 'delay', 'seed'],
             x_axis='Iteration',
@@ -68,7 +68,7 @@ class MainWindow(ManagedWindow):
         self.setWindowTitle('GUI Example')
 
     def _setup_ui(self):
-        super(MainWindow, self)._setup_ui()
+        super()._setup_ui()
         self.inputs.hide()
         self.inputs = fromUi('gui_custom_inputs.ui')
 

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -103,7 +103,7 @@ class TestProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=TestProcedure,
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -59,7 +59,7 @@ class TestProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=TestProcedure,
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -75,7 +75,7 @@ class TestImageGUI(ManagedImageWindow):
     def __init__(self):
         # Note the new z axis. This can be changed in the GUI. the X and Y axes
         # must be the DATA_COLUMNS corresponding to our special parameters.
-        super(TestImageGUI, self).__init__(
+        super().__init__(
             procedure_class=TestImageProcedure,
             x_axis='X',
             y_axis='Y',

--- a/examples/Current-Voltage Measurements/iv_keithley.py
+++ b/examples/Current-Voltage Measurements/iv_keithley.py
@@ -92,7 +92,7 @@ class IVProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=IVProcedure,
             inputs=[
                 'max_current', 'min_current', 'current_step',

--- a/examples/Current-Voltage Measurements/iv_yokogawa.py
+++ b/examples/Current-Voltage Measurements/iv_yokogawa.py
@@ -92,7 +92,7 @@ class IVProcedure(Procedure):
 class MainWindow(ManagedWindow):
 
     def __init__(self):
-        super(MainWindow, self).__init__(
+        super().__init__(
             procedure_class=IVProcedure,
             inputs=[
                 'max_current', 'min_current', 'current_step',

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -26,7 +26,7 @@ import numpy as np
 from copy import copy
 
 
-class Adapter(object):
+class Adapter:
     """ Base class for Adapter child classes, which adapt between the Instrument
     object and the connection, to allow flexible use of different connection
     techniques.

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -146,7 +146,7 @@ class PrologixAdapter(SerialAdapter):
             address_command = "++addr %d\n" % self.address
             self.connection.write(address_command.encode())
         super().write_binary_values(command, values, **kwargs)
-        self.connection.write('\n'.encode())
+        self.connection.write(b'\n')
 
     def read(self):
         """ Reads the response of the instrument until timeout

--- a/pymeasure/adapters/vxi11.py
+++ b/pymeasure/adapters/vxi11.py
@@ -113,4 +113,4 @@ class VXI11Adapter(Adapter):
         return self.connection.ask_raw(command)
 
     def __repr__(self):
-        return '<VXI11Adapter(host={})>'.format(self.connection.host)
+        return f'<VXI11Adapter(host={self.connection.host})>'

--- a/pymeasure/console.py
+++ b/pymeasure/console.py
@@ -32,7 +32,7 @@ log.addHandler(logging.NullHandler())
 log.warning('not implemented yet')
 
 
-class ProgressBar(object):
+class ProgressBar:
     """ ProgressBar keeps track of the progress, predicts the
     estimated time of arrival (ETA), and formats the bar for
     display in the console

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class Input(object):
+class Input:
     """
     Mix-in class that connects a :mod:`Parameter <.parameters>` object to a GUI
     input box.
@@ -254,7 +254,7 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
             return self._parameter.default
 
     def textFromValue(self, value):
-        string = "{:g}".format(value).replace("e+", "e")
+        string = f"{value:g}".replace("e+", "e")
         string = re.sub(r"e(-?)0*(\d+)", r"e\1\2", string)
         return string
 

--- a/pymeasure/display/listeners.py
+++ b/pymeasure/display/listeners.py
@@ -59,7 +59,7 @@ class QListener(StoppableQThread):
         self.port = port
         self.topic = topic
         self.context = zmq.Context()
-        log.debug("%s has ZMQ Context: %r" % (self.__class__.__name__, self.context))
+        log.debug(f"{self.__class__.__name__} has ZMQ Context: {self.context!r}")
         self.subscriber = self.context.socket(zmq.SUB)
         self.subscriber.connect('tcp://localhost:%d' % port)
         self.subscriber.setsockopt(zmq.SUBSCRIBE, topic.encode())
@@ -81,7 +81,7 @@ class QListener(StoppableQThread):
         return self.poller.poll(self.timeout)
 
     def __repr__(self):
-        return "<%s(port=%s,topic=%s,should_stop=%s)>" % (
+        return "<{}(port={},topic={},should_stop={})>".format(
             self.__class__.__name__, self.port, self.topic, self.should_stop())
 
 

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -46,7 +46,7 @@ class Plotter(StoppableThread):
     """
 
     def __init__(self, results, refresh_time=0.1, linewidth=1):
-        super(Plotter, self).__init__()
+        super().__init__()
         self.results = results
         self.refresh_time = refresh_time
         self.linewidth = linewidth

--- a/pymeasure/display/thread.py
+++ b/pymeasure/display/thread.py
@@ -51,7 +51,7 @@ class StoppableQThread(QtCore.QThread):
         self._should_stop.wait(timeout)
         if not self.should_stop():
             self.stop()
-        super(StoppableQThread, self).wait()
+        super().wait()
 
     def stop(self):
         self._should_stop.set()
@@ -60,5 +60,5 @@ class StoppableQThread(QtCore.QThread):
         return self._should_stop.is_set()
 
     def __repr__(self):
-        return "<%s(should_stop=%s)>" % (
+        return "<{}(should_stop={})>".format(
             self.__class__.__name__, self.should_stop())

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -101,7 +101,7 @@ class PlotFrame(QtGui.QFrame):
         self.timer.start(int(self.refresh_time * 1e3))
 
     def update_coordinates(self, x, y):
-        self.coordinates.setText("(%g, %g)" % (x, y))
+        self.coordinates.setText(f"({x:g}, {y:g})")
 
     def update_curves(self):
         for item in self.plot.items:
@@ -174,7 +174,7 @@ class ImageFrame(PlotFrame):
         self.z_axis_changed.emit(axis)
 
 
-class TabWidget(object):
+class TabWidget:
     """ Utility class to define default implementation for some basic methods.
 
         When defining a widget to be used in subclasses of ManagedWindowBase, users should inherit
@@ -514,7 +514,7 @@ class InputsWidget(QtGui.QWidget):
                 toggle(group_el.currentText())
             else:
                 raise NotImplementedError(
-                    "Grouping based on %s (%s) is not implemented." % (group_name, group_el))
+                    f"Grouping based on {group_name} ({group_el}) is not implemented.")
 
     def toggle_group(self, state, group_name, group):
         for (name, condition, group_state) in group:
@@ -830,7 +830,7 @@ class SequencerWidget(QtGui.QWidget):
 
         item = QtGui.QTreeWidgetItem(parent, [""])
         depth = self._depth_of_child(item)
-        item.setText(0, "{:d}".format(depth))
+        item.setText(0, f"{depth:d}")
 
         self.tree.setItemWidget(item, 1, comboBox)
         self.tree.setItemWidget(item, 2, lineEdit)
@@ -919,7 +919,7 @@ class SequencerWidget(QtGui.QWidget):
 
         content = []
 
-        with open(fileName, "r") as file:
+        with open(fileName) as file:
             content = file.readlines()
 
         pattern = re.compile("([-]+) \"(.*?)\", \"(.*?)\"")
@@ -1057,15 +1057,15 @@ class SequencerWidget(QtGui.QWidget):
                 raise SequenceEvaluationException()
             except SyntaxError:
                 log.error("SyntaxError, likely unbalanced brackets " +
-                          "for parameter '{}', depth {}".format(name, depth))
+                          f"for parameter '{name}', depth {depth}")
                 raise SequenceEvaluationException()
             except ValueError:
                 log.error("ValueError, likely wrong function argument " +
-                          "for parameter '{}', depth {}".format(name, depth))
+                          f"for parameter '{name}', depth {depth}")
                 raise SequenceEvaluationException()
         else:
             log.error("No sequence entered for " +
-                      "for parameter '{}', depth {}".format(name, depth))
+                      f"for parameter '{name}', depth {depth}")
             raise SequenceEvaluationException()
 
         evaluated_string = numpy.array(evaluated_string)

--- a/pymeasure/experiment/experiment.py
+++ b/pymeasure/experiment/experiment.py
@@ -73,7 +73,7 @@ def create_filename(title):
     return filename
 
 
-class Experiment(object):
+class Experiment:
     """ Class which starts logging and creates/runs the results and worker processes.
 
     .. code-block:: python

--- a/pymeasure/experiment/listeners.py
+++ b/pymeasure/experiment/listeners.py
@@ -66,7 +66,7 @@ class Listener(StoppableThread):
         self.port = port
         self.topic = topic
         self.context = zmq.Context()
-        log.debug("%s has ZMQ Context: %r" % (self.__class__.__name__, self.context))
+        log.debug(f"{self.__class__.__name__} has ZMQ Context: {self.context!r}")
         self.subscriber = self.context.socket(zmq.SUB)
         self.subscriber.setsockopt(zmq.SUBSCRIBE, topic.encode())
         self.subscriber.connect('tcp://localhost:%d' % port)
@@ -89,7 +89,7 @@ class Listener(StoppableThread):
         return self.poller.poll(self.timeout * 1000)  # poll timeout is in ms
 
     def __repr__(self):
-        return "<%s(port=%s,topic=%s,should_stop=%s)>" % (
+        return "<{}(port={},topic={},should_stop={})>".format(
             self.__class__.__name__, self.port, self.topic, self.should_stop())
 
 

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -23,7 +23,7 @@
 #
 
 
-class Parameter(object):
+class Parameter:
     """ Encapsulates the information for an experiment parameter
     with information about the name, and units if supplied.
 
@@ -84,7 +84,7 @@ class Parameter(object):
         return str(self._value) if self.is_set() else ''
 
     def __repr__(self):
-        return "<%s(name=%s,value=%s,default=%s)>" % (
+        return "<{}(name={},value={},default={})>".format(
             self.__class__.__name__, self.name, self._value, self.default)
 
 
@@ -144,7 +144,7 @@ class IntegerParameter(Parameter):
         return result
 
     def __repr__(self):
-        return "<%s(name=%s,value=%s,units=%s,default=%s)>" % (
+        return "<{}(name={},value={},units={},default={})>".format(
             self.__class__.__name__, self.name, self._value, self.units, self.default)
 
 
@@ -243,7 +243,7 @@ class FloatParameter(Parameter):
         return result
 
     def __repr__(self):
-        return "<%s(name=%s,value=%s,units=%s,default=%s)>" % (
+        return "<{}(name={},value={},units={},default={})>".format(
             self.__class__.__name__, self.name, self._value, self.units, self.default)
 
 
@@ -311,7 +311,7 @@ class VectorParameter(Parameter):
         return result
 
     def __repr__(self):
-        return "<%s(name=%s,value=%s,units=%s,length=%s)>" % (
+        return "<{}(name={},value={},units={},length={})>".format(
             self.__class__.__name__, self.name, self._value, self.units, self._length)
 
 
@@ -453,7 +453,7 @@ class PhysicalParameter(VectorParameter):
     def __str__(self):
         if not self.is_set():
             return ''
-        result = "%g +/- %g" % (self._value[0], self._value[1])
+        result = f"{self._value[0]:g} +/- {self._value[1]:g}"
         if self.units:
             result += " %s" % self.units
         if self._utype.value is not None:
@@ -461,11 +461,11 @@ class PhysicalParameter(VectorParameter):
         return result
 
     def __repr__(self):
-        return "<%s(name=%s,value=%s,units=%s,uncertaintyType=%s)>" % (
+        return "<{}(name={},value={},units={},uncertaintyType={})>".format(
             self.__class__.__name__, self.name, self._value, self.units, self._utype.value)
 
 
-class Measurable(object):
+class Measurable:
     """ Encapsulates the information for a measurable experiment parameter
     with information about the name, fget function and units if supplied.
     The value property is called when the procedure retrieves a datapoint

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -34,7 +34,7 @@ log = logging.getLogger()
 log.addHandler(logging.NullHandler())
 
 
-class Procedure(object):
+class Procedure:
     """Provides the base class of a procedure to organize the experiment
     execution. Procedures should be run by Workers to ensure that
     asynchronous execution is properly managed.
@@ -71,7 +71,7 @@ class Procedure(object):
         for key in kwargs:
             if key in self._parameters.keys():
                 setattr(self, key, kwargs[key])
-                log.info('Setting parameter %s to %s' % (key, kwargs[key]))
+                log.info(f'Setting parameter {key} to {kwargs[key]}')
         self.gen_measurement()
 
     def gen_measurement(self):
@@ -127,7 +127,7 @@ class Procedure(object):
         for name, parameter in self._parameters.items():
             value = getattr(self, name)
             if value is None:
-                raise NameError("Missing %s '%s' in %s" % (
+                raise NameError("Missing {} '{}' in {}".format(
                     parameter.__class__, name, self.__class__))
 
     def parameter_values(self):
@@ -177,7 +177,7 @@ class Procedure(object):
                 setattr(self, name, self._parameters[name].value)
             else:
                 if except_missing:
-                    raise NameError("Parameter '%s' does not belong to '%s'" % (
+                    raise NameError("Parameter '{}' does not belong to '{}'".format(
                         name, repr(self)))
 
     def startup(self):
@@ -240,7 +240,7 @@ class UnknownProcedure(Procedure):
         raise NotImplementedError("UnknownProcedure can not be run")
 
 
-class ProcedureWrapper(object):
+class ProcedureWrapper:
 
     def __init__(self, procedure):
         self.procedure = procedure

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -104,14 +104,14 @@ def unique_filename(directory, prefix='DATA', suffix='', ext='csv',
         os.makedirs(directory)
     if index:
         i = 1
-        basename = "%s%s" % (prefix, now.strftime(datetimeformat))
+        basename = f"{prefix}{now.strftime(datetimeformat)}"
         basepath = os.path.join(directory, basename)
         filename = "%s_%d%s.%s" % (basepath, i, suffix, ext)
         while os.path.exists(filename):
             i += 1
             filename = "%s_%d%s.%s" % (basepath, i, suffix, ext)
     else:
-        basename = "%s%s%s.%s" % (prefix, now.strftime(datetimeformat), suffix, ext)
+        basename = f"{prefix}{now.strftime(datetimeformat)}{suffix}.{ext}"
         filename = os.path.join(directory, basename)
     return filename
 
@@ -138,13 +138,13 @@ class CSVFormatter(logging.Formatter):
         :type record: dict
         :return: a string
         """
-        return self.delimiter.join('{}'.format(record[x]) for x in self.columns)
+        return self.delimiter.join(f'{record[x]}' for x in self.columns)
 
     def format_header(self):
         return self.delimiter.join(self.columns)
 
 
-class Results(object):
+class Results:
     """ The Results class provides a convenient interface to reading and
     writing data in connection with a :class:`.Procedure` object.
 
@@ -235,7 +235,7 @@ class Results(object):
         h.append("Procedure: <%s>" % procedure)
         h.append("Parameters:")
         for name, parameter in self.parameters.items():
-            h.append("\t%s: %s" % (parameter.name, str(
+            h.append("\t{}: {}".format(parameter.name, str(
                 parameter).encode("unicode_escape").decode("utf-8")))
         h.append("Data:")
         self._header_count = len(h)
@@ -311,7 +311,7 @@ class Results(object):
                 value = parameters[parameter.name]
                 setattr(procedure, name, value)
             else:
-                raise Exception("Missing '%s' parameter when loading '%s' class" % (
+                raise Exception("Missing '{}' parameter when loading '{}' class".format(
                     parameter.name, procedure_class))
 
         procedure.refresh_parameters()  # Enforce update of meta data
@@ -325,7 +325,7 @@ class Results(object):
         header = ""
         header_read = False
         header_count = 0
-        with open(data_filename, 'r') as f:
+        with open(data_filename) as f:
             while not header_read:
                 line = f.readline()
                 if line.startswith(Results.COMMENT):

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -181,7 +181,7 @@ class Worker(StoppableThread):
             self.stop()
 
     def __repr__(self):
-        return "<%s(port=%s,procedure=%s,should_stop=%s)>" % (
+        return "<{}(port={},procedure={},should_stop={})>".format(
             self.__class__.__name__, self.port,
             self.procedure.__class__.__name__,
             self.should_stop()

--- a/pymeasure/instruments/advantest/advantestR3767CG.py
+++ b/pymeasure/instruments/advantest/advantestR3767CG.py
@@ -68,7 +68,7 @@ class AdvantestR3767CG(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(AdvantestR3767CG, self).__init__(
+        super().__init__(
             resourceName,
             "Advantest R3767CG",
             **kwargs

--- a/pymeasure/instruments/agilent/agilent33220A.py
+++ b/pymeasure/instruments/agilent/agilent33220A.py
@@ -70,7 +70,7 @@ class Agilent33220A(Instrument):
     """
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent33220A, self).__init__(
+        super().__init__(
             adapter,
             "Agilent 33220A Arbitrary Waveform generator",
             **kwargs

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -79,7 +79,7 @@ class Agilent33500(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent33500, self).__init__(
+        super().__init__(
             adapter,
             "Agilent 33500 Function/Arbitrary Waveform generator family",
             **kwargs
@@ -381,15 +381,15 @@ class Agilent33500(Instrument):
             separator = ', '
             data_points_str = [str(item) for item in data_points]  # Turn list entries into strings
             data_string = separator.join(data_points_str)  # Join strings with separator
-            print("DATA:ARB:DAC {}, {}".format(arb_name, data_string))
-            self.write("DATA:ARB:DAC {}, {}".format(arb_name, data_string))
+            print(f"DATA:ARB:DAC {arb_name}, {data_string}")
+            self.write(f"DATA:ARB:DAC {arb_name}, {data_string}")
             return
         elif data_format == 'float':
             separator = ', '
             data_points_str = [str(item) for item in data_points]  # Turn list entries into strings
             data_string = separator.join(data_points_str)  # Join strings with separator
-            print("DATA:ARB {}, {}".format(arb_name, data_string))
-            self.write("DATA:ARB {}, {}".format(arb_name, data_string))
+            print(f"DATA:ARB {arb_name}, {data_string}")
+            self.write(f"DATA:ARB {arb_name}, {data_string}")
             return
         elif data_format == 'binary':
             raise NotImplementedError(

--- a/pymeasure/instruments/agilent/agilent33521A.py
+++ b/pymeasure/instruments/agilent/agilent33521A.py
@@ -40,7 +40,7 @@ class Agilent33521A(Agilent33500):
     """
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent33521A, self).__init__(
+        super().__init__(
             adapter,
             **kwargs
         )

--- a/pymeasure/instruments/agilent/agilent34410A.py
+++ b/pymeasure/instruments/agilent/agilent34410A.py
@@ -47,6 +47,6 @@ class Agilent34410A(Instrument):
         "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms")
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent34410A, self).__init__(
+        super().__init__(
             adapter, "HP/Agilent/Keysight 34410A Multimeter", **kwargs
         )

--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -81,7 +81,7 @@ class Agilent34450A(Instrument):
                     self.mode = 'ac voltage'
                 self.write(":configure:freq")
         else:
-            raise ValueError('Value {} is not a supported mode for this device.'.format(value))
+            raise ValueError(f'Value {value} is not a supported mode for this device.')
 
     ###############
     # Current (A) #
@@ -368,7 +368,7 @@ class Agilent34450A(Instrument):
                                         )
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent34450A, self).__init__(
+        super().__init__(
             adapter, "HP/Agilent/Keysight 34450A Multimeter", **kwargs
         )
         # Configuration changes can necessitate up to 8.8 secs (per datasheet)

--- a/pymeasure/instruments/agilent/agilent4156.py
+++ b/pymeasure/instruments/agilent/agilent4156.py
@@ -241,8 +241,8 @@ class Agilent4156(Instrument):
             self.write(":PAGE:SCON:MEAS:SING; *OPC?")
 
         else:
-            self.write(":PAGE:MEAS:SAMP:PER {}".format(period))
-            self.write(":PAGE:MEAS:SAMP:POIN {}".format(points))
+            self.write(f":PAGE:MEAS:SAMP:PER {period}")
+            self.write(f":PAGE:MEAS:SAMP:POIN {points}")
             self.write(":PAGE:SCON:MEAS:SING; *OPC?")
 
     def disable_all(self):
@@ -291,7 +291,7 @@ class Agilent4156(Instrument):
                     'VAR2': self.var2,
                     'VARD': self.vard
                     }
-        with open(config_file, 'r') as stream:
+        with open(config_file) as stream:
             try:
                 instr_settings = json.load(stream)
             except json.JSONDecodeError as e:
@@ -325,9 +325,9 @@ class Agilent4156(Instrument):
                 raise RuntimeError('Maximum of 8 variables allowed')
             else:
                 for name in trace_list:
-                    self.write(":PAGE:DISP:LIST \'{}\'".format(name))
+                    self.write(f":PAGE:DISP:LIST \'{name}\'")
         elif isinstance(trace_list, str):
-            self.write(":PAGE:DISP:LIST \'{}\'".format(trace_list))
+            self.write(f":PAGE:DISP:LIST \'{trace_list}\'")
         else:
             raise TypeError(
                 'Must be a string if only one variable is saved, or else a list if'
@@ -354,9 +354,9 @@ class Agilent4156(Instrument):
                 raise RuntimeError('Maximum of 2 variables allowed')
             else:
                 for name in trace_list:
-                    self.write(":PAGE:DISP:DVAR \'{}\'".format(name))
+                    self.write(f":PAGE:DISP:DVAR \'{name}\'")
         elif isinstance(trace_list, str):
-            self.write(":PAGE:DISP:DVAR \'{}\'".format(trace_list))
+            self.write(f":PAGE:DISP:DVAR \'{trace_list}\'")
         else:
             raise TypeError(
                 'Must be a string if only one variable is saved, or else a list if'
@@ -403,7 +403,7 @@ class Agilent4156(Instrument):
         self.write(":FORM:DATA ASC")
         # recursively get data for each variable
         for i, listvar in enumerate(header):
-            data = self.values(":DATA? \'{}\'".format(listvar))
+            data = self.values(f":DATA? \'{listvar}\'")
             time.sleep(0.01)
             if i == 0:
                 lastdata = data
@@ -446,7 +446,7 @@ class SMU(Instrument):
 
             instr.smu1.channel_mode = "V"
         """
-        value = self.ask(":PAGE:CHAN:{}:MODE?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:MODE?")
         self.check_errors()
         return value
 
@@ -455,7 +455,7 @@ class SMU(Instrument):
         validator = strict_discrete_set
         values = ["V", "I", "COMM"]
         value = validator(mode, values)
-        self.write(":PAGE:CHAN:{0}:MODE {1}".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:MODE {value}")
         self.check_errors()
 
     @property
@@ -468,7 +468,7 @@ class SMU(Instrument):
 
             instr.smu1.channel_function = "VAR1"
         """
-        value = self.ask(":PAGE:CHAN:{}:FUNC?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:FUNC?")
         self.check_errors()
         return value
 
@@ -477,7 +477,7 @@ class SMU(Instrument):
         validator = strict_discrete_set
         values = ["VAR1", "VAR2", "VARD", "CONS"]
         value = validator(function, values)
-        self.write(":PAGE:CHAN:{0}:FUNC {1}".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:FUNC {value}")
         self.check_errors()
 
     @property
@@ -491,7 +491,7 @@ class SMU(Instrument):
             instr.smu1.series_resistance = "10KOHM"
 
         """
-        value = self.ask(":PAGE:CHAN:{}:SRES?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:SRES?")
         self.check_errors()
         return value
 
@@ -500,7 +500,7 @@ class SMU(Instrument):
         validator = strict_discrete_set
         values = ["0OHM", "10KOHM", "100KOHM", "1MOHM"]
         value = validator(sres, values)
-        self.write(":PAGE:CHAN:{0}:SRES {1}".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:SRES {value}")
         self.check_errors()
 
     @property
@@ -511,7 +511,7 @@ class SMU(Instrument):
 
             instr.smu1.disable()
         """
-        self.write(":PAGE:CHAN:{}:DIS".format(self.channel))
+        self.write(f":PAGE:CHAN:{self.channel}:DIS")
         self.check_errors()
 
     @property
@@ -530,9 +530,9 @@ class SMU(Instrument):
 
         """
         if Agilent4156.analyzer_mode.fget(self) == "SWEEP":
-            value = self.ask(":PAGE:MEAS:CONS:{}?".format(self.channel))
+            value = self.ask(f":PAGE:MEAS:CONS:{self.channel}?")
         else:
-            value = self.ask(":PAGE:MEAS:SAMP:CONS:{}?".format(self.channel))
+            value = self.ask(f":PAGE:MEAS:SAMP:CONS:{self.channel}?")
         self.check_errors()
         return value
 
@@ -542,9 +542,9 @@ class SMU(Instrument):
         values = self.__validate_cons()
         value = validator(const_value, values)
         if Agilent4156.analyzer_mode.fget(self) == 'SWEEP':
-            self.write(":PAGE:MEAS:CONS:{0} {1}".format(self.channel, value))
+            self.write(f":PAGE:MEAS:CONS:{self.channel} {value}")
         else:
-            self.write(":PAGE:MEAS:SAMP:CONS:{0} {1}".format(
+            self.write(":PAGE:MEAS:SAMP:CONS:{} {}".format(
                 self.channel, value))
         self.check_errors()
 
@@ -563,10 +563,10 @@ class SMU(Instrument):
             instr.smu1.compliance = 0.1
         """
         if Agilent4156.analyzer_mode.fget(self) == "SWEEP":
-            value = self.ask(":PAGE:MEAS:CONS:{}:COMP?".format(self.channel))
+            value = self.ask(f":PAGE:MEAS:CONS:{self.channel}:COMP?")
         else:
             value = self.ask(
-                ":PAGE:MEAS:SAMP:CONS:{}:COMP?".format(self.channel))
+                f":PAGE:MEAS:SAMP:CONS:{self.channel}:COMP?")
         self.check_errors()
         return value
 
@@ -576,10 +576,10 @@ class SMU(Instrument):
         values = self.__validate_compl()
         value = validator(comp, values)
         if Agilent4156.analyzer_mode.fget(self) == 'SWEEP':
-            self.write(":PAGE:MEAS:CONS:{0}:COMP {1}".format(
+            self.write(":PAGE:MEAS:CONS:{}:COMP {}".format(
                 self.channel, value))
         else:
-            self.write(":PAGE:MEAS:SAMP:CONS:{0}:COMP {1}".format(
+            self.write(":PAGE:MEAS:SAMP:CONS:{}:COMP {}".format(
                 self.channel, value))
         self.check_errors()
 
@@ -594,13 +594,13 @@ class SMU(Instrument):
 
             instr.smu1.voltage_name = "Vbase"
         """
-        value = self.ask("PAGE:CHAN:{}:VNAME?".format(self.channel))
+        value = self.ask(f"PAGE:CHAN:{self.channel}:VNAME?")
         return value
 
     @voltage_name.setter
     def voltage_name(self, vname):
         value = check_current_voltage_name(vname)
-        self.write(":PAGE:CHAN:{0}:VNAME \'{1}\'".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:VNAME \'{value}\'")
 
     @property
     def current_name(self):
@@ -613,13 +613,13 @@ class SMU(Instrument):
 
             instr.smu1.current_name = "Ibase"
         """
-        value = self.ask("PAGE:CHAN:{}:INAME?".format(self.channel))
+        value = self.ask(f"PAGE:CHAN:{self.channel}:INAME?")
         return value
 
     @current_name.setter
     def current_name(self, iname):
         value = check_current_voltage_name(iname)
-        self.write(":PAGE:CHAN:{0}:INAME \'{1}\'".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:INAME \'{value}\'")
 
     def __validate_cons(self):
         """Validates the instrument settings for operation in constant mode.
@@ -668,13 +668,13 @@ class VMU(Instrument):
 
             instr.vmu1.voltage_name = "Vanode"
         """
-        value = self.ask("PAGE:CHAN:{}:VNAME?".format(self.channel))
+        value = self.ask(f"PAGE:CHAN:{self.channel}:VNAME?")
         return value
 
     @voltage_name.setter
     def voltage_name(self, vname):
         value = check_current_voltage_name(vname)
-        self.write(":PAGE:CHAN:{0}:VNAME \'{1}\'".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:VNAME \'{value}\'")
 
     @property
     def disable(self):
@@ -684,7 +684,7 @@ class VMU(Instrument):
 
             instr.vmu1.disable()
         """
-        self.write(":PAGE:CHAN:{}:DIS".format(self.channel))
+        self.write(f":PAGE:CHAN:{self.channel}:DIS")
         self.check_errors()
 
     @property
@@ -693,7 +693,7 @@ class VMU(Instrument):
 
         - Values: :code:`V`, :code:`DVOL`
         """
-        value = self.ask(":PAGE:CHAN:{}:MODE?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:MODE?")
         self.check_errors()
         return value
 
@@ -702,7 +702,7 @@ class VMU(Instrument):
         validator = strict_discrete_set
         values = ["V", "DVOL"]
         value = validator(mode, values)
-        self.write(":PAGE:CHAN:{0}:MODE {1}".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:MODE {value}")
         self.check_errors()
 
 
@@ -726,13 +726,13 @@ class VSU(Instrument):
 
             instr.vsu1.voltage_name = "Ve"
         """
-        value = self.ask("PAGE:CHAN:{}:VNAME?".format(self.channel))
+        value = self.ask(f"PAGE:CHAN:{self.channel}:VNAME?")
         return value
 
     @voltage_name.setter
     def voltage_name(self, vname):
         value = check_current_voltage_name(vname)
-        self.write(":PAGE:CHAN:{0}:VNAME \'{1}\'".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:VNAME \'{value}\'")
 
     @property
     def disable(self):
@@ -742,13 +742,13 @@ class VSU(Instrument):
 
             instr.vsu1.disable()
         """
-        self.write(":PAGE:CHAN:{}:DIS".format(self.channel))
+        self.write(f":PAGE:CHAN:{self.channel}:DIS")
         self.check_errors()
 
     @property
     def channel_mode(self):
         """ Get channel mode of VSU<n>."""
-        value = self.ask(":PAGE:CHAN:{}:MODE?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:MODE?")
         self.check_errors()
         return value
 
@@ -761,9 +761,9 @@ class VSU(Instrument):
             instr.vsu1.constant_value = 0
         """
         if Agilent4156.analyzer_mode.fget(self) == "SWEEP":
-            value = self.ask(":PAGE:MEAS:CONS:{}?".format(self.channel))
+            value = self.ask(f":PAGE:MEAS:CONS:{self.channel}?")
         else:
-            value = self.ask(":PAGE:MEAS:SAMP:CONS:{}?".format(self.channel))
+            value = self.ask(f":PAGE:MEAS:SAMP:CONS:{self.channel}?")
         self.check_errors()
         return value
 
@@ -773,9 +773,9 @@ class VSU(Instrument):
         values = [-200, 200]
         value = validator(const_value, values)
         if Agilent4156.analyzer_mode.fget(self) == 'SWEEP':
-            self.write(":PAGE:MEAS:CONS:{0} {1}".format(self.channel, value))
+            self.write(f":PAGE:MEAS:CONS:{self.channel} {value}")
         else:
-            self.write(":PAGE:MEAS:SAMP:CONS:{0} {1}".format(
+            self.write(":PAGE:MEAS:SAMP:CONS:{} {}".format(
                 self.channel, value))
         self.check_errors()
 
@@ -785,7 +785,7 @@ class VSU(Instrument):
 
         - Value: :code:`VAR1`, :code:`VAR2`, :code:`VARD` or :code:`CONS`.
         """
-        value = self.ask(":PAGE:CHAN:{}:FUNC?".format(self.channel))
+        value = self.ask(f":PAGE:CHAN:{self.channel}:FUNC?")
         self.check_errors()
         return value
 
@@ -794,7 +794,7 @@ class VSU(Instrument):
         validator = strict_discrete_set
         values = ["VAR1", "VAR2", "VARD", "CONS"]
         value = validator(function, values)
-        self.write(":PAGE:CHAN:{0}:FUNC {1}".format(self.channel, value))
+        self.write(f":PAGE:CHAN:{self.channel}:FUNC {value}")
         self.check_errors()
 
 #################
@@ -817,9 +817,9 @@ class VARX(Instrument):
     def channel_mode(self):
         channels = ['SMU1', 'SMU2', 'SMU3', 'SMU4', 'VSU1', 'VSU2']
         for ch in channels:
-            ch_func = self.ask(":PAGE:CHAN:{}:FUNC?".format(ch))
+            ch_func = self.ask(f":PAGE:CHAN:{ch}:FUNC?")
             if ch_func == self.var:
-                ch_mode = self.ask(":PAGE:CHAN:{}:MODE?".format(ch))
+                ch_mode = self.ask(f":PAGE:CHAN:{ch}:MODE?")
         return ch_mode
 
     @property
@@ -830,7 +830,7 @@ class VARX(Instrument):
 
             instr.var1.start = 0
         """
-        value = self.ask(":PAGE:MEAS:{}:STAR?".format(self.var))
+        value = self.ask(f":PAGE:MEAS:{self.var}:STAR?")
         self.check_errors()
         return value
 
@@ -839,7 +839,7 @@ class VARX(Instrument):
         validator = strict_range
         values = valid_iv(self.channel_mode)
         set_value = validator(value, values)
-        self.write(":PAGE:MEAS:{}:STAR {}".format(self.var, set_value))
+        self.write(f":PAGE:MEAS:{self.var}:STAR {set_value}")
         self.check_errors()
 
     @property
@@ -850,7 +850,7 @@ class VARX(Instrument):
 
             instr.var1.stop = 3
         """
-        value = self.ask(":PAGE:MEAS:{}:STOP?".format(self.var))
+        value = self.ask(f":PAGE:MEAS:{self.var}:STOP?")
         self.check_errors()
         return value
 
@@ -859,7 +859,7 @@ class VARX(Instrument):
         validator = strict_range
         values = valid_iv(self.channel_mode)
         set_value = validator(value, values)
-        self.write(":PAGE:MEAS:{}:STOP {}".format(self.var, set_value))
+        self.write(f":PAGE:MEAS:{self.var}:STOP {set_value}")
         self.check_errors()
 
     @property
@@ -870,7 +870,7 @@ class VARX(Instrument):
 
             instr.var1.step = 0.1
         """
-        value = self.ask(":PAGE:MEAS:{}:STEP?".format(self.var))
+        value = self.ask(f":PAGE:MEAS:{self.var}:STEP?")
         self.check_errors()
         return value
 
@@ -879,7 +879,7 @@ class VARX(Instrument):
         validator = strict_range
         values = 2 * valid_iv(self.channel_mode)
         set_value = validator(value, values)
-        self.write(":PAGE:MEAS:{}:STEP {}".format(self.var, set_value))
+        self.write(f":PAGE:MEAS:{self.var}:STEP {set_value}")
         self.check_errors()
 
     @property
@@ -899,7 +899,7 @@ class VARX(Instrument):
         validator = strict_range
         values = 2 * valid_compliance(self.channel_mode)
         set_value = validator(value, values)
-        self.write(":PAGE:MEAS:{}:COMP {}".format(self.var, set_value))
+        self.write(f":PAGE:MEAS:{self.var}:COMP {set_value}")
         self.check_errors()
 
 
@@ -979,9 +979,9 @@ class VARD(Instrument):
     def channel_mode(self):
         channels = ['SMU1', 'SMU2', 'SMU3', 'SMU4', 'VSU1', 'VSU2']
         for ch in channels:
-            ch_func = self.ask(":PAGE:CHAN:{}:FUNC?".format(ch))
+            ch_func = self.ask(f":PAGE:CHAN:{ch}:FUNC?")
             if ch_func == "VARD":
-                ch_mode = self.ask(":PAGE:CHAN:{}:MODE?".format(ch))
+                ch_mode = self.ask(f":PAGE:CHAN:{ch}:MODE?")
         return ch_mode
 
     @property
@@ -1005,7 +1005,7 @@ class VARD(Instrument):
         validator = strict_range
         values = 2 * valid_iv(self.channel_mode)
         value = validator(offset_value, values)
-        self.write(":PAGE:MEAS:VARD:OFFSET {}".format(value))
+        self.write(f":PAGE:MEAS:VARD:OFFSET {value}")
         self.check_errors()
 
     ratio = Instrument.control(
@@ -1041,14 +1041,14 @@ class VARD(Instrument):
         validator = strict_range
         values = 2 * valid_compliance(self.channel_mode)
         set_value = validator(value, values)
-        self.write(":PAGE:MEAS:VARD:COMP {}".format(set_value))
+        self.write(f":PAGE:MEAS:VARD:COMP {set_value}")
         self.check_errors()
 
 
 def check_current_voltage_name(name):
     if (len(name) > 6) or not name[0].isalpha():
         new_name = 'a' + name[:5]
-        log.info("Renaming %s to %s..." % (name, new_name))
+        log.info(f"Renaming {name} to {new_name}...")
         name = new_name
     return name
 

--- a/pymeasure/instruments/agilent/agilent8257D.py
+++ b/pymeasure/instruments/agilent/agilent8257D.py
@@ -250,7 +250,7 @@ class Agilent8257D(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(Agilent8257D, self).__init__(
+        super().__init__(
             adapter, "Agilent 8257D RF Signal Generator", **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilent8722ES.py
+++ b/pymeasure/instruments/agilent/agilent8722ES.py
@@ -74,7 +74,7 @@ class Agilent8722ES(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(Agilent8722ES, self).__init__(
+        super().__init__(
             resourceName,
             "Agilent 8722ES Vector Network Analyzer",
             **kwargs

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -124,7 +124,7 @@ class AgilentB1500(Instrument):
                     # i+1: channels start at 1 not at 0
                 except Exception:
                     raise NotImplementedError(
-                        'Module {} is not implented yet!'.format(module[0]))
+                        f'Module {module[0]} is not implented yet!')
         return out
 
     def initialize_smu(self, channel, smu_type, name):
@@ -194,8 +194,8 @@ class AgilentB1500(Instrument):
         if int(error[0]) == 0:
             return
         else:
-            raise IOError(
-                "Agilent B1500 Error {0}: {1}".format(error[0], error[1]))
+            raise OSError(
+                f"Agilent B1500 Error {error[0]}: {error[1]}")
 
     def check_idle(self):
         """ Check if instrument is idle (``*OPC?``)
@@ -304,7 +304,7 @@ class AgilentB1500(Instrument):
                 self.size = sizes[output_format_str]
             except Exception:
                 raise NotImplementedError(
-                    ("Data Format {0} is not "
+                    ("Data Format {} is not "
                      "implemented so far.").format(output_format_str))
             self.format = output_format_str
             data_names_C = {
@@ -358,7 +358,7 @@ class AgilentB1500(Instrument):
             if name is False:
                 name = ''
             else:
-                name = ' {}'.format(name)
+                name = f' {name}'
 
             status = re.search(
                 r'(?P<number>[0-9]*)(?P<letter>[ A-Z]*)',
@@ -384,7 +384,7 @@ class AgilentB1500(Instrument):
                 if status not in ['N', 'W', 'E']:
                     try:
                         status = self.status[status]
-                        log.info('Agilent B1500{}: {}'.format(name, status))
+                        log.info(f'Agilent B1500{name}: {status}')
                     except KeyError:
                         log_failed()
             else:
@@ -498,7 +498,7 @@ class AgilentB1500(Instrument):
             format_class = classes[output_format_str]
         except KeyError:
             log.error((
-                "Data Format {0} is not implemented "
+                "Data Format {} is not implemented "
                 "so far. Please set appropriate Data Format."
             ).format(output_format_str))
             return
@@ -528,13 +528,15 @@ class AgilentB1500(Instrument):
         self.check_errors()
         if self._smu_names == {}:
             print(
-                ('No SMU names available for formatting, '
-                 'instead channel numbers will be used. '
-                 'Call data_format after initializing all SMUs.'))
+                'No SMU names available for formatting, '
+                'instead channel numbers will be used. '
+                'Call data_format after initializing all SMUs.'
+            )
             log.info(
-                ('No SMU names available for formatting, '
-                 'instead channel numbers will be used. '
-                 'Call data_format after initializing all SMUs.'))
+                'No SMU names available for formatting, '
+                'instead channel numbers will be used. '
+                'Call data_format after initializing all SMUs.'
+            )
         self._data_format = self._data_formatting(
             "FMT%d" % output_format, self._smu_names)
 
@@ -810,13 +812,13 @@ class AgilentB1500(Instrument):
                     raise ValueError(
                         'Bias hold time does not match either '
                         + 'of the two possible specifications: '
-                        + '{} {}'.format(error1, error2))
+                        + f'{error1} {error2}')
             if interval >= 0.0001 + 0.00002 * (n_channels - 1):
                 interval = strict_discrete_range(interval,
                                                  (0, 0.00199), 0.00001)
             else:
                 raise ValueError(
-                    'Sampling interval {} is too short.'.format(interval))
+                    f'Sampling interval {interval} is too short.')
         number = strict_discrete_range(number, (0, int(100001 / n_channels)), 1)
         # ToDo: different restrictions apply for logarithmic sampling!
         hold_base = strict_discrete_range(hold_base, (0, 655.35), 0.01)
@@ -1148,8 +1150,8 @@ class SMU():
             start = float(status[cmd][1])  # current output value
         else:
             log.info(
-                ("{0} in different state. "
-                 "Changing to {1} Source.").format(self.name, source_type))
+                ("{} in different state. "
+                 "Changing to {} Source.").format(self.name, source_type))
             start = 0
 
         # calculate number of points based on maximum stepsize
@@ -1274,8 +1276,9 @@ class SMU():
                 pass
             else:
                 raise ValueError(
-                    ("For Log Sweep Start and Stop Values must "
-                     "have the same polarity."))
+                    "For Log Sweep Start and Stop Values must "
+                    "have the same polarity."
+                )
         steps = strict_range(steps, range(1, 10002))
         # check on comp value not yet implemented
         cmd += ("%d, %d, %d, %g, %g, %g, %g" %

--- a/pymeasure/instruments/agilent/agilentE4408B.py
+++ b/pymeasure/instruments/agilent/agilentE4408B.py
@@ -77,7 +77,7 @@ class AgilentE4408B(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(AgilentE4408B, self).__init__(
+        super().__init__(
             resourceName,
             "Agilent E4408B Spectrum Analyzer",
             **kwargs

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -99,7 +99,7 @@ Select trigger source; accept the values:
                                         values=["HOLD", "INT", "BUS", "EXT"])
 
     def __init__(self, adapter, **kwargs):
-        super(AgilentE4980, self).__init__(
+        super().__init__(
             adapter, "Agilent E4980A/AL LCR meter", **kwargs
         )
         self.timeout = 30000
@@ -160,6 +160,6 @@ Select trigger source; accept the values:
             return read_values[0], int(read_values[1])
         else:
             if time.upper() in ["SHORT", "MED", "LONG"]:
-                self.write(":APER {0}, {1}".format(time, averages))
+                self.write(f":APER {time}, {averages}")
             else:
                 raise Exception("Time must be a string: SHORT, MED, LONG")

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -176,7 +176,7 @@ class Ametek7270(Instrument):
                                 )
 
     def __init__(self, resourceName, **kwargs):
-        super(Ametek7270, self).__init__(
+        super().__init__(
             resourceName,
             "Ametek DSP 7270",
             **kwargs

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -59,7 +59,7 @@ class AMI430(Instrument):
 
     def __init__(self, resourceName, **kwargs):
         kwargs.setdefault('read_termination', '\n')
-        super(AMI430, self).__init__(
+        super().__init__(
             resourceName,
             "AMI superconducting magnet power supply.",
             includeSCPI=True,

--- a/pymeasure/instruments/anapico/apsin12G.py
+++ b/pymeasure/instruments/anapico/apsin12G.py
@@ -63,7 +63,7 @@ class APSIN12G(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(APSIN12G, self).__init__(
+        super().__init__(
             resourceName,
             "Anapico APSIN12G Signal Generator",
             **kwargs

--- a/pymeasure/instruments/andeenhagerling/ah2500a.py
+++ b/pymeasure/instruments/andeenhagerling/ah2500a.py
@@ -44,7 +44,7 @@ class AH2500A(Instrument):
                  write_termination="\n", read_termination="\n",
                  **kwargs):
         kwargs.setdefault("includeSCPI", False)
-        super(AH2500A, self).__init__(
+        super().__init__(
             adapter,
             name or "Andeen Hagerling 2500A Precision Capacitance Bridge",
             write_termination=write_termination,

--- a/pymeasure/instruments/andeenhagerling/ah2700a.py
+++ b/pymeasure/instruments/andeenhagerling/ah2700a.py
@@ -32,7 +32,7 @@ class AH2700A(AH2500A):
     """
     def __init__(self, adapter, name="Andeen Hagerling 2700A Precision Capacitance Bridge",
                  timeout=5000, **kwargs):
-        super(AH2700A, self).__init__(
+        super().__init__(
             adapter,
             name=name,
             timeout=timeout,

--- a/pymeasure/instruments/anritsu/anritsuMG3692C.py
+++ b/pymeasure/instruments/anritsu/anritsuMG3692C.py
@@ -40,7 +40,7 @@ class AnritsuMG3692C(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(AnritsuMG3692C, self).__init__(
+        super().__init__(
             resourceName,
             "Anritsu MG3692C Signal Generator",
             **kwargs

--- a/pymeasure/instruments/anritsu/anritsuMS9710C.py
+++ b/pymeasure/instruments/anritsu/anritsuMS9710C.py
@@ -70,7 +70,7 @@ class AnritsuMS9710C(Instrument):
     def __init__(self, adapter, name="Anritsu MS9710C Optical Spectrum Analyzer", **kwargs):
         """Constructor."""
         self.analysis_mode = None
-        super(AnritsuMS9710C, self).__init__(adapter, name=name, **kwargs)
+        super().__init__(adapter, name=name, **kwargs)
 
     #############
     #  Mappings #
@@ -289,8 +289,8 @@ class AnritsuMS9710C(Instrument):
 
     def read_memory(self, slot="A"):
         """Read the scan saved in a memory slot."""
-        cond_attr = "data_memory_{}_condition".format(slot.lower())
-        data_attr = "data_memory_{}_values".format(slot.lower())
+        cond_attr = f"data_memory_{slot.lower()}_condition"
+        data_attr = f"data_memory_{slot.lower()}_values"
 
         scan = getattr(self, cond_attr)
         wavelengths = np.linspace(scan[0], scan[1], int(scan[2]))
@@ -304,7 +304,7 @@ class AnritsuMS9710C(Instrument):
         res = self.adapter.ask("*OPC?")
         n_attempts = n
         while(res == ''):
-            log.debug("Empty OPC Repsonse. {} remaining".format(n_attempts))
+            log.debug(f"Empty OPC Response. {n_attempts} remaining")
             if n_attempts == 0:
                 break
             n_attempts -= 1
@@ -321,13 +321,13 @@ class AnritsuMS9710C(Instrument):
         log.debug("Waiting for spectrum sweep")
 
         while(self.esr2 != 3 and n > 0):
-            log.debug("Wait for sweep [{}]".format(n))
+            log.debug(f"Wait for sweep [{n}]")
             # log.debug("ESR2: {}".format(esr2))
             sleep(delay)
             n -= 1
 
         if n <= 0:
-            log.warning("Sweep Timeout Occurred ({} s)".format(int(delay * n)))
+            log.warning(f"Sweep Timeout Occurred ({int(delay * n)} s)")
 
     def single_sweep(self, **kwargs):
         """Perform a single sweep and wait for completion."""

--- a/pymeasure/instruments/anritsu/anritsuMS9740A.py
+++ b/pymeasure/instruments/anritsu/anritsuMS9740A.py
@@ -40,7 +40,7 @@ class AnritsuMS9740A(AnritsuMS9710C):
     def __init__(self, adapter, **kwargs):
         """Constructor."""
         self.analysis_mode = None
-        super(AnritsuMS9740A, self).__init__(
+        super().__init__(
             adapter, name="Anritsu MS9740A Optical Spectrum Analyzer", **kwargs)
 
     ####################################

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -58,7 +58,7 @@ truncated_int_array_strict_length = joined_validators(strict_length,
                                                       truncated_int_array)
 
 
-class Axis(object):
+class Axis:
     """ Represents a single open loop axis of the Attocube ANC350
 
     :param axis: axis identifier, integer from 1 to 7

--- a/pymeasure/instruments/bkprecision/bkprecision9130b.py
+++ b/pymeasure/instruments/bkprecision/bkprecision9130b.py
@@ -61,7 +61,7 @@ class BKPrecision9130B(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(BKPrecision9130B, self).__init__(
+        super().__init__(
             adapter, "BK Precision 9130B Source", **kwargs
         )
 

--- a/pymeasure/instruments/comedi.py
+++ b/pymeasure/instruments/comedi.py
@@ -78,7 +78,7 @@ def writeAO(device, channel, voltage, range=None):
     ao.data_write(converter.from_physical(voltage))
 
 
-class SynchronousAI(object):
+class SynchronousAI:
 
     def __init__(self, channels, period, samples):
         self.channels = channels

--- a/pymeasure/instruments/danfysik/adapters.py
+++ b/pymeasure/instruments/danfysik/adapters.py
@@ -38,7 +38,7 @@ class DanfysikAdapter(SerialAdapter):
     """
 
     def __init__(self, port):
-        super(DanfysikAdapter, self).__init__(port, baudrate=9600, timeout=0.5)
+        super().__init__(port, baudrate=9600, timeout=0.5)
 
     def write(self, command):
         """ Overwrites the :func:`SerialAdapter.write <pymeasure.adapters.SerialAdapter.write>`

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -58,7 +58,7 @@ class Danfysik8500(Instrument):
     )
 
     def __init__(self, port):
-        super(Danfysik8500, self).__init__(
+        super().__init__(
             DanfysikAdapter(port),
             "Danfysik 8500 Current Supply",
             includeSCPI=False

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -95,7 +95,7 @@ class SM7045D(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(SM7045D, self).__init__(
+        super().__init__(
             resourceName,
             "Delta Elektronika SM 70-45 D",
             **kwargs

--- a/pymeasure/instruments/edwards/nxds.py
+++ b/pymeasure/instruments/edwards/nxds.py
@@ -39,7 +39,7 @@ class Nxds(Instrument):
                                 values=(0, 1),)
 
     def __init__(self, resourceName, **kwargs):
-        super(Nxds, self).__init__(
+        super().__init__(
             resourceName,
             "Edwards NXDS Vacuum Pump",
             includeSCPI=False,

--- a/pymeasure/instruments/fluke/fluke7341.py
+++ b/pymeasure/instruments/fluke/fluke7341.py
@@ -55,7 +55,7 @@ class Fluke7341(Instrument):
     id = Instrument.measurement("*ver",
                                 """ Read the instrument model """,
                                 preprocess_reply=lambda x: x,
-                                get_process=lambda x: "Fluke,{},NA,{}".format(x[0][4:], x[1])
+                                get_process=lambda x: f"Fluke,{x[0][4:]},NA,{x[1]}"
                                 )
 
     def __init__(self, resource_name, **kwargs):

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -75,7 +75,7 @@ class FWBell5080(Instrument):
     )
 
     def __init__(self, port):
-        super(FWBell5080, self).__init__(
+        super().__init__(
             SerialAdapter(port, 2400, timeout=0.5),
             "F.W. Bell 5080 Handheld Gaussmeter"
         )
@@ -108,19 +108,19 @@ class FWBell5080(Instrument):
         """ Overwrites the :meth:`Instrument.read <pymeasure.instruments.Instrument.read>`
         method to remove the last 2 characters from the output.
         """
-        return super(FWBell5080, self).read()[:-2]
+        return super().read()[:-2]
 
     def ask(self, command):
         """ Overwrites the :meth:`Instrument.ask <pymeasure.instruments.Instrument.ask>`
         method to remove the last 2 characters from the output.
         """
-        return super(FWBell5080, self).ask()[:-2]
+        return super().ask()[:-2]
 
     def values(self, command):
         """ Overwrites the :meth:`Instrument.values <pymeasure.instruments.Instrument.values>`
         method to remove the lastv2 characters from the output.
         """
-        return super(FWBell5080, self).values()[:-2]
+        return super().values()[:-2]
 
     def reset(self):
         """ Resets the instrument. """

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -106,7 +106,7 @@ class HP33120A(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(HP33120A, self).__init__(
+        super().__init__(
             resourceName,
             "Hewlett Packard 33120A Function Generator",
             **kwargs

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -43,7 +43,7 @@ class HP34401A(Instrument):
         "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms")
 
     def __init__(self, resourceName, **kwargs):
-        super(HP34401A, self).__init__(
+        super().__init__(
             resourceName,
             "HP 34401A",
             asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},

--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -152,7 +152,7 @@ class HP3478A(Instrument):
     def __init__(self, resourceName, **kwargs):
         kwargs.setdefault('read_termination', '\r\n')
         kwargs.setdefault('send_end', True)
-        super(HP3478A, self).__init__(
+        super().__init__(
             resourceName,
             "Hewlett-Packard HP3478A",
             includeSCPI=False,

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -60,7 +60,7 @@ class HP8116A(Instrument):
         kwargs.setdefault('read_termination', '\r\n')
         kwargs.setdefault('write_termination', '\r\n')
         kwargs.setdefault('send_end', True)
-        super(HP8116A, self).__init__(
+        super().__init__(
             resourceName,
             'Hewlett-Packard 8116A',
             includeSCPI=False,

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -96,7 +96,7 @@ class DynamicProperty(property):
         self.name = name
 
 
-class Instrument(object):
+class Instrument:
     """ The base class for all Instrument definitions.
 
     It makes use of one of the :py:class:`~pymeasure.adapters.Adapter` classes for communication
@@ -203,7 +203,7 @@ class Instrument(object):
         if hasattr(self, '_special_names'):
             if name in self._special_names:
                 raise AttributeError(
-                    "{} is a reserved variable name and it cannot be read".format(name))
+                    f"{name} is a reserved variable name and it cannot be read")
         return super().__getattribute__(name)
 
     @property
@@ -367,7 +367,7 @@ class Instrument(object):
                     for k, v in values.items():
                         if v == value:
                             return k
-                    raise KeyError("Value {} not found in mapped values".format(value))
+                    raise KeyError(f"Value {value} not found in mapped values")
                 else:
                     raise ValueError(
                         'Values of type `{}` are not allowed '
@@ -519,7 +519,7 @@ class Instrument(object):
             while True:
                 err = self.values("SYST:ERR?")
                 if int(err[0]) != 0:
-                    log.error("{}: {}, {}".format(self.name, err[0], err[1]))
+                    log.error(f"{self.name}: {err[0]}, {err[1]}")
                     errors.append(err)
                 else:
                     break

--- a/pymeasure/instruments/keithley/buffer.py
+++ b/pymeasure/instruments/keithley/buffer.py
@@ -35,7 +35,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class KeithleyBuffer(object):
+class KeithleyBuffer:
     """ Implements the basic buffering capability found in
     many Keithley instruments. """
 

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -437,7 +437,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2000, self).__init__(
+        super().__init__(
             adapter, "Keithley 2000 Multimeter", **kwargs
         )
 
@@ -592,4 +592,4 @@ class Keithley2000(Instrument, KeithleyBuffer):
         :param frequency: A frequency in Hz between 65 Hz and 2 MHz
         :param duration: A time in seconds between 0 and 7.9 seconds
         """
-        self.write(":SYST:BEEP %g, %g" % (frequency, duration))
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -370,7 +370,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
     ####################
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2400, self).__init__(
+        super().__init__(
             adapter, "Keithley 2400 SourceMeter", **kwargs
         )
 
@@ -485,7 +485,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
         :param frequency: A frequency in Hz between 65 Hz and 2 MHz
         :param duration: A time in seconds between 0 and 7.9 seconds
         """
-        self.write(":SYST:BEEP %g, %g" % (frequency, duration))
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")
 
     def triad(self, base_frequency, duration):
         """ Sounds a musical triad using the system beep.

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -362,7 +362,7 @@ class Keithley2450(Instrument, KeithleyBuffer):
     ####################
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2450, self).__init__(
+        super().__init__(
             adapter, "Keithley 2450 SourceMeter", **kwargs
         )
 
@@ -476,7 +476,7 @@ class Keithley2450(Instrument, KeithleyBuffer):
         :param frequency: A frequency in Hz between 65 Hz and 2 MHz
         :param duration: A time in seconds between 0 and 7.9 seconds
         """
-        self.write(":SYST:BEEP %g, %g" % (frequency, duration))
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")
 
     def triad(self, base_frequency, duration):
         """ Sounds a musical triad using the system beep.

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -36,7 +36,7 @@ class Keithley2600(Instrument):
     """Represents the Keithley 2600 series (channel A and B) SourceMeter"""
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2600, self).__init__(
+        super().__init__(
             adapter,
             "Keithley 2600 SourceMeter",
             **kwargs
@@ -59,7 +59,7 @@ class Keithley2600(Instrument):
             message = err[1].replace('"', '')
         else:
             code = message = err[0]
-        log.info("ERROR %s,%s - len %s" % (str(code), str(message), str(len(err))))
+        log.info(f"ERROR {str(code)},{str(message)} - len {str(len(err))}")
         return (code, message)
 
     def check_errors(self):
@@ -74,23 +74,23 @@ class Keithley2600(Instrument):
                 log.warning("Timed out for Keithley 2600 error retrieval.")
 
 
-class Channel(object):
+class Channel:
 
     def __init__(self, instrument, channel):
         self.instrument = instrument
         self.channel = channel
 
     def ask(self, cmd):
-        return float(self.instrument.ask('print(smu%s.%s)' % (self.channel, cmd)))
+        return float(self.instrument.ask(f'print(smu{self.channel}.{cmd})'))
 
     def write(self, cmd):
-        self.instrument.write('smu%s.%s' % (self.channel, cmd))
+        self.instrument.write(f'smu{self.channel}.{cmd}')
 
     def values(self, cmd, **kwargs):
         """ Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.
         """
-        return self.instrument.values('print(smu%s.%s)' % (self.channel, cmd))
+        return self.instrument.values(f'print(smu{self.channel}.{cmd})')
 
     def binary_values(self, cmd, header_bytes=0, dtype=np.float32):
         return self.instrument.binary_values('print(smu%s.%s)' %

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -48,11 +48,11 @@ def clist_validator(value, values):
     if isinstance(value, str):
         clist = [value.strip(" @(),")]
     elif isinstance(value, (int, float)):
-        clist = ["{:d}".format(value)]
+        clist = [f"{value:d}"]
     elif isinstance(value, (list, tuple, np.ndarray, range)):
-        clist = ["{:d}".format(x) for x in value]
+        clist = [f"{x:d}" for x in value]
     else:
-        raise ValueError("Type of value ({}) not valid".format(type(value)))
+        raise ValueError(f"Type of value ({type(value)}) not valid")
 
     # Pad numbers to length (if required)
     clist = [c.rjust(2, "0") for c in clist]
@@ -62,7 +62,7 @@ def clist_validator(value, values):
     for c in clist:
         if int(c) not in values:
             raise ValueError(
-                "Channel number {:g} not valid.".format(value)
+                f"Channel number {value:g} not valid."
             )
 
     # Convert list of strings to clist format
@@ -140,7 +140,7 @@ class Keithley2700(Instrument, KeithleyBuffer):
         self.write(":ROUTe:OPEN:ALL")
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2700, self).__init__(
+        super().__init__(
             adapter, "Keithley 2700 MultiMeter/Switch System", **kwargs
         )
 
@@ -167,7 +167,7 @@ class Keithley2700(Instrument, KeithleyBuffer):
                 channels = range(1, 51)
             else:
                 log.warning(
-                    "Card type %s at slot %s is not yet implemented." % (card, slot)
+                    f"Card type {card} at slot {slot} is not yet implemented."
                 )
                 continue
 
@@ -263,7 +263,7 @@ class Keithley2700(Instrument, KeithleyBuffer):
         :param frequency: A frequency in Hz between 65 Hz and 2 MHz
         :param duration: A time in seconds between 0 and 7.9 seconds
         """
-        self.write(":SYST:BEEP %g, %g" % (frequency, duration))
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")
 
     def triad(self, base_frequency, duration):
         """ Sounds a musical triad using the system beep.

--- a/pymeasure/instruments/keithley/keithley2750.py
+++ b/pymeasure/instruments/keithley/keithley2750.py
@@ -60,7 +60,7 @@ class Keithley2750(Instrument):
                                              get_process=clean_closed_channels)
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley2750, self).__init__(
+        super().__init__(
             adapter, "Keithley 2750 Multimeter/Switch System", **kwargs
         )
 
@@ -70,7 +70,7 @@ class Keithley2750(Instrument):
         :param int channel: 3-digit number for the channel
         :return: None
         """
-        self.write(":ROUTe:MULTiple:OPEN (@{})".format(channel))
+        self.write(f":ROUTe:MULTiple:OPEN (@{channel})")
 
     def close(self, channel):
         """ Closes (connects) the specified channel.
@@ -80,7 +80,7 @@ class Keithley2750(Instrument):
         """
         # Note: if `MULTiple` is omitted, then the specified channel will close,
         # but all other channels will open.
-        self.write(":ROUTe:MULTiple:CLOSe (@{})".format(channel))
+        self.write(f":ROUTe:MULTiple:CLOSe (@{channel})")
 
     def open_all(self):
         """ Opens (disconnects) all the channels on the switch matrix.

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -272,7 +272,7 @@ class Keithley6221(Instrument, KeithleyBuffer):
         self.waveform_function = "arbitrary%d" % location
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley6221, self).__init__(
+        super().__init__(
             adapter, "Keithley 6221 SourceMeter", **kwargs
         )
 
@@ -292,7 +292,7 @@ class Keithley6221(Instrument, KeithleyBuffer):
         :param frequency: A frequency in Hz between 65 Hz and 2 MHz
         :param duration: A time in seconds between 0 and 7.9 seconds
         """
-        self.write(":SYST:BEEP %g, %g" % (frequency, duration))
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")
 
     def triad(self, base_frequency, duration):
         """ Sounds a musical triad using the system beep.

--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -193,7 +193,7 @@ class Keithley6517B(Instrument, KeithleyBuffer):
     ####################
 
     def __init__(self, adapter, **kwargs):
-        super(Keithley6517B, self).__init__(
+        super().__init__(
             adapter, "Keithley 6517B Electrometer/High Resistance Meter",
             **kwargs
         )

--- a/pymeasure/instruments/keysight/keysightDSOX1102G.py
+++ b/pymeasure/instruments/keysight/keysightDSOX1102G.py
@@ -244,7 +244,7 @@ class KeysightDSOX1102G(Instrument):
     BOOLS = {True: 1, False: 0}
 
     def __init__(self, adapter, **kwargs):
-        super(KeysightDSOX1102G, self).__init__(
+        super().__init__(
             adapter, "Keysight DSOX1102G Oscilloscope", **kwargs
         )
         # Account for setup time for timebase_mode, waveform_points_mode

--- a/pymeasure/instruments/keysight/keysightN5767A.py
+++ b/pymeasure/instruments/keysight/keysightN5767A.py
@@ -96,7 +96,7 @@ class KeysightN5767A(Instrument):
         return bool(self._status)
 
     def __init__(self, adapter, **kwargs):
-        super(KeysightN5767A, self).__init__(
+        super().__init__(
             adapter, "Keysight N5767A power supply", **kwargs
         )
         # Set up data transfer format

--- a/pymeasure/instruments/lakeshore/adapters.py
+++ b/pymeasure/instruments/lakeshore/adapters.py
@@ -36,7 +36,7 @@ class LakeShoreUSBAdapter(SerialAdapter):
     """
 
     def __init__(self, port):
-        super(LakeShoreUSBAdapter, self).__init__(
+        super().__init__(
             port,
             baudrate=57600,
             timeout=0.5,
@@ -51,4 +51,4 @@ class LakeShoreUSBAdapter(SerialAdapter):
 
         :param command: SCPI command string to be sent to the instrument
         """
-        super(LakeShoreUSBAdapter, self).write(command + "\n")
+        super().write(command + "\n")

--- a/pymeasure/instruments/lakeshore/lakeshore331.py
+++ b/pymeasure/instruments/lakeshore/lakeshore331.py
@@ -78,7 +78,7 @@ class LakeShore331(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(LakeShore331, self).__init__(
+        super().__init__(
             adapter,
             "Lake Shore 331 Temperature Controller",
             **kwargs

--- a/pymeasure/instruments/lakeshore/lakeshore425.py
+++ b/pymeasure/instruments/lakeshore/lakeshore425.py
@@ -75,7 +75,7 @@ class LakeShore425(Instrument):
     )
 
     def __init__(self, port):
-        super(LakeShore425, self).__init__(
+        super().__init__(
             LakeShoreUSBAdapter(port),
             "LakeShore 425 Gaussmeter",
         )

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -74,7 +74,7 @@ class AxisError(Exception):
         self.message = self.MESSAGES[self.error]
 
     def __str__(self):
-        return "Newport ESP300 axis %s reported the error: %s" % (
+        return "Newport ESP300 axis {} reported the error: {}".format(
             self.axis, self.message)
 
 
@@ -127,7 +127,7 @@ class GeneralError(Exception):
             self.message)
 
 
-class Axis(object):
+class Axis:
     """ Represents an axis of the Newport ESP300 Motor Controller,
     which can have independent parameters from the other axes.
     """
@@ -250,7 +250,7 @@ class ESP300(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(ESP300, self).__init__(
+        super().__init__(
             resourceName,
             "Newport ESP 300 Motion Controller",
             **kwargs

--- a/pymeasure/instruments/ni/daqmx.py
+++ b/pymeasure/instruments/ni/daqmx.py
@@ -40,7 +40,7 @@ except OSError as err:
     log.info('Failed loading the NI-DAQmx library. '
              + 'Check the NI-DAQmx documentation on how to '
              + 'install this external dependency. '
-             + 'OSError: {}'.format(err))
+             + f'OSError: {err}')
     raise
 
 # Data Types
@@ -57,11 +57,11 @@ DAQmx_Val_FiniteSamps = 10178
 DAQmx_Val_GroupByChannel = 1
 
 
-class DAQmx(object):
+class DAQmx:
     """Instrument object for interfacing with NI-DAQmx devices."""
 
     def __init__(self, name, *args, **kwargs):
-        super(DAQmx, self).__init__()
+        super().__init__()
         self.resourceName = name  # NOTE: Device number, e.g. Dev1 or PXI1Slot2
         self.numChannels = 0
         self.numSamples = 0

--- a/pymeasure/instruments/ni/nidaq.py
+++ b/pymeasure/instruments/ni/nidaq.py
@@ -42,7 +42,7 @@ class NIDAQ(Instrument):
 
     def __init__(self, name='Dev1', *args, **kwargs):
         self._daq = ni.NIDAQ(name)
-        super(NIDAQ, self).__init__(
+        super().__init__(
             None,
             "NIDAQ",
             includeSCPI=False,

--- a/pymeasure/instruments/ni/virtualbench.py
+++ b/pymeasure/instruments/ni/virtualbench.py
@@ -49,7 +49,7 @@ except ModuleNotFoundError as err:
     log.info('Failed loading the pyvirtualbench package. '
              + 'Check the NI VirtualBench documentation on how to '
              + 'install this external dependency. '
-             + 'ImportError: {}'.format(err))
+             + f'ImportError: {err}')
     raise
 
 
@@ -143,7 +143,7 @@ class VirtualBench():
         :rtype: (int, float)
         """
         if not isinstance(timestamp, pyvb.Timestamp):
-            raise ValueError("{0} is not a VirtualBench Timestamp object"
+            raise ValueError("{} is not a VirtualBench Timestamp object"
                              .format(timestamp))
         return self.vb.convert_timestamp_to_values(timestamp)
 
@@ -186,7 +186,7 @@ class VirtualBench():
         :rtype: (str, int)
         """
         if not isinstance(names_in, str):
-            raise ValueError("{0} is not a string".format(names_in))
+            raise ValueError(f"{names_in} is not a string")
         return self.vb.collapse_channel_string(names_in)
 
     def expand_channel_string(self, names_in):
@@ -366,7 +366,7 @@ class VirtualBench():
 
             def error(lines=lines):
                 raise ValueError(
-                    "Line specification {0} is not valid!".format(lines))
+                    f"Line specification {lines} is not valid!")
 
             lines = self._vb_handle.expand_channel_string(lines)[0]
             lines = lines.split(', ')
@@ -411,7 +411,7 @@ class VirtualBench():
                 if validate_init is True:
                     if line not in self._line_numbers:
                         raise ValueError(
-                            "Digital Line {} is not initialized".format(line))
+                            f"Digital Line {line} is not initialized")
 
             # create comma separated channel string
             return_lines = ', '.join(return_lines)
@@ -478,8 +478,8 @@ class VirtualBench():
                     strict_discrete_set(value, [True, False])
             except Exception:
                 raise ValueError(
-                    "Data {} is not iterable (list or tuple).".format(data))
-            log.debug("{}: {} output {}.".format(self.name, lines, data))
+                    f"Data {data} is not iterable (list or tuple).")
+            log.debug(f"{self.name}: {lines} output {data}.")
             self.dio.write(lines, data)
 
         def read(self, lines):
@@ -928,7 +928,7 @@ class VirtualBench():
             """
             def error(channel=channel):
                 raise ValueError(
-                    "Channel specification {0} is not valid!".format(channel))
+                    f"Channel specification {channel} is not valid!")
             channels = self._vb_handle.expand_channel_string(channel)[0]
             channels = channels.split(', ')
             return_value = []
@@ -1448,7 +1448,7 @@ class VirtualBench():
         def outputs_enabled(self, enable_outputs):
             enable_outputs = strict_discrete_set(
                 enable_outputs, [True, False])
-            log.info("%s Output %s." % (self.name, enable_outputs))
+            log.info(f"{self.name} Output {enable_outputs}.")
             self.ps.enable_all_outputs(enable_outputs)
 
         @property

--- a/pymeasure/instruments/oxfordinstruments/itc503.py
+++ b/pymeasure/instruments/oxfordinstruments/itc503.py
@@ -195,7 +195,7 @@ class ITC503(Instrument):
                  max_temperature=301, min_temperature=0, **kwargs):
         kwargs.setdefault('read_termination', '\r')
         kwargs.setdefault('send_end', True)
-        super(ITC503, self).__init__(
+        super().__init__(
             resourceName,
             "Oxford ITC503",
             includeSCPI=False,

--- a/pymeasure/instruments/parker/parkerGV6.py
+++ b/pymeasure/instruments/parker/parkerGV6.py
@@ -37,7 +37,7 @@ class ParkerGV6(Instrument):
     degrees_per_count = 0.00045  # 90 deg per 200,000 count
 
     def __init__(self, port):
-        super(ParkerGV6, self).__init__(
+        super().__init__(
             SerialAdapter(port, 9600, timeout=0.5),
             "Parker GV6 Motor Controller"
         )

--- a/pymeasure/instruments/razorbill/razorbillRP100.py
+++ b/pymeasure/instruments/razorbill/razorbillRP100.py
@@ -108,7 +108,7 @@ class razorbillRP100(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(razorbillRP100, self).__init__(
+        super().__init__(
             adapter, "Razorbill RP100 Piezo Stack Powersupply", **kwargs
         )
         self.timeout = 20

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -51,7 +51,7 @@ class FSL(Instrument):
     """
 
     def __init__(self, resourceName, **kwargs):
-        super(FSL, self).__init__(
+        super().__init__(
             resourceName, "Rohde&Schwarz FSL", includeSCPI=True, **kwargs
         )
 

--- a/pymeasure/instruments/rohdeschwarz/sfm.py
+++ b/pymeasure/instruments/rohdeschwarz/sfm.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class Sound_Channel(object):
+class Sound_Channel:
     """
     Class object for the two sound channels
 
@@ -203,7 +203,7 @@ class SFM(Instrument):
     """
 
     def __init__(self, resourceName, **kwargs):
-        super(SFM, self).__init__(
+        super().__init__(
             resourceName,
             "Rohde&Schwarz SFM",
             includeSCPI=True,

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -367,7 +367,7 @@ class DSP7265(Instrument):
             ])
 
         # remove all possible duplicates
-        quantities = list(set([q.lower() for q in quantities]))
+        quantities = list({q.lower() for q in quantities})
 
         bits = 0
         for q in quantities:

--- a/pymeasure/instruments/srs/sg380.py
+++ b/pymeasure/instruments/srs/sg380.py
@@ -51,7 +51,7 @@ class SG380(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(SG380, self).__init__(
+        super().__init__(
             resourceName,
             "Stanford Research Systems SG380 RF Signal Generator",
             **kwargs

--- a/pymeasure/instruments/srs/sr510.py
+++ b/pymeasure/instruments/srs/sr510.py
@@ -79,7 +79,7 @@ class SR510(Instrument):
 
     def __init__(self, resourceName, **kwargs):
         kwargs.setdefault('write_termination', '\r')
-        super(SR510, self).__init__(
+        super().__init__(
             resourceName,
             "Stanford Research Systems SR510 Lock-in amplifier",
             includeSCPI=False,

--- a/pymeasure/instruments/srs/sr570.py
+++ b/pymeasure/instruments/srs/sr570.py
@@ -30,7 +30,7 @@ from pymeasure.instruments.validators import strict_discrete_set, \
 class SR570(Instrument):
 
     def __init__(self, resourceName, **kwargs):
-        super(SR570, self).__init__(
+        super().__init__(
             resourceName,
             "Stanford Research Systems SR570 Lock-in amplifier",
             **kwargs

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -325,7 +325,7 @@ class SR830(Instrument):
     adc4 = aux_in_4
 
     def __init__(self, resourceName, **kwargs):
-        super(SR830, self).__init__(
+        super().__init__(
             resourceName,
             "Stanford Research Systems SR830 Lock-in amplifier",
             **kwargs

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -560,7 +560,7 @@ class SR860(Instrument):
     )
 
     def __init__(self, resourceName, **kwargs):
-        super(SR860, self).__init__(
+        super().__init__(
             resourceName,
             "Stanford Research Systems SR860 Lock-in amplifier",
             **kwargs

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -26,7 +26,7 @@ from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 
-class Channel(object):
+class Channel:
     SHAPES = {
         "sinusoidal": "SIN",
         "square": "SQU",
@@ -198,7 +198,7 @@ class AFG3152C(Instrument):
     """
 
     def __init__(self, adapter, **kwargs):
-        super(AFG3152C, self).__init__(
+        super().__init__(
             adapter,
             "Tektronix AFG3152C arbitrary function generator",
             **kwargs

--- a/pymeasure/instruments/tektronix/tds2000.py
+++ b/pymeasure/instruments/tektronix/tds2000.py
@@ -30,7 +30,7 @@ class TDS2000(Instrument):
     and provides a high-level for interacting with the instrument
     """
 
-    class Measurement(object):
+    class Measurement:
 
         SOURCE_VALUES = ['CH1', 'CH2', 'MATH']
 
@@ -56,9 +56,9 @@ class TDS2000(Instrument):
         @source.setter
         def source(self, value):
             if value in TDS2000.Measurement.SOURCE_VALUES:
-                self.parent.write("%sSOU %s" % (self.preamble, value))
+                self.parent.write(f"{self.preamble}SOU {value}")
             else:
-                raise ValueError("Invalid source ('%s') provided to %s" % (
+                raise ValueError("Invalid source ('{}') provided to {}".format(
                                  self.parent, value))
 
         @property
@@ -68,9 +68,9 @@ class TDS2000(Instrument):
         @type.setter
         def type(self, value):
             if value in TDS2000.Measurement.TYPE_VALUES:
-                self.parent.write("%sTYP %s" % (self.preamble, value))
+                self.parent.write(f"{self.preamble}TYP {value}")
             else:
-                raise ValueError("Invalid type ('%s') provided to %s" % (
+                raise ValueError("Invalid type ('{}') provided to {}".format(
                                  self.parent, value))
 
         @property
@@ -80,13 +80,13 @@ class TDS2000(Instrument):
         @unit.setter
         def unit(self, value):
             if value in TDS2000.Measurement.UNIT_VALUES:
-                self.parent.write("%sUNI %s" % (self.preamble, value))
+                self.parent.write(f"{self.preamble}UNI {value}")
             else:
-                raise ValueError("Invalid unit ('%s') provided to %s" % (
+                raise ValueError("Invalid unit ('{}') provided to {}".format(
                                  self.parent, value))
 
     def __init__(self, resourceName, **kwargs):
-        super(TDS2000, self).__init__(
+        super().__init__(
             resourceName,
             "Tektronix TDS 2000 Oscilliscope",
             **kwargs

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -35,7 +35,7 @@ class ThorlabsPM100USB(Instrument):
     """Represents Thorlabs PM100USB powermeter."""
 
     def __init__(self, adapter, **kwargs):
-        super(ThorlabsPM100USB, self).__init__(
+        super().__init__(
             adapter, "ThorlabsPM100USB powermeter", **kwargs
         )
         self.timout = 3000
@@ -68,7 +68,7 @@ class ThorlabsPM100USB(Instrument):
             value = truncated_range(
                 value, [self._wavelength_min, self._wavelength_max]
             )
-            self.write("SENSE:CORR:WAV {}".format(value))
+            self.write(f"SENSE:CORR:WAV {value}")
         else:
             raise AttributeError(
                 f"{self.sensor_name} does not allow setting the wavelength."
@@ -96,7 +96,7 @@ class ThorlabsPM100USB(Instrument):
         """Get sensor info and write flags."""
         response = self.values("SYST:SENSOR:IDN?")
         if response[0] == "no sensor":
-            raise IOError("No sensor connected.")
+            raise OSError("No sensor connected.")
         self.sensor_name = response[0]
         self.sensor_sn = response[1]
         self.sensor_cal_msg = response[2]

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -33,7 +33,7 @@ class ThorlabsPro8000(Instrument):
     STATUS = ['ON', 'OFF']
 
     def __init__(self, resourceName, **kwargs):
-        super(ThorlabsPro8000, self).__init__(
+        super().__init__(
             resourceName,
             "Thorlabs Pro 8000",
             **kwargs
@@ -56,7 +56,7 @@ class ThorlabsPro8000(Instrument):
     )
     LDCPolarity = Instrument.control(
         ":LIMC:SET?", ":LIMC:SET %s",
-        """Set laser diode polarity. Allowed values are: {}""".format(LDC_POLARITIES),
+        f"""Set laser diode polarity. Allowed values are: {LDC_POLARITIES}""",
         validator=strict_discrete_set,
         values=LDC_POLARITIES,
         map_values=False
@@ -72,7 +72,7 @@ class ThorlabsPro8000(Instrument):
 
     # Code for TED-xxxx daughter boards (TEC driver)
     TEDStatus = Instrument.control(":TEC?", ":TEC %s",
-                                   """Set TEC status. Allowed values are: {}""".format(STATUS),
+                                   f"""Set TEC status. Allowed values are: {STATUS}""",
                                    validator=strict_discrete_set,
                                    values=STATUS,
                                    map_values=False)

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -173,7 +173,7 @@ def joined_validators(*validators):
                 return validator(value, vals)
             except (ValueError, TypeError):
                 pass
-        raise ValueError("Value of {} does not match any of the joined validators".format(value))
+        raise ValueError(f"Value of {value} does not match any of the joined validators")
 
     return validate
 

--- a/pymeasure/instruments/yokogawa/yokogawa7651.py
+++ b/pymeasure/instruments/yokogawa/yokogawa7651.py
@@ -132,7 +132,7 @@ class Yokogawa7651(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(Yokogawa7651, self).__init__(
+        super().__init__(
             adapter, "Yokogawa 7651 Programmable DC Source", **kwargs
         )
 
@@ -218,4 +218,4 @@ class Yokogawa7651(Instrument):
         self.ramp_to_current(0.0, steps=25)
         self.source_current = 0.0
         self.disable_source()
-        super(Yokogawa7651, self).shutdown()
+        super().shutdown()

--- a/pymeasure/instruments/yokogawa/yokogawags200.py
+++ b/pymeasure/instruments/yokogawa/yokogawags200.py
@@ -87,7 +87,7 @@ class YokogawaGS200(Instrument):
     )
 
     def __init__(self, adapter, **kwargs):
-        super(YokogawaGS200, self).__init__(
+        super().__init__(
             adapter, "Yokogawa GS200 Source", **kwargs
         )
 

--- a/pymeasure/process.py
+++ b/pymeasure/process.py
@@ -62,5 +62,5 @@ class StoppableProcess(context.Process):
         return self._should_stop.is_set()
 
     def __repr__(self):
-        return "<%s(should_stop=%s)>" % (
+        return "<{}(should_stop={})>".format(
             self.__class__.__name__, self.should_stop())

--- a/pymeasure/thread.py
+++ b/pymeasure/thread.py
@@ -76,5 +76,5 @@ class StoppableThread(Thread):
         return self._should_stop.is_set()
 
     def __repr__(self):
-        return "<%s(should_stop=%s)>" % (
+        return "<{}(should_stop={})>".format(
             self.__class__.__name__, self.should_stop())

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -44,9 +44,9 @@ def test_adapter_write(test_input, expected):
 
 @pytest.mark.parametrize(
     "test_input,expected", [
-        ([1, 2, 3], prefix.encode() + b'OUTP#13\x01\x02\x03' + "\n".encode()),
+        ([1, 2, 3], prefix.encode() + b'OUTP#13\x01\x02\x03' + b"\n"),
         ([43, 27, 10, 13, 97, 98, 99], prefix.encode() +
-         b'OUTP#17\x1b\x2b\x1b\x1b\x1b\x0a\x1b\x0dabc' + "\n".encode())
+         b'OUTP#17\x1b\x2b\x1b\x1b\x1b\x0a\x1b\x0dabc' + b"\n")
     ]
 )
 def test_adapter_write_binary_values(test_input, expected):


### PR DESCRIPTION
This mainly starts using f-strings and .format instead of the % notation, and removes superfluous super() arguments.

Used the pyupgrade tool to do this: `find . -name '*.py' -exec pyupgrade --py37-plus {} +`