### PR TITLE
Add numpy's bool_ to the sequencer

### DIFF
--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -41,6 +41,7 @@ SAFE_FUNCTIONS = {
     'range': range,
     'sorted': sorted,
     'list': list,
+    'bool': bool,
     'arange': numpy.arange,
     'linspace': numpy.linspace,
     'arccos': numpy.arccos,

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -22,6 +22,7 @@
 # THE SOFTWARE.
 #
 
+from numpy import bool_
 
 class Parameter:
     """ Encapsulates the information for an experiment parameter
@@ -177,7 +178,7 @@ class BooleanParameter(Parameter):
                 raise ValueError("BooleanParameter given string value of '%s'" % value)
         elif isinstance(value, (int, float)) and value in [0, 1]:
             self._value = bool(value)
-        elif isinstance(value, bool):
+        elif isinstance(value, (bool, bool_)):
             self._value = value
         else:
             raise ValueError("BooleanParameter given non-boolean value of "


### PR DESCRIPTION
This addresses the edge case where you might want to do an array of booleans in the sequencer. As far as I tried
``[True, True, False]`` does not play nicely with the output type of the BooleanInput (a numpy style bool). A hack is to do something like ``[bool(1),bool(1),bool(0)]`` by allowing bool as a safe funtion.