### PR TITLE
DPSeriesMotorController bug fix

### DIFF
--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -325,7 +325,7 @@ class DPSeriesMotorController(Instrument):
         elif "%" in command or "~" in command:
             cmd_str = "@%s" % command
         else:
-            cmd_str = "@%i%s" % (self.address, command)
+            cmd_str = "@%i%s" % (self._address, command)
         super().write(cmd_str)
 
     def values(self, command, **kwargs):
@@ -338,7 +338,7 @@ class DPSeriesMotorController(Instrument):
         if "%" in command or "~" in command:
             vals = super().values("@%s" % command, **kwargs)
         else:
-            vals = super().values("@%i%s" % (self.address, command))
+            vals = super().values("@%i%s" % (self._address, command))
 
         return vals
 
@@ -352,7 +352,7 @@ class DPSeriesMotorController(Instrument):
         if "%" in command or "~" in command:
             val = super().ask("@%s" % command)
         else:
-            val = super().ask("@%i%s" % (self.address, command))
+            val = super().ask("@%i%s" % (self._address, command))
 
         return val
 


### PR DESCRIPTION
In the overriden `ask()`, `write()`, and `values()` methods I was using `self.address` to prepend command strings with the address of the motor controller. This causes collisions when multiple controllers are connected to the same rs485 line. Thus I have changed this to `self._address`.