### PR TITLE
Add feature: Protocol tests without hardware present

### DIFF
--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -14,6 +14,16 @@ Adapter base class
     :members:
     :undoc-members:
 
+================
+Protocol adapter
+================
+
+.. autoclass:: pymeasure.adapters.ProtocolAdapter
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:
+
 ============
 VISA adapter
 ============

--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -66,18 +66,21 @@ Telnet adapter
     :inherited-members:
     :show-inheritance:
 
-================
-Protocol adapter
-================
+=============
+Test adapters
+=============
+
+These pieces are useful when writing tests.
+
+.. automodule:: pymeasure.test
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 .. autoclass:: pymeasure.adapters.ProtocolAdapter
     :members:
     :undoc-members:
     :show-inheritance:
-
-============
-Fake adapter
-============
 
 .. autoclass:: pymeasure.adapters.FakeAdapter
     :members:

--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -14,16 +14,6 @@ Adapter base class
     :members:
     :undoc-members:
 
-================
-Protocol adapter
-================
-
-.. autoclass:: pymeasure.adapters.ProtocolAdapter
-    :members:
-    :undoc-members:
-    :inherited-members:
-    :show-inheritance:
-
 ============
 VISA adapter
 ============
@@ -74,6 +64,15 @@ Telnet adapter
     :members:
     :undoc-members:
     :inherited-members:
+    :show-inheritance:
+
+================
+Protocol adapter
+================
+
+.. autoclass:: pymeasure.adapters.ProtocolAdapter
+    :members:
+    :undoc-members:
     :show-inheritance:
 
 ============

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -709,12 +709,13 @@ In the above example, :code:`MultimeterA` and :code:`MultimeterB` use a differen
 Writing tests
 =============
 
-Tests are an important method for writing good code. We distinguish two groups of tests for instruments: Tests which verify the working of the code against expectation (device manual) only, and tests with a device connected.
+Tests are very useful for writing good code. We distinguish two groups of tests for instruments: the first group does not rely on a connected instrument. These tests verify the working of the code against expectation (for example according to a device manual) only. The second group tests the code with a device connected.
+
 
 Code tests
 **********
 
-In order to verify the expected working of the device code, it is good to test every part of the written code. The method `expected_protocol` with the `ProtocolAdapter` enables to simulate communication to a device.
+In order to verify the expected working of the device code, it is good to test every part of the written code. The method `expected_protocol` with the `ProtocolAdapter` simulates the communication to a device and verifies that the instrument driver behaves according to the expectation.
 
 .. code-block:: python
 
@@ -745,12 +746,15 @@ Here is the definition of expected_protocol:
 
 The first parameter, Extreme5000, is the class to be tested.
 Setting the voltage is expected to send a message (":VOLT 0.345"), but not to respond any (None). Getting the voltage (":VOLT?"), however, responds with a string. Therefore we expect two pairs of send/receive, the list of those pairs is the second argument.
-Finally an instance of the class is returned as `inst` with those messages prepared.
+Finally an instance of the class is returned as `inst`, which expects those send messages and returns the corresponding answers messages.
 If the communication of the driver does not correspond to the expected messages, an Exception is raised.
 
 The expected messages are **without** the termination characters, as they depend on the connection type and are handled by the adapter (e.g. VISA).
 
+
 Device tests
 ************
 
-# TODO
+It is useful as well, to test the code against an actual device. The necessary device setup (for example: connect a probe to the test output) should be written in the header of the test file. There should be the connection configuration (for example serial port), too.
+
+This file should be called `testing_extreme5000.py`. By beginning with `testing`, pytest requires to call it manually, which is desired, as it can only pass, if the device is connected.

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -709,13 +709,21 @@ In the above example, :code:`MultimeterA` and :code:`MultimeterB` use a differen
 Writing tests
 =============
 
-Tests are very useful for writing good code. We distinguish two groups of tests for instruments: the first group does not rely on a connected instrument. These tests verify the working of the code against expectation (for example according to a device manual) only. The second group tests the code with a device connected.
+Tests are very useful for writing good code.
+We have a number of tests checking the correctness of the pymeasure implementation.
+Those tests (located in the :code:`tests` directory) are run automatically on our CI server, but you can also run them locally using :code:`pytest`.
+
+When adding instruments, your primary concern will be tests for the *instrument driver* you implement.
+We distinguish two groups of tests for instruments: the first group does not rely on a connected instrument.
+These tests verify that the implemented instrument driver exchanges the correct messages with a device (for example according to a device manual).
+We call those "protocol tests".
+The second group tests the code with a device connected.
 
 Implement device tests by adding files in the :code:`tests/instruments/...` directory tree, mirroring the structure of the instrument implementations.
 There are other instrument tests already available that can serve as inspiration.
 
-Code tests
-**********
+Protocol tests
+**************
 
 In order to verify the expected working of the device code, it is good to test every part of the written code. The :func:`~pymeasure.test.expected_protocol` context manager (using a :class:`~pymeasure.adapters.ProtocolAdapter` internally) simulates the communication with a device and verifies that the sent/received messages triggered by the code inside the :code:`with` statement match the expectation.
 
@@ -751,6 +759,12 @@ If the communication of the driver does not correspond to the expected messages,
 
 .. note::
     The expected messages are **without** the termination characters, as they depend on the connection type and are handled by the normal adapter (e.g. :class:`VISAAdapter`).
+
+Some protocol tests in the test suite can serve as examples:
+
+* Testing a simple instrument: :code:`tests/instruments/keithley/test_keithley2000.py`
+* Testing a multi-channel instrument: :code:`tests/instruments/tektronix/test_afg3152.py`
+* Testing instruments using frame-based communication: :code:`tests/instruments/hcp/tc038.py`
 
 Device tests
 ************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Information about development is also available:
 
 .. toctree::
    :maxdepth: 1
-   :caption: API References
+   :caption: API Reference
 
    api/adapters
    api/experiment/index

--- a/pymeasure/adapters/__init__.py
+++ b/pymeasure/adapters/__init__.py
@@ -25,6 +25,8 @@ import logging
 
 from .adapter import Adapter, FakeAdapter
 
+from .protocol import ProtocolAdapter
+
 from pymeasure.adapters.telnet import TelnetAdapter
 
 log = logging.getLogger(__name__)

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -39,3 +39,11 @@ class ProtocolAdapter(Adapter):
     def __init__(self, preprocess_reply=None, **kwargs):
         super().__init__(preprocess_reply=preprocess_reply)
         # TODO: Make this skeleton implementation workable
+
+    # TODO: Harmonise ask being write+read (i.e., remove from VISAAdapter),
+    #   use protocol tests to confirm it works correctly
+    # TODO: Remove all now-unnecessary ask() implementations -
+    #   read and write implementations should have all (test this)
+    # TODO: Implement over-the-wire message-traffic logging here, first
+    # TODO: Check timing impact of non-firing logging messages
+    # TODO: Roll out message-traffic logging to all Adapters, try to DRY

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -84,10 +84,11 @@ class ProtocolAdapter(Adapter):
         except IndexError:
             raise ValueError(f"No communication pair left to write {content}.")
         if self._write_buffer == to_bytes(p_write):
-            # TODO improve error message.
             assert self._read_buffer == b"", (
                 f"Unread response '{self._read_buffer}' present when writing. "
-                "Read the response; maybe a property's 'check_set_errors' is not accounted for?")
+                "Maybe a property's 'check_set_errors' is not accounted for, "
+                "a read() call is missing in a method, or the defined protocol is incorrect?"
+            )
             # Clear the write buffer
             self._write_buffer = b""
             self._read_buffer = to_bytes(p_read)

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -117,11 +117,3 @@ class ProtocolAdapter(Adapter):
             self._read_buffer = to_bytes(p_read)[count:]
             self._index += 1
             return to_bytes(p_read)[:count]
-
-    # TODO: Harmonise ask being write+read (i.e., remove from VISAAdapter),
-    #   use protocol tests to confirm it works correctly
-    # TODO: Remove all now-unnecessary ask() implementations -
-    #   read and write implementations should have all (test this)
-    # TODO: Implement over-the-wire message-traffic logging here, first
-    # TODO: Check timing impact of non-firing logging messages
-    # TODO: Roll out message-traffic logging to all Adapters, try to DRY

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -30,15 +30,88 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+def to_bytes(command):
+    """Change `command` to a bytes object"""
+    if isinstance(command, (bytes, bytearray)):
+        return command
+    elif command is None:
+        return b""
+    elif isinstance(command, str):
+        return command.encode("utf-8")
+    elif isinstance(command, (list, tuple)):
+        try:
+            return bytes(command)
+        except TypeError:
+            raise
+    elif isinstance(command, int):
+        return bytes((command,))
+    raise TypeError("Invalid input")
+
+
 class ProtocolAdapter(Adapter):
     """ Adapter class testing command exchange without instrument hardware.
 
     :param kwargs: TBD key-word arguments
     """
 
-    def __init__(self, preprocess_reply=None, **kwargs):
+    def __init__(self, comm_pairs, preprocess_reply=None, **kwargs):
         super().__init__(preprocess_reply=preprocess_reply)
+        self.read_buffer = b""
+        self.write_buffer = b""
+        self.comm_pairs = comm_pairs
+        self.index = 0
         # TODO: Make this skeleton implementation workable
+
+    def write(self, command):
+        """Compare the command with the expected one and fill the buffer."""
+        pair = self.comm_pairs[self.index]
+        self.index += 1
+        assert to_bytes(pair[0]) == to_bytes(command), (
+                f"Command '{command}' written, but {pair[0]} expected.")
+        print(pair)
+        try:
+            self.read_buffer = to_bytes(pair[1])
+        except IndexError:
+            # No response in the pair.
+            self.read_buffer = b""
+
+    def write_bytes(self, content):
+        """Write the bytes `content`. If a command is full, fill the read."""
+        self.write_buffer += content
+        pair = self.comm_pairs[self.index]
+        if self.write_buffer == pair[0]:
+            assert self.read_buffer == b"", "Responses have not been read yet."
+            # Clear the write buffer
+            self.write_buffer = b""
+            self.index += 1
+            try:
+                self.read_buffer = pair[1]
+            except IndexError:
+                self.read_buffer = b""
+
+    def read(self):
+        """Read the prepared read bufferr and return it as a string."""
+        if self.read_buffer:
+            return self.read_buffer.decode("utf-8")
+        else:
+            pair = self.comm_pairs[self.index]
+            assert pair[0] is None, "Unexpected read without prior write."
+            self.index += 1
+            return to_bytes(pair[1]).decode("utf-8")
+
+    def read_bytes(self, count):
+        """Read `count` number of bytes."""
+        if self.read_buffer:
+            read = self.read_buffer[:count]
+            self.read_buffer = self.read_buffer[count:]
+            return read
+        else:
+            pair = self.comm_pairs[self.index]
+            assert pair[0] is None, "Unexpected read without prior write."
+            self.index += 1
+            read = pair[1][:count]
+            self.read_buffer = pair[1][count:]
+            return read
 
     # TODO: Harmonise ask being write+read (i.e., remove from VISAAdapter),
     #   use protocol tests to confirm it works correctly

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -58,6 +58,9 @@ class ProtocolAdapter(Adapter):
         """Generate the adapter and initialize internal buffers."""
         assert isinstance(comm_pairs, (list, tuple)), (
             "Parameter comm_pairs has to be a list or tuple.")
+        for pair in comm_pairs:
+            if len(pair) != 2:
+                raise ValueError(f'Comm_pairs element {pair} does not have two elements!')
         super().__init__(preprocess_reply=preprocess_reply, **kwargs)
         self._read_buffer = b""
         self._write_buffer = b""

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -56,12 +56,12 @@ class ProtocolAdapter(Adapter):
 
     def __init__(self, comm_pairs=[], preprocess_reply=None, **kwargs):
         """Generate the adapter and initialize internal buffers."""
+        super().__init__(preprocess_reply=preprocess_reply, **kwargs)
         assert isinstance(comm_pairs, (list, tuple)), (
             "Parameter comm_pairs has to be a list or tuple.")
         for pair in comm_pairs:
             if len(pair) != 2:
                 raise ValueError(f'Comm_pairs element {pair} does not have two elements!')
-        super().__init__(preprocess_reply=preprocess_reply, **kwargs)
         self._read_buffer = b""
         self._write_buffer = b""
         self.comm_pairs = comm_pairs

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -1,0 +1,41 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from .adapter import Adapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class ProtocolAdapter(Adapter):
+    """ Adapter class testing command exchange without instrument hardware.
+
+    :param kwargs: TBD key-word arguments
+    """
+
+    def __init__(self, preprocess_reply=None, **kwargs):
+        super().__init__(preprocess_reply=preprocess_reply)
+        # TODO: Make this skeleton implementation workable

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -81,11 +81,15 @@ class ProtocolAdapter(Adapter):
         if self._write_buffer == to_bytes(p_write):
             assert self._read_buffer == b"", (
                 f"Unread response '{self._read_buffer}' present when writing. "
-                "Read the response or enable the property's 'check_set_errors'")
+                "Read the response; maybe a property's 'check_set_errors' is not accounted for?")
             # Clear the write buffer
             self._write_buffer = b""
             self._read_buffer = to_bytes(p_read)
             self._index += 1
+        # If _write_buffer does _not_ agree with p_write, this is not cause for
+        # concern, because you can in principle compose a message over several writes.
+        # It's not clear how relevant this is in real-world use, but it's analogous
+        # to the possibility to fetch a (binary) message over several reads.
 
     def read(self):
         """Return an already present or freshly fetched read buffer as a string."""

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -61,7 +61,7 @@ class ProtocolAdapter(Adapter):
         """Generate the adapter and initialize internal buffers."""
         assert isinstance(comm_pairs, (list, tuple)), (
             "Parameter comm_pairs has to be a list or tuple.")
-        super().__init__(preprocess_reply=preprocess_reply)
+        super().__init__(preprocess_reply=preprocess_reply, **kwargs)
         self._read_buffer = b""
         self._write_buffer = b""
         self.comm_pairs = comm_pairs
@@ -98,7 +98,9 @@ class ProtocolAdapter(Adapter):
     def read(self):
         """Read the prepared read bufferr and return it as a string."""
         if self._read_buffer:
-            return self._read_buffer.decode("utf-8")
+            buffer = self._read_buffer.decode("utf-8")
+            self._read_buffer = b""
+            return buffer
         else:
             pair = self.comm_pairs[self._index]
             assert pair[0] is None, "Unexpected read without prior write."

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -48,7 +48,7 @@ def to_bytes(command):
 class ProtocolAdapter(Adapter):
     """ Adapter class for testing the command exchange protocol without instrument hardware.
 
-    This adapter is primarily meant for use within `pymeasure.test.expected_protocol()`.
+    This adapter is primarily meant for use within :func:`pymeasure.test.expected_protocol()`.
 
     :param list comm_pairs: List of "reference" message pair tuples. The first element is
         what is sent to the instrument, the second one is the returned message.

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -46,13 +46,14 @@ def to_bytes(command):
 
 
 class ProtocolAdapter(Adapter):
-    """ Adapter class testing command exchange without instrument hardware.
+    """ Adapter class for testing the command exchange protocol without instrument hardware.
 
-    :param list of lists comm_pairs: List of message pairs. First message is
-        the write one, the second one is the read message.
+    This adapter is primarily meant for use within `pymeasure.test.expected_protocol()`.
+
+    :param list comm_pairs: List of "reference" message pair tuples. The first element is
+        what is sent to the instrument, the second one is the returned message.
         'None' indicates that a pair member (write or read) does not exist.
-        The messages do not include the termination characters.
-    :param kwargs: TBD key-word arguments
+        The messages do **not** include the termination characters.
     """
 
     def __init__(self, comm_pairs=[], preprocess_reply=None, **kwargs):

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -123,6 +123,10 @@ class VISAAdapter(Adapter):
         """
         return self.connection.read()
 
+    def write_bytes(self, data):
+        """Write `data` as bytes object to the instrument."""
+        self.connection.write_raw(data)
+
     def read_bytes(self, size):
         """ Reads specified number of bytes from the buffer and returns
         the resulting ASCII response

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -73,7 +73,7 @@ class TC038(Instrument):
     """
 
     def __init__(self, resourceName, address=1, timeout=1000,
-                 includeSCPI=False):
+                 includeSCPI=False, **kwargs):
         """
         Initialize the communication.
 
@@ -88,7 +88,7 @@ class TC038(Instrument):
         """
         super().__init__(resourceName, "TC038", timeout=timeout,
                          write_termination="\r", read_termination="\r",
-                         parity=Parity.even,)
+                         parity=Parity.even, **kwargs)
         self.address = address
 
         self.set_monitored_quantity()  # start to monitor the temperature

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -85,9 +85,9 @@ class TC038D(Instrument):
         else:  # an error occurred
             end = self.adapter.read_bytes(2)  # empty the buffer
             if got[2] == 0x02:
-                raise ValueError("The read start address is incorrect.")
+                raise ValueError(f"The read start address {address} is invalid.")
             if got[2] == 0x03:
-                raise ValueError("The number of elements exceeds the allowed range")
+                raise ValueError(f"The number of elements {count} exceeds the allowed range.")
             raise ConnectionError(f"Unknown read error. Received: {got} {end}")
 
     def writeMultiple(self, address, values):
@@ -108,8 +108,8 @@ class TC038D(Instrument):
                 for i in range(self.byteMode - 1, -1, -1):
                     data.append(element >> i * 8 & 0xFF)
         else:
-            raise ValueError(("Values has to be an integer or an iterable of "
-                              f"integers. values: {values}"))
+            raise TypeError(("Values has to be an integer or an iterable of "
+                             f"integers. values: {values}"))
         data += CRC16(data)
         self.adapter.write_bytes(bytes(data))
         got = self.adapter.read_bytes(2)

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -57,9 +57,9 @@ class TC038D(Instrument):
     functions = {'read': 0x03, 'writeMultiple': 0x10,
                  'writeSingle': 0x06, 'echo': 0x08}
 
-    def __init__(self, resourceName, address=1, timeout=1000):
+    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000):
         """Initialize the device."""
-        super().__init__(resourceName, "TC038D", timeout=timeout)
+        super().__init__(resourceName, name, timeout=timeout)
         self.address = address
 
     def readRegister(self, address, count=1):
@@ -71,18 +71,18 @@ class TC038D(Instrument):
         data += [address >> 8, address & 0xFF]  # 2B address
         data += [count >> 8, count & 0xFF]  # 2B number of elements
         data += CRC16(data)
-        self.adapter.connection.write_raw(bytes(data))
+        self.adapter.write_bytes(bytes(data))
         # Slave address, function, length
-        got = self.adapter.connection.read_bytes(3)
+        got = self.adapter.read_bytes(3)
         if got[1] == self.functions['read']:
             length = got[2]
             # data length, 2 Byte CRC
-            read = self.adapter.connection.read_bytes(length + 2)
+            read = self.adapter.read_bytes(length + 2)
             if read[-2:] != bytes(CRC16(got + read[:-2])):
                 raise ConnectionError("Response CRC does not match.")
             return read[:-2]
         else:  # an error occurred
-            end = self.adapter.connection.read_bytes(2)  # empty the buffer
+            end = self.adapter.read_bytes(2)  # empty the buffer
             if got[2] == 0x02:
                 raise ValueError("The read start address is incorrect.")
             if got[2] == 0x03:
@@ -110,16 +110,16 @@ class TC038D(Instrument):
             raise ValueError(("Values has to be an integer or an iterable of "
                               f"integers. values: {values}"))
         data += CRC16(data)
-        self.adapter.connection.write_raw(bytes(data))
-        got = self.adapter.connection.read_bytes(2)
+        self.adapter.write_bytes(bytes(data))
+        got = self.adapter.read_bytes(2)
         # slave address, function
         if got[1] == self.functions['writeMultiple']:
             # start address, number elements, CRC; each 2 Bytes long
-            got += self.adapter.connection.read_bytes(2 + 2 + 2)
+            got += self.adapter.read_bytes(2 + 2 + 2)
             if got[-2:] != bytes(CRC16(got[:-2])):
                 raise ConnectionError("Response CRC does not match.")
         else:
-            end = self.adapter.connection.read_bytes(3)  # error code and CRC
+            end = self.adapter.read_bytes(3)  # error code and CRC
             errors = {0x02: "Wrong start address",
                       0x03: "Variable data error",
                       0x04: "Operation error"}

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -57,9 +57,10 @@ class TC038D(Instrument):
     functions = {'read': 0x03, 'writeMultiple': 0x10,
                  'writeSingle': 0x06, 'echo': 0x08}
 
-    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000):
+    def __init__(self, resourceName, name="TC038D", address=1, timeout=1000,
+                 **kwargs):
         """Initialize the device."""
-        super().__init__(resourceName, name, timeout=timeout)
+        super().__init__(resourceName, name, timeout=timeout, **kwargs)
         self.address = address
 
     def readRegister(self, address, count=1):

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -24,7 +24,6 @@
 
 import logging
 import numpy as np
-from pymeasure.adapters.protocol import ProtocolAdapter
 from pymeasure.adapters.visa import VISAAdapter
 
 log = logging.getLogger(__name__)
@@ -147,9 +146,7 @@ class Instrument:
 
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
-        if adapter == "test":
-            adapter = ProtocolAdapter(**kwargs)
-        elif isinstance(adapter, (int, str)):
+        if isinstance(adapter, (int, str)):
             try:
                 adapter = VISAAdapter(adapter, **kwargs)
             except ImportError:

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -24,6 +24,7 @@
 
 import logging
 import numpy as np
+from pymeasure.adapters.protocol import ProtocolAdapter
 from pymeasure.adapters.visa import VISAAdapter
 
 log = logging.getLogger(__name__)
@@ -146,12 +147,14 @@ class Instrument:
 
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
-        try:
-            if isinstance(adapter, (int, str)):
+        if adapter == "test":
+            adapter = ProtocolAdapter(**kwargs)
+        elif isinstance(adapter, (int, str)):
+            try:
                 adapter = VISAAdapter(adapter, **kwargs)
-        except ImportError:
-            raise Exception("Invalid Adapter provided for Instrument since "
-                            "PyVISA is not present")
+            except ImportError:
+                raise Exception("Invalid Adapter provided for Instrument since"
+                                " PyVISA is not present")
 
         self.name = name
         self.SCPI = includeSCPI

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -49,8 +49,11 @@ def expected_protocol(instrument_cls, comm_pairs):
          e.g. `(None, 'RESP1')`.
     """
     protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, "Virtual instrument")
+    instr = instrument_cls(protocol, name="Virtual instrument")
     yield instr
+    assert protocol._index == len(comm_pairs), "Not all messages exchanged."
+    assert protocol._write_buffer == b"", "Non empty write buffer."
+    assert protocol._read_buffer == b"", "Non empty read buffer."
 
     # TODO: Make this skeleton implementation produce reasonable tests
     # TODO: Assert correct state of comm_pairs after yield

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -53,7 +53,7 @@ def expected_protocol(instrument_cls, comm_pairs, **kwargs):
         Keyword arguments for the instantiation of the instrument.
     """
     protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, name="Virtual instrument", **kwargs)
+    instr = instrument_cls(protocol, **kwargs)
     yield instr
     assert protocol._index == len(comm_pairs), (
         "Unprocessed protocol definitions remain: "

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -48,9 +48,10 @@ def expected_protocol(instrument_cls, comm_pairs):
         To represent a response-only communication, use `None` for the command part,
          e.g. `(None, 'RESP1')`.
     """
-    protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, name="Virtual instrument")
+    instr = instrument_cls("test", name="Virtual instrument",
+                           comm_pairs=comm_pairs)
     yield instr
+    protocol = instr.adapter
     assert protocol._index == len(comm_pairs), "Not all messages exchanged."
     assert protocol._write_buffer == b"", "Non empty write buffer."
     assert protocol._read_buffer == b"", "Non empty read buffer."

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -1,0 +1,55 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from contextlib import contextmanager
+
+from pymeasure.adapters.protocol import ProtocolAdapter
+
+
+@contextmanager
+def expected_protocol(instrument_cls, comm_pairs):
+    """Context manager that checks sent/received instrument commands without a device connected.
+
+    Given an instrument class and a list of command-response pairs, this context
+    manager confirms that the code in the context manager block produces the expected
+    messages.
+
+    Parameters
+    ----------
+    instrument_cls : `~pymeasure.Instrument`
+        `~pymeasure.Instrument` subclass to instantiate
+    comm_pairs : list[2-tuples[str]]
+        List of command-response pairs, i.e. 2-tuples like `('VOLT?', '3.14')`.
+        A tuple of length 1, e.g. `('MYCMD',)`, represents a command without expected response.
+        To represent a response-only communication, use `None` for the command part,
+         e.g. `(None, 'RESP1')`.
+    """
+    protocol = ProtocolAdapter(comm_pairs)
+    instr = instrument_cls(protocol, "Virtual instrument")
+    yield instr
+
+    # TODO: Make this skeleton implementation produce reasonable tests
+    # TODO: Assert correct state of comm_pairs after yield
+    # TODO: Enable user query for responses
+    # TODO: Add explanatory documentation with examples in :doc:`adding-instruments`

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -35,6 +35,9 @@ def expected_protocol(instrument_cls, comm_pairs):
     manager confirms that the code in the context manager block produces the expected
     messages.
 
+    Terminators are excluded from the protocol definition, as those are typically a detail of the
+     communication method (i.e. Adapter), and not the protocol.
+
     Parameters
     ----------
     instrument_cls : `~pymeasure.Instrument`

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -40,16 +40,14 @@ def expected_protocol(instrument_cls, comm_pairs, **kwargs):
     typically a detail of the communication method (i.e. Adapter), and not the
     protocol itself.
 
-    Parameters
-    ----------
-    instrument_cls : `~pymeasure.Instrument`
-        `~pymeasure.Instrument` subclass to instantiate.
-    comm_pairs : list[2-tuples[str]]
+    :param pymeasure.Instrument instrument_cls:
+        :class:`~pymeasure.instruments.Instrument` subclass to instantiate.
+    :param list[2-tuples[str]] comm_pairs:
         List of command-response pairs, i.e. 2-tuples like `('VOLT?', '3.14')`.
         'None' indicates that a pair member (command or response) does not
         exist, e.g. `(None, 'RESP1')`. Commands and responses are without
         termination characters.
-    kwargs : dict, optional
+    :param \\**kwargs:
         Keyword arguments for the instantiation of the instrument.
     """
     protocol = ProtocolAdapter(comm_pairs)

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -28,7 +28,7 @@ from pymeasure.adapters.protocol import ProtocolAdapter
 
 
 @contextmanager
-def expected_protocol(instrument_cls, comm_pairs):
+def expected_protocol(instrument_cls, comm_pairs, **kwargs):
     """Context manager that checks sent/received instrument commands without a
     device connected.
 
@@ -43,15 +43,17 @@ def expected_protocol(instrument_cls, comm_pairs):
     Parameters
     ----------
     instrument_cls : `~pymeasure.Instrument`
-        `~pymeasure.Instrument` subclass to instantiate
+        `~pymeasure.Instrument` subclass to instantiate.
     comm_pairs : list[2-tuples[str]]
         List of command-response pairs, i.e. 2-tuples like `('VOLT?', '3.14')`.
         'None' indicates that a pair member (command or response) does not
         exist, e.g. `(None, 'RESP1')`. Commands and responses are without
         termination characters.
+    kwargs : dict, optional
+        Keyword arguments for the instantiation of the instrument.
     """
     protocol = ProtocolAdapter(comm_pairs)
-    instr = instrument_cls(protocol, name="Virtual instrument")
+    instr = instrument_cls(protocol, name="Virtual instrument", **kwargs)
     yield instr
     assert protocol._index == len(comm_pairs), (
         "Unprocessed protocol definitions remain: "

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -57,6 +57,6 @@ def expected_protocol(instrument_cls, comm_pairs, **kwargs):
         "Unprocessed protocol definitions remain: "
         f"{comm_pairs[protocol._index:]}.")
     assert protocol._write_buffer == b"", (
-        f"Non-empty write buffer: '{protocol._write_buffer}'.")
+        f"Non-empty write buffer remains: '{protocol._write_buffer}'.")
     assert protocol._read_buffer == b"", (
-        f"Non-empty read buffer: '{protocol._read_buffer}'.")
+        f"Non-empty read buffer remains: '{protocol._read_buffer}'.")

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -47,7 +47,8 @@ def expected_protocol(instrument_cls, comm_pairs):
     comm_pairs : list[2-tuples[str]]
         List of command-response pairs, i.e. 2-tuples like `('VOLT?', '3.14')`.
         'None' indicates that a pair member (command or response) does not
-        exist, e.g. `(None, 'RESP1')`.
+        exist, e.g. `(None, 'RESP1')`. Commands and responses are without
+        termination characters.
     """
     protocol = ProtocolAdapter(comm_pairs)
     instr = instrument_cls(protocol, name="Virtual instrument")
@@ -59,8 +60,3 @@ def expected_protocol(instrument_cls, comm_pairs):
         f"Non-empty write buffer: '{protocol._write_buffer}'.")
     assert protocol._read_buffer == b"", (
         f"Non-empty read buffer: '{protocol._read_buffer}'.")
-
-    # TODO: Make this skeleton implementation produce reasonable tests
-    # TODO: Assert correct state of comm_pairs after yield
-    # TODO: Enable user query for responses
-    # TODO: Add explanatory documentation with examples in :doc:`adding-instruments`

--- a/tests/adapters/test_adapter.py
+++ b/tests/adapters/test_adapter.py
@@ -30,6 +30,9 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+# TODO: When restructuring adapter logging, investigate timing impact of enabled debug logging
+
+
 def test_adapter_values():
     a = FakeAdapter()
     assert a.values("5,6,7") == [5, 6, 7]

--- a/tests/adapters/test_adapter.py
+++ b/tests/adapters/test_adapter.py
@@ -30,9 +30,6 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-# TODO: When restructuring adapter logging, investigate timing impact of enabled debug logging
-
-
 def test_adapter_values():
     a = FakeAdapter()
     assert a.values("5,6,7") == [5, 6, 7]

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -179,3 +179,8 @@ def test_write_and_read_with_and_without_bytes():
     a.write("1")
     assert a.read_bytes(1) == b"a"
     assert a.read() == "1"
+
+
+def test_comm_pairs_are_all_length_2():
+    with raises(ValueError):
+        ProtocolAdapter([("c1", "a1"), ("c2",), (None, "a3", "c4")])

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -27,6 +27,10 @@ from pymeasure.adapters.protocol import to_bytes, ProtocolAdapter
 from pytest import mark, raises, fixture
 
 
+# TODO: add test for when an instrument sends too many commands (e.g. if command_pairs is too short)
+#   Currently, there is only an IndexError. That should be caught an appropriate message raised
+
+
 @mark.parametrize("input, output", (("superXY", b"superXY"),
                                     ([1, 2, 3, 4], b"\x01\x02\x03\x04"),
                                     (5, b"5"),

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -129,9 +129,15 @@ class Test_read:
                                            (b"Bytes", "Bytes"),
                                            ))
     def test_works(self, buffer, returned):
-        a = ProtocolAdapter([])
+        a = ProtocolAdapter()
         a._read_buffer = buffer
         assert a.read() == returned
+
+    def test_read_buffer_emptied(self):
+        a = ProtocolAdapter()
+        a._read_buffer = b"jklasdf"
+        a.read()
+        assert a._read_buffer == b""
 
     def test_unsolicited_response(self):
         a = ProtocolAdapter([(None, "Response")])

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -1,0 +1,31 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.adapters.protocol import ProtocolAdapter
+
+
+def test_protocol_instantiation():
+    a = ProtocolAdapter()
+    assert not a
+    # TODO: Make this first test assert something useful

--- a/tests/instruments/hcp/test_tc038.py
+++ b/tests/instruments/hcp/test_tc038.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+Unit tests for the HCP TC038
+"""
+
+import pytest
+
+from pymeasure.test import expected_protocol
+
+
+from pymeasure.instruments.hcp import TC038
+
+
+def test_setpoint():
+    with expected_protocol(
+            TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+                    (b"\x0201010WRDD0120,01\x03", b"\x020101OK00C8\x03")]
+            ) as inst:
+        assert inst.setpoint == 20
+
+
+def test_setpoint_setter():
+    # Communication from manual.
+    with expected_protocol(
+        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+                (b"\x0201010WWRD0120,01,00C8\x03", b"\x020101OK\x03")]
+    ) as inst:
+        inst.setpoint = 20
+
+
+def test_temperature():
+    # Communication from manual.
+    with expected_protocol(
+        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+                (b"\x0201010WRDD0002,01\x03", b"\x020101OK00C8\x03")]
+    ) as inst:
+        assert 20 == inst.temperature
+
+
+def test_monitored():
+    # Communication from manual.
+    with expected_protocol(
+        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+                (b"\x0201010WRM\x03", b"\x020101OK00C8\x03")]
+    ) as inst:
+        assert 20 == inst.monitored_value
+
+
+def test_set_monitored():
+    # Communication from manual.
+    with expected_protocol(
+        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
+    ):
+        pass
+
+
+def test_set_monitored_wrong_input():
+    with expected_protocol(TC038,
+                           [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
+                           ) as inst:
+        with pytest.raises(KeyError):
+            inst.set_monitored_quantity("temper")
+
+
+def test_information():
+    # Communication from manual.
+    with expected_protocol(
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+         (b"\x0201010INF6\x03",
+          b"\x020101OKUT150333 V01.R001111222233334444\x03")]
+    ) as inst:
+        value = inst.information
+        assert value == "UT150333 V01.R001111222233334444"

--- a/tests/instruments/hcp/test_tc038.py
+++ b/tests/instruments/hcp/test_tc038.py
@@ -13,17 +13,19 @@ from pymeasure.instruments.hcp import TC038
 
 def test_setpoint():
     with expected_protocol(
-            TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
-                    (b"\x0201010WRDD0120,01\x03", b"\x020101OK00C8\x03")]
-            ) as inst:
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+         (b"\x0201010WRDD0120,01\x03", b"\x020101OK00C8\x03")]
+    ) as inst:
         assert inst.setpoint == 20
 
 
 def test_setpoint_setter():
     # Communication from manual.
     with expected_protocol(
-        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
-                (b"\x0201010WWRD0120,01,00C8\x03", b"\x020101OK\x03")]
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+         (b"\x0201010WWRD0120,01,00C8\x03", b"\x020101OK\x03")]
     ) as inst:
         inst.setpoint = 20
 
@@ -31,8 +33,9 @@ def test_setpoint_setter():
 def test_temperature():
     # Communication from manual.
     with expected_protocol(
-        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
-                (b"\x0201010WRDD0002,01\x03", b"\x020101OK00C8\x03")]
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+         (b"\x0201010WRDD0002,01\x03", b"\x020101OK00C8\x03")]
     ) as inst:
         assert 20 == inst.temperature
 
@@ -40,8 +43,9 @@ def test_temperature():
 def test_monitored():
     # Communication from manual.
     with expected_protocol(
-        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
-                (b"\x0201010WRM\x03", b"\x020101OK00C8\x03")]
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03"),
+         (b"\x0201010WRM\x03", b"\x020101OK00C8\x03")]
     ) as inst:
         assert 20 == inst.monitored_value
 
@@ -49,15 +53,17 @@ def test_monitored():
 def test_set_monitored():
     # Communication from manual.
     with expected_protocol(
-        TC038, [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
     ):
-        pass
+        pass  # Instantiation calls set_monitored_quantity()
 
 
 def test_set_monitored_wrong_input():
-    with expected_protocol(TC038,
-                           [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
-                           ) as inst:
+    with expected_protocol(
+        TC038,
+        [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
+    ) as inst:
         with pytest.raises(KeyError):
             inst.set_monitored_quantity("temper")
 

--- a/tests/instruments/hcp/test_tc038d.py
+++ b/tests/instruments/hcp/test_tc038d.py
@@ -25,6 +25,7 @@ def test_write_multiple():
 
 
 def test_write_multiple_CRC_error():
+    """Test whether an invalid response CRC code raises an Exception."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
@@ -34,26 +35,27 @@ def test_write_multiple_CRC_error():
             inst.setpoint = 32.1
 
 
-def test_write_multiple_wrong_values():
+def test_write_multiple_wrong_type():
     with expected_protocol(
         TC038D, []
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             inst.writeMultiple(0x010A, 5.5)
 
 
-def test_write_multiple_Value_error():
+def test_write_multiple_handle_wrong_start_address():
+    """Test whether the error code (byte 2) of 2 raises the right error."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
           b"\x01\x90\x02\x06\x00")],
     ) as inst:
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="Wrong start address"):
             inst.setpoint = 32.1
-            assert str(exc) == "Wrong start address"
 
 
 def test_read_CRC_error():
+    """Test whether an invalid response CRC code raises an Exception."""
     with expected_protocol(
         TC038D,
         [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
@@ -64,26 +66,29 @@ def test_read_CRC_error():
 
 
 def test_read_address_error():
+    """Test whether the error code (byte 2) of 2 raises the right error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
               b"\x01\x83\x02\01\02")],
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The read start address"):
             inst.temperature
 
 
 def test_read_elements_error():
+    """Test whether the error code (byte 2) of 3 raises the right error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
               b"\x01\x83\x03\01\02")],
     ) as inst:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="The number of elements"):
             inst.temperature
 
 
 def test_read_any_error():
+    """Test whether any wrong message (byte 1 is not 3) raises an error."""
     with expected_protocol(
             TC038D,
             [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",

--- a/tests/instruments/hcp/test_tc038d.py
+++ b/tests/instruments/hcp/test_tc038d.py
@@ -37,7 +37,8 @@ def test_write_multiple_CRC_error():
 
 def test_write_multiple_wrong_type():
     with expected_protocol(
-        TC038D, []
+        TC038D,
+        []
     ) as inst:
         with pytest.raises(TypeError):
             inst.writeMultiple(0x010A, 5.5)
@@ -68,9 +69,9 @@ def test_read_CRC_error():
 def test_read_address_error():
     """Test whether the error code (byte 2) of 2 raises the right error."""
     with expected_protocol(
-            TC038D,
-            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
-              b"\x01\x83\x02\01\02")],
+        TC038D,
+        [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+          b"\x01\x83\x02\01\02")],
     ) as inst:
         with pytest.raises(ValueError, match="The read start address"):
             inst.temperature

--- a/tests/instruments/hcp/test_tc038d.py
+++ b/tests/instruments/hcp/test_tc038d.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""
+Unit tests for the HCP TC038D
+"""
+
+# IMPORTS #####################################################################
+
+
+import pytest
+
+from pymeasure.test import expected_protocol
+
+
+from pymeasure.instruments.hcp import TC038D
+
+
+def test_write_multiple():
+    # Communication from manual.
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x0A\x00\x04\x08\x00\x00\x03\xE8\xFF\xFF\xFC\x18\x8D\xE9",
+          b"\x01\x10\x01\x0A\x00\x04\xE0\x34")]
+    ) as inst:
+        inst.writeMultiple(0x010A, [1000, -1000])
+
+
+def test_write_multiple_CRC_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x10\x01\x06\x00\x02\x01\x02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.setpoint = 32.1
+
+
+def test_write_multiple_wrong_values():
+    with expected_protocol(
+        TC038D, []
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.writeMultiple(0x010A, 5.5)
+
+
+def test_write_multiple_Value_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x90\x02\x06\x00")],
+    ) as inst:
+        with pytest.raises(ValueError) as exc:
+            inst.setpoint = 32.1
+            assert str(exc) == "Wrong start address"
+
+
+def test_read_CRC_error():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+          b"\x01\x03\x04\x00\x00\x03\xE8\x01\x02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.temperature
+
+
+def test_read_address_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x83\x02\01\02")],
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.temperature
+
+
+def test_read_elements_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x83\x03\01\02")],
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.temperature
+
+
+def test_read_any_error():
+    with expected_protocol(
+            TC038D,
+            [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+              b"\x01\x43\x05\01\02")],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.temperature
+
+
+def test_setpoint():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x01\x06\x00\x02\x25\xf6",
+          b"\x01\x03\x04\x00\x00\x00\x99:Y")],
+    ) as inst:
+        assert inst.setpoint == 15.3
+
+
+def test_setpoint_setter():
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x10\x01\x06\x00\x02\x04\x00\x00\x01A\xbf\xb5",
+          b"\x01\x10\x01\x06\x00\x02\xa0\x35")],
+    ) as inst:
+        inst.setpoint = 32.1
+
+
+def test_temperature():
+    # Communication from manual.
+    # Tests readRegister as well.
+    with expected_protocol(
+        TC038D,
+        [(b"\x01\x03\x00\x00\x00\x02\xC4\x0B",
+         b"\x01\x03\x04\x00\x00\x03\xE8\xFA\x8D")],
+    ) as inst:
+        assert inst.temperature == 100

--- a/tests/instruments/keithley/test_keithley2000.py
+++ b/tests/instruments/keithley/test_keithley2000.py
@@ -1,0 +1,79 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.keithley.keithley2000 import Keithley2000
+
+
+def test_voltage_read():
+    with expected_protocol(
+        Keithley2000,
+        [(":READ?", "3.1415")],
+    ) as inst:
+        assert inst.voltage == pytest.approx(3.1415)
+
+
+def test_voltage_range():
+    with expected_protocol(
+        Keithley2000,
+        [(":SENS:VOLT:RANG?", "955"),
+         (":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG 234", None)
+         ],
+    ) as inst:
+        assert inst.voltage_range == 955
+        inst.voltage_range = 234
+
+
+def test_voltage_range_trunc():
+    with expected_protocol(
+        Keithley2000,
+        [(":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG 1010", None),
+         (":SENS:VOLT:RANG?", "1010"),
+         ],
+    ) as inst:
+        inst.voltage_range = 3333  # too large, gets truncated
+        assert inst.voltage_range == 1010
+
+
+def test_mode():
+    "Confirm that mode string mapping works correctly"
+    with expected_protocol(
+        Keithley2000,
+        [(":CONF?", "VOLT:AC"),
+         (":CONF:FRES", None),
+         ],
+    ) as inst:
+        assert inst.mode == 'voltage ac'
+        inst.mode = 'resistance 4W'
+
+
+def test_measure_voltage():
+    with expected_protocol(
+        Keithley2000,
+        [(":CONF:VOLT:AC", None),
+         (":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:AC:RANG 300", None),
+         ],
+    ) as inst:
+        inst.measure_voltage(max_voltage=300, ac=True)

--- a/tests/instruments/tektronix/test_afg3152.py
+++ b/tests/instruments/tektronix/test_afg3152.py
@@ -1,0 +1,49 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.tektronix.afg3152c import AFG3152C
+
+
+def test_shape():
+    # Demonstrate message prefix identifying the channel
+    # Note how the implementation of the shape property does not show that
+    # prefix (it is added in the Channel class)
+    with expected_protocol(
+        AFG3152C,
+        [("source1:function:shape?", "LOR"),
+         ("source2:function:shape HAV", None),
+         ],
+    ) as inst:
+        assert inst.ch1.shape == 'lorentz'
+        inst.ch2.shape = 'haversine'
+
+
+def test_beep():
+    # A message common to all channels does not have a prefix
+    with expected_protocol(
+        AFG3152C,
+        [("system:beep", None)],
+    ) as inst:
+        inst.beep()

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -1,0 +1,49 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments import Instrument
+
+
+class BasicTestInstrument(Instrument):
+    simple = Instrument.control(
+        "VOLT?", "VOLT %s V",
+        """Simple property replying with plain floats""",
+    )
+
+
+def test_simple_protocol():
+    """Test a property without parsing or channel prefixes."""
+    with expected_protocol(BasicTestInstrument,
+                           [('VOLT?', 3.14),
+                            ('VOLT 4.5 V',),
+                            ]) as instr:
+        assert instr.simple == 3.14
+        instr.simple = 4.5
+
+
+# After completing expected_protocol tests, add tests elsewhere:
+# TODO: Add protocol tests for a simple instrument
+# TODO: Add protocol tests for an instrument with multiple channels
+# TODO: Add protocol tests for a frame-based instrument (recommend: TC038, TC038D)

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -30,8 +30,8 @@ from pymeasure.instruments import Instrument
 
 
 class BasicTestInstrument(Instrument):
-    def __init__(self, adapter, name, **kwargs):
-        super().__init__(adapter, name)
+    def __init__(self, adapter, **kwargs):
+        super().__init__(adapter, "Basic Test Instrument")
         self.kwargs = kwargs
 
     simple = Instrument.control(

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -39,7 +39,9 @@ class InstrumentWithPreprocess(BasicTestInstrument):
     def values(self, command, **kwargs):
         return super().values(command, preprocess_reply=lambda v: v+"2345", **kwargs)
 
-    def __init__2(self, adapter, **kwargs):
+    # For now preprocess_reply at init level is nonfunctional because this
+    # lives in the adapter, should be fixed with #567
+    def __broken__init__(self, adapter, **kwargs):
         super().__init__(adapter, preprocess_reply=lambda v: v+"2345", **kwargs)
 
 

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -95,7 +95,7 @@ def test_not_all_communication_used():
 
 
 def test_non_empty_write_buffer():
-    with raises(AssertionError, match="Non-empty write buffer"):
+    with raises(AssertionError, match="Non-empty write buffer remains"):
         with expected_protocol(
             BasicTestInstrument,
             [('VOLT?', 3.14)]
@@ -105,7 +105,7 @@ def test_non_empty_write_buffer():
 
 
 def test_non_empty_read_buffer():
-    with raises(AssertionError, match="Non-empty read buffer"):
+    with raises(AssertionError, match="Non-empty read buffer remains"):
         with expected_protocol(
             BasicTestInstrument,
             [('VOLT?', 3.14)]

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -48,30 +48,36 @@ class BasicTestInstrument(Instrument):
 
 def test_simple_protocol():
     """Test a property without parsing or channel prefixes."""
-    with expected_protocol(BasicTestInstrument,
-                           [('VOLT?', 3.14),
-                            ('VOLT 4.5 V', None),
-                            ]) as instr:
+    with expected_protocol(
+        BasicTestInstrument,
+        [('VOLT?', 3.14),
+         ('VOLT 4.5 V', None)]
+    ) as instr:
         assert instr.simple == 3.14
         instr.simple = 4.5
 
 
 def test_kwargs():
     """Test whether the kwargs are handed over correctly."""
-    with expected_protocol(BasicTestInstrument,
-                           [],
-                           test=5, xyz="abc") as instr:
+    with expected_protocol(
+        BasicTestInstrument,
+        [],
+        test=5,
+        xyz="abc"
+    ) as instr:
         assert instr.kwargs == {'test': 5, 'xyz': "abc"}
 
 
 def test_error_checks():
     """Test protocol for getting and setting with error checks."""
-    with expected_protocol(BasicTestInstrument,
-                           [('VOLT?', 3.14),
-                            ('SYST:ERR?', '0, 0'),
-                            ('VOLT 4.5 V', None),
-                            ('SYST:ERR?', '0, 0'),
-                            ]) as instr:
+    with expected_protocol(
+        BasicTestInstrument,
+        [('VOLT?', 3.14),
+         ('SYST:ERR?', '0, 0'),
+         ('VOLT 4.5 V', None),
+         ('SYST:ERR?', '0, 0'),
+         ]
+    ) as instr:
         assert instr.with_error_checks == 3.14
         instr.with_error_checks = 4.5
 
@@ -79,27 +85,31 @@ def test_error_checks():
 def test_not_all_communication_used():
     """Test whether unused communication raises an error."""
     with raises(AssertionError, match="Unprocessed protocol definitions remain"):
-        with expected_protocol(BasicTestInstrument,
-                               [('VOLT?', 3.14),
-                                ('VOLT 4.5 V', None),
-                                ]) as instr:
+        with expected_protocol(
+            BasicTestInstrument,
+            [('VOLT?', 3.14),
+             ('VOLT 4.5 V', None),
+             ]
+        ) as instr:
             assert instr.simple == 3.14
 
 
 def test_non_empty_write_buffer():
     with raises(AssertionError, match="Non-empty write buffer"):
-        with expected_protocol(BasicTestInstrument,
-                               [('VOLT?', 3.14),
-                                ]) as instr:
+        with expected_protocol(
+            BasicTestInstrument,
+            [('VOLT?', 3.14)]
+        ) as instr:
             instr.adapter.write_bytes(b"VOLT")
             instr.adapter._index = 1
 
 
 def test_non_empty_read_buffer():
     with raises(AssertionError, match="Non-empty read buffer"):
-        with expected_protocol(BasicTestInstrument,
-                               [('VOLT?', 3.14),
-                                ]) as instr:
+        with expected_protocol(
+            BasicTestInstrument,
+            [('VOLT?', 3.14)]
+        ) as instr:
             instr.write("VOLT?")
 
 
@@ -109,8 +119,10 @@ def test_preprocess_reply_on_values():
         def values(self, command, **kwargs):
             return super().values(command, preprocess_reply=lambda v: v + "2345", **kwargs)
 
-    with expected_protocol(InstrumentWithPreprocessValues,
-                           [("VOLT?", "3.1")]) as instr:
+    with expected_protocol(
+        InstrumentWithPreprocessValues,
+        [("VOLT?", "3.1")]
+    ) as instr:
         assert instr.simple == 3.12345
 
 
@@ -122,6 +134,8 @@ def test_preprocess_reply_on_init():
         def __init__(self, adapter, **kwargs):
             super().__init__(adapter, preprocess_reply=lambda v: v + "2345", **kwargs)
 
-    with expected_protocol(InstrumentWithPreprocess,
-                           [("VOLT?", "3.1")]) as instr:
+    with expected_protocol(
+        InstrumentWithPreprocess,
+        [("VOLT?", "3.1")]
+    ) as instr:
         assert instr.simple == 3.12345

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -113,11 +113,3 @@ def test_preprocess_reply_on_init():
     with expected_protocol(InstrumentWithPreprocess,
                            [("VOLT?", "3.1")]) as instr:
         assert instr.simple == 3.12345
-
-
-# After completing expected_protocol tests, add tests elsewhere:
-# TODO: Add protocol tests for a simple instrument
-# TODO: Add protocol tests for an instrument with multiple channels
-# TODO: Add protocol tests for a frame-based instrument (recommend: TC038, TC038D)
-# TODO: (Later) Add protocol tests for an instrument with a custom Adapter, refactor that (probably)
-# TODO: (Later) Search for any custom Adapters and refactor those

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -30,6 +30,10 @@ from pymeasure.instruments import Instrument
 
 
 class BasicTestInstrument(Instrument):
+    def __init__(self, adapter, name, **kwargs):
+        super().__init__(adapter, name)
+        self.kwargs = kwargs
+
     simple = Instrument.control(
         "VOLT?", "VOLT %s V",
         """Simple property replying with plain floats""",
@@ -50,6 +54,14 @@ def test_simple_protocol():
                             ]) as instr:
         assert instr.simple == 3.14
         instr.simple = 4.5
+
+
+def test_kwargs():
+    """Test whether the kwargs are handed over correctly."""
+    with expected_protocol(BasicTestInstrument,
+                           [],
+                           test=5, xyz="abc") as instr:
+        assert instr.kwargs == {'test': 5, 'xyz': "abc"}
 
 
 def test_error_checks():

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -47,3 +47,5 @@ def test_simple_protocol():
 # TODO: Add protocol tests for a simple instrument
 # TODO: Add protocol tests for an instrument with multiple channels
 # TODO: Add protocol tests for a frame-based instrument (recommend: TC038, TC038D)
+# TODO: (Later) Add protocol tests for an instrument with a custom Adapter, refactor that (probably)
+# TODO: (Later) Search for any custom Adapters and refactor those

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -35,6 +35,11 @@ class BasicTestInstrument(Instrument):
     )
 
 
+class InstrumentWithPreprocess(BasicTestInstrument):
+    def __init__(self, adapter, **kwargs):
+        super().__init__(adapter, preprocess_reply=lambda v: v+"2345", **kwargs)
+
+
 def test_simple_protocol():
     """Test a property without parsing or channel prefixes."""
     with expected_protocol(BasicTestInstrument,
@@ -74,6 +79,11 @@ def test_non_empty_read_buffer():
             instr.write("VOLT?")
     assert str(exc.value) == "Non empty read buffer."
 
+
+def test_preprocess():
+    with expected_protocol(InstrumentWithPreprocess,
+                           [("VOLT?", "3.1")]) as instr:
+        assert instr.simple == 3.12345
 
 # After completing expected_protocol tests, add tests elsewhere:
 # TODO: Add protocol tests for a simple instrument


### PR DESCRIPTION
This will be useful to test pymeasure instrument implementations without having the hardware present (see #627).

@bmoneke I have now gone through my notes for now and opened this PR so we can iterate further and knock out the remaining `TODO` items together. If you're up to it we can to PRs against this branch again, I think this worked well for collaborative design/implementation.

* [x] ~~What I still have noted down to do is "Debug/investigate and comment on what ProtocolAdapter.read() is doing with those indices" because it was not clear to me at review time :sweat_smile:, but I didn't put that as a formal TODO.~~ let's skip this to not get bogged down even longer
* [x] Also, when the implementation is converged, we need to write useful user-facing documentation, with examples, that we can point people at when we ask them to write protocol tests. Adding those tests being a painless process, with little boilerplate/distractions, is I think important to get people to add instrument tests.
* [x] Add protocol tests for a (real) simple instrument
* [x] Add protocol tests for a (real) instrument with multiple channels

Closes #627 
Closes #249