### PR TITLE
Adapter thread safety

### DIFF
--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -122,7 +122,8 @@ class Adapter:
     def __getattribute__(self, name):
         """ Override to acquire the 'connection_lock' lock through the duration of attribute access.
         """
-        if name not in ("connection_lock", "connection_lock_initialized") and self.connection_lock_initialized:
+        if name not in ("connection_lock", "connection_lock_initialized") \
+                and self.connection_lock_initialized:
             with self.connection_lock:
                 ret = super().__getattribute__(name)
         else:

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -120,6 +120,8 @@ class Adapter:
                         "binary_values method")
 
     def __getattribute__(self, name):
+        """ Override to acquire the 'connection_lock' lock through the duration of attribute access.
+        """
         if not name == "connection_lock" and object.__getattribute__(self, "connection_lock_initialized"):
             with object.__getattribute__(self, "connection_lock"):
                 ret = object.__getattribute__(self, name)
@@ -129,6 +131,8 @@ class Adapter:
         return ret
 
     def __setattr__(self, name, value):
+        """ Override to acquire the 'connection_lock' lock through the duration of attribute setting.
+        """
         if not name == "connection_lock" and object.__getattribute__(self, "connection_lock_initialized"):
             with object.__getattribute__(self, "connection_lock"):
                 object.__setattr__(self, name, value)

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -122,7 +122,8 @@ class Adapter:
     def __getattribute__(self, name):
         """ Override to acquire the 'connection_lock' lock through the duration of attribute access.
         """
-        if not name == "connection_lock" and object.__getattribute__(self, "connection_lock_initialized"):
+        if not name == "connection_lock" and \
+                object.__getattribute__(self, "connection_lock_initialized"):
             with object.__getattribute__(self, "connection_lock"):
                 ret = object.__getattribute__(self, name)
         else:
@@ -133,11 +134,13 @@ class Adapter:
     def __setattr__(self, name, value):
         """ Override to acquire the 'connection_lock' lock through the duration of attribute setting.
         """
-        if not name == "connection_lock" and object.__getattribute__(self, "connection_lock_initialized"):
+        if not name == "connection_lock" and \
+                object.__getattribute__(self, "connection_lock_initialized"):
             with object.__getattribute__(self, "connection_lock"):
                 object.__setattr__(self, name, value)
 
-        elif name == "connection_lock" and object.__getattribute__(self, "connection_lock_initialized"):
+        elif name == "connection_lock" and \
+                object.__getattribute__(self, "connection_lock_initialized"):
             raise ValueError("Adapter connection_lock cannot be modified!")
 
         else:

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -122,29 +122,24 @@ class Adapter:
     def __getattribute__(self, name):
         """ Override to acquire the 'connection_lock' lock through the duration of attribute access.
         """
-        if not name == "connection_lock" and \
-                object.__getattribute__(self, "connection_lock_initialized"):
-            with object.__getattribute__(self, "connection_lock"):
-                ret = object.__getattribute__(self, name)
+        if name not in ("connection_lock", "connection_lock_initialized") and self.connection_lock_initialized:
+            with self.connection_lock:
+                ret = super().__getattribute__(name)
         else:
-            ret = object.__getattribute__(self, name)
+            ret = super().__getattribute__(name)
 
         return ret
 
     def __setattr__(self, name, value):
         """ Override to acquire the 'connection_lock' lock through the duration of attribute setting.
         """
-        if not name == "connection_lock" and \
-                object.__getattribute__(self, "connection_lock_initialized"):
-            with object.__getattribute__(self, "connection_lock"):
-                object.__setattr__(self, name, value)
-
-        elif name == "connection_lock" and \
-                object.__getattribute__(self, "connection_lock_initialized"):
+        if name != "connection_lock" and self.connection_lock_initialized:
+            with self.connection_lock:
+                super().__setattr__(name, value)
+        elif name == "connection_lock" and self.connection_lock_initialized:
             raise ValueError("Adapter connection_lock cannot be modified!")
-
         else:
-            object.__setattr__(self, name, value)
+            super().__setattr__(name, value)
 
 
 class FakeAdapter(Adapter):


### PR DESCRIPTION
This PR addresses the thread safety measures discussed in #512 and #506. This is not a full restructure of the `Adapter` class, but rather I've simply added an attribute, `connection_lock` of type `threading.Lock`. I've also overridden the `__getattribute__` and `__setattr__` methods so that the lock is held for the duration of attribute access. In this way, multiple threads can read/write from the same instrument as all `Adapter` attributes are protected by this lock.