### PR TITLE
GUI: Enable spinbox functionality for IntergerParameter and FloatParameter

### DIFF
--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -109,13 +109,24 @@ class IntegerInput(Input, QtGui.QSpinBox):
 
     def __init__(self, parameter, parent=None, **kwargs):
         super().__init__(parameter=parameter, parent=parent, **kwargs)
-        self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+        if parameter.step:
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+            self.setSingleStep(parameter.step)
+            self.setEnabled(True)
+        else:
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
         self.setMinimum(parameter.minimum)
         self.setMaximum(parameter.maximum)
         super().set_parameter(parameter)  # default gets set here, after min/max
+
+    def stepEnabled(self):
+        if self.parameter.step:
+            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+        else:
+            return QtGui.QAbstractSpinBox.StepNone
 
 
 class BooleanInput(Input, QtGui.QCheckBox):
@@ -195,7 +206,12 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
 
     def __init__(self, parameter, parent=None, **kwargs):
         super().__init__(parameter=parameter, parent=parent, **kwargs)
-        self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+        if parameter.step:
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+            self.setSingleStep(parameter.step)
+            self.setEnabled(True)
+        else:
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -238,4 +254,8 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
         return string
 
     def stepEnabled(self):
-        return QtGui.QAbstractSpinBox.StepNone
+        if self.parameter.step:
+            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+        else:
+            return QtGui.QAbstractSpinBox.StepNone
+

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -102,27 +102,6 @@ class StringInput(Input, QtGui.QLineEdit):
         return super().text()
 
 
-class FloatInput(Input, QtGui.QDoubleSpinBox):
-    """
-    Spin input box for floating-point values, connected to a
-    :class:`FloatParameter`.
-
-    .. seealso::
-        Class :class:`~.ScientificInput`
-            For inputs in scientific notation.
-    """
-
-    def __init__(self, parameter, parent=None, **kwargs):
-        super().__init__(parameter=parameter, parent=parent, **kwargs)
-        self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
-
-    def set_parameter(self, parameter):
-        # Override from :class:`Input`
-        self.setMinimum(parameter.minimum)
-        self.setMaximum(parameter.maximum)
-        super().set_parameter(parameter)  # default gets set here, after min/max
-
-
 class IntegerInput(Input, QtGui.QSpinBox):
     """
     Spin input box for integer values, connected to a :class:`IntegerParameter`.

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -258,4 +258,3 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
             return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
         else:
             return QtGui.QAbstractSpinBox.StepNone
-

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -100,13 +100,15 @@ class IntegerParameter(Parameter):
     :param maximum: The maximum allowed value (default: 1e9)
     :param default: The default integer value
     :param ui_class: A Qt class to use for the UI of this parameter
+    :param step: integer step size to use in UI spinbox for this parameter. If None, spinbox will have step disabled
     """
 
-    def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, **kwargs):
+    def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, step=None, **kwargs):
         super().__init__(name, **kwargs)
         self.units = units
         self.minimum = int(minimum)
         self.maximum = int(maximum)
+        self.step = int(step) if step else None
 
     @property
     def value(self):
@@ -197,15 +199,17 @@ class FloatParameter(Parameter):
     :param decimals: The number of decimals considered (default: 15)
     :param default: The default floating point value
     :param ui_class: A Qt class to use for the UI of this parameter
+    :param step: step size to use in UI spinbox for this parameter. If None, spinbox will have step disabled
     """
 
     def __init__(self, name, units=None, minimum=-1e9, maximum=1e9,
-                 decimals=15, **kwargs):
+                 decimals=15, step=None, **kwargs):
         super().__init__(name, **kwargs)
         self.units = units
         self.minimum = minimum
         self.maximum = maximum
         self.decimals = decimals
+        self.step = step
 
     @property
     def value(self):

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -100,7 +100,7 @@ class IntegerParameter(Parameter):
     :param maximum: The maximum allowed value (default: 1e9)
     :param default: The default integer value
     :param ui_class: A Qt class to use for the UI of this parameter
-    :param step: integer step size to use in UI spinbox for this parameter. If None, spinbox will have step disabled
+    :param step: int step size for parameter's UI spinbox. If None, spinbox will have step disabled
     """
 
     def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, step=None, **kwargs):
@@ -199,7 +199,7 @@ class FloatParameter(Parameter):
     :param decimals: The number of decimals considered (default: 15)
     :param default: The default floating point value
     :param ui_class: A Qt class to use for the UI of this parameter
-    :param step: step size to use in UI spinbox for this parameter. If None, spinbox will have step disabled
+    :param step: step size for parameter's UI spinbox. If None, spinbox will have step disabled
     """
 
     def __init__(self, name, units=None, minimum=-1e9, maximum=1e9,


### PR DESCRIPTION
I like to use spin boxes for my `IntegerParameter` and `FloatParameters`, which I've previously been implementing with the `ui_class` kwarg. This seems like a feature that could have general appeal, so I made this PR with a potential implementation:

The `IntegerParameter` and `FloatParameter` classes now accept a `step` kwarg. If provided, the corresponding GUI input will be a spinbox with step size = `step`. The current behavior is unchanged if `step` is not provided.

I also removed the unused `FloatInput` class. It seems to have been replaced by the `ScientificInput` class.

Please let me know if you'd like me to make any changes or add an example of this to the docs.