### PR TITLE
Modified navigation of ManagedWindow directory widget

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,3 +44,4 @@ Andreas Maeder
 Bastian Leykauf
 Matthew Delaney
 Marco von Rosenberg
+Jack Van Sambeek

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -51,3 +51,4 @@ The following developers have contributed to the PyMeasure package:
 | Bastian Leykauf
 | Matthew Delaney
 | Marco von Rosenberg
+| Jack Van Sambeek

--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -309,12 +309,13 @@ This file can also be automatically loaded at the start of the program by adding
 Using the directory input
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to add a directory input in order to choose where the experiment's result will be saved. This option is activated by passing a boolean key-word argument :code:`directory_input` during the :class:`~pymeasure.display.windows.ManagedWindow` init. The value of the directory can be retrieved using the property :code:`directory`.
+It is possible to add a directory input in order to choose where the experiment's result will be saved. This option is activated by passing a boolean key-word argument :code:`directory_input` during the :class:`~pymeasure.display.windows.ManagedWindow` init. The value of the directory can be retrieved and set using the property :code:`directory`.
+A default directory can be defined by setting the :code:`directory` property in the MainWindow init.
 
 Only the MainWindow needs to be modified in order to use this option (modified lines are marked).
 
 .. code-block:: python
-   :emphasize-lines: 10,15,16
+   :emphasize-lines: 10,13,16,17
 
     class MainWindow(ManagedWindow):
 
@@ -325,12 +326,13 @@ Only the MainWindow needs to be modified in order to use this option (modified l
                 displays=['iterations', 'delay', 'seed'],
                 x_axis='Iteration',
                 y_axis='Random Number',
-                directory_input=True,                                # Added line
+                directory_input=True,                                # Added line, enables directory widget
             )
             self.setWindowTitle('GUI Example')
+            self.directory = r'C:/Path/to/default/directory'         # Added line, sets default directory for GUI load
 
         def queue(self):
-            directory = self.directory
+            directory = self.directory                               # Added line
             filename = unique_filename(directory)                    # Modified line
 
             results = Results(procedure, filename)

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -1099,8 +1099,16 @@ class DirectoryLineEdit(QtGui.QLineEdit):
 
         self.addAction(browse_action, QtGui.QLineEdit.TrailingPosition)
 
+    def _get_starting_directory(self):
+        current_text = self.text()
+        if current_text != '' and QtCore.QDir(current_text).exists():
+            return current_text
+
+        else:
+            return '/'
+
     def browse_triggered(self):
-        path = QtGui.QFileDialog.getExistingDirectory(self, 'Directory', '/')
+        path = QtGui.QFileDialog.getExistingDirectory(self, 'Directory', self._get_starting_directory())
         if path != '':
             self.setText(path)
 

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -187,7 +187,6 @@ class ManagedWindowBase(QtGui.QMainWindow):
         code:`Load sequence` button
     :param inputs_in_scrollarea: boolean that display or hide a scrollbar to the input area
     :param directory_input: specify, if present, where the experiment's result will be saved.
-    :param default_directory_path: specify default path for directory input
     :param hide_groups: a boolean controlling whether parameter groups are hidden (True, default)
         or disabled/grayed-out (False) when the group conditions are not met.
     """
@@ -205,7 +204,6 @@ class ManagedWindowBase(QtGui.QMainWindow):
                  sequence_file=None,
                  inputs_in_scrollarea=False,
                  directory_input=False,
-                 default_directory_path='',
                  hide_groups=True,
                  ):
 
@@ -221,7 +219,6 @@ class ManagedWindowBase(QtGui.QMainWindow):
         self.sequence_file = sequence_file
         self.inputs_in_scrollarea = inputs_in_scrollarea
         self.directory_input = directory_input
-        self.default_directory_path = default_directory_path
         self.log = logging.getLogger(log_channel)
         self.log_level = log_level
         log.setLevel(log_level)
@@ -239,8 +236,6 @@ class ManagedWindowBase(QtGui.QMainWindow):
             self.directory_label = QtGui.QLabel(self)
             self.directory_label.setText('Directory')
             self.directory_line = DirectoryLineEdit(parent=self)
-            if self.default_directory_path:
-                self.directory_line.setText(self.default_directory_path)
 
         self.queue_button = QtGui.QPushButton('Queue', self)
         self.queue_button.clicked.connect(self._queue)
@@ -624,6 +619,13 @@ class ManagedWindowBase(QtGui.QMainWindow):
         if not self.directory_input:
             raise ValueError("No directory input in the ManagedWindow")
         return self.directory_line.text()
+
+    @directory.setter
+    def directory(self, value):
+        if not self.directory_input:
+            raise ValueError("No directory input in the ManagedWindow")
+
+        self.directory_line.setText(value)
 
 
 class ManagedWindow(ManagedWindowBase):

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -625,7 +625,7 @@ class ManagedWindowBase(QtGui.QMainWindow):
         if not self.directory_input:
             raise ValueError("No directory input in the ManagedWindow")
 
-        self.directory_line.setText(value)
+        self.directory_line.setText(str(value))
 
 
 class ManagedWindow(ManagedWindowBase):

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -187,6 +187,7 @@ class ManagedWindowBase(QtGui.QMainWindow):
         code:`Load sequence` button
     :param inputs_in_scrollarea: boolean that display or hide a scrollbar to the input area
     :param directory_input: specify, if present, where the experiment's result will be saved.
+    :param default_directory_path: specify default path for directory input
     :param hide_groups: a boolean controlling whether parameter groups are hidden (True, default)
         or disabled/grayed-out (False) when the group conditions are not met.
     """
@@ -204,6 +205,7 @@ class ManagedWindowBase(QtGui.QMainWindow):
                  sequence_file=None,
                  inputs_in_scrollarea=False,
                  directory_input=False,
+                 default_directory_path='',
                  hide_groups=True,
                  ):
 
@@ -219,6 +221,7 @@ class ManagedWindowBase(QtGui.QMainWindow):
         self.sequence_file = sequence_file
         self.inputs_in_scrollarea = inputs_in_scrollarea
         self.directory_input = directory_input
+        self.default_directory_path = default_directory_path
         self.log = logging.getLogger(log_channel)
         self.log_level = log_level
         log.setLevel(log_level)
@@ -236,6 +239,8 @@ class ManagedWindowBase(QtGui.QMainWindow):
             self.directory_label = QtGui.QLabel(self)
             self.directory_label.setText('Directory')
             self.directory_line = DirectoryLineEdit(parent=self)
+            if self.default_directory_path:
+                self.directory_line.setText(self.default_directory_path)
 
         self.queue_button = QtGui.QPushButton('Queue', self)
         self.queue_button.clicked.connect(self._queue)


### PR DESCRIPTION
This is a very small PR with two changes to the `ManagedWindow`'s directory widget:
1. The QFileDialog now opens at the currently entered directory (if there is one)
2. Added the kwarg `default_directory_path` to `ManagedWindowBase`. If provided, the directory widget will be populated with this path when the GUI loads

Please let me know if you'd like me to make any changes.