### PR TITLE
Compatibility with Qt 6

### DIFF
--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -172,7 +172,7 @@ Below we adapt our previous example to use a ManagedWindow. ::
         app = QtWidgets.QApplication(sys.argv)
         window = MainWindow()
         window.show()
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -91,4 +91,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -130,4 +130,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -96,4 +96,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -88,4 +88,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -99,4 +99,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = TestImageGUI()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Current-Voltage Measurements/iv_keithley.py
+++ b/examples/Current-Voltage Measurements/iv_keithley.py
@@ -122,4 +122,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Current-Voltage Measurements/iv_yokogawa.py
+++ b/examples/Current-Voltage Measurements/iv_yokogawa.py
@@ -122,4 +122,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -31,6 +31,11 @@ log.addHandler(logging.NullHandler())
 
 QtCore.QSignal = QtCore.Signal
 
+# Should be removed when PySide2 provides QtWidgets.QApplication.exec() or when support for PySide2
+# is dropped
+if not hasattr(QtWidgets.QApplication, 'exec'):
+    QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
+
 
 def fromUi(*args, **kwargs):
     """ Returns a Qt object constructed using loadUiType

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -29,8 +29,6 @@ from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType  # noqa: F401
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-QtCore.QSignal = QtCore.Signal
-
 # Should be removed when PySide2 provides QtWidgets.QApplication.exec() or when support for PySide2
 # is dropped
 if not hasattr(QtWidgets.QApplication, 'exec'):

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 # Should be removed when PySide2 provides QtWidgets.QApplication.exec() or when support for PySide2
-# is dropped
+# is dropped (https://doc.qt.io/qtforpython/porting_from2.html#class-function-deprecations)
 if not hasattr(QtWidgets.QApplication, 'exec'):
     QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
 if not hasattr(QtWidgets.QMenu, 'exec'):

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -35,6 +35,10 @@ QtCore.QSignal = QtCore.Signal
 # is dropped
 if not hasattr(QtWidgets.QApplication, 'exec'):
     QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
+if not hasattr(QtWidgets.QMenu, 'exec'):
+    def exec(self, *args, **kwargs):
+        self.exec_(*args, **kwargs)
+    QtWidgets.QMenu.exec = exec
 
 
 def fromUi(*args, **kwargs):

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -43,8 +43,8 @@ class BrowserItem(QtWidgets.QTreeWidgetItem):
         pixelmap = QtGui.QPixmap(24, 24)
         pixelmap.fill(color)
         self.setIcon(0, QtGui.QIcon(pixelmap))
-        self.setFlags(self.flags() | QtCore.Qt.ItemIsUserCheckable)
-        self.setCheckState(0, QtCore.Qt.Checked)
+        self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+        self.setCheckState(0, QtCore.Qt.CheckState.Checked)
         self.setText(1, basename(results.data_filename))
 
         self.setStatus(results.procedure.status)
@@ -103,7 +103,7 @@ class Browser(QtWidgets.QTreeWidget):
         self.setHeaderLabels(header_labels)
         self.setSortingEnabled(True)
         if sort_by_filename:
-            self.sortItems(1, QtCore.Qt.AscendingOrder)
+            self.sortItems(1, QtCore.Qt.SortOrder.AscendingOrder)
 
         for i, width in enumerate([80, 140]):
             self.header().resizeSection(i, width)

--- a/pymeasure/display/curves.py
+++ b/pymeasure/display/curves.py
@@ -172,7 +172,7 @@ class Crosshairs(QtCore.QObject):
         """ Initiates the crosshars onto a plot given the pen style.
 
         Example pen:
-        pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.DashLine)
+        pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.PenStyle.DashLine)
         """
         super().__init__()
 

--- a/pymeasure/display/curves.py
+++ b/pymeasure/display/curves.py
@@ -135,7 +135,7 @@ class BufferCurve(pg.PlotDataItem):
     """ Creates a curve based on a predefined buffer size and allows data to be added dynamically.
     """
 
-    data_updated = QtCore.QSignal()
+    data_updated = QtCore.Signal()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -166,7 +166,7 @@ class Crosshairs(QtCore.QObject):
     x and y graph coordinates
     """
 
-    coordinates = QtCore.QSignal(float, float)
+    coordinates = QtCore.Signal(float, float)
 
     def __init__(self, plot, pen=None):
         """ Initiates the crosshars onto a plot given the pen style.

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -114,7 +114,7 @@ class IntegerInput(Input, QtWidgets.QSpinBox):
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -124,10 +124,10 @@ class IntegerInput(Input, QtWidgets.QSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtWidgets.QAbstractSpinBox.StepUpEnabled | \
-                QtWidgets.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepUpEnabled | \
+                QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepDownEnabled
         else:
-            return QtWidgets.QAbstractSpinBox.StepNone
+            return QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepNone
 
 
 class BooleanInput(Input, QtWidgets.QCheckBox):
@@ -212,7 +212,7 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -226,7 +226,7 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
         self.setDecimals(parameter.decimals)
         self.setMinimum(parameter.minimum)
         self.setMaximum(parameter.maximum)
-        self.validator.setNotation(QtGui.QDoubleValidator.ScientificNotation)
+        self.validator.setNotation(QtGui.QDoubleValidator.Notation.ScientificNotation)
         super().set_parameter(parameter)  # default gets set here, after min/max
 
     def validate(self, text, pos):
@@ -256,7 +256,7 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtWidgets.QAbstractSpinBox.StepUpEnabled | \
-                QtWidgets.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepUpEnabled | \
+                QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepDownEnabled
         else:
-            return QtWidgets.QAbstractSpinBox.StepNone
+            return QtWidgets.QAbstractSpinBox.StepEnabledFlag.StepNone

--- a/pymeasure/display/listeners.py
+++ b/pymeasure/display/listeners.py
@@ -91,13 +91,13 @@ class Monitor(QtCore.QThread):
     are losts
     """
 
-    status = QtCore.QSignal(int)
-    progress = QtCore.QSignal(float)
-    log = QtCore.QSignal(object)
-    worker_running = QtCore.QSignal()
-    worker_failed = QtCore.QSignal()
-    worker_finished = QtCore.QSignal()  # Distinguished from QThread.finished
-    worker_abort_returned = QtCore.QSignal()
+    status = QtCore.Signal(int)
+    progress = QtCore.Signal(float)
+    log = QtCore.Signal(object)
+    worker_running = QtCore.Signal()
+    worker_failed = QtCore.Signal()
+    worker_finished = QtCore.Signal()  # Distinguished from QThread.finished
+    worker_abort_returned = QtCore.Signal()
 
     def __init__(self, queue):
         super().__init__()

--- a/pymeasure/display/log.py
+++ b/pymeasure/display/log.py
@@ -41,7 +41,7 @@ class LogHandler(Handler):
     # 4. A new utility class Emitter subclass of QObject is
     # introduced to handle record Signal and workaround the problem
     class Emitter(QtCore.QObject):
-        record = QtCore.QSignal(object)
+        record = QtCore.Signal(object)
 
     def __init__(self):
         super().__init__()

--- a/pymeasure/display/manager.py
+++ b/pymeasure/display/manager.py
@@ -124,13 +124,13 @@ class Manager(QtCore.QObject):
     """
     _is_continuous = True
     _start_on_add = True
-    queued = QtCore.QSignal(object)
-    running = QtCore.QSignal(object)
-    finished = QtCore.QSignal(object)
-    failed = QtCore.QSignal(object)
-    aborted = QtCore.QSignal(object)
-    abort_returned = QtCore.QSignal(object)
-    log = QtCore.QSignal(object)
+    queued = QtCore.Signal(object)
+    running = QtCore.Signal(object)
+    finished = QtCore.Signal(object)
+    failed = QtCore.Signal(object)
+    aborted = QtCore.Signal(object)
+    abort_returned = QtCore.Signal(object)
+    log = QtCore.Signal(object)
 
     def __init__(self, widget_list, browser, port=5888, log_level=logging.INFO, parent=None):
         super().__init__(parent)

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -56,7 +56,7 @@ class Plotter(StoppableThread):
         self.setup_plot(window.plot)
         app.aboutToQuit.connect(window.quit)
         window.show()
-        app.exec_()
+        app.exec()
 
     def setup_plot(self, plot):
         """

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -44,6 +44,7 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
         completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
 
         model = QtGui.QFileSystemModel(completer)
+        model.setRootPath(model.myComputer())
         model.setFilter(QtCore.QDir.Filter.Dirs |
                         QtCore.QDir.Filter.Drives |
                         QtCore.QDir.Filter.NoDotAndDotDot |

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -41,11 +41,13 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
         super().__init__(parent=parent)
 
         completer = QtWidgets.QCompleter(self)
-        completer.setCompletionMode(QtWidgets.QCompleter.PopupCompletion)
+        completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
 
         model = QtWidgets.QDirModel(completer)
-        model.setFilter(QtCore.QDir.Dirs | QtCore.QDir.Drives |
-                        QtCore.QDir.NoDotAndDotDot | QtCore.QDir.AllDirs)
+        model.setFilter(QtCore.QDir.Filter.Dirs |
+                        QtCore.QDir.Filter.Drives |
+                        QtCore.QDir.Filter.NoDotAndDotDot |
+                        QtCore.QDir.Filter.AllDirs)
         completer.setModel(model)
 
         self.setCompleter(completer)
@@ -55,7 +57,7 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
             getattr(QtWidgets.QStyle, 'SP_DialogOpenButton')))
         browse_action.triggered.connect(self.browse_triggered)
 
-        self.addAction(browse_action, QtWidgets.QLineEdit.TrailingPosition)
+        self.addAction(browse_action, QtWidgets.QLineEdit.ActionPosition.TrailingPosition)
 
     def _get_starting_directory(self):
         current_text = self.text()

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from ..Qt import QtCore, QtWidgets
+from ..Qt import QtCore, QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -43,7 +43,7 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
         completer = QtWidgets.QCompleter(self)
         completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
 
-        model = QtWidgets.QDirModel(completer)
+        model = QtGui.QFileSystemModel(completer)
         model.setFilter(QtCore.QDir.Filter.Dirs |
                         QtCore.QDir.Filter.Drives |
                         QtCore.QDir.Filter.NoDotAndDotDot |
@@ -52,9 +52,9 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
 
         self.setCompleter(completer)
 
-        browse_action = QtWidgets.QAction(self)
+        browse_action = QtGui.QAction(self)
         browse_action.setIcon(self.style().standardIcon(
-            getattr(QtWidgets.QStyle, 'SP_DialogOpenButton')))
+            getattr(QtWidgets.QStyle.StandardPixmap, 'SP_DialogOpenButton')))
         browse_action.triggered.connect(self.browse_triggered)
 
         self.addAction(browse_action, QtWidgets.QLineEdit.ActionPosition.TrailingPosition)

--- a/pymeasure/display/widgets/estimator_widget.py
+++ b/pymeasure/display/widgets/estimator_widget.py
@@ -36,7 +36,7 @@ log.addHandler(logging.NullHandler())
 
 
 class EstimatorThread(StoppableQThread):
-    new_estimates = QtCore.QSignal(list)
+    new_estimates = QtCore.Signal(list)
 
     def __init__(self, get_estimates_callable):
         StoppableQThread.__init__(self)

--- a/pymeasure/display/widgets/estimator_widget.py
+++ b/pymeasure/display/widgets/estimator_widget.py
@@ -137,7 +137,7 @@ class EstimatorWidget(QtWidgets.QWidget):
 
             qle = QtWidgets.QLineEdit(self)
             qle.setEnabled(False)
-            qle.setAlignment(QtCore.Qt.AlignRight)
+            qle.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
 
             self.line_edits.append((qlb, qle))
 

--- a/pymeasure/display/widgets/image_frame.py
+++ b/pymeasure/display/widgets/image_frame.py
@@ -37,7 +37,7 @@ class ImageFrame(PlotFrame):
     to plot also axis Z using colors
     """
     ResultsClass = ResultsImage
-    z_axis_changed = QtCore.QSignal(str)
+    z_axis_changed = QtCore.Signal(str)
 
     def __init__(self, x_axis, y_axis, z_axis=None,
                  refresh_time=0.2, check_status=True, parent=None):

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -58,8 +58,8 @@ class PlotFrame(QtWidgets.QFrame):
     def _setup_ui(self):
         self.setAutoFillBackground(False)
         self.setStyleSheet("background: #fff")
-        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
-        self.setFrameShadow(QtWidgets.QFrame.Sunken)
+        self.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.setFrameShadow(QtWidgets.QFrame.Shadow.Sunken)
         self.setMidLineWidth(1)
 
         vbox = QtWidgets.QVBoxLayout(self)
@@ -70,7 +70,9 @@ class PlotFrame(QtWidgets.QFrame):
         self.coordinates.setStyleSheet("background: #fff")
         self.coordinates.setText("")
         self.coordinates.setAlignment(
-            QtCore.Qt.AlignRight | QtCore.Qt.AlignTrailing | QtCore.Qt.AlignVCenter)
+            QtCore.Qt.AlignmentFlag.AlignRight |
+            QtCore.Qt.AlignmentFlag.AlignTrailing |
+            QtCore.Qt.AlignmentFlag.AlignVCenter)
 
         vbox.addWidget(self.plot_widget)
         vbox.addWidget(self.coordinates)
@@ -79,7 +81,8 @@ class PlotFrame(QtWidgets.QFrame):
         self.plot = self.plot_widget.getPlotItem()
 
         self.crosshairs = Crosshairs(self.plot,
-                                     pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.DashLine))
+                                     pen=pg.mkPen(color='#AAAAAA',
+                                                  style=QtCore.Qt.PenStyle.DashLine))
         self.crosshairs.coordinates.connect(self.update_coordinates)
 
         self.timer = QtCore.QTimer()

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -42,10 +42,10 @@ class PlotFrame(QtWidgets.QFrame):
     """
 
     LABEL_STYLE = {'font-size': '10pt', 'font-family': 'Arial', 'color': '#000000'}
-    updated = QtCore.QSignal()
+    updated = QtCore.Signal()
     ResultsClass = ResultsCurve
-    x_axis_changed = QtCore.QSignal(str)
-    y_axis_changed = QtCore.QSignal(str)
+    x_axis_changed = QtCore.Signal(str)
+    y_axis_changed = QtCore.Signal(str)
 
     def __init__(self, x_axis=None, y_axis=None, refresh_time=0.2, check_status=True, parent=None):
         super().__init__(parent)

--- a/pymeasure/display/widgets/results_dialog.py
+++ b/pymeasure/display/widgets/results_dialog.py
@@ -49,7 +49,7 @@ class ResultsDialog(QtWidgets.QFileDialog):
         super().__init__(parent)
         self.columns = columns
         self.x_axis, self.y_axis = x_axis, y_axis
-        self.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
+        self.setOption(QtWidgets.QFileDialog.Option.DontUseNativeDialog, True)
         self._setup_ui()
 
     def _setup_ui(self):
@@ -79,7 +79,7 @@ class ResultsDialog(QtWidgets.QFileDialog):
         self.setMinimumSize(900, 500)
         self.resize(900, 500)
 
-        self.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
+        self.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFiles)
         self.currentChanged.connect(self.update_plot)
 
     def update_plot(self, filename):
@@ -110,4 +110,4 @@ class ResultsDialog(QtWidgets.QFileDialog):
             for key, param in results.procedure.parameter_objects().items():
                 new_item = QtWidgets.QTreeWidgetItem([param.name, str(param)])
                 self.preview_param.addTopLevelItem(new_item)
-            self.preview_param.sortItems(0, QtCore.Qt.AscendingOrder)
+            self.preview_param.sortItems(0, QtCore.Qt.SortOrder.AscendingOrder)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -389,21 +389,21 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu = QtWidgets.QMenu(self)
 
             # Open
-            action_open = QtWidgets.QAction(menu)
+            action_open = QtGui.QAction(menu)
             action_open.setText("Open Data Externally")
             action_open.triggered.connect(
                 lambda: self.open_file_externally(experiment.results.data_filename))
             menu.addAction(action_open)
 
             # Change Color
-            action_change_color = QtWidgets.QAction(menu)
+            action_change_color = QtGui.QAction(menu)
             action_change_color.setText("Change Color")
             action_change_color.triggered.connect(
                 lambda: self.change_color(experiment))
             menu.addAction(action_change_color)
 
             # Remove
-            action_remove = QtWidgets.QAction(menu)
+            action_remove = QtGui.QAction(menu)
             action_remove.setText("Remove Graph")
             if self.manager.is_running():
                 if self.manager.running_experiment() == experiment:  # Experiment running
@@ -412,7 +412,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu.addAction(action_remove)
 
             # Delete
-            action_delete = QtWidgets.QAction(menu)
+            action_delete = QtGui.QAction(menu)
             action_delete.setText("Delete Data File")
             if self.manager.is_running():
                 if self.manager.running_experiment() == experiment:  # Experiment running
@@ -421,12 +421,12 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu.addAction(action_delete)
 
             # Use parameters
-            action_use = QtWidgets.QAction(menu)
+            action_use = QtGui.QAction(menu)
             action_use.setText("Use These Parameters")
             action_use.triggered.connect(
                 lambda: self.set_parameters(experiment.procedure.parameter_objects()))
             menu.addAction(action_use)
-            menu.exec_(self.browser.viewport().mapToGlobal(position))
+            menu.exec(self.browser.viewport().mapToGlobal(position))
 
     def remove_experiment(self, experiment):
         reply = QtWidgets.QMessageBox.question(self, 'Remove Graph',
@@ -464,7 +464,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
     def open_experiment(self):
         dialog = ResultsDialog(self.procedure_class.DATA_COLUMNS, self.x_axis, self.y_axis)
-        if dialog.exec_():
+        if dialog.exec():
             filenames = dialog.selectedFiles()
             for filename in map(str, filenames):
                 if filename in self.manager.experiments:
@@ -480,7 +480,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                     for curve in experiment.curve_list:
                         if curve:
                             curve.update_data()
-                    experiment.browser_item.progressbar.setValue(100.)
+                    experiment.browser_item.progressbar.setValue(100)
                     self.manager.load(experiment)
                     log.info('Opened data file %s' % filename)
 

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -256,7 +256,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         self.browser_widget.open_button.clicked.connect(self.open_experiment)
         self.browser = self.browser_widget.browser
 
-        self.browser.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.browser.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.browser.customContextMenuRequested.connect(self.browser_item_menu)
         self.browser.itemChanged.connect(self.browser_item_changed)
 
@@ -311,9 +311,10 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         if self.inputs_in_scrollarea:
             inputs_scroll = QtWidgets.QScrollArea()
             inputs_scroll.setWidgetResizable(True)
-            inputs_scroll.setFrameStyle(QtWidgets.QScrollArea.NoFrame)
+            inputs_scroll.setFrameStyle(QtWidgets.QScrollArea.Shape.NoFrame)
 
-            self.inputs.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
+            self.inputs.setSizePolicy(QtWidgets.QSizePolicy.Policy.Minimum,
+                                      QtWidgets.QSizePolicy.Policy.Fixed)
             inputs_scroll.setWidget(self.inputs)
             inputs_vbox.addWidget(inputs_scroll, 1)
 
@@ -330,26 +331,26 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
         dock = QtWidgets.QDockWidget('Input Parameters')
         dock.setWidget(inputs_dock)
-        dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
-        self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dock)
+        dock.setFeatures(QtWidgets.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+        self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, dock)
 
         if self.use_sequencer:
             sequencer_dock = QtWidgets.QDockWidget('Sequencer')
             sequencer_dock.setWidget(self.sequencer)
-            sequencer_dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
-            self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, sequencer_dock)
+            sequencer_dock.setFeatures(QtWidgets.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+            self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, sequencer_dock)
 
         if self.use_estimator:
             estimator_dock = QtWidgets.QDockWidget('Estimator')
             estimator_dock.setWidget(self.estimator)
-            estimator_dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
-            self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, estimator_dock)
+            estimator_dock.setFeatures(QtWidgets.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+            self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, estimator_dock)
 
         self.tabs = QtWidgets.QTabWidget(self.main)
         for wdg in self.widget_list:
             self.tabs.addTab(wdg, wdg.name)
 
-        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         splitter.addWidget(self.tabs)
         splitter.addWidget(self.browser_widget)
 
@@ -430,17 +431,19 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
     def remove_experiment(self, experiment):
         reply = QtWidgets.QMessageBox.question(self, 'Remove Graph',
                                                "Are you sure you want to remove the graph?",
-                                               QtWidgets.QMessageBox.Yes |
-                                               QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-        if reply == QtWidgets.QMessageBox.Yes:
+                                               QtWidgets.QMessageBox.StandardButton.Yes |
+                                               QtWidgets.QMessageBox.StandardButton.No,
+                                           QtWidgets.QMessageBox.StandardButton.No)
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
 
     def delete_experiment_data(self, experiment):
         reply = QtWidgets.QMessageBox.question(self, 'Delete Data',
                                                "Are you sure you want to delete this data file?",
-                                               QtWidgets.QMessageBox.Yes |
-                                               QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-        if reply == QtWidgets.QMessageBox.Yes:
+                                               QtWidgets.QMessageBox.StandardButton.Yes |
+                                               QtWidgets.QMessageBox.StandardButton.No,
+                                           QtWidgets.QMessageBox.StandardButton.No)
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
             os.unlink(experiment.data_filename)
 
@@ -448,13 +451,13 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         root = self.browser.invisibleRootItem()
         for i in range(root.childCount()):
             item = root.child(i)
-            item.setCheckState(0, QtCore.Qt.Checked)
+            item.setCheckState(0, QtCore.Qt.CheckState.Checked)
 
     def hide_experiments(self):
         root = self.browser.invisibleRootItem()
         for i in range(root.childCount()):
             item = root.child(i)
-            item.setCheckState(0, QtCore.Qt.Unchecked)
+            item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
 
     def clear_experiments(self):
         self.manager.clear()

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -433,7 +433,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                                                "Are you sure you want to remove the graph?",
                                                QtWidgets.QMessageBox.StandardButton.Yes |
                                                QtWidgets.QMessageBox.StandardButton.No,
-                                           QtWidgets.QMessageBox.StandardButton.No)
+                                               QtWidgets.QMessageBox.StandardButton.No)
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
 
@@ -442,7 +442,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                                                "Are you sure you want to delete this data file?",
                                                QtWidgets.QMessageBox.StandardButton.Yes |
                                                QtWidgets.QMessageBox.StandardButton.No,
-                                           QtWidgets.QMessageBox.StandardButton.No)
+                                               QtWidgets.QMessageBox.StandardButton.No)
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
             os.unlink(experiment.data_filename)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -373,7 +373,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         if column == 0:
             state = item.checkState(0)
             experiment = self.manager.experiments.with_browser_item(item)
-            if state == 0:
+            if state == QtCore.Qt.CheckState.Unchecked:
                 for wdg, curve in zip(self.widget_list, experiment.curve_list):
                     wdg.remove(curve)
             else:


### PR DESCRIPTION
Updates to make pymeasure compatible with Qt 6 (both PyQt6 and PySide6) while maintaining compatibility with Qt 5 (both PyQt5 and PySide2).

The most changes involve changing the shorthand name of the enum-flags by their full name (I hope to have found all of them).
Also, the getting QApplication for QtGui is deprecated, and I've therefore replaced it by QtWidget.QApplication.

The only issue I have found so far is `QtWidget.QApplication.exec_()` (in `sys.exit(app.exec_())`): in PyQt6 `exec_` has been replaced by `exec`, but PySide2 does not support this (PyQt5 and PySide6 support both `exec_` and `exec`, but whenever `exec_` is used, a deprecation warning is issued. I've solved this now by manually adding `exec` to QtWidgets.QApplication if it is not present, but I'm not sure if this is the best solution.