### PR TITLE
Fix HPLegacyInstrument initializer API

### DIFF
--- a/pymeasure/instruments/hp/hplegacyinstrument.py
+++ b/pymeasure/instruments/hp/hplegacyinstrument.py
@@ -107,7 +107,7 @@ class HPLegacyInstrument(Instrument):
     """
     status_desc = StatusBitsBase  # To be overriden by subclasses
 
-    def __init__(self, adapter, name, **kwargs):
+    def __init__(self, adapter, name="HP legacy instrument", **kwargs):
         super().__init__(
             adapter, name,
             includeSCPI=False,


### PR DESCRIPTION
This should unbreak our CI. See also #651 and e.g. https://github.com/pymeasure/pymeasure/runs/7903178007?check_suite_focus=true