### PR TITLE
Remove dynamic use of docstring from ATS545 and make more generic

### DIFF
--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -56,3 +56,4 @@ The following developers have contributed to the PyMeasure package:
 | Benedikt Moneke
 | Asaf Yagoda
 | Fabio Garzetti
+| Daniel Schmeer

--- a/pymeasure/instruments/temptronic/temptronic_ats545.py
+++ b/pymeasure/instruments/temptronic/temptronic_ats545.py
@@ -53,11 +53,6 @@ class ATS545(ATSBase):
 
     temperature_limit_air_low_values = [-80, 25]
 
-    mode_doc = """Returns an integer indicating what the system is doing at the time the query is processed.
-                  10 = on Operator screen (manual mode)
-                  0 = on Cycle screen (program mode)
-                  63 = initial state after power-up
-               """
     mode_values = {'manual': 10,    # 5 in ATSbase
                    'program': 0,    # 6 in ATSbase
                    'initial': 63},  # after power up, reading is 63

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -544,7 +544,7 @@ class ATSBase(Instrument):
 
     mode = Instrument.measurement(
         "WHAT?",
-        """Returns an integer indicating what the system is doing at the time the query is processed.
+        """Returns an string indicating what the system is doing at the time the query is processed.
 
         :type: string
         """,

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -547,6 +547,7 @@ class ATSBase(Instrument):
         """Returns an string indicating what the system is doing at the time the query is processed.
 
         :type: string
+        
         """,
         values={'manual': 5,
                 'program': 6,

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -547,7 +547,7 @@ class ATSBase(Instrument):
         """Returns an string indicating what the system is doing at the time the query is processed.
 
         :type: string
-        
+
         """,
         values={'manual': 5,
                 'program': 6,

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -546,8 +546,7 @@ class ATSBase(Instrument):
         "WHAT?",
         """Returns an integer indicating what the system is doing at the time the query is processed.
 
-        5: on Operator screen (manual mode)
-        6: on Cycle screen (program mode)
+        :type: string
         """,
         values={'manual': 5,
                 'program': 6,


### PR DESCRIPTION
Fixing docstring issue from #679 and following discussion in commit #2f8526a