### PR TITLE
Add black configuration

### DIFF
--- a/docs/dev/coding_standards.rst
+++ b/docs/dev/coding_standards.rst
@@ -12,12 +12,17 @@ The `PEP8 style guide`_ and `PEP257 docstring conventions`_ should be followed.
 .. _PEP8 style guide: https://www.python.org/dev/peps/pep-0008/
 .. _PEP257 docstring conventions: https://www.python.org/dev/peps/pep-0257/
 
-Function and variable names should be lower case with underscores as needed to seperate words. CamelCase should only be used for class names, unless working with Qt, where its use is common.
+Function and variable names should be lower case with underscores as needed to separate words. CamelCase should only be used for class names, unless working with Qt, where its use is common.
 
 In addition, there is a configuration for the `flake8`_ linter present. Our codebase should not trigger any warnings.
 Many editors/IDEs can run this tool in the background while you work, showing results inline. Alternatively, you can run ``flake8`` in the repository root to check for problems. In addition, our automation on Github also runs some checkers. As this results in a much slower feedback loop for you, it's not recommended to rely only on this.
 
 .. _flake8: https://flake8.pycqa.org/en/latest/
+
+It is allowed but not required to use the `black`_ code formatter. Do only format files that you are actively working on and make a dedicated commit for the initial formatting when working on an existing file that does not adhere to the black code style to facilitate code review. If there are conflicts between black's output and flake8 (especially related to `E203`_), flake8 takes precedence. Use ``#noqa : E203`` to disable E203 warnings for a specific line if appropriate.
+
+.. _black: https://black.readthedocs.io/en/stable/
+.. _E203: https://www.flake8rules.com/rules/E203.html
 
 There are no plans to support type hinting in PyMeasure code. This adds a lot of additional code to manage, without a clear advantage for this project. 
 Type documentation should be placed in the docstring where not clear from the variable name.

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -1810,7 +1810,7 @@ class QueryLearn():
     def _get_smu(key, smu_references):
         # command without channel
         command = re.findall(r'(?P<command>[A-Z]+)', key)[0]
-        channel = key[len(command):]
+        channel = key[len(command) :]  # noqa: E203
         return smu_references[int(channel)]
 
     # SMU Modes

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -274,7 +274,8 @@ class DPSeriesMotorController(Instrument):
         raise NotImplementedError("steps_to_absolute() must be implemented in subclasses!")
 
     def reset_position(self):
-        """ Reset the position as counted by the motor controller and an externally connected encoder to 0.
+        """
+        Reset position as counted by the motor controller and an externally connected encoder to 0.
         """
         # reset encoder recorded position #
         self.write("ET")

--- a/pymeasure/instruments/hp/hp3437A.py
+++ b/pymeasure/instruments/hp/hp3437A.py
@@ -242,7 +242,7 @@ class HP3437A(HPLegacyInstrument):
         else:
             processed_data = []
             for i in range(0, len(read_data), 2):
-                processed_data.append(self._unpack_data(read_data[i:i+2]))
+                processed_data.append(self._unpack_data(read_data[i : i + 2]))  # noqa: E203
             return_value = np.array(processed_data)
         self.adapter.connection.timeout = current_timeout
         return return_value

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -277,18 +277,18 @@ class Instrument:
     @staticmethod
     def control(  # noqa: C901 accept that this is a complex method
         get_command,
-            set_command,
-            docs,
-            validator=lambda v, vs: v,
-            values=(),
-            map_values=False,
-            get_process=lambda v: v,
-            set_process=lambda v: v,
-            command_process=lambda c: c,
-            check_set_errors=False,
-            check_get_errors=False,
-            dynamic=False,
-            **kwargs
+        set_command,
+        docs,
+        validator=lambda v, vs: v,
+        values=(),
+        map_values=False,
+        get_process=lambda v: v,
+        set_process=lambda v: v,
+        command_process=lambda c: c,
+        check_set_errors=False,
+        check_get_errors=False,
+        dynamic=False,
+        **kwargs
     ):
         """Returns a property for the class based on the supplied
         commands. This property may be set and read from the

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -275,19 +275,21 @@ class Instrument:
         return self.adapter.binary_values(command, header_bytes, dtype)
 
     @staticmethod
-    def control(get_command,  # noqa: C901 accept that this is a complex method
-                set_command,
-                docs,
-                validator=lambda v, vs: v,
-                values=(),
-                map_values=False,
-                get_process=lambda v: v,
-                set_process=lambda v: v,
-                command_process=lambda c: c,
-                check_set_errors=False,
-                check_get_errors=False,
-                dynamic=False,
-                **kwargs):
+    def control(  # noqa: C901 accept that this is a complex method
+        get_command,
+            set_command,
+            docs,
+            validator=lambda v, vs: v,
+            values=(),
+            map_values=False,
+            get_process=lambda v: v,
+            set_process=lambda v: v,
+            command_process=lambda c: c,
+            check_set_errors=False,
+            check_get_errors=False,
+            dynamic=False,
+            **kwargs
+    ):
         """Returns a property for the class based on the supplied
         commands. This property may be set and read from the
         instrument. See also :meth:`measurement` and :meth:`setting`.

--- a/pymeasure/instruments/keysight/keysightDSOX1102G.py
+++ b/pymeasure/instruments/keysight/keysightDSOX1102G.py
@@ -104,7 +104,7 @@ class Channel():
 
     scale = Instrument.control(
         "SCALe?", "SCALe %f",
-        """ A float parameter that specifies the vertical scale, or units per division, in Volts."""
+        """A float parameter that specifies the vertical scale, or units per division, in Volts."""
     )
 
     def __init__(self, instrument, number):

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -473,8 +473,8 @@ class SR830(Instrument):
                 self.pause_buffer()
                 return ch1, ch2
         self.pauseBuffer()
-        ch1[index:count + 1] = self.buffer_data(1, index, count)
-        ch2[index:count + 1] = self.buffer_data(2, index, count)
+        ch1[index : count + 1] = self.buffer_data(1, index, count)  # noqa: E203
+        ch2[index : count + 1] = self.buffer_data(2, index, count)  # noqa: E203
         return ch1, ch2
 
     def buffer_measure(self, count, stopRequest=None, delay=1e-3):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # write_to = "pymeasure/_version.py"
+
+[tool.black]
+line-length = 100

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ tests =
 
 [flake8]
 exclude = .git,__pycache__,docs/conf.py,build,dist
-# The GitHub editor is 127 chars wide, maybe reduce this to 100 later
 max-line-length = 100
 max-complexity = 15
 per-file-ignores =

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,4 @@ max-line-length = 100
 max-complexity = 15
 per-file-ignores =
     __init__.py:F401
+extend-ignore = E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,4 +51,3 @@ max-line-length = 100
 max-complexity = 15
 per-file-ignores =
     __init__.py:F401
-extend-ignore = E203


### PR DESCRIPTION
I think there are some people out there using black as a code formatter, so it might be useful to include some configuration for this in `pyproject.toml` and `setup.cfg`.

 In this PR, I added some configurations to make it easier to use it with the custom line length of 100 (flake8 is configured with line length 100 in `setup.cfg`). 

I also added the recommended options from https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html as separate commits.

For people not using black, nothing should change, except maybe flake8 warnings regarding E203 (which according to the link above is not PEP8 compliant anyway).