### PR TITLE
Fleshed out version of ProtocolAdapter.

### DIFF
--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -30,15 +30,88 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+def to_bytes(command):
+    """Change `command` to a bytes object"""
+    if isinstance(command, (bytes, bytearray)):
+        return command
+    elif command is None:
+        return b""
+    elif isinstance(command, str):
+        return command.encode("utf-8")
+    elif isinstance(command, (list, tuple)):
+        try:
+            return bytes(command)
+        except TypeError:
+            raise
+    elif isinstance(command, int):
+        return bytes((command,))
+    raise TypeError("Invalid input")
+
+
 class ProtocolAdapter(Adapter):
     """ Adapter class testing command exchange without instrument hardware.
 
     :param kwargs: TBD key-word arguments
     """
 
-    def __init__(self, preprocess_reply=None, **kwargs):
+    def __init__(self, comm_pairs, preprocess_reply=None, **kwargs):
         super().__init__(preprocess_reply=preprocess_reply)
+        self.read_buffer = b""
+        self.write_buffer = b""
+        self.comm_pairs = comm_pairs
+        self.index = 0
         # TODO: Make this skeleton implementation workable
+
+    def write(self, command):
+        """Compare the command with the expected one and fill the buffer."""
+        pair = self.comm_pairs[self.index]
+        self.index += 1
+        assert to_bytes(pair[0]) == to_bytes(command), (
+                f"Command '{command}' written, but {pair[0]} expected.")
+        print(pair)
+        try:
+            self.read_buffer = to_bytes(pair[1])
+        except IndexError:
+            # No response in the pair.
+            self.read_buffer = b""
+
+    def write_bytes(self, content):
+        """Write the bytes `content`. If a command is full, fill the read."""
+        self.write_buffer += content
+        pair = self.comm_pairs[self.index]
+        if self.write_buffer == pair[0]:
+            assert self.read_buffer == b"", "Responses have not been read yet."
+            # Clear the write buffer
+            self.write_buffer = b""
+            self.index += 1
+            try:
+                self.read_buffer = pair[1]
+            except IndexError:
+                self.read_buffer = b""
+
+    def read(self):
+        """Read the prepared read bufferr and return it as a string."""
+        if self.read_buffer:
+            return self.read_buffer.decode("utf-8")
+        else:
+            pair = self.comm_pairs[self.index]
+            assert pair[0] is None, "Unexpected read without prior write."
+            self.index += 1
+            return to_bytes(pair[1]).decode("utf-8")
+
+    def read_bytes(self, count):
+        """Read `count` number of bytes."""
+        if self.read_buffer:
+            read = self.read_buffer[:count]
+            self.read_buffer = self.read_buffer[count:]
+            return read
+        else:
+            pair = self.comm_pairs[self.index]
+            assert pair[0] is None, "Unexpected read without prior write."
+            self.index += 1
+            read = pair[1][:count]
+            self.read_buffer = pair[1][count:]
+            return read
 
     # TODO: Harmonise ask being write+read (i.e., remove from VISAAdapter),
     #   use protocol tests to confirm it works correctly

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -61,7 +61,7 @@ class ProtocolAdapter(Adapter):
         """Generate the adapter and initialize internal buffers."""
         assert isinstance(comm_pairs, (list, tuple)), (
             "Parameter comm_pairs has to be a list or tuple.")
-        super().__init__(preprocess_reply=preprocess_reply)
+        super().__init__(preprocess_reply=preprocess_reply, **kwargs)
         self._read_buffer = b""
         self._write_buffer = b""
         self.comm_pairs = comm_pairs
@@ -98,7 +98,9 @@ class ProtocolAdapter(Adapter):
     def read(self):
         """Read the prepared read bufferr and return it as a string."""
         if self._read_buffer:
-            return self._read_buffer.decode("utf-8")
+            buffer = self._read_buffer.decode("utf-8")
+            self._read_buffer = b""
+            return buffer
         else:
             pair = self.comm_pairs[self._index]
             assert pair[0] is None, "Unexpected read without prior write."

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -123,6 +123,10 @@ class VISAAdapter(Adapter):
         """
         return self.connection.read()
 
+    def write_bytes(self, data):
+        """Write `data` as bytes object to the instrument."""
+        self.connection.write_raw(data)
+
     def read_bytes(self, size):
         """ Reads specified number of bytes from the buffer and returns
         the resulting ASCII response

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -85,9 +85,9 @@ class TC038D(Instrument):
         else:  # an error occurred
             end = self.adapter.read_bytes(2)  # empty the buffer
             if got[2] == 0x02:
-                raise ValueError("The read start address is incorrect.")
+                raise ValueError(f"The read start address {address} is invalid.")
             if got[2] == 0x03:
-                raise ValueError("The number of elements exceeds the allowed range")
+                raise ValueError(f"The number of elements {count} exceeds the allowed range.")
             raise ConnectionError(f"Unknown read error. Received: {got} {end}")
 
     def writeMultiple(self, address, values):
@@ -108,8 +108,8 @@ class TC038D(Instrument):
                 for i in range(self.byteMode - 1, -1, -1):
                     data.append(element >> i * 8 & 0xFF)
         else:
-            raise ValueError(("Values has to be an integer or an iterable of "
-                              f"integers. values: {values}"))
+            raise TypeError(("Values has to be an integer or an iterable of "
+                             f"integers. values: {values}"))
         data += CRC16(data)
         self.adapter.write_bytes(bytes(data))
         got = self.adapter.read_bytes(2)

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -57,9 +57,9 @@ class TC038D(Instrument):
     functions = {'read': 0x03, 'writeMultiple': 0x10,
                  'writeSingle': 0x06, 'echo': 0x08}
 
-    def __init__(self, resourceName, address=1, timeout=1000):
+    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000):
         """Initialize the device."""
-        super().__init__(resourceName, "TC038D", timeout=timeout)
+        super().__init__(resourceName, name, timeout=timeout)
         self.address = address
 
     def readRegister(self, address, count=1):
@@ -71,18 +71,18 @@ class TC038D(Instrument):
         data += [address >> 8, address & 0xFF]  # 2B address
         data += [count >> 8, count & 0xFF]  # 2B number of elements
         data += CRC16(data)
-        self.adapter.connection.write_raw(bytes(data))
+        self.adapter.write_bytes(bytes(data))
         # Slave address, function, length
-        got = self.adapter.connection.read_bytes(3)
+        got = self.adapter.read_bytes(3)
         if got[1] == self.functions['read']:
             length = got[2]
             # data length, 2 Byte CRC
-            read = self.adapter.connection.read_bytes(length + 2)
+            read = self.adapter.read_bytes(length + 2)
             if read[-2:] != bytes(CRC16(got + read[:-2])):
                 raise ConnectionError("Response CRC does not match.")
             return read[:-2]
         else:  # an error occurred
-            end = self.adapter.connection.read_bytes(2)  # empty the buffer
+            end = self.adapter.read_bytes(2)  # empty the buffer
             if got[2] == 0x02:
                 raise ValueError("The read start address is incorrect.")
             if got[2] == 0x03:
@@ -110,16 +110,16 @@ class TC038D(Instrument):
             raise ValueError(("Values has to be an integer or an iterable of "
                               f"integers. values: {values}"))
         data += CRC16(data)
-        self.adapter.connection.write_raw(bytes(data))
-        got = self.adapter.connection.read_bytes(2)
+        self.adapter.write_bytes(bytes(data))
+        got = self.adapter.read_bytes(2)
         # slave address, function
         if got[1] == self.functions['writeMultiple']:
             # start address, number elements, CRC; each 2 Bytes long
-            got += self.adapter.connection.read_bytes(2 + 2 + 2)
+            got += self.adapter.read_bytes(2 + 2 + 2)
             if got[-2:] != bytes(CRC16(got[:-2])):
                 raise ConnectionError("Response CRC does not match.")
         else:
-            end = self.adapter.connection.read_bytes(3)  # error code and CRC
+            end = self.adapter.read_bytes(3)  # error code and CRC
             errors = {0x02: "Wrong start address",
                       0x03: "Variable data error",
                       0x04: "Operation error"}

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -57,9 +57,10 @@ class TC038D(Instrument):
     functions = {'read': 0x03, 'writeMultiple': 0x10,
                  'writeSingle': 0x06, 'echo': 0x08}
 
-    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000):
+    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000,
+                 **kwargs):
         """Initialize the device."""
-        super().__init__(resourceName, name, timeout=timeout)
+        super().__init__(resourceName, name, timeout=timeout, **kwargs)
         self.address = address
 
     def readRegister(self, address, count=1):

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -24,7 +24,6 @@
 
 import logging
 import numpy as np
-from pymeasure.adapters.protocol import ProtocolAdapter
 from pymeasure.adapters.visa import VISAAdapter
 
 log = logging.getLogger(__name__)
@@ -147,9 +146,7 @@ class Instrument:
 
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
-        if adapter == "test":
-            adapter = ProtocolAdapter(**kwargs)
-        elif isinstance(adapter, (int, str)):
+        if isinstance(adapter, (int, str)):
             try:
                 adapter = VISAAdapter(adapter, **kwargs)
             except ImportError:

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -24,6 +24,7 @@
 
 import logging
 import numpy as np
+from pymeasure.adapters.protocol import ProtocolAdapter
 from pymeasure.adapters.visa import VISAAdapter
 
 log = logging.getLogger(__name__)
@@ -146,12 +147,14 @@ class Instrument:
 
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
-        try:
-            if isinstance(adapter, (int, str)):
+        if adapter == "test":
+            adapter = ProtocolAdapter(**kwargs)
+        elif isinstance(adapter, (int, str)):
+            try:
                 adapter = VISAAdapter(adapter, **kwargs)
-        except ImportError:
-            raise Exception("Invalid Adapter provided for Instrument since "
-                            "PyVISA is not present")
+            except ImportError:
+                raise Exception("Invalid Adapter provided for Instrument since"
+                                " PyVISA is not present")
 
         self.name = name
         self.SCPI = includeSCPI

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -49,8 +49,11 @@ def expected_protocol(instrument_cls, comm_pairs):
          e.g. `(None, 'RESP1')`.
     """
     protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, "Virtual instrument")
+    instr = instrument_cls(protocol, name="Virtual instrument")
     yield instr
+    assert protocol._index == len(comm_pairs), "Not all messages exchanged."
+    assert protocol._write_buffer == b"", "Non empty write buffer."
+    assert protocol._read_buffer == b"", "Non empty read buffer."
 
     # TODO: Make this skeleton implementation produce reasonable tests
     # TODO: Assert correct state of comm_pairs after yield

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -48,9 +48,10 @@ def expected_protocol(instrument_cls, comm_pairs):
         To represent a response-only communication, use `None` for the command part,
          e.g. `(None, 'RESP1')`.
     """
-    protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, name="Virtual instrument")
+    instr = instrument_cls("test", name="Virtual instrument",
+                           comm_pairs=comm_pairs)
     yield instr
+    protocol = instr.adapter
     assert protocol._index == len(comm_pairs), "Not all messages exchanged."
     assert protocol._write_buffer == b"", "Non empty write buffer."
     assert protocol._read_buffer == b"", "Non empty read buffer."

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -129,9 +129,15 @@ class Test_read:
                                            (b"Bytes", "Bytes"),
                                            ))
     def test_works(self, buffer, returned):
-        a = ProtocolAdapter([])
+        a = ProtocolAdapter()
         a._read_buffer = buffer
         assert a.read() == returned
+
+    def test_read_buffer_emptied(self):
+        a = ProtocolAdapter()
+        a._read_buffer = b"jklasdf"
+        a.read()
+        assert a._read_buffer == b""
 
     def test_unsolicited_response(self):
         a = ProtocolAdapter([(None, "Response")])

--- a/tests/instruments/hcp/test_tc038d.py
+++ b/tests/instruments/hcp/test_tc038d.py
@@ -25,6 +25,7 @@ def test_write_multiple():
 
 
 def test_write_multiple_CRC_error():
+    """Test whether an invalid response CRC code raises an Exception."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
@@ -34,26 +35,27 @@ def test_write_multiple_CRC_error():
             inst.setpoint = 32.1
 
 
-def test_write_multiple_wrong_values():
+def test_write_multiple_wrong_type():
     with expected_protocol(
         TC038D, []
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             inst.writeMultiple(0x010A, 5.5)
 
 
-def test_write_multiple_Value_error():
+def test_write_multiple_handle_wrong_start_address():
+    """Test whether the error code (byte 2) of 2 raises the right error."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
           b"\x01\x90\x02\x06\x00")],
     ) as inst:
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="Wrong start address"):
             inst.setpoint = 32.1
-            assert str(exc) == "Wrong start address"
 
 
 def test_read_CRC_error():
+    """Test whether an invalid response CRC code raises an Exception."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
@@ -64,26 +66,29 @@ def test_read_CRC_error():
 
 
 def test_read_address_error():
+    """Test whether the error code (byte 2) of 2 raises the right error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
               b"\x01\x83\x02\01\02")],
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The read start address"):
             inst.temperature
 
 
 def test_read_elements_error():
+    """Test whether the error code (byte 2) of 3 raises the right error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
               b"\x01\x83\x03\01\02")],
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The number of elements"):
             inst.temperature
 
 
 def test_read_any_error():
+    """Test whether any wrong message (byte 1 is not 3) raises an error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",

--- a/tests/instruments/hcp/test_tc038d.py
+++ b/tests/instruments/hcp/test_tc038d.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""
+Unit tests for the HCP TC038D
+"""
+
+# IMPORTS #####################################################################
+
+
+import pytest
+
+from pymeasure.test import expected_protocol
+
+
+from pymeasure.instruments.hcp import TC038D
+
+
+def test_write_multiple():
+    # Communication from manual.
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x0A\x00\x04\x08\x00\x00\x03\xE8\xFF\xFF\xFC\x18\x8D\xE9",
+          b"\x01\x10\x01\x0A\x00\x04\xE0\x34")]
+    ) as inst:
+        inst.writeMultiple(0x010A, [1000, -1000])
+
+
+def test_write_multiple_CRC_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x10\x01\x06\x00\x02\x01\x02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.setpoint = 32.1
+
+
+def test_write_multiple_wrong_values():
+    with expected_protocol(
+        TC038D, []
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.writeMultiple(0x010A, 5.5)
+
+
+def test_write_multiple_Value_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x90\x02\x06\x00")],
+    ) as inst:
+        with pytest.raises(ValueError) as exc:
+            inst.setpoint = 32.1
+            assert str(exc) == "Wrong start address"
+
+
+def test_read_CRC_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+          b"\x01\x03\x04\x00\x00\x03\xE8\x01\x02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.temperature
+
+
+def test_read_address_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x83\x02\01\02")],
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.temperature
+
+
+def test_read_elements_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x83\x03\01\02")],
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.temperature
+
+
+def test_read_any_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x43\x05\01\02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.temperature
+
+
+def test_setpoint():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x01\x06\x00\x02\x25\xf6",
+          b"\x01\x03\x04\x00\x00\x00\x99:Y")],
+    ) as inst:
+        assert inst.setpoint == 15.3
+
+
+def test_setpoint_setter():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x10\x01\x06\x00\x02\xa0\x35")],
+    ) as inst:
+        inst.setpoint = 32.1
+
+
+def test_temperature():
+    # Communication from manual.
+    # Tests readRegister as well.
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+         b"\x01\x03\x04\x00\x00\x03\xE8\xFA\x8D")],
+    ) as inst:
+        assert inst.temperature == 100

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -35,6 +35,11 @@ class BasicTestInstrument(Instrument):
     )
 
 
+class InstrumentWithPreprocess(BasicTestInstrument):
+    def __init__(self, adapter, **kwargs):
+        super().__init__(adapter, preprocess_reply=lambda v: v+"2345", **kwargs)
+
+
 def test_simple_protocol():
     """Test a property without parsing or channel prefixes."""
     with expected_protocol(BasicTestInstrument,
@@ -74,6 +79,11 @@ def test_non_empty_read_buffer():
             instr.write("VOLT?")
     assert str(exc.value) == "Non empty read buffer."
 
+
+def test_preprocess():
+    with expected_protocol(InstrumentWithPreprocess,
+                           [("VOLT?", "3.1")]) as instr:
+        assert instr.simple == 3.12345
 
 # After completing expected_protocol tests, add tests elsewhere:
 # TODO: Add protocol tests for a simple instrument


### PR DESCRIPTION
I implemented a version of the ProtocolAdapter, which can read and write according to the message_pairs.
This implementation maintains the message pairs throughout, and only the read/write is done in bytes.

Tests are added for the normal read/write.

Frame-based communication needs new methods (I used instr.adapter.connection.read_bytes in the tc038d) in the adapters themselves in order to write and read bytes. Therefore we have to decide on the adapter implementation first, before doing to much work regarding the ProtocolAdapter Version. For that reason, I did not add tests for those methods.

In order to use some adapter configuration (here `preprocess_reply`, as I learnt writing tests for another driver), I had to let `Instrument` open the ProtocolAdapter (with the adaptername "test", but the modality can be changed).