### PR TITLE
Fix typo in Keithley 2600 driver

### DIFF
--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -177,7 +177,7 @@ class Channel:
     )
 
     compliance_voltage = Instrument.control(
-        'source.limitv', 'source.limiv=%f',
+        'source.limitv', 'source.limitv=%f',
         """ Property controlling the source compliance voltage """,
         validator=truncated_range,
         values=[-200, 200]


### PR DESCRIPTION
Fixes a typo in the VISA command for compliance voltage from "source.limiv=%f" to "source.limitv=%f"