### PR TITLE
Customizable error query as instrument constructor argument

### DIFF
--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -119,6 +119,7 @@ class Instrument:
     :param adapter: A string, integer, or :py:class:`~pymeasure.adapters.Adapter` subclass object
     :param string name: The name of the instrument. Often the model designation by default.
     :param includeSCPI: A boolean, which toggles the inclusion of standard SCPI commands
+    :param error_query: The string to be sent to the instrument to query for errors.
     :param \\**kwargs: In case ``adapter`` is a string or integer, additional arguments passed on
         to :py:class:`~pymeasure.adapters.VISAAdapter` (check there for details).
         Discarded otherwise.
@@ -145,7 +146,7 @@ class Instrument:
     __reserved_prefix = "___"
 
     # noinspection PyPep8Naming
-    def __init__(self, adapter, name, includeSCPI=True, **kwargs):
+    def __init__(self, adapter, name, includeSCPI=True, error_query="SYST:ERR?", **kwargs):
         try:
             if isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
@@ -156,6 +157,7 @@ class Instrument:
         self.name = name
         self.SCPI = includeSCPI
         self.adapter = adapter
+        self.error_query = error_query
 
         self.isShutdown = False
         self._special_names = self._setup_special_names()
@@ -519,7 +521,7 @@ class Instrument:
         if self.SCPI:
             errors = []
             while True:
-                err = self.values("SYST:ERR?")
+                err = self.values(self.error_query)
                 if int(err[0]) != 0:
                     log.error(f"{self.name}: {err[0]}, {err[1]}")
                     errors.append(err)

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -144,9 +144,6 @@ class Instrument:
     # Prefix used to store reserved variables
     __reserved_prefix = "___"
 
-    # The command to be sent to the instrument to query for errors
-    _error_query = "SYST:ERR?"
-
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
@@ -522,12 +519,22 @@ class Instrument:
         if self.SCPI:
             errors = []
             while True:
-                err = self.values(self._error_query)
+                err = self.next_error()
                 if int(err[0]) != 0:
                     log.error(f"{self.name}: {err[0]}, {err[1]}")
                     errors.append(err)
                 else:
                     break
             return errors
+        else:
+            raise NotImplementedError("Non SCPI instruments require implementation in subclasses")
+
+    def next_error(self):
+        """ Read the next error from the instrument.
+
+        :return: error entry
+        """
+        if self.SCPI:
+            return self.values("SYST:ERR?")
         else:
             raise NotImplementedError("Non SCPI instruments require implementation in subclasses")

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -119,7 +119,6 @@ class Instrument:
     :param adapter: A string, integer, or :py:class:`~pymeasure.adapters.Adapter` subclass object
     :param string name: The name of the instrument. Often the model designation by default.
     :param includeSCPI: A boolean, which toggles the inclusion of standard SCPI commands
-    :param error_query: The string to be sent to the instrument to query for errors.
     :param \\**kwargs: In case ``adapter`` is a string or integer, additional arguments passed on
         to :py:class:`~pymeasure.adapters.VISAAdapter` (check there for details).
         Discarded otherwise.
@@ -145,8 +144,11 @@ class Instrument:
     # Prefix used to store reserved variables
     __reserved_prefix = "___"
 
+    # The command to be sent to the instrument to query for errors
+    _error_query = "SYST:ERR?"
+
     # noinspection PyPep8Naming
-    def __init__(self, adapter, name, includeSCPI=True, error_query="SYST:ERR?", **kwargs):
+    def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
             if isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
@@ -157,7 +159,6 @@ class Instrument:
         self.name = name
         self.SCPI = includeSCPI
         self.adapter = adapter
-        self.error_query = error_query
 
         self.isShutdown = False
         self._special_names = self._setup_special_names()
@@ -521,7 +522,7 @@ class Instrument:
         if self.SCPI:
             errors = []
             while True:
-                err = self.values(self.error_query)
+                err = self.values(self._error_query)
                 if int(err[0]) != 0:
                     log.error(f"{self.name}: {err[0]}, {err[1]}")
                     errors.append(err)


### PR DESCRIPTION
This PR adds the option to specify a custom command for querying errors.
For example, the HP 54540A needs the command `SYST:ERR? STR` instead of just `SYST:ERR?` to return the error number and error description.
Since the `check_errors()` method contains quite a bit of logic, I would argue that it is cleaner to specify just the command instead of copying the whole method to a subclass with just the command changed.