### PR TITLE
Patch hcp instruments documentation

### DIFF
--- a/docs/api/instruments/hcp/tc038.rst
+++ b/docs/api/instruments/hcp/tc038.rst
@@ -2,6 +2,6 @@
 HCP TC038 crystal oven
 ######################
 
-.. autoclass:: pymeasure.instruments.hcp.tc038
+.. autoclass:: pymeasure.instruments.hcp.TC038
     :members:
     :show-inheritance:

--- a/docs/api/instruments/hcp/tc038d.rst
+++ b/docs/api/instruments/hcp/tc038d.rst
@@ -2,6 +2,6 @@
 HCP TC038D crystal oven
 #######################
 
-.. autoclass:: pymeasure.instruments.hcp.tc038d
+.. autoclass:: pymeasure.instruments.hcp.TC038D
     :members:
     :show-inheritance:


### PR DESCRIPTION
The documentation links to the hcp devices did not work, because they linked to the module, now they should work.