### PR TITLE
Add Rohde&Schwarz HMP4040 power supply.

### DIFF
--- a/docs/api/instruments/rohdeschwarz/hmp.rst
+++ b/docs/api/instruments/rohdeschwarz/hmp.rst
@@ -1,0 +1,7 @@
+######################################
+R&S HMP4040 Power Supply
+######################################
+
+.. autoclass:: pymeasure.instruments.rohdeschwarz.hmp.HMP4040
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/rohdeschwarz/index.rst
+++ b/docs/api/instruments/rohdeschwarz/index.rst
@@ -11,3 +11,4 @@ This section contains specific documentation on the Rohde & Schwarz instruments 
 
    sfm
    fsl
+   hmp

--- a/pymeasure/instruments/rohdeschwarz/__init__.py
+++ b/pymeasure/instruments/rohdeschwarz/__init__.py
@@ -24,3 +24,4 @@
 
 from .sfm import SFM
 from .fsl import FSL
+from .hmp import HMP4040

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -190,24 +190,17 @@ class HMP4040(Instrument):
         map_values=True,
     )
 
-    # The following commands are for making it easier to change selected the
-    # selected channel and activate/deactivate them.
+    # The following commands are for making it easier to change the selected
+    # channels and activate/deactivate them.
 
-    def activate_channel(self, channel):
-        """Activate a channel."""
+    def set_channel_state(self, channel: int, state: bool):
+        """
+        Set the state of the channel to active (True) or inactive (False).
+        """
         # Save current selected channel before switching.
         selected_channel = self.selected_channel
         self.selected_channel = channel
-        self.selected_channel_active = True
-        # Restore previously selected channel.
-        self.selected_channel = selected_channel
-
-    def deactivate_channel(self, channel):
-        """Deactivate a channel."""
-        # Save current selected channel before switching.
-        selected_channel = self.selected_channel
-        self.selected_channel = channel
-        self.selected_channel_active = False
+        self.selected_channel_active = state
         # Restore previously selected channel.
         self.selected_channel = selected_channel
 

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -61,7 +61,7 @@ class HMP4040(Instrument):
     # System Setting Commands -------------------------------------------------
 
     def beep(self):
-        """Return a single beep immediately."""
+        """Emit a single beep immediately."""
         self.write("SYST:BEEP")
 
     control = Instrument.setting(
@@ -125,11 +125,11 @@ class HMP4040(Instrument):
         values=[0, 32.050],
     )
 
-    def voltage_up(self):
+    def step_voltage_up(self):
         """Increase voltage by one step."""
         self.write("VOLT UP")
 
-    def voltage_down(self):
+    def step_voltage_down(self):
         """Decrease voltage by one step."""
         self.write("VOLT DOWN")
 
@@ -161,11 +161,11 @@ class HMP4040(Instrument):
         "CURR:STEP?", "CURR:STEP %s", "Current step in A."
     )
 
-    def current_up(self):
+    def step_current_up(self):
         """Increase current by one step."""
         self.write("CURR UP")
 
-    def current_down(self):
+    def step_current_down(self):
         """Decreases current by one step."""
         self.write("CURR DOWN")
 
@@ -187,7 +187,7 @@ class HMP4040(Instrument):
         map_values=True,
     )
 
-    output_on = Instrument.control(
+    output_enabled = Instrument.control(
         "OUTP:GEN?",
         "OUTP:GEN %s",
         "Set the output on or off or check the output status.",
@@ -219,11 +219,11 @@ class HMP4040(Instrument):
     # Convenience functions to make turning on/off the output more natural.
     def turn_output_on(self):
         """Turn output on."""
-        self.output_on = True
+        self.output_enabled = True
 
     def turn_output_off(self):
         """Turn output off."""
-        self.output_on = False
+        self.output_enabled = False
 
     # Measurement Commands ----------------------------------------------------
 
@@ -253,7 +253,7 @@ class HMP4040(Instrument):
         "ARB:REP?",
         "ARB:REP %s",
         "Number of repetitions (0...255). If 0 is entered, the sequence is"
-        "repeated infinitely.",
+        "repeated indefinitely.",
         validator=strict_discrete_set,
         values=range(256),
         get_process=lambda x: int(x),

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -87,7 +87,7 @@ class HMP4040(Instrument):
         "Selected channel.",
         validator=strict_discrete_set,
         values=[1, 2, 3, 4],
-        get_process=lambda x: int(x),
+        cast=int
     )
 
     # Voltage Settings --------------------------------------------------------
@@ -242,7 +242,7 @@ class HMP4040(Instrument):
         "repeated indefinitely.",
         validator=strict_discrete_set,
         values=range(256),
-        get_process=lambda x: int(x),
+        cast=int,
     )
 
     def load_sequence(self, slot):

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -251,7 +251,10 @@ class HMP4040(Instrument):
         self.write(f"ARB:REST {slot}")
 
     def save_sequence(self, slot):
-        """Save the sequence to internal memory (slot 1, 2 or 3)."""
+        """
+        Save the sequence defined in the sequence property to internal memory
+        (slot 1, 2 or 3).
+        """
         slot = strict_discrete_set(slot, [1, 2, 3])
         self.write(f"ARB:SAVE {slot}")
 

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -257,11 +257,15 @@ class HMP4040(Instrument):
         self.write(f"ARB:START {channel}")
 
     def stop_sequence(self, channel):
-        """Stop the sequence of the selected channel."""
+        """Stop the sequence defined in the sequence property of the selected
+        channel."""
         channel = strict_discrete_set(channel, [1, 2, 3, 4])
         self.write(f"ARB:STOP {channel}")
 
     def transfer_sequence(self, channel):
-        """Transfer the defined sequence to the selected channel."""
+        """
+        Transfer the sequence defined in the sequence property to the selected
+        channel.
+        """
         channel = strict_discrete_set(channel, [1, 2, 3, 4])
         self.write(f"ARB:TRAN {channel}")

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -23,33 +23,30 @@
 #
 
 import logging
+from typing import List
 
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import (
-    strict_discrete_set,
-    truncated_range,
-)
+from pymeasure.instruments.validators import (strict_discrete_set,
+                                              truncated_range)
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def process_sequence(sequence):
+def process_sequence(sequence: List[float]) -> str:
     """
     Check and prepare sequence data.
 
-    The form of the sequence data is Voltage1, Current1, Time1, Voltage2,
-    Current2, Time2,..., Voltage128, Current128, Time128 with voltages in V,
+    The form of the sequence data is "Voltage1,Current1,Time1,Voltage2,
+    Current2,Time2,...,Voltage128,Current128,Time128" with voltages in V,
     currents in A, and times in s. Dwell times are between 0.06 and 10 s.
     """
     if not len(sequence) % 3 == 0:
         raise ValueError("Sequence must contain multiple of 3 values.")
-    if any(t > 10 or t < 0.06 for t in sequence[2:3:-1]):
+    if any(t > 10 or t < 0.06 for t in sequence[2::3]):
         raise ValueError("Dwell times must be between 0.06 and 10 s.")
     # turn sequence data into a string
-    sequence = str(sequence).strip('[](){}')
-    sequence.replace(" ", "")
-    print(sequence)
+    sequence = ",".join(str(s) for s in sequence)
     return sequence
 
 

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -96,7 +96,7 @@ class HMP4040(Instrument):
         "VOLT?", "VOLT %s", "Output voltage in V. Increment 0.001 V."
     )
 
-    minimum_voltage = Instrument.measurement(
+    min_voltage = Instrument.measurement(
         "VOLT? MIN", "Minimum voltage in V."
     )
 

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -43,7 +43,7 @@ def process_sequence(sequence):
     :type sequence: list of float
     :return: Sequence data in the form "Voltage1,Current1,Time1,Voltage2,
         Current2,Time2,...,Voltage128,Current128,Time128"
-    :rtpye: str
+    :rtype: str
     """
     if not len(sequence) % 3 == 0:
         raise ValueError("Sequence must contain multiple of 3 values.")

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -23,7 +23,6 @@
 #
 
 import logging
-from typing import List
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import (strict_discrete_set,
@@ -33,13 +32,18 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def process_sequence(sequence: List[float]) -> str:
+def process_sequence(sequence):
     """
     Check and prepare sequence data.
 
-    The form of the sequence data is "Voltage1,Current1,Time1,Voltage2,
-    Current2,Time2,...,Voltage128,Current128,Time128" with voltages in V,
-    currents in A, and times in s. Dwell times are between 0.06 and 10 s.
+    :param sequence: Sequence data, in the form [voltage1, current1, time1,
+        voltage2, current2, time2, ..., voltage128, current128, time128] with
+        voltages in V, currents in A, and times in s. Dwell times are between
+        0.06 and 10 s.
+    :type sequence: list of float
+    :return: Sequence data in the form "Voltage1,Current1,Time1,Voltage2,
+        Current2,Time2,...,Voltage128,Current128,Time128"
+    :rtpye: str
     """
     if not len(sequence) % 3 == 0:
         raise ValueError("Sequence must contain multiple of 3 values.")
@@ -194,9 +198,15 @@ class HMP4040(Instrument):
     # The following commands are for making it easier to change the selected
     # channels and activate/deactivate them.
 
-    def set_channel_state(self, channel: int, state: bool):
+    def set_channel_state(self, channel, state):
         """
-        Set the state of the channel to active (True) or inactive (False).
+        Set the state of the channel to active or inactive.
+
+        :param channel: Channel number to set the state of.
+        :type channel: int
+        :param state: State of the channel, i.e. True for active, False for
+            inactive.
+        :type state: bool
         """
         # Save current selected channel before switching.
         selected_channel = self.selected_channel

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -53,9 +53,9 @@ def process_sequence(sequence: List[float]) -> str:
 class HMP4040(Instrument):
     """Represents a Rohde&Schwarz HMP4040 power supply."""
 
-    def __init__(self, resourceName, **kwargs):
+    def __init__(self, resourceName, name="Rohde&Schwarz HMP4040", **kwargs):
         super().__init__(
-            resourceName, "Rohde&Schwarz HMP4040", includeSCPI=True, **kwargs
+            resourceName, name, includeSCPI=True, **kwargs
         )
 
     # System Setting Commands -------------------------------------------------

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -53,9 +53,10 @@ def process_sequence(sequence: List[float]) -> str:
 class HMP4040(Instrument):
     """Represents a Rohde&Schwarz HMP4040 power supply."""
 
-    def __init__(self, resourceName, name="Rohde&Schwarz HMP4040", **kwargs):
+    def __init__(self, adapter, **kwargs):
+        kwargs.setdefault("name", "Rohde&Schwarz HMP4040")
         super().__init__(
-            resourceName, name, includeSCPI=True, **kwargs
+            adapter, includeSCPI=True, **kwargs
         )
 
     # System Setting Commands -------------------------------------------------

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -1,0 +1,288 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import (
+    strict_discrete_set,
+    truncated_range,
+)
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+def process_sequence(sequence):
+    """
+    Check and prepare sequence data.
+
+    The form of the sequence data is Voltage1, Current1, Time1, Voltage2,
+    Current2, Time2,..., Voltage128, Current128, Time128 with voltages in V,
+    currents in A, and times in s. Dwell times are between 0.06 and 10 s.
+    """
+    if not len(sequence) % 3 == 0:
+        raise ValueError("Sequence must contain multiple of 3 values.")
+    if any(t > 10 or t < 0.06 for t in sequence[2:3:-1]):
+        raise ValueError("Dwell times must be between 0.06 and 10 s.")
+    # turn sequence data into a string
+    sequence = str(sequence).strip('[](){}')
+    sequence.replace(" ", "")
+    print(sequence)
+    return sequence
+
+
+class HMP4040(Instrument):
+    """Represents a Rohde&Schwarz HMP4040 power supply."""
+
+    def __init__(self, resourceName, **kwargs):
+        super().__init__(
+            resourceName, "Rohde&Schwarz HMP4040", includeSCPI=True, **kwargs
+        )
+
+    # System Setting Commands -------------------------------------------------
+
+    def beep(self):
+        """Return a single beep immediately."""
+        self.write("SYST:BEEP")
+
+    control = Instrument.setting(
+        "SYST:%s",
+        """
+        Enables manual front panel ('LOC'), remote ('REM') or manual/remote
+        control('MIX') control or locks the the front panel control ('RWL').
+        """,
+        validator=strict_discrete_set,
+        values=["LOC", "REM", "MIX", "RWL"],
+    )
+
+    version = Instrument.measurement(
+        "SYST:VERS?",
+        "The SCPI version the instrument's command set complies with.",
+    )
+
+    # Channel Selection Commands ----------------------------------------------
+
+    selected_channel = Instrument.control(
+        "INST:NSEL?",
+        "INST:NSEL %s",
+        "Selected channel.",
+        validator=strict_discrete_set,
+        values=[1, 2, 3, 4],
+        get_process=lambda x: int(x),
+    )
+
+    # Implemented as a more natural way of selecting a channel.
+    def select_channel(self, channel):
+        """Select a channel."""
+        self.selected_channel = channel
+
+    # Voltage Settings --------------------------------------------------------
+
+    voltage = Instrument.control(
+        "VOLT?", "VOLT %s", "Output voltage in V. Increment 0.001 V."
+    )
+
+    minimum_voltage = Instrument.measurement(
+        "VOLT? MIN", "Minimum voltage in V."
+    )
+
+    max_voltage = Instrument.measurement(
+        "VOLT? MAX", "Maximum voltage in V."
+    )
+
+    def voltage_to_min(self):
+        """Set voltage of the selected channel to its minimum value."""
+        self.write("VOLT MIN")
+
+    def voltage_to_max(self):
+        """Set voltage of the selected channel to its maximum value."""
+        self.write("VOLT MAX")
+
+    voltage_step = Instrument.control(
+        "VOLT:STEP?",
+        "VOLT:STEP %s",
+        "Voltage step in V. Default 1 V.",
+        validator=truncated_range,
+        values=[0, 32.050],
+    )
+
+    def voltage_up(self):
+        """Increase voltage by one step."""
+        self.write("VOLT UP")
+
+    def voltage_down(self):
+        """Decrease voltage by one step."""
+        self.write("VOLT DOWN")
+
+    # Current Settings --------------------------------------------------------
+
+    current = Instrument.control(
+        "CURR?",
+        "CURR %s",
+        "Output current in A. Range depends on instrument type.",
+    )
+
+    min_current = Instrument.measurement(
+        "CURR? MIN", "Minimum current in A."
+    )
+
+    max_current = Instrument.measurement(
+        "CURR? MAX", "Maximum current in A."
+    )
+
+    def current_to_min(self):
+        """Set current of the selected channel to its minimum value."""
+        self.write("CURR MIN")
+
+    def current_to_max(self):
+        """Set current of the selected channel to its maximum value."""
+        self.write("CURR MAX")
+
+    current_step = Instrument.control(
+        "CURR:STEP?", "CURR:STEP %s", "Current step in A."
+    )
+
+    def current_up(self):
+        """Increase current by one step."""
+        self.write("CURR UP")
+
+    def current_down(self):
+        """Decreases current by one step."""
+        self.write("CURR DOWN")
+
+    # Combined Voltage And Current Settings -----------------------------------
+
+    voltage_and_current = Instrument.control(
+        "APPL?",
+        "APPL %s, %s",
+        "Output voltage (V) and current (A).",
+    )
+
+    # Output Settings ---------------------------------------------------------
+
+    selected_channel_active = Instrument.control(
+        "OUTP:SEL?",
+        "OUTPUT:SEL %s",
+        "Set the selected channel to active or inactive or check its status.",
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    output_on = Instrument.control(
+        "OUTP:GEN?",
+        "OUTP:GEN %s",
+        "Set the output on or off or check the output status.",
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    # The following commands are for making it easier to change selected the
+    # selected channel and activate/deactivate them.
+
+    def activate_channel(self, channel):
+        """Activate a channel."""
+        # Save current selected channel before switching.
+        selected_channel = self.selected_channel
+        self.selected_channel = channel
+        self.selected_channel_active = True
+        # Restore previously selected channel.
+        self.selected_channel = selected_channel
+
+    def deactivate_channel(self, channel):
+        """Deactivate a channel."""
+        # Save current selected channel before switching.
+        selected_channel = self.selected_channel
+        self.selected_channel = channel
+        self.selected_channel_active = False
+        # Restore previously selected channel.
+        self.selected_channel = selected_channel
+
+    # Convenience functions to make turning on/off the output more natural.
+    def turn_output_on(self):
+        """Turn output on."""
+        self.output_on = True
+
+    def turn_output_off(self):
+        """Turn output off."""
+        self.output_on = False
+
+    # Measurement Commands ----------------------------------------------------
+
+    measured_voltage = Instrument.measurement(
+        "MEAS:VOLT?", "Measured voltage in V."
+    )
+
+    measured_current = Instrument.measurement(
+        "MEAS:CURR?", "Measured current in A."
+    )
+
+    # Arbitrary Sequence Commands ---------------------------------------------
+
+    def clear_sequence(self, channel):
+        """Clear the sequence of the selected channel."""
+        channel = strict_discrete_set(channel, [1, 2, 3, 4])
+        self.write(f"ARB:CLEAR {channel}")
+
+    sequence = Instrument.setting(
+        "ARB:DATA %s",
+        "Define sequence of triplets of voltage (V), current (A) and dwell "
+        "time (s).",
+        set_process=process_sequence,
+    )
+
+    repetitions = Instrument.control(
+        "ARB:REP?",
+        "ARB:REP %s",
+        "Number of repetitions (0...255). If 0 is entered, the sequence is"
+        "repeated infinitely.",
+        validator=strict_discrete_set,
+        values=range(256),
+        get_process=lambda x: int(x),
+    )
+
+    def load_sequence(self, slot):
+        """Load a saved waveform from internal memory (slot 1, 2 or 3)."""
+        slot = strict_discrete_set(slot, [1, 2, 3])
+        self.write(f"ARB:REST {slot}")
+
+    def save_sequence(self, slot):
+        """Save the sequence to internal memory (slot 1, 2 or 3)."""
+        slot = strict_discrete_set(slot, [1, 2, 3])
+        self.write(f"ARB:SAVE {slot}")
+
+    def start_sequence(self, channel):
+        """Start the sequence of the selected channel."""
+        channel = strict_discrete_set(channel, [1, 2, 3, 4])
+        self.write(f"ARB:START {channel}")
+
+    def stop_sequence(self, channel):
+        """Stop the sequence of the selected channel."""
+        channel = strict_discrete_set(channel, [1, 2, 3, 4])
+        self.write(f"ARB:STOP {channel}")
+
+    def transfer_sequence(self, channel):
+        """Transfer the defined sequence to the selected channel."""
+        channel = strict_discrete_set(channel, [1, 2, 3, 4])
+        self.write(f"ARB:TRAN {channel}")

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -61,7 +61,7 @@ class HMP4040(Instrument):
     # System Setting Commands -------------------------------------------------
 
     def beep(self):
-        """Emit a single beep immediately."""
+        """Emit a single beep from the instrument."""
         self.write("SYST:BEEP")
 
     control = Instrument.setting(

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -64,7 +64,7 @@ class HMP4040(Instrument):
         """Emit a single beep from the instrument."""
         self.write("SYST:BEEP")
 
-    control = Instrument.setting(
+    control_method = Instrument.setting(
         "SYST:%s",
         """
         Enables manual front panel ('LOC'), remote ('REM') or manual/remote

--- a/pymeasure/instruments/rohdeschwarz/hmp.py
+++ b/pymeasure/instruments/rohdeschwarz/hmp.py
@@ -90,11 +90,6 @@ class HMP4040(Instrument):
         get_process=lambda x: int(x),
     )
 
-    # Implemented as a more natural way of selecting a channel.
-    def select_channel(self, channel):
-        """Select a channel."""
-        self.selected_channel = channel
-
     # Voltage Settings --------------------------------------------------------
 
     voltage = Instrument.control(
@@ -215,15 +210,6 @@ class HMP4040(Instrument):
         self.selected_channel_active = False
         # Restore previously selected channel.
         self.selected_channel = selected_channel
-
-    # Convenience functions to make turning on/off the output more natural.
-    def turn_output_on(self):
-        """Turn output on."""
-        self.output_enabled = True
-
-    def turn_output_off(self):
-        """Turn output off."""
-        self.output_enabled = False
 
     # Measurement Commands ----------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,39 @@
 # THE SOFTWARE.
 #
 
-import pytest  # noqa
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--instrument-present",
+        action="store_true",
+        default=False,
+        help="""Run tests that need an instrument.
+                Provide the resource name via --resource-name."""
+    )
+    parser.addoption(
+        "--resource-name",
+        action="store",
+        default=None,
+        dest="resource_name",
+        help="""Pass a resource name for an instrument needed for a test.
+                See also --instrument-present."""
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", """needs_instrument:
+                        mark test that needs an instrument to be present."""
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--instrument-present"):
+        skipper = pytest.mark.skip(
+            reason="Only run when --instrument-present is given"
+            )
+        for item in items:
+            if "needs_instrument" in item.keywords:
+                item.add_marker(skipper)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,39 +22,4 @@
 # THE SOFTWARE.
 #
 
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--instrument-present",
-        action="store_true",
-        default=False,
-        help="""Run tests that need an instrument.
-                Provide the resource name via --resource-name."""
-    )
-    parser.addoption(
-        "--resource-name",
-        action="store",
-        default=None,
-        dest="resource_name",
-        help="""Pass a resource name for an instrument needed for a test.
-                See also --instrument-present."""
-    )
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", """needs_instrument:
-                        mark test that needs an instrument to be present."""
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    if not config.getoption("--instrument-present"):
-        skipper = pytest.mark.skip(
-            reason="Only run when --instrument-present is given"
-            )
-        for item in items:
-            if "needs_instrument" in item.keywords:
-                item.add_marker(skipper)
+import pytest  # noqa

--- a/tests/instruments/rohdeschwarz/test_hmp.py
+++ b/tests/instruments/rohdeschwarz/test_hmp.py
@@ -1,0 +1,45 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from pymeasure.instruments.rohdeschwarz.hmp import process_sequence
+
+
+def test_process_sequence():
+    "Test `process_sequence` function."
+
+    # Sequence must contain multiple of 3 values.
+    with pytest.raises(ValueError):
+        process_sequence([1.0, 1.0, 1.0, 2.0, 2.0])
+
+    # Dwell times must be between 0.06 and 10 s.
+    with pytest.raises(ValueError):
+        process_sequence([1.0, 1.0, 1.0, 2.0, 2.0, 0.05])
+
+    with pytest.raises(ValueError):
+        process_sequence([1.0, 1.0, 1.0, 2.0, 2.0, 10.1])
+
+    # Test with a valid sequence.
+    sequence = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert process_sequence(sequence) == "1.0,2.0,3.0,4.0,5.0,6.0"

--- a/tests/instruments/rohdeschwarz/test_hmp.py
+++ b/tests/instruments/rohdeschwarz/test_hmp.py
@@ -22,14 +22,12 @@
 # THE SOFTWARE.
 #
 
-from time import sleep
-
 import pytest
-from pymeasure.instruments.rohdeschwarz.hmp import HMP4040, process_sequence
+from pymeasure.instruments.rohdeschwarz.hmp import process_sequence
 
 
 def test_process_sequence():
-    """Test `process_sequence` function."""
+    "Test `process_sequence` function."
 
     # Sequence must contain multiple of 3 values.
     with pytest.raises(ValueError):
@@ -45,78 +43,3 @@ def test_process_sequence():
     # Test with a valid sequence.
     sequence = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert process_sequence(sequence) == "1.0,2.0,3.0,4.0,5.0,6.0"
-
-
-# The following tests need a real instrument. ---------------------------------
-
-@pytest.fixture(scope="session")
-def hmp4040(pytestconfig):
-    """
-    Return a HMP4040 instrument. The resource name can be specified via the
-    --resource-name command line option. Make sure --instrument-present is also
-    set in order to run the tests.
-    """
-    resource_name = pytestconfig.getoption("resource_name")
-    hmp4040 = HMP4040(resource_name)
-    hmp4040.reset()
-    return hmp4040
-
-
-@pytest.mark.needs_instrument
-def test_beep(hmp4040):
-    """Test emission of a beep from the instrument."""
-    hmp4040.beep()
-    hmp4040.reset()
-
-
-@pytest.mark.needs_instrument
-def test_voltage_limits(hmp4040):
-    """Test minimum and maximum voltages."""
-    hmp4040.voltage_to_min()
-    assert hmp4040.voltage == hmp4040.min_voltage
-    hmp4040.voltage_to_max()
-    assert hmp4040.voltage == hmp4040.max_voltage
-    hmp4040.reset()
-
-
-@pytest.mark.needs_instrument
-def test_voltage_stepping(hmp4040):
-    """Test stepping voltages up and down."""
-    hmp4040.voltage = 0.0
-    hmp4040.step_voltage_up()
-    assert hmp4040.voltage == hmp4040.voltage_step
-    hmp4040.step_voltage_down()
-    assert hmp4040.voltage == 0.0
-    hmp4040.reset()
-
-
-@pytest.mark.needs_instrument
-def test_channel_state(hmp4040):
-    """Test activation and deactivation of channels."""
-    hmp4040.selected_channel = 1
-    assert hmp4040.selected_channel == 1
-
-    hmp4040.set_channel_state(2, True)
-    # check that the selected channel is reset to 2.
-    assert hmp4040.selected_channel == 1
-    hmp4040.reset()
-
-
-@pytest.mark.needs_instrument
-def test_sequence(hmp4040):
-    """Test sequence execution."""
-    # NOTE: There are actually no assertations in this test. But it is possible
-    # to check the sequence execution by looking at display of the instrument.
-    hmp4040.selected_channel == 1
-    hmp4040.voltage = 0.0
-    hmp4040.sequence = [1.0, 1.0, 1.0, 2.0, 2.0, 1.0]
-    hmp4040.repetitions = 0
-    hmp4040.transfer_sequence(1)
-    hmp4040.output_enabled = True
-    hmp4040.selected_channel_active = True
-    hmp4040.start_sequence(1)
-    sleep(4)
-    hmp4040.stop_sequence(1)
-    hmp4040.output_enabled = False
-    hmp4040.clear_sequence(1)
-    hmp4040.reset()

--- a/tests/instruments/rohdeschwarz/test_hmp.py
+++ b/tests/instruments/rohdeschwarz/test_hmp.py
@@ -22,12 +22,14 @@
 # THE SOFTWARE.
 #
 
+from time import sleep
+
 import pytest
-from pymeasure.instruments.rohdeschwarz.hmp import process_sequence
+from pymeasure.instruments.rohdeschwarz.hmp import HMP4040, process_sequence
 
 
 def test_process_sequence():
-    "Test `process_sequence` function."
+    """Test `process_sequence` function."""
 
     # Sequence must contain multiple of 3 values.
     with pytest.raises(ValueError):
@@ -43,3 +45,78 @@ def test_process_sequence():
     # Test with a valid sequence.
     sequence = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert process_sequence(sequence) == "1.0,2.0,3.0,4.0,5.0,6.0"
+
+
+# The following tests need a real instrument. ---------------------------------
+
+@pytest.fixture(scope="session")
+def hmp4040(pytestconfig):
+    """
+    Return a HMP4040 instrument. The resource name can be specified via the
+    --resource-name command line option. Make sure --instrument-present is also
+    set in order to run the tests.
+    """
+    resource_name = pytestconfig.getoption("resource_name")
+    hmp4040 = HMP4040(resource_name)
+    hmp4040.reset()
+    return hmp4040
+
+
+@pytest.mark.needs_instrument
+def test_beep(hmp4040):
+    """Test emission of a beep from the instrument."""
+    hmp4040.beep()
+    hmp4040.reset()
+
+
+@pytest.mark.needs_instrument
+def test_voltage_limits(hmp4040):
+    """Test minimum and maximum voltages."""
+    hmp4040.voltage_to_min()
+    assert hmp4040.voltage == hmp4040.min_voltage
+    hmp4040.voltage_to_max()
+    assert hmp4040.voltage == hmp4040.max_voltage
+    hmp4040.reset()
+
+
+@pytest.mark.needs_instrument
+def test_voltage_stepping(hmp4040):
+    """Test stepping voltages up and down."""
+    hmp4040.voltage = 0.0
+    hmp4040.step_voltage_up()
+    assert hmp4040.voltage == hmp4040.voltage_step
+    hmp4040.step_voltage_down()
+    assert hmp4040.voltage == 0.0
+    hmp4040.reset()
+
+
+@pytest.mark.needs_instrument
+def test_channel_state(hmp4040):
+    """Test activation and deactivation of channels."""
+    hmp4040.selected_channel = 1
+    assert hmp4040.selected_channel == 1
+
+    hmp4040.set_channel_state(2, True)
+    # check that the selected channel is reset to 2.
+    assert hmp4040.selected_channel == 1
+    hmp4040.reset()
+
+
+@pytest.mark.needs_instrument
+def test_sequence(hmp4040):
+    """Test sequence execution."""
+    # NOTE: There are actually no assertations in this test. But it is possible
+    # to check the sequence execution by looking at display of the instrument.
+    hmp4040.selected_channel == 1
+    hmp4040.voltage = 0.0
+    hmp4040.sequence = [1.0, 1.0, 1.0, 2.0, 2.0, 1.0]
+    hmp4040.repetitions = 0
+    hmp4040.transfer_sequence(1)
+    hmp4040.output_enabled = True
+    hmp4040.selected_channel_active = True
+    hmp4040.start_sequence(1)
+    sleep(4)
+    hmp4040.stop_sequence(1)
+    hmp4040.output_enabled = False
+    hmp4040.clear_sequence(1)
+    hmp4040.reset()

--- a/tests/instruments/rohdeschwarz/test_hmp_instrument.py
+++ b/tests/instruments/rohdeschwarz/test_hmp_instrument.py
@@ -1,0 +1,98 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from time import sleep
+
+import pytest
+from pymeasure.instruments.rohdeschwarz.hmp import HMP4040
+
+pytest.skip('Only works with connected hardware', allow_module_level=True)
+
+# change the resource name to the address of your instrument
+RESOURCE = "ASRL5::INSTR"
+
+
+@pytest.fixture(scope="session")
+def hmp4040():
+    """
+    Return a HMP4040 instrument.
+    """
+    hmp4040 = HMP4040(RESOURCE)
+    hmp4040.reset()
+    return hmp4040
+
+
+def test_beep(hmp4040):
+    """Test emission of a beep from the instrument."""
+    hmp4040.beep()
+    hmp4040.reset()
+
+
+def test_voltage_limits(hmp4040):
+    """Test minimum and maximum voltages."""
+    hmp4040.voltage_to_min()
+    assert hmp4040.voltage == hmp4040.min_voltage
+    hmp4040.voltage_to_max()
+    assert hmp4040.voltage == hmp4040.max_voltage
+    hmp4040.reset()
+
+
+def test_voltage_stepping(hmp4040):
+    """Test stepping voltages up and down."""
+    hmp4040.voltage = 0.0
+    hmp4040.step_voltage_up()
+    assert hmp4040.voltage == hmp4040.voltage_step
+    hmp4040.step_voltage_down()
+    assert hmp4040.voltage == 0.0
+    hmp4040.reset()
+
+
+def test_channel_state(hmp4040):
+    """Test activation and deactivation of channels."""
+    hmp4040.selected_channel = 1
+    assert hmp4040.selected_channel == 1
+
+    hmp4040.set_channel_state(2, True)
+    # check that the selected channel is reset to 2.
+    assert hmp4040.selected_channel == 1
+    hmp4040.reset()
+
+
+def test_sequence(hmp4040):
+    """Test sequence execution."""
+    # NOTE: There are actually no assertations in this test. But it is possible
+    # to check the sequence execution by looking at display of the instrument.
+    hmp4040.selected_channel == 1
+    hmp4040.voltage = 0.0
+    hmp4040.sequence = [1.0, 1.0, 1.0, 2.0, 2.0, 1.0]
+    hmp4040.repetitions = 0
+    hmp4040.transfer_sequence(1)
+    hmp4040.output_enabled = True
+    hmp4040.selected_channel_active = True
+    hmp4040.start_sequence(1)
+    sleep(4)
+    hmp4040.stop_sequence(1)
+    hmp4040.output_enabled = False
+    hmp4040.clear_sequence(1)
+    hmp4040.reset()

--- a/tests/instruments/rohdeschwarz/test_hmp_instrument.py
+++ b/tests/instruments/rohdeschwarz/test_hmp_instrument.py
@@ -81,7 +81,7 @@ def test_channel_state(hmp4040):
 
 def test_sequence(hmp4040):
     """Test sequence execution."""
-    # NOTE: There are actually no assertations in this test. But it is possible
+    # NOTE: There are actually no assertions in this test. But it is possible
     # to check the sequence execution by looking at display of the instrument.
     hmp4040.selected_channel == 1
     hmp4040.voltage = 0.0


### PR DESCRIPTION
I added most commands for the Rohde&Schwarz HMP4040 with the exception of the fuse commands (since I could not test those commands). 

For some commands I implemented both `Instrument.control` and defined a callable member function since it seems a little odd to for example select a channel via `hmp.selected_channel = 1`; I think it is more natural to do this via `hmp.select_channel(1)`. These commands are annotated in the source code. Let me know what you think :)

Manual for the device for reference: https://scdn.rohde-schwarz.com/ur/pws/dl_downloads/dl_common_library/dl_manuals/gb_1/h/hmp_serie/HMP_GettingStarted_en_02.pdf

