### PR TITLE
Fwbell 5080 updates

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -52,3 +52,4 @@ Benedikt Moneke
 Asaf Yagoda
 Fabio Garzetti
 Daniel Schmeer
+Mike Manno

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -55,7 +55,9 @@ class FWBell5080(Instrument):
         ":MEASure:FLUX?",
         """ Reads a floating point value of the field in the appropriate units.
         """,
-        get_process=lambda v: float(v.replace('T','').replace('G','').replace('Am',''))  # Remove units
+        # Remove units
+        get_process=lambda v: float(v.replace('T', '').replace('G', '').replace('Am', ''))
+
     )
     UNITS = {
         'gauss': 'DC:GAUSS', 'gauss ac': 'AC:GAUSS',
@@ -82,11 +84,11 @@ class FWBell5080(Instrument):
         | Value  | gauss  |  tesla  | amp-meter |
         +--------+--------+---------+-----------+
         | 0      | 300 G  |  30  mT | 23.88 kAm |
-        +--------+------------------+-----------+
+        +--------+--------+---------+-----------+
         | 1      | 3 kG   |  300 mT | 238.8 kAm |
         +--------+--------+---------+-----------+
         | 2      | 30 kG  |  3 T    | 2388  kAm |
-        +--------+--------+---------+-----------+        
+        +--------+--------+---------+-----------+
         """,
         validator=strict_discrete_set,
         values=[0, 1, 2],
@@ -102,11 +104,12 @@ class FWBell5080(Instrument):
                   'timeout': 500},
             **kwargs
         )
+
     def read(self):
         """ Overwrites the :meth:`Instrument.read <pymeasure.instruments.Instrument.read>`
-        method to remove the last 2 characters from the output.
+        method to remove semicolons and replace spaces with colons.
         """
-        return super().read().replace(' ', ':').replace(';', '') # replace space with colon, remove semicolon
+        return super().read().replace(' ', ':').replace(';', '')
 
     def reset(self):
         """ Resets the instrument. """
@@ -124,6 +127,7 @@ class FWBell5080(Instrument):
             return array(data, dtype=float64)
 
     def auto_range(self):
-        """ Enables the auto range functionality. Instrument needs time before next command """
+        """ Enables the auto range functionality. """
         self.write(":SENS:FLUX:RANG:AUTO")
+        # Instrument needs a delay before next command
         sleep(2)

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -23,8 +23,9 @@
 #
 
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import truncated_discrete_set, strict_discrete_set
+from pymeasure.instruments.validators import strict_discrete_set
 from numpy import array, float64
+from time import sleep
 
 
 class FWBell5080(Instrument):
@@ -39,7 +40,7 @@ class FWBell5080(Instrument):
         meter = FWBell5080('/dev/ttyUSB0')  # Connects over serial port /dev/ttyUSB0 (Linux)
 
         meter.units = 'gauss'               # Sets the measurement units to Gauss
-        meter.range = 3e3                   # Sets the range to 3 kG
+        meter.range = 1                     # Sets the range to 3 kG
         print(meter.field)                  # Reads and prints a field measurement in G
 
         fields = meter.fields(100)          # Samples 100 field measurements
@@ -48,13 +49,14 @@ class FWBell5080(Instrument):
     """
 
     id = Instrument.measurement(
-        "*IDN?", """ Reads the idenfitication information. """
+        "*IDN?", """ Reads the identification information. """
     )
     field = Instrument.measurement(
-        ":MEAS:FLUX?",
+        ":MEASure:FLUX?",
         """ Reads a floating point value of the field in the appropriate units.
         """,
-        get_process=lambda v: v.split(' ')[0]  # Remove units
+        get_process=lambda v: float(v[:-2])  # Remove semicolon and units
+
     )
     UNITS = {
         'gauss': 'DC:GAUSS', 'gauss ac': 'AC:GAUSS',
@@ -62,8 +64,7 @@ class FWBell5080(Instrument):
         'amp-meter': 'DC:AM', 'amp-meter ac': 'AC:AM'
     }
     units = Instrument.control(
-        # TODO a newer version expects ':UNIT:FLUX:%s', is this right?
-        ":UNIT:FLUX?", ":UNIT:FLUX%s",
+        ":UNIT:FLUX?", ":UNIT:FLUX:%s",
         """ A string property that controls the field units, which can take the
         values: 'gauss', 'gauss ac', 'tesla', 'tesla ac', 'amp-meter', and
         'amp-meter ac'. The AC versions configure the instrument to measure AC.
@@ -71,47 +72,39 @@ class FWBell5080(Instrument):
         validator=strict_discrete_set,
         values=UNITS,
         map_values=True,
-        get_process=lambda v: v.replace(' ', ':')  # Make output consistent with input
+    )
+
+    range = Instrument.control(
+        ":SENS:FLUX:RANG?", ":SENS:FLUX:RANG %d",
+        """ An integer property that controls the maximum field range in the active units.
+        Value is dependent on the currently selected units (gauss, tesla, amp-meter)
+
+        +--------+--------+---------+-----------+
+        | Value  | gauss  |  tesla  | amp-meter |
+        +--------+--------+---------+-----------+
+        | 0      | 300 G  |  30  mT | 23.88 kAm |
+        +--------+------------------+-----------+
+        | 1      | 3 kG   |  300 mT | 238.8 kAm |
+        +--------+--------+---------+-----------+
+        | 2      | 30 kG  |  3 T    | 2388  kAm |
+        +--------+--------+---------+-----------+        
+        """,
+        validator=strict_discrete_set,
+        values=[0, 1, 2],
+        get_process=lambda v: int(v)
     )
 
     def __init__(self, adapter, **kwargs):
+        # Replace spaces with colon and remove semicolons from instrument response
+        kwargs.setdefault('preprocess_reply', lambda x: x.replace(' ', ':').replace(';', ''))
         super().__init__(
             adapter,
             "F.W. Bell 5080 Handheld Gaussmeter",
+            includeSCPI=True,
             asrl={'baud_rate': 2400,
                   'timeout': 500},
             **kwargs
         )
-
-    @property
-    def range(self):
-        """ A floating point property that controls the maximum field
-        range in the active units. This can take the values of 300 G,
-        3 kG, and 30 kG for Gauss, 30 mT, 300 mT, and 3 T for Tesla,
-        and 23.88 kAm, 238.8 kAm, and 2388 kAm for Amp-meter. """
-        i = self.values(":SENS:FLUX:RANG?", cast=int)
-        if 'gauss' in self.units:
-            return [300, 3e3, 30e3][i]
-        elif 'tesla' in self.units:
-            return [30e-3, 300e-3, 3][i]
-        elif 'amp-meter' in self.units:
-            return [23.88e3, 238.8e3, 2388e3][i]
-
-    @range.setter
-    def range(self, value):
-        if 'gauss' in self.units:
-            i = truncated_discrete_set(value, [300, 3e3, 30e3])
-        elif 'tesla' in self.units:
-            i = truncated_discrete_set(value, [30e-3, 300e-3, 3])
-        elif 'amp-meter' in self.units:
-            i = truncated_discrete_set(value, [23.88e3, 238.8e3, 2388e3])
-        self.write(":SENS:FLUX:RANG %d" % i)
-
-    def read(self):
-        """ Overwrites the :meth:`Instrument.read <pymeasure.instruments.Instrument.read>`
-        method to remove the last 2 characters from the output.
-        """
-        return super().read()[:-2]
 
     def reset(self):
         """ Resets the instrument. """
@@ -129,5 +122,6 @@ class FWBell5080(Instrument):
             return array(data, dtype=float64)
 
     def auto_range(self):
-        """ Enables the auto range functionality. """
+        """ Enables the auto range functionality. Instrument needs time before next command """
         self.write(":SENS:FLUX:RANG:AUTO")
+        sleep(2)

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -48,6 +48,16 @@ class FWBell5080(Instrument):
 
     """
 
+    def __init__(self, adapter, **kwargs):
+        kwargs.setdefault('timeout', 500)
+        kwargs.setdefault('baudrate', 2400)
+        super().__init__(
+            adapter,
+            "F.W. Bell 5080 Handheld Gaussmeter",
+            includeSCPI=True,
+            **kwargs
+        )
+
     field = Instrument.measurement(
         ":MEASure:FLUX?",
         """ Reads a floating point value of the field in the appropriate units.
@@ -92,20 +102,14 @@ class FWBell5080(Instrument):
         cast=int
     )
 
-    def __init__(self, adapter, **kwargs):
-        kwargs.setdefault('timeout', 500)
-        kwargs.setdefault('baudrate', 2400)
-        super().__init__(
-            adapter,
-            "F.W. Bell 5080 Handheld Gaussmeter",
-            includeSCPI=True,
-            **kwargs
-        )
-
     def read(self):
         """ Overwrites the :meth:`Instrument.read <pymeasure.instruments.Instrument.read>`
         method to remove semicolons and replace spaces with colons.
         """
+        # To set the unit mode to DC Tesla you need to write(':UNIT:FLUX:DC:TESLA')
+        # However the response from ask(':UNIT:FLUX?') is "DC TESLA", with no colon.
+        # We replace space with colon to preserve the mapping in UNITS.
+        # Semicolons may be appended to end of response from FW Bell 5080, and are removed
         return super().read().replace(' ', ':').replace(';', '')
 
     def reset(self):

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -85,7 +85,8 @@ class FWBell5080(Instrument):
     range = Instrument.control(
         ":SENS:FLUX:RANG?", ":SENS:FLUX:RANG %d",
         """ An integer property that controls the maximum field range in the active units.
-        Value is dependent on the currently selected units (gauss, tesla, amp-meter)
+        The range unit is dependent on the current units mode (gauss, tesla, amp-meter). Value
+        sets an equivalent range across units that increases in magnitude (1, 10, 100).
 
         +--------+--------+---------+-----------+
         | Value  | gauss  |  tesla  | amp-meter |

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -110,7 +110,7 @@ class FWBell5080(Instrument):
 
     def reset(self):
         """ Resets the instrument. """
-        self.write("*OPC")
+        self.write("*CLS")
 
     def fields(self, samples=1):
         """ Returns a numpy array of field samples for a given sample number.

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -114,7 +114,7 @@ class FWBell5080(Instrument):
 
     def reset(self):
         """ Resets the instrument. """
-        self.write("*CLS")
+        self.clear()
 
     def fields(self, samples=1):
         """ Returns a numpy array of field samples for a given sample number.

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -48,9 +48,6 @@ class FWBell5080(Instrument):
 
     """
 
-    id = Instrument.measurement(
-        "*IDN?", """ Reads the identification information. """
-    )
     field = Instrument.measurement(
         ":MEASure:FLUX?",
         """ Reads a floating point value of the field in the appropriate units.
@@ -92,16 +89,16 @@ class FWBell5080(Instrument):
         """,
         validator=strict_discrete_set,
         values=[0, 1, 2],
-        get_process=lambda v: int(v)
+        cast=int
     )
 
     def __init__(self, adapter, **kwargs):
+        kwargs.setdefault('timeout', 500)
+        kwargs.setdefault('baudrate', 2400)
         super().__init__(
             adapter,
             "F.W. Bell 5080 Handheld Gaussmeter",
             includeSCPI=True,
-            asrl={'baud_rate': 2400,
-                  'timeout': 500},
             **kwargs
         )
 

--- a/tests/instruments/fwbell/test_fwbell5080.py
+++ b/tests/instruments/fwbell/test_fwbell5080.py
@@ -22,8 +22,6 @@
 # THE SOFTWARE.
 #
 
-import pytest
-
 from pymeasure.test import expected_protocol
 
 from pymeasure.instruments.fwbell import FWBell5080
@@ -33,22 +31,21 @@ def test_init():
     with expected_protocol(
             FWBell5080,
             [],
-            ):
+    ):
         pass  # Verify the expected communication.
 
 
 def test_units():
     with expected_protocol(
             FWBell5080,
-            [(b":UNIT:FLUXDC:GAUSS", None)],
-            ) as instr:
+            [(b":UNIT:FLUX:DC:GAUSS", None)],
+    ) as instr:
         instr.units = 'gauss'
 
 
-@pytest.mark.xfail  # implementation is broken.
 def test_field():
     with expected_protocol(
             FWBell5080,
-            [(b":MEAS:FLUX?", b"123.45 T")],
-            ) as instr:
+            [(b":MEASure:FLUX?", b"+123.45T")],
+    ) as instr:
         assert instr.field == 123.45


### PR DESCRIPTION
Updated fwbell5080 to fixed errors, migrate `inst.range()` to an `Instrument.control` property, and fixed unit tests.

In modifying `inst.range` we modified the way ranges are set.

Previously the `inst.range` property would validate by a `truncated_discrete_set` which would allow any numeric input and map it to the current `inst.unit` `truncated_discrete_set`. Rather that memorizing the exact ranges in the `truncated_discrete_set`, which were different depending on `inst.unit`, we will ask the user to explicitly put in a value from `strict_discrete_set` of [0,1,2], which maps to the different ranges by unit. The mapping of values to ranges by unit is in the instrument docstring.