### PR TITLE
Remove deprecated access to QtWidgets through QtGui

### DIFF
--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -113,7 +113,7 @@ Below we adapt our previous example to use a ManagedWindow. ::
     import random
     from time import sleep
     from pymeasure.log import console_log
-    from pymeasure.display.Qt import QtGui
+    from pymeasure.display.Qt import QtWidgets
     from pymeasure.display.windows import ManagedWindow
     from pymeasure.experiment import Procedure, Results
     from pymeasure.experiment import IntegerParameter, FloatParameter, Parameter
@@ -169,7 +169,7 @@ Below we adapt our previous example to use a ManagedWindow. ::
 
 
     if __name__ == "__main__":
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
         window = MainWindow()
         window.show()
         sys.exit(app.exec_())

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -16,7 +16,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -78,7 +78,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -63,8 +63,7 @@ class MainWindow(ManagedWindow):
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],
             x_axis='Iteration',
-            y_axis='Random Number',
-            directory_input=True
+            y_axis='Random Number'
         )
         self.setWindowTitle('GUI Example')
 

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -63,7 +63,8 @@ class MainWindow(ManagedWindow):
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],
             x_axis='Iteration',
-            y_axis='Random Number'
+            y_axis='Random Number',
+            directory_input=True
         )
         self.setWindowTitle('GUI Example')
 

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -17,7 +17,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui, fromUi
+from pymeasure.display.Qt import QtWidgets, fromUi
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -88,7 +88,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -127,7 +127,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -17,7 +17,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 # Import the InstrumentKit package
@@ -93,7 +93,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -17,7 +17,7 @@ from time import sleep
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, \
     FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -85,7 +85,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -16,7 +16,7 @@ from pymeasure.experiment import Results, unique_filename
 from pymeasure.experiment import Procedure
 from pymeasure.display.windows import ManagedImageWindow  # new ManagedWindow class
 from pymeasure.experiment import FloatParameter
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 
 import logging
 log = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class TestImageGUI(ManagedImageWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = TestImageGUI()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Current-Voltage Measurements/iv_keithley.py
+++ b/examples/Current-Voltage Measurements/iv_keithley.py
@@ -18,7 +18,7 @@ from time import sleep
 import numpy as np
 
 from pymeasure.instruments.keithley import Keithley2000, Keithley2400
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 from pymeasure.experiment import (
     Procedure, FloatParameter, unique_filename, Results
@@ -119,7 +119,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Current-Voltage Measurements/iv_yokogawa.py
+++ b/examples/Current-Voltage Measurements/iv_yokogawa.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from pymeasure.instruments.keithley import Keithley2000
 from pymeasure.instruments.yokogawa import Yokogawa7651
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 from pymeasure.experiment import (
     Procedure, FloatParameter, unique_filename, Results
@@ -119,7 +119,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from pyqtgraph.Qt import QtGui, QtCore, loadUiType
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType  # noqa: F401
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -45,6 +45,6 @@ def fromUi(*args, **kwargs):
     form.retranslateUi(widget)
     for name in dir(form):
         element = getattr(form, name)
-        if isinstance(element, QtGui.QWidget):
+        if isinstance(element, QtWidgets.QWidget):
             setattr(widget, name, element)
     return widget

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -26,8 +26,8 @@ import logging
 
 from os.path import basename
 
-from .Qt import QtCore, QtWidgets
-from pyqtgraph.Qt import QtGui
+from .Qt import QtCore, QtGui, QtWidgets
+
 from ..experiment import Procedure
 
 log = logging.getLogger(__name__)

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -26,14 +26,14 @@ import logging
 
 from os.path import basename
 
-from .Qt import QtCore, QtGui
+from .Qt import QtCore, QtGui, QtWidgets
 from ..experiment import Procedure
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class BrowserItem(QtGui.QTreeWidgetItem):
+class BrowserItem(QtWidgets.QTreeWidgetItem):
     """ Represent a row in the :class:`~pymeasure.display.browser.Browser` tree widget """
 
     def __init__(self, results, color, parent=None):
@@ -77,7 +77,7 @@ class BrowserItem(QtGui.QTreeWidgetItem):
         self.progressbar.setValue(int(progress))
 
 
-class Browser(QtGui.QTreeWidget):
+class Browser(QtWidgets.QTreeWidget):
     """Graphical list view of :class:`Experiment<pymeasure.display.manager.Experiment>`
     objects allowing the user to view the status of queued Experiments as well as
     loading and displaying data from previous runs.

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -26,7 +26,8 @@ import logging
 
 from os.path import basename
 
-from .Qt import QtCore, QtGui, QtWidgets
+from .Qt import QtCore, QtWidgets
+from pyqtgraph.Qt import QtGui
 from ..experiment import Procedure
 
 log = logging.getLogger(__name__)

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -48,7 +48,7 @@ class BrowserItem(QtWidgets.QTreeWidgetItem):
 
         self.setStatus(results.procedure.status)
 
-        self.progressbar = QtGui.QProgressBar()
+        self.progressbar = QtWidgets.QProgressBar()
         self.progressbar.setRange(0, 100)
         self.progressbar.setValue(0)
 

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -124,7 +124,8 @@ class IntegerInput(Input, QtWidgets.QSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtWidgets.QAbstractSpinBox.StepUpEnabled | QtWidgets.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepUpEnabled | \
+                QtWidgets.QAbstractSpinBox.StepDownEnabled
         else:
             return QtWidgets.QAbstractSpinBox.StepNone
 
@@ -255,6 +256,7 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtWidgets.QAbstractSpinBox.StepUpEnabled | QtWidgets.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepUpEnabled | \
+                QtWidgets.QAbstractSpinBox.StepDownEnabled
         else:
             return QtWidgets.QAbstractSpinBox.StepNone

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -26,7 +26,8 @@ import logging
 
 import re
 
-from .Qt import QtGui, QtWidgets
+from .Qt import QtWidgets
+from pyqtgraph.Qt import QtGui
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -91,14 +91,14 @@ class StringInput(Input, QtWidgets.QLineEdit):
         super().__init__(parameter=parameter, parent=parent, **kwargs)
 
     def setValue(self, value):
-        # QtGui.QLineEdit has a setText() method instead of setValue()
+        # QtWidgets.QLineEdit has a setText() method instead of setValue()
         return super().setText(value)
 
     def setSuffix(self, value):
         pass
 
     def value(self):
-        # QtGui.QLineEdit has a text() method instead of value()
+        # QtWidgets.QLineEdit has a text() method instead of value()
         return super().text()
 
 
@@ -110,11 +110,11 @@ class IntegerInput(Input, QtWidgets.QSpinBox):
     def __init__(self, parameter, parent=None, **kwargs):
         super().__init__(parameter=parameter, parent=parent, **kwargs)
         if parameter.step:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -124,9 +124,9 @@ class IntegerInput(Input, QtWidgets.QSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepUpEnabled | QtWidgets.QAbstractSpinBox.StepDownEnabled
         else:
-            return QtGui.QAbstractSpinBox.StepNone
+            return QtWidgets.QAbstractSpinBox.StepNone
 
 
 class BooleanInput(Input, QtWidgets.QCheckBox):
@@ -207,11 +207,11 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
     def __init__(self, parameter, parent=None, **kwargs):
         super().__init__(parameter=parameter, parent=parent, **kwargs)
         if parameter.step:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.ButtonSymbols.UpDownArrows)
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -255,6 +255,6 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+            return QtWidgets.QAbstractSpinBox.StepUpEnabled | QtWidgets.QAbstractSpinBox.StepDownEnabled
         else:
-            return QtGui.QAbstractSpinBox.StepNone
+            return QtWidgets.QAbstractSpinBox.StepNone

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -26,7 +26,7 @@ import logging
 
 import re
 
-from .Qt import QtGui
+from .Qt import QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -80,7 +80,7 @@ class Input:
         return self._parameter
 
 
-class StringInput(Input, QtGui.QLineEdit):
+class StringInput(Input, QtWidgets.QLineEdit):
     """
     String input box connected to a :class:`Parameter`. Parameter subclasses
     that are string-based may also use this input, but non-string parameters
@@ -102,7 +102,7 @@ class StringInput(Input, QtGui.QLineEdit):
         return super().text()
 
 
-class IntegerInput(Input, QtGui.QSpinBox):
+class IntegerInput(Input, QtWidgets.QSpinBox):
     """
     Spin input box for integer values, connected to a :class:`IntegerParameter`.
     """
@@ -129,7 +129,7 @@ class IntegerInput(Input, QtGui.QSpinBox):
             return QtGui.QAbstractSpinBox.StepNone
 
 
-class BooleanInput(Input, QtGui.QCheckBox):
+class BooleanInput(Input, QtWidgets.QCheckBox):
     """
     Checkbox for boolean values, connected to a :class:`BooleanParameter`.
     """
@@ -152,7 +152,7 @@ class BooleanInput(Input, QtGui.QCheckBox):
         return super().isChecked()
 
 
-class ListInput(Input, QtGui.QComboBox):
+class ListInput(Input, QtWidgets.QComboBox):
     """
     Dropdown for list values, connected to a :class:`ListParameter`.
     """
@@ -193,7 +193,7 @@ class ListInput(Input, QtGui.QComboBox):
         return self._parameter.choices[self.currentIndex()]
 
 
-class ScientificInput(Input, QtGui.QDoubleSpinBox):
+class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
     """
     Spinner input box for floating-point values, connected to a
     :class:`FloatParameter`. This box will display and accept values in

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -26,8 +26,7 @@ import logging
 
 import re
 
-from .Qt import QtWidgets
-from pyqtgraph.Qt import QtGui
+from .Qt import QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -27,7 +27,7 @@ import logging
 import sys
 import time
 
-from .Qt import QtGui
+from .Qt import QtWidgets
 from .windows import PlotterWindow
 from ..thread import StoppableThread
 
@@ -51,7 +51,7 @@ class Plotter(StoppableThread):
         self.linewidth = linewidth
 
     def run(self):
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
         window = PlotterWindow(self, refresh_time=self.refresh_time, linewidth=self.linewidth)
         self.setup_plot(window.plot)
         app.aboutToQuit.connect(window.quit)

--- a/pymeasure/display/widgets/browser_widget.py
+++ b/pymeasure/display/widgets/browser_widget.py
@@ -25,7 +25,7 @@
 import logging
 
 from ..browser import Browser
-from ..Qt import QtGui, QtWidgets
+from ..Qt import QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -43,20 +43,20 @@ class BrowserWidget(QtWidgets.QWidget):
 
     def _setup_ui(self):
         self.browser = Browser(*self.browser_args, parent=self)
-        self.clear_button = QtGui.QPushButton('Clear all', self)
+        self.clear_button = QtWidgets.QPushButton('Clear all', self)
         self.clear_button.setEnabled(False)
-        self.hide_button = QtGui.QPushButton('Hide all', self)
+        self.hide_button = QtWidgets.QPushButton('Hide all', self)
         self.hide_button.setEnabled(False)
-        self.show_button = QtGui.QPushButton('Show all', self)
+        self.show_button = QtWidgets.QPushButton('Show all', self)
         self.show_button.setEnabled(False)
-        self.open_button = QtGui.QPushButton('Open', self)
+        self.open_button = QtWidgets.QPushButton('Open', self)
         self.open_button.setEnabled(True)
 
     def _layout(self):
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(0)
 
-        hbox = QtGui.QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(10)
         hbox.setContentsMargins(-1, 6, -1, 6)
         hbox.addWidget(self.show_button)

--- a/pymeasure/display/widgets/browser_widget.py
+++ b/pymeasure/display/widgets/browser_widget.py
@@ -25,13 +25,13 @@
 import logging
 
 from ..browser import Browser
-from ..Qt import QtGui
+from ..Qt import QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class BrowserWidget(QtGui.QWidget):
+class BrowserWidget(QtWidgets.QWidget):
     """
     Widget wrapper for :class:`Browser<pymeasure.display.browser.Browser>` class
     """

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -24,13 +24,13 @@
 
 import logging
 
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class DirectoryLineEdit(QtGui.QLineEdit):
+class DirectoryLineEdit(QtWidgets.QLineEdit):
     """
     Widget that allows to choose a directory path.
     A completer is implemented for quick completion.

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -40,22 +40,22 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
 
-        completer = QtGui.QCompleter(self)
-        completer.setCompletionMode(QtGui.QCompleter.PopupCompletion)
+        completer = QtWidgets.QCompleter(self)
+        completer.setCompletionMode(QtWidgets.QCompleter.PopupCompletion)
 
-        model = QtGui.QDirModel(completer)
+        model = QtWidgets.QDirModel(completer)
         model.setFilter(QtCore.QDir.Dirs | QtCore.QDir.Drives |
                         QtCore.QDir.NoDotAndDotDot | QtCore.QDir.AllDirs)
         completer.setModel(model)
 
         self.setCompleter(completer)
 
-        browse_action = QtGui.QAction(self)
+        browse_action = QtWidgets.QAction(self)
         browse_action.setIcon(self.style().standardIcon(
-            getattr(QtGui.QStyle, 'SP_DialogOpenButton')))
+            getattr(QtWidgets.QStyle, 'SP_DialogOpenButton')))
         browse_action.triggered.connect(self.browse_triggered)
 
-        self.addAction(browse_action, QtGui.QLineEdit.TrailingPosition)
+        self.addAction(browse_action, QtWidgets.QLineEdit.TrailingPosition)
 
     def _get_starting_directory(self):
         current_text = self.text()
@@ -66,7 +66,7 @@ class DirectoryLineEdit(QtWidgets.QLineEdit):
             return '/'
 
     def browse_triggered(self):
-        path = QtGui.QFileDialog.getExistingDirectory(
+        path = QtWidgets.QFileDialog.getExistingDirectory(
             self, 'Directory', self._get_starting_directory())
         if path != '':
             self.setText(path)

--- a/pymeasure/display/widgets/estimator_widget.py
+++ b/pymeasure/display/widgets/estimator_widget.py
@@ -28,7 +28,7 @@ from inspect import signature
 from datetime import datetime, timedelta
 
 from ..thread import StoppableQThread
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from .sequencer_widget import SequenceEvaluationException
 
 log = logging.getLogger(__name__)
@@ -133,29 +133,29 @@ class EstimatorWidget(QtWidgets.QWidget):
     def _setup_ui(self):
         self.line_edits = list()
         for idx in range(self.number_of_estimates):
-            qlb = QtGui.QLabel(self)
+            qlb = QtWidgets.QLabel(self)
 
-            qle = QtGui.QLineEdit(self)
+            qle = QtWidgets.QLineEdit(self)
             qle.setEnabled(False)
             qle.setAlignment(QtCore.Qt.AlignRight)
 
             self.line_edits.append((qlb, qle))
 
         # Add a checkbox for continuous updating
-        self.update_box = QtGui.QCheckBox(self)
+        self.update_box = QtWidgets.QCheckBox(self)
         self.update_box.setTristate(True)
         self.update_box.stateChanged.connect(self._set_continuous_updating)
 
         # Add a button for instant updating
-        self.update_button = QtGui.QPushButton("Update", self)
+        self.update_button = QtWidgets.QPushButton("Update", self)
         self.update_button.clicked.connect(self.update_estimates)
 
     def _layout(self):
-        f_layout = QtGui.QFormLayout(self)
+        f_layout = QtWidgets.QFormLayout(self)
         for row in self.line_edits:
             f_layout.addRow(*row)
 
-        update_hbox = QtGui.QHBoxLayout()
+        update_hbox = QtWidgets.QHBoxLayout()
         update_hbox.addWidget(self.update_box)
         update_hbox.addWidget(self.update_button)
         f_layout.addRow("Update continuously", update_hbox)

--- a/pymeasure/display/widgets/estimator_widget.py
+++ b/pymeasure/display/widgets/estimator_widget.py
@@ -28,7 +28,7 @@ from inspect import signature
 from datetime import datetime, timedelta
 
 from ..thread import StoppableQThread
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from .sequencer_widget import SequenceEvaluationException
 
 log = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ class EstimatorThread(StoppableQThread):
             self.new_estimates.emit(estimates)
 
 
-class EstimatorWidget(QtGui.QWidget):
+class EstimatorWidget(QtWidgets.QWidget):
     """
     Widget that allows to display up-front estimates of the measurement
     procedure.

--- a/pymeasure/display/widgets/image_widget.py
+++ b/pymeasure/display/widgets/image_widget.py
@@ -26,7 +26,7 @@ import logging
 
 import pyqtgraph as pg
 from ..curves import ResultsImage
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from .tab_widget import TabWidget
 from .image_frame import ImageFrame
 
@@ -54,11 +54,11 @@ class ImageWidget(TabWidget, QtWidgets.QWidget):
             self.image_frame.change_z_axis(z_axis)
 
     def _setup_ui(self):
-        self.columns_z_label = QtGui.QLabel(self)
+        self.columns_z_label = QtWidgets.QLabel(self)
         self.columns_z_label.setMaximumSize(QtCore.QSize(45, 16777215))
         self.columns_z_label.setText('Z Axis:')
 
-        self.columns_z = QtGui.QComboBox(self)
+        self.columns_z = QtWidgets.QComboBox(self)
         for column in self.columns:
             self.columns_z.addItem(column)
         self.columns_z.activated.connect(self.update_z_column)
@@ -75,10 +75,10 @@ class ImageWidget(TabWidget, QtWidgets.QWidget):
         self.columns_z.setCurrentIndex(2)
 
     def _layout(self):
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(0)
 
-        hbox = QtGui.QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(10)
         hbox.setContentsMargins(-1, 6, -1, 6)
         hbox.addWidget(self.columns_z_label)

--- a/pymeasure/display/widgets/image_widget.py
+++ b/pymeasure/display/widgets/image_widget.py
@@ -26,7 +26,7 @@ import logging
 
 import pyqtgraph as pg
 from ..curves import ResultsImage
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from .tab_widget import TabWidget
 from .image_frame import ImageFrame
 
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class ImageWidget(TabWidget, QtGui.QWidget):
+class ImageWidget(TabWidget, QtWidgets.QWidget):
     """ Extends the :class:`ImageFrame<pymeasure.display.widgets.image_frame.ImageFrame>`
     to allow different columns of the data to be dynamically chosen
     """

--- a/pymeasure/display/widgets/inputs_widget.py
+++ b/pymeasure/display/widgets/inputs_widget.py
@@ -27,14 +27,14 @@ import logging
 from functools import partial
 
 from ..inputs import BooleanInput, IntegerInput, ListInput, ScientificInput, StringInput
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from ...experiment import parameters
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class InputsWidget(QtGui.QWidget):
+class InputsWidget(QtWidgets.QWidget):
     """
     Widget wrapper for various :doc:`inputs`
     """

--- a/pymeasure/display/widgets/inputs_widget.py
+++ b/pymeasure/display/widgets/inputs_widget.py
@@ -27,7 +27,7 @@ import logging
 from functools import partial
 
 from ..inputs import BooleanInput, IntegerInput, ListInput, ScientificInput, StringInput
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from ...experiment import parameters
 
 log = logging.getLogger(__name__)
@@ -77,14 +77,14 @@ class InputsWidget(QtWidgets.QWidget):
             setattr(self, name, element)
 
     def _layout(self):
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(6)
 
         self.labels = {}
         parameters = self._procedure.parameter_objects()
         for name in self._inputs:
             if not isinstance(getattr(self, name), self.NO_LABEL_INPUTS):
-                label = QtGui.QLabel(self)
+                label = QtWidgets.QLabel(self)
                 label.setText("%s:" % parameters[name].name)
                 vbox.addWidget(label)
                 self.labels[name] = label

--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -25,14 +25,14 @@
 import logging
 
 from ..log import LogHandler
-from ..Qt import QtGui
+from ..Qt import QtGui, QtWidgets
 from .tab_widget import TabWidget
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class LogWidget(TabWidget, QtGui.QWidget):
+class LogWidget(TabWidget, QtWidgets.QWidget):
     """ Widget to display logging information in GUI
 
     It is recommended to include this widget in all subclasses of

--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -25,7 +25,7 @@
 import logging
 
 from ..log import LogHandler
-from ..Qt import QtGui, QtWidgets
+from ..Qt import QtWidgets
 from .tab_widget import TabWidget
 
 log = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self._layout()
 
     def _setup_ui(self):
-        self.view = QtGui.QPlainTextEdit()
+        self.view = QtWidgets.QPlainTextEdit()
         self.view.setReadOnly(True)
         self.handler = LogHandler()
         self.handler.setFormatter(logging.Formatter(
@@ -55,7 +55,7 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self.handler.connect(self.view.appendPlainText)
 
     def _layout(self):
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(0)
 
         vbox.addWidget(self.view)

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -28,14 +28,14 @@ import re
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve, Crosshairs
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from ...experiment import Procedure
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class PlotFrame(QtGui.QFrame):
+class PlotFrame(QtWidgets.QFrame):
     """ Combines a PyQtGraph Plot with Crosshairs. Refreshes
     the plot based on the refresh_time, and allows the axes
     to be changed on the fly, which updates the plotted data

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -28,7 +28,7 @@ import re
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve, Crosshairs
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from ...experiment import Procedure
 
 log = logging.getLogger(__name__)
@@ -58,14 +58,14 @@ class PlotFrame(QtWidgets.QFrame):
     def _setup_ui(self):
         self.setAutoFillBackground(False)
         self.setStyleSheet("background: #fff")
-        self.setFrameShape(QtGui.QFrame.StyledPanel)
-        self.setFrameShadow(QtGui.QFrame.Sunken)
+        self.setFrameShape(QtWidgets.QFrame.StyledPanel)
+        self.setFrameShadow(QtWidgets.QFrame.Sunken)
         self.setMidLineWidth(1)
 
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
 
         self.plot_widget = pg.PlotWidget(self, background='#ffffff')
-        self.coordinates = QtGui.QLabel(self)
+        self.coordinates = QtWidgets.QLabel(self)
         self.coordinates.setMinimumSize(QtCore.QSize(0, 20))
         self.coordinates.setStyleSheet("background: #fff")
         self.coordinates.setText("")

--- a/pymeasure/display/widgets/plot_widget.py
+++ b/pymeasure/display/widgets/plot_widget.py
@@ -27,7 +27,7 @@ import logging
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from .tab_widget import TabWidget
 from .plot_frame import PlotFrame
 
@@ -57,15 +57,15 @@ class PlotWidget(TabWidget, QtWidgets.QWidget):
             self.plot_frame.change_y_axis(y_axis)
 
     def _setup_ui(self):
-        self.columns_x_label = QtGui.QLabel(self)
+        self.columns_x_label = QtWidgets.QLabel(self)
         self.columns_x_label.setMaximumSize(QtCore.QSize(45, 16777215))
         self.columns_x_label.setText('X Axis:')
-        self.columns_y_label = QtGui.QLabel(self)
+        self.columns_y_label = QtWidgets.QLabel(self)
         self.columns_y_label.setMaximumSize(QtCore.QSize(45, 16777215))
         self.columns_y_label.setText('Y Axis:')
 
-        self.columns_x = QtGui.QComboBox(self)
-        self.columns_y = QtGui.QComboBox(self)
+        self.columns_x = QtWidgets.QComboBox(self)
+        self.columns_y = QtWidgets.QComboBox(self)
         for column in self.columns:
             self.columns_x.addItem(column)
             self.columns_y.addItem(column)
@@ -84,10 +84,10 @@ class PlotWidget(TabWidget, QtWidgets.QWidget):
         self.columns_y.setCurrentIndex(1)
 
     def _layout(self):
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(0)
 
-        hbox = QtGui.QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(10)
         hbox.setContentsMargins(-1, 6, -1, 6)
         hbox.addWidget(self.columns_x_label)

--- a/pymeasure/display/widgets/plot_widget.py
+++ b/pymeasure/display/widgets/plot_widget.py
@@ -27,7 +27,7 @@ import logging
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from .tab_widget import TabWidget
 from .plot_frame import PlotFrame
 
@@ -35,7 +35,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class PlotWidget(TabWidget, QtGui.QWidget):
+class PlotWidget(TabWidget, QtWidgets.QWidget):
     """ Extends :class:`PlotFrame<pymeasure.display.widgets.plot_frame.PlotFrame>`
     to allow different columns of the data to be dynamically chosen
     """

--- a/pymeasure/display/widgets/results_dialog.py
+++ b/pymeasure/display/widgets/results_dialog.py
@@ -28,7 +28,7 @@ import os
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 from ...experiment.results import Results
 from .plot_widget import PlotWidget
 
@@ -49,21 +49,21 @@ class ResultsDialog(QtWidgets.QFileDialog):
         super().__init__(parent)
         self.columns = columns
         self.x_axis, self.y_axis = x_axis, y_axis
-        self.setOption(QtGui.QFileDialog.DontUseNativeDialog, True)
+        self.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
         self._setup_ui()
 
     def _setup_ui(self):
-        preview_tab = QtGui.QTabWidget()
-        vbox = QtGui.QVBoxLayout()
-        param_vbox = QtGui.QVBoxLayout()
-        vbox_widget = QtGui.QWidget()
-        param_vbox_widget = QtGui.QWidget()
+        preview_tab = QtWidgets.QTabWidget()
+        vbox = QtWidgets.QVBoxLayout()
+        param_vbox = QtWidgets.QVBoxLayout()
+        vbox_widget = QtWidgets.QWidget()
+        param_vbox_widget = QtWidgets.QWidget()
 
         self.plot_widget = PlotWidget("Results", self.columns,
                                       self.x_axis, self.y_axis, parent=self)
         self.plot = self.plot_widget.plot
-        self.preview_param = QtGui.QTreeWidget()
-        param_header = QtGui.QTreeWidgetItem(["Name", "Value"])
+        self.preview_param = QtWidgets.QTreeWidget()
+        param_header = QtWidgets.QTreeWidgetItem(["Name", "Value"])
         self.preview_param.setHeaderItem(param_header)
         self.preview_param.setColumnWidth(0, 150)
         self.preview_param.setAlternatingRowColors(True)
@@ -79,7 +79,7 @@ class ResultsDialog(QtWidgets.QFileDialog):
         self.setMinimumSize(900, 500)
         self.resize(900, 500)
 
-        self.setFileMode(QtGui.QFileDialog.ExistingFiles)
+        self.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
         self.currentChanged.connect(self.update_plot)
 
     def update_plot(self, filename):
@@ -108,6 +108,6 @@ class ResultsDialog(QtWidgets.QFileDialog):
 
             self.preview_param.clear()
             for key, param in results.procedure.parameter_objects().items():
-                new_item = QtGui.QTreeWidgetItem([param.name, str(param)])
+                new_item = QtWidgets.QTreeWidgetItem([param.name, str(param)])
                 self.preview_param.addTopLevelItem(new_item)
             self.preview_param.sortItems(0, QtCore.Qt.AscendingOrder)

--- a/pymeasure/display/widgets/results_dialog.py
+++ b/pymeasure/display/widgets/results_dialog.py
@@ -28,7 +28,7 @@ import os
 import pyqtgraph as pg
 
 from ..curves import ResultsCurve
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 from ...experiment.results import Results
 from .plot_widget import PlotWidget
 
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class ResultsDialog(QtGui.QFileDialog):
+class ResultsDialog(QtWidgets.QFileDialog):
     """
     Widget that displays a dialog box for loading a past experiment run.
     It shows a preview of curves from the results file when selected in the dialog box.

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -31,7 +31,7 @@ from collections import ChainMap
 from itertools import product
 from inspect import signature
 
-from ..Qt import QtGui, QtWidgets
+from ..Qt import QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -141,42 +141,42 @@ class SequencerWidget(QtWidgets.QWidget):
         self.names_inv = {name: key for key, name in self.names.items()}
 
     def _setup_ui(self):
-        self.tree = QtGui.QTreeWidget(self)
+        self.tree = QtWidgets.QTreeWidget(self)
         self.tree.setHeaderLabels(["Level", "Parameter", "Sequence"])
         width = self.tree.viewport().size().width()
         self.tree.setColumnWidth(0, int(0.7 * width))
         self.tree.setColumnWidth(1, int(0.9 * width))
         self.tree.setColumnWidth(2, int(0.9 * width))
 
-        self.add_root_item_btn = QtGui.QPushButton("Add root item")
+        self.add_root_item_btn = QtWidgets.QPushButton("Add root item")
         self.add_root_item_btn.clicked.connect(
             partial(self._add_tree_item, level=0)
         )
 
-        self.add_tree_item_btn = QtGui.QPushButton("Add item")
+        self.add_tree_item_btn = QtWidgets.QPushButton("Add item")
         self.add_tree_item_btn.clicked.connect(self._add_tree_item)
 
-        self.remove_tree_item_btn = QtGui.QPushButton("Remove item")
+        self.remove_tree_item_btn = QtWidgets.QPushButton("Remove item")
         self.remove_tree_item_btn.clicked.connect(self._remove_selected_tree_item)
 
-        self.load_seq_button = QtGui.QPushButton("Load sequence")
+        self.load_seq_button = QtWidgets.QPushButton("Load sequence")
         self.load_seq_button.clicked.connect(self.load_sequence)
         self.load_seq_button.setToolTip("Load a sequence from a file.")
 
-        self.queue_button = QtGui.QPushButton("Queue sequence")
+        self.queue_button = QtWidgets.QPushButton("Queue sequence")
         self.queue_button.clicked.connect(self.queue_sequence)
 
     def _layout(self):
-        btn_box = QtGui.QHBoxLayout()
+        btn_box = QtWidgets.QHBoxLayout()
         btn_box.addWidget(self.add_root_item_btn)
         btn_box.addWidget(self.add_tree_item_btn)
         btn_box.addWidget(self.remove_tree_item_btn)
 
-        btn_box_2 = QtGui.QHBoxLayout()
+        btn_box_2 = QtWidgets.QHBoxLayout()
         btn_box_2.addWidget(self.load_seq_button)
         btn_box_2.addWidget(self.queue_button)
 
-        vbox = QtGui.QVBoxLayout(self)
+        vbox = QtWidgets.QVBoxLayout(self)
         vbox.setSpacing(6)
         vbox.addWidget(self.tree)
         vbox.addLayout(btn_box)
@@ -209,12 +209,12 @@ class SequencerWidget(QtWidgets.QWidget):
                 parent = parent.parent()
                 p_depth = self._depth_of_child(parent)
 
-        comboBox = QtGui.QComboBox()
-        lineEdit = QtGui.QLineEdit()
+        comboBox = QtWidgets.QComboBox()
+        lineEdit = QtWidgets.QLineEdit()
 
         comboBox.addItems(list(sorted(self.names_inv.keys())))
 
-        item = QtGui.QTreeWidgetItem(parent, [""])
+        item = QtWidgets.QTreeWidgetItem(parent, [""])
         depth = self._depth_of_child(item)
         item.setText(0, f"{depth:d}")
 
@@ -280,7 +280,7 @@ class SequencerWidget(QtWidgets.QWidget):
             )
 
             for entry in sequence:
-                QtGui.QApplication.processEvents()
+                QtWidgets.QApplication.processEvents()
                 parameters = dict(ChainMap(*entry[::-1]))
 
                 procedure = self._parent.make_procedure()
@@ -298,7 +298,7 @@ class SequencerWidget(QtWidgets.QWidget):
         """
 
         if fileName is None:
-            fileName, _ = QtGui.QFileDialog.getOpenFileName(self, 'OpenFile')
+            fileName, _ = QtWidgets.QFileDialog.getOpenFileName(self, 'OpenFile')
 
         if len(fileName) == 0:
             return
@@ -335,7 +335,7 @@ class SequencerWidget(QtWidgets.QWidget):
         Generate a list of parameters from the sequence tree.
         """
 
-        iterator = QtGui.QTreeWidgetItemIterator(self.tree)
+        iterator = QtWidgets.QTreeWidgetItemIterator(self.tree)
         sequences = []
         current_sequence = [[] for i in range(self.MAXDEPTH)]
         temp_sequence = [[] for i in range(self.MAXDEPTH)]

--- a/pymeasure/display/widgets/sequencer_widget.py
+++ b/pymeasure/display/widgets/sequencer_widget.py
@@ -31,7 +31,7 @@ from collections import ChainMap
 from itertools import product
 from inspect import signature
 
-from ..Qt import QtGui
+from ..Qt import QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -78,7 +78,7 @@ class SequenceEvaluationException(Exception):
     pass
 
 
-class SequencerWidget(QtGui.QWidget):
+class SequencerWidget(QtWidgets.QWidget):
     """
     Widget that allows to generate a sequence of measurements with varying
     parameters. Moreover, one can write a simple text file to easily load a

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -34,7 +34,8 @@ import pyqtgraph as pg
 from .browser import BrowserItem
 from .curves import ResultsCurve
 from .manager import Manager, Experiment
-from .Qt import QtCore, QtGui, QtWidgets
+from .Qt import QtCore, QtWidgets
+from pyqtgraph.Qt import QtGui
 from .widgets import (
     PlotWidget,
     BrowserWidget,
@@ -428,19 +429,19 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu.exec_(self.browser.viewport().mapToGlobal(position))
 
     def remove_experiment(self, experiment):
-        reply = QtGui.QMessageBox.question(self, 'Remove Graph',
-                                           "Are you sure you want to remove the graph?",
-                                           QtGui.QMessageBox.Yes |
-                                           QtGui.QMessageBox.No, QtGui.QMessageBox.No)
-        if reply == QtGui.QMessageBox.Yes:
+        reply = QtWidgets.QMessageBox.question(self, 'Remove Graph',
+                                               "Are you sure you want to remove the graph?",
+                                               QtWidgets.QMessageBox.Yes |
+                                               QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
+        if reply == QtWidgets.QMessageBox.Yes:
             self.manager.remove(experiment)
 
     def delete_experiment_data(self, experiment):
-        reply = QtGui.QMessageBox.question(self, 'Delete Data',
-                                           "Are you sure you want to delete this data file?",
-                                           QtGui.QMessageBox.Yes |
-                                           QtGui.QMessageBox.No, QtGui.QMessageBox.No)
-        if reply == QtGui.QMessageBox.Yes:
+        reply = QtWidgets.QMessageBox.question(self, 'Delete Data',
+                                               "Are you sure you want to delete this data file?",
+                                               QtWidgets.QMessageBox.Yes |
+                                               QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
+        if reply == QtWidgets.QMessageBox.Yes:
             self.manager.remove(experiment)
             os.unlink(experiment.data_filename)
 
@@ -465,7 +466,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             filenames = dialog.selectedFiles()
             for filename in map(str, filenames):
                 if filename in self.manager.experiments:
-                    QtGui.QMessageBox.warning(
+                    QtWidgets.QMessageBox.warning(
                         self, "Load Error",
                         "The file %s cannot be opened twice." % os.path.basename(filename)
                     )

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -34,8 +34,7 @@ import pyqtgraph as pg
 from .browser import BrowserItem
 from .curves import ResultsCurve
 from .manager import Manager, Experiment
-from .Qt import QtCore, QtWidgets
-from pyqtgraph.Qt import QtGui
+from .Qt import QtCore, QtWidgets, QtGui
 from .widgets import (
     PlotWidget,
     BrowserWidget,

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -34,7 +34,7 @@ import pyqtgraph as pg
 from .browser import BrowserItem
 from .curves import ResultsCurve
 from .manager import Manager, Experiment
-from .Qt import QtCore, QtGui
+from .Qt import QtCore, QtGui, QtWidgets
 from .widgets import (
     PlotWidget,
     BrowserWidget,
@@ -52,7 +52,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class PlotterWindow(QtGui.QMainWindow):
+class PlotterWindow(QtWidgets.QMainWindow):
     """
     A window for plotting experiment results. Should not be
     instantiated directly, but only via the
@@ -129,7 +129,7 @@ class PlotterWindow(QtGui.QMainWindow):
             QtCore.QCoreApplication.instance().quit()
 
 
-class ManagedWindowBase(QtGui.QMainWindow):
+class ManagedWindowBase(QtWidgets.QMainWindow):
     """
     Base class for GUI experiment management .
 

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -80,19 +80,19 @@ class PlotterWindow(QtWidgets.QMainWindow):
         columns = plotter.results.procedure.DATA_COLUMNS
 
         self.setWindowTitle('Results Plotter')
-        self.main = QtGui.QWidget(self)
+        self.main = QtWidgets.QWidget(self)
 
-        vbox = QtGui.QVBoxLayout(self.main)
+        vbox = QtWidgets.QVBoxLayout(self.main)
         vbox.setSpacing(0)
 
-        hbox = QtGui.QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(6)
         hbox.setContentsMargins(-1, 6, -1, -1)
 
-        file_label = QtGui.QLabel(self.main)
+        file_label = QtWidgets.QLabel(self.main)
         file_label.setText('Data Filename:')
 
-        self.file = QtGui.QLineEdit(self.main)
+        self.file = QtWidgets.QLineEdit(self.main)
         self.file.setText(plotter.results.data_filename)
 
         hbox.addWidget(file_label)
@@ -233,14 +233,14 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
     def _setup_ui(self):
         if self.directory_input:
-            self.directory_label = QtGui.QLabel(self)
+            self.directory_label = QtWidgets.QLabel(self)
             self.directory_label.setText('Directory')
             self.directory_line = DirectoryLineEdit(parent=self)
 
-        self.queue_button = QtGui.QPushButton('Queue', self)
+        self.queue_button = QtWidgets.QPushButton('Queue', self)
         self.queue_button.clicked.connect(self._queue)
 
-        self.abort_button = QtGui.QPushButton('Abort', self)
+        self.abort_button = QtWidgets.QPushButton('Abort', self)
         self.abort_button.setEnabled(False)
         self.abort_button.clicked.connect(self.abort)
 
@@ -290,12 +290,12 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             )
 
     def _layout(self):
-        self.main = QtGui.QWidget(self)
+        self.main = QtWidgets.QWidget(self)
 
-        inputs_dock = QtGui.QWidget(self)
-        inputs_vbox = QtGui.QVBoxLayout(self.main)
+        inputs_dock = QtWidgets.QWidget(self)
+        inputs_vbox = QtWidgets.QVBoxLayout(self.main)
 
-        hbox = QtGui.QHBoxLayout()
+        hbox = QtWidgets.QHBoxLayout()
         hbox.setSpacing(10)
         hbox.setContentsMargins(-1, 6, -1, 6)
         hbox.addWidget(self.queue_button)
@@ -303,17 +303,17 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         hbox.addStretch()
 
         if self.directory_input:
-            vbox = QtGui.QVBoxLayout()
+            vbox = QtWidgets.QVBoxLayout()
             vbox.addWidget(self.directory_label)
             vbox.addWidget(self.directory_line)
             vbox.addLayout(hbox)
 
         if self.inputs_in_scrollarea:
-            inputs_scroll = QtGui.QScrollArea()
+            inputs_scroll = QtWidgets.QScrollArea()
             inputs_scroll.setWidgetResizable(True)
-            inputs_scroll.setFrameStyle(QtGui.QScrollArea.NoFrame)
+            inputs_scroll.setFrameStyle(QtWidgets.QScrollArea.NoFrame)
 
-            self.inputs.setSizePolicy(QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Fixed)
+            self.inputs.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Fixed)
             inputs_scroll.setWidget(self.inputs)
             inputs_vbox.addWidget(inputs_scroll, 1)
 
@@ -328,32 +328,32 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         inputs_vbox.addStretch(0)
         inputs_dock.setLayout(inputs_vbox)
 
-        dock = QtGui.QDockWidget('Input Parameters')
+        dock = QtWidgets.QDockWidget('Input Parameters')
         dock.setWidget(inputs_dock)
-        dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
+        dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dock)
 
         if self.use_sequencer:
-            sequencer_dock = QtGui.QDockWidget('Sequencer')
+            sequencer_dock = QtWidgets.QDockWidget('Sequencer')
             sequencer_dock.setWidget(self.sequencer)
-            sequencer_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
+            sequencer_dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
             self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, sequencer_dock)
 
         if self.use_estimator:
-            estimator_dock = QtGui.QDockWidget('Estimator')
+            estimator_dock = QtWidgets.QDockWidget('Estimator')
             estimator_dock.setWidget(self.estimator)
-            estimator_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
+            estimator_dock.setFeatures(QtWidgets.QDockWidget.NoDockWidgetFeatures)
             self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, estimator_dock)
 
-        self.tabs = QtGui.QTabWidget(self.main)
+        self.tabs = QtWidgets.QTabWidget(self.main)
         for wdg in self.widget_list:
             self.tabs.addTab(wdg, wdg.name)
 
-        splitter = QtGui.QSplitter(QtCore.Qt.Vertical)
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
         splitter.addWidget(self.tabs)
         splitter.addWidget(self.browser_widget)
 
-        vbox = QtGui.QVBoxLayout(self.main)
+        vbox = QtWidgets.QVBoxLayout(self.main)
         vbox.setSpacing(0)
         vbox.addWidget(splitter)
 

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -385,24 +385,24 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         if item is not None:
             experiment = self.manager.experiments.with_browser_item(item)
 
-            menu = QtGui.QMenu(self)
+            menu = QtWidgets.QMenu(self)
 
             # Open
-            action_open = QtGui.QAction(menu)
+            action_open = QtWidgets.QAction(menu)
             action_open.setText("Open Data Externally")
             action_open.triggered.connect(
                 lambda: self.open_file_externally(experiment.results.data_filename))
             menu.addAction(action_open)
 
             # Change Color
-            action_change_color = QtGui.QAction(menu)
+            action_change_color = QtWidgets.QAction(menu)
             action_change_color.setText("Change Color")
             action_change_color.triggered.connect(
                 lambda: self.change_color(experiment))
             menu.addAction(action_change_color)
 
             # Remove
-            action_remove = QtGui.QAction(menu)
+            action_remove = QtWidgets.QAction(menu)
             action_remove.setText("Remove Graph")
             if self.manager.is_running():
                 if self.manager.running_experiment() == experiment:  # Experiment running
@@ -411,7 +411,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu.addAction(action_remove)
 
             # Delete
-            action_delete = QtGui.QAction(menu)
+            action_delete = QtWidgets.QAction(menu)
             action_delete.setText("Delete Data File")
             if self.manager.is_running():
                 if self.manager.running_experiment() == experiment:  # Experiment running
@@ -420,7 +420,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             menu.addAction(action_delete)
 
             # Use parameters
-            action_use = QtGui.QAction(menu)
+            action_use = QtWidgets.QAction(menu)
             action_use.setText("Use These Parameters")
             action_use.triggered.connect(
                 lambda: self.set_parameters(experiment.procedure.parameter_objects()))
@@ -482,7 +482,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                     log.info('Opened data file %s' % filename)
 
     def change_color(self, experiment):
-        color = QtGui.QColorDialog.getColor(
+        color = QtWidgets.QColorDialog.getColor(
             parent=self)
         if color.isValid():
             pixelmap = QtGui.QPixmap(24, 24)


### PR DESCRIPTION
Following a recent pyqtgraph update, accessing QtWidgets through QtGui has been deprecated (see Issue #694). 

This PR should resolve this issue by just swapping QtGui for QtWidgets and adding an import for QtWidgets in `Qt.py`. So far it has been tested with the examples given by pymeasure. I hope I have not missed anything, but it may very well be...