### PR TITLE
Add autodoc warnings to the problem matcher.

### DIFF
--- a/.github/sphinx.json
+++ b/.github/sphinx.json
@@ -21,6 +21,18 @@
                     "message": 3
                 }
             ]
+        },
+        {
+            "owner": "sphinx-extension",
+            "pattern": [
+                {
+                    "regexp": "^(?<severity>WARNING|ERROR): (?<code>\\S+): (?<message>.+)(?<dummy_file_entry>)$",
+                    "severity": 1,
+                    "code": 2,
+                    "message": 3,
+                    "file": 4
+                }
+            ]
         }
     ]
 }

--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -37,26 +37,24 @@ jobs:
       - name: Set up flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Lint with flake8
-        continue-on-error: true
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings
-          flake8 . --count --exit-zero --statistics
+          # Be sure to check for Python syntax errors or undefined names
+          flake8 . --count --extend-select=E9,F63,F7,F82 --show-source --statistics
       - uses: ammaraskar/sphinx-problem-matcher@master
       - name: Generate docs
+        if: always()  # run even if the previous step failed
         working-directory: ./docs
         run: |
           echo "::add-matcher::.github/sphinx.json"
-          make html
+          make html SPHINXOPTS="-W --keep-going"
       - name: Run doctests
+        if: always()  # run even if the previous step failed
         working-directory: ./docs
         run: |
           echo "::add-matcher::.github/sphinx.json"
-          make doctest
+          make doctest SPHINXOPTS="-W --keep-going"
   test:
     name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
-    needs: docs_lint  # no need to continue if the docs/lint job fails
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/docs/api/instruments/instruments.rst
+++ b/docs/api/instruments/instruments.rst
@@ -5,6 +5,10 @@ Instrument classes
 .. autoclass:: pymeasure.instruments.Instrument
     :members:
 
-.. autoclass:: pymeasure.instruments.SwissArmyFake
+.. autoclass:: pymeasure.instruments.fakes.FakeInstrument
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.fakes.SwissArmyFake
     :members:
     :show-inheritance:

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -1108,7 +1108,8 @@ class DirectoryLineEdit(QtGui.QLineEdit):
             return '/'
 
     def browse_triggered(self):
-        path = QtGui.QFileDialog.getExistingDirectory(self, 'Directory', self._get_starting_directory())
+        path = QtGui.QFileDialog.getExistingDirectory(
+            self, 'Directory', self._get_starting_directory())
         if path != '':
             self.setText(path)
 


### PR DESCRIPTION
This should enable us to at least flag autodoc
import errors in the diff view.
Catching error otherwise is not feasible, see #583.