### PR TITLE
add docs for naming derived instruments

### DIFF
--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -698,7 +698,9 @@ In the above example, :code:`MultimeterA` and :code:`MultimeterB` use a differen
 Naming derived instruments
 **************************
 
-When deriving an instrument from an existing implementation, you might want to give separate names to any derived instrument. Two possible schemes for this are the following: 
+When deriving an instrument from an existing implementation, the derived instrument typically has a different name (e.g. another model number).
+In addition, a user might want to give instantiated instruments setup-specific names (e.g. `Helmholtz_coil_driver` instead of `GenericPSU123`), especially if there is more than one device of the same make in a setup.
+To accomodate these needs, there are two similar ways: 
 
 .. code-block:: python
 

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -698,7 +698,7 @@ In the above example, :code:`MultimeterA` and :code:`MultimeterB` use a differen
 Naming derived instruments
 **************************
 
-When deriving an instrument from an existing implementation, you might want to give separate names to any derived instrument. The suggested scheme for this is the following: 
+When deriving an instrument from an existing implementation, you might want to give separate names to any derived instrument. Two possible schemes for this are the following: 
 
 .. code-block:: python
     class BaseClass:

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -701,6 +701,7 @@ Naming derived instruments
 When deriving an instrument from an existing implementation, you might want to give separate names to any derived instrument. Two possible schemes for this are the following: 
 
 .. code-block:: python
+
     class BaseClass:
         def __init__(self, adapter, name=None, **kwargs):
             #...

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -693,3 +693,29 @@ Another use case involves maintaining compatibility between instruments with com
 
 In the above example, :code:`MultimeterA` and :code:`MultimeterB` use a different command to read the voltage, but the rest of the behaviour is identical.
 :code:`MultimeterB` can be defined subclassing :code:`MultimeterA` and just implementing the difference.
+
+
+Naming derived instruments
+**************************
+
+When deriving an instrument from an existing implementation, you might want to give separate names to any derived instrument. The suggested scheme for this is the following: 
+
+.. code-block:: python
+    class BaseClass:
+        def __init__(self, adapter, name=None, **kwargs):
+            #...
+            super().__init__(
+                adapter,
+                name or "Base instrument name",
+                **kwargs,
+            )
+
+    class DerivedClass(BaseClass):
+        # or do the name handling like this
+        def __init__(self, adapter, name="Derived instrument name", **kwargs):
+            #...
+            super().__init__(
+                adapter,
+                name=name,
+                **kwargs,
+            )


### PR DESCRIPTION
This naming scheme was suggested by @bilderbuchi in CasperSchippers/pymeasure#5 for derived classes. I think it would be good to add this info to the docs, since it has now become easier (in general) to derive instruments from each other. 

Possibly I could also put this heading one level higher, introducing a new heading for "Deriving new instruments from existing ones" and then rearrange the docs about how to use the dynamic properties from above to be included in the section about derived instruments. 
Apart from that, it might be good to change the minimal implementation shown in the docs, including the `name=Extreme 5000` as default in the `__init__`, to facilitate deriving from those classes in the future. 

Also, since I am not very familiar with Sphinx and the automatic generation of the docs, I wonder whether in the docs for derived instruments we will see all the properties and functions, and not just those which are implemented in the derived class? 
