### PR TITLE
New Instrument: Siglent SPDxxxxX series Power Supplies

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -48,6 +48,7 @@ Instruments by manufacturer:
    pendulum/index
    razorbill/index
    rohdeschwarz/index
+   siglenttechnologies/index
    signalrecovery/index
    srs/index
    tektronix/index

--- a/docs/api/instruments/siglenttechnologies/index.rst
+++ b/docs/api/instruments/siglenttechnologies/index.rst
@@ -11,3 +11,4 @@ This section contains specific documentation on the Siglent Technologies instrum
 
    siglent_spdbase
    siglent_spd1168x
+   siglent_spd1305x

--- a/docs/api/instruments/siglenttechnologies/index.rst
+++ b/docs/api/instruments/siglenttechnologies/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.siglenttechnologies
+####################
+Siglent Technologies
+####################
+
+This section contains specific documentation on the Siglent Technologies instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   siglent_spdbase
+   siglent_spd1168x

--- a/docs/api/instruments/siglenttechnologies/index.rst
+++ b/docs/api/instruments/siglenttechnologies/index.rst
@@ -1,4 +1,5 @@
 .. module:: pymeasure.instruments.siglenttechnologies
+
 ####################
 Siglent Technologies
 ####################

--- a/docs/api/instruments/siglenttechnologies/siglent_spd1168x.rst
+++ b/docs/api/instruments/siglenttechnologies/siglent_spd1168x.rst
@@ -1,0 +1,7 @@
+#############################
+Siglent SPD1168X Power Supply
+#############################
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.SPD1168X
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/siglenttechnologies/siglent_spd1305x.rst
+++ b/docs/api/instruments/siglenttechnologies/siglent_spd1305x.rst
@@ -1,0 +1,7 @@
+#############################
+Siglent SPD1305X Power Supply
+#############################
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.SPD1305X
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
+++ b/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
@@ -6,7 +6,7 @@ Siglent Technologies Base Class
     :members:
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.ControlledSPDChannel
+.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.SPDChannel
     :members:
     :show-inheritance:
 

--- a/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
+++ b/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
@@ -2,7 +2,11 @@
 Siglent Technologies Base Class
 ###############################
 
-.. autoclass:: pymeasure.instruments.siglenttechnologies.SPDBase
+.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.SPDBase
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.SPDSingleChannelBase
     :members:
     :show-inheritance:
 

--- a/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
+++ b/docs/api/instruments/siglenttechnologies/siglent_spdbase.rst
@@ -1,0 +1,13 @@
+###############################
+Siglent Technologies Base Class
+###############################
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.SPDBase
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.ControlledSPDChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.siglenttechnologies.siglent_spdbase.SystemStatusCode

--- a/pymeasure/instruments/siglenttechnologies/__init__.py
+++ b/pymeasure/instruments/siglenttechnologies/__init__.py
@@ -22,6 +22,5 @@
 # THE SOFTWARE.
 #
 
-from .siglent_spdbase import SPDBase
 from .siglent_spd1168x import SPD1168X
 from .siglent_spd1305x import SPD1305X

--- a/pymeasure/instruments/siglenttechnologies/__init__.py
+++ b/pymeasure/instruments/siglenttechnologies/__init__.py
@@ -24,3 +24,4 @@
 
 from .siglent_spdbase import SPDBase
 from .siglent_spd1168x import SPD1168X
+from .siglent_spd1305x import SPD1305X

--- a/pymeasure/instruments/siglenttechnologies/__init__.py
+++ b/pymeasure/instruments/siglenttechnologies/__init__.py
@@ -22,43 +22,5 @@
 # THE SOFTWARE.
 #
 
-from ..errors import RangeError, RangeException
-from .instrument import Instrument
-from .resources import list_resources
-from .validators import discreteTruncate
-
-from . import activetechnologies
-from . import advantest
-from . import agilent
-from . import ametek
-from . import ami
-from . import anaheimautomation
-from . import anapico
-from . import andeenhagerling
-from . import anritsu
-from . import attocube
-from . import danfysik
-from . import deltaelektronika
-from . import fluke
-from . import fwbell
-from . import hcp
-from . import heidenhain
-from . import hp
-from . import keithley
-from . import keysight
-from . import lakeshore
-from . import newport
-from . import ni
-from . import oxfordinstruments
-from . import parker
-from . import razorbill
-from . import rohdeschwarz
-from . import siglenttechnologies
-from . import signalrecovery
-from . import srs
-from . import tektronix
-from . import temptronic
-from . import thermotron
-from . import thorlabs
-from . import toptica
-from . import yokogawa
+from .siglent_spdbase import SPDBase
+from .siglent_spd1168x import SPD1168X

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from pymeasure.instruments.instrument import Instrument
+from pymeasure.instruments.validators import strict_discrete_set
 from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
 
 
@@ -37,6 +39,19 @@ class SPD1168X(SPDBase):
 
         self.ch = {}
         self.ch[1] = SPDChannel(self, 1)
+
+    enable_4W_mode = Instrument.setting(
+        "MODE:SET %s",
+        """Configure 4-wire mode.
+
+        :type: bool
+            ``True``: enables 4-wire mode
+            ``False``: disables it.
+        """,
+        validator=strict_discrete_set,
+        values={False: "2W", True: "4W"},
+        map_values=True
+    )
 
     def shutdown(self):
         """ Ensure that the voltage is turned to zero

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -37,7 +37,6 @@ class SPD1168X(SPDBase):
             **kwargs
         )
 
-        self.ch = {}
         self.ch[1] = SPDChannel(self, 1)
 
     enable_4W_mode = Instrument.setting(
@@ -52,9 +51,3 @@ class SPD1168X(SPDBase):
         values={False: "2W", True: "4W"},
         map_values=True
     )
-
-    def shutdown(self):
-        """ Ensure that the voltage is turned to zero
-        and disable the output. """
-        self.ch[1].voltage_setpoint = 0
-        self.ch[1].enable_output(False)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -1,0 +1,56 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
+
+
+class SPD1168X(SPDBase):
+    """Represent the Siglent SPD1168X Power Supply.
+    """
+
+    def __init__(self, adapter, **kwargs):
+        super().__init__(
+            adapter,
+            name="Siglent SPD1168X Power Supply",
+            **kwargs
+        )
+        self.CH1 = SPDChannel(self, 1)
+
+    def shutdown(self):
+        """ Ensures that the voltage is turned to zero
+        and disables the output. """
+        self.CH1.set_voltage(0.0)
+        self.CH1.disable()
+
+
+if __name__ == "__main__":
+    psu = SPD1168X("TCPIP0::10.20.2.245::5025::SOCKET")
+    print(psu.id)
+    print(psu.selected_channel)
+    psu.CH1.set_current = 1
+    psu.CH1.output = False
+
+    print(psu.CH1.set_voltage)
+    print(psu.CH1.set_current)
+    print(psu.CH1.voltage)
+    print(psu.error)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -41,18 +41,5 @@ class SPD1168X(SPDBase):
     def shutdown(self):
         """ Ensure that the voltage is turned to zero
         and disable the output. """
-        self.ch[1].set_voltage(0.0)
-        self.ch[1].disable()
-
-
-if __name__ == "__main__":
-    psu = SPD1168X("TCPIP0::10.20.2.245::5025::SOCKET")
-    print(psu.id)
-    print(psu.selected_channel)
-    psu.ch[1].set_current = 1
-    psu.ch[1].disable()
-
-    print(psu.ch[1].set_voltage)
-    print(psu.ch[1].set_current)
-    print(psu.ch[1].voltage)
-    print(psu.error)
+        self.ch[1].voltage_setpoint = 0
+        self.ch[1].enable_output(False)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -31,7 +31,7 @@ class SPD1168X(SPDBase):
     def __init__(self, adapter, **kwargs):
         super().__init__(
             adapter,
-            name="Siglent SPD1168X Power Supply",
+            name="Siglent Technologies SPD1168X Power Supply",
             **kwargs
         )
         self.CH1 = SPDChannel(self, 1)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -21,12 +21,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from pymeasure.instruments.instrument import Instrument
-from pymeasure.instruments.validators import strict_discrete_set
-from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
+from pymeasure.instruments.siglenttechnologies.siglent_spdbase import (SPDSingleChannelBase,
+                                                                       SPDChannel)
 
 
-class SPD1168X(SPDBase):
+class SPD1168X(SPDSingleChannelBase):
     """Represent the Siglent SPD1168X Power Supply.
     """
 
@@ -38,16 +37,3 @@ class SPD1168X(SPDBase):
         )
 
         self.ch[1] = SPDChannel(self, 1)
-
-    enable_4W_mode = Instrument.setting(
-        "MODE:SET %s",
-        """Configure 4-wire mode.
-
-        :type: bool
-            ``True``: enables 4-wire mode
-            ``False``: disables it.
-        """,
-        validator=strict_discrete_set,
-        values={False: "2W", True: "4W"},
-        map_values=True
-    )

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -24,14 +24,19 @@
 from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
 
 
-class SPD1168X(SPDBase):
-    """Represent the Siglent SPD1168X Power Supply.
+class SPD1305X(SPDBase):
+    """Represent the Siglent SPD1305X Power Supply.
     """
 
+    set_voltage_values = [0, 30]
+
+    set_current_values = [0, 5]
+
     def __init__(self, adapter, **kwargs):
+
         super().__init__(
             adapter,
-            name="Siglent Technologies SPD1168X Power Supply",
+            name="Siglent Technologies SPD1305X Power Supply",
             **kwargs
         )
 
@@ -43,16 +48,3 @@ class SPD1168X(SPDBase):
         and disables the output. """
         self.ch[1].set_voltage(0.0)
         self.ch[1].disable()
-
-
-if __name__ == "__main__":
-    psu = SPD1168X("TCPIP0::10.20.2.245::5025::SOCKET")
-    print(psu.id)
-    print(psu.selected_channel)
-    psu.ch[1].set_current = 1
-    psu.ch[1].disable()
-
-    print(psu.ch[1].set_voltage)
-    print(psu.ch[1].set_current)
-    print(psu.ch[1].voltage)
-    print(psu.error)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -28,10 +28,6 @@ class SPD1305X(SPDBase):
     """Represent the Siglent SPD1305X Power Supply.
     """
 
-    set_voltage_values = [0, 30]
-
-    set_current_values = [0, 5]
-
     def __init__(self, adapter, **kwargs):
 
         super().__init__(
@@ -42,6 +38,9 @@ class SPD1305X(SPDBase):
 
         self.ch = {}
         self.ch[1] = SPDChannel(self, 1)
+
+        self.ch[1].set_voltage_values = [0, 30]
+        self.ch[1].set_current_values = [0, 5]
 
     def shutdown(self):
         """ Ensures that the voltage is turned to zero

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -35,15 +35,17 @@ class SPD1305X(SPDBase):
             name="Siglent Technologies SPD1305X Power Supply",
             **kwargs
         )
+        voltage_limits = [0, 30]
+        current_limits = [0, 5]
 
         self.ch = {}
         self.ch[1] = SPDChannel(self, 1)
 
-        self.ch[1].set_voltage_values = [0, 30]
-        self.ch[1].set_current_values = [0, 5]
+        self.ch[1].voltage_setpoint_values = voltage_limits
+        self.ch[1].current_limit_values = current_limits
 
     def shutdown(self):
         """ Ensures that the voltage is turned to zero
         and disables the output. """
-        self.ch[1].set_voltage(0.0)
-        self.ch[1].disable()
+        self.ch[1].voltage_setpoint = 0
+        self.ch[1].enable_output(False)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -21,6 +21,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from pymeasure.instruments.instrument import Instrument
+from pymeasure.instruments.validators import strict_discrete_set
 from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
 
 
@@ -43,6 +45,19 @@ class SPD1305X(SPDBase):
 
         self.ch[1].voltage_setpoint_values = voltage_limits
         self.ch[1].current_limit_values = current_limits
+
+    enable_4W_mode = Instrument.setting(
+        "MODE:SET %s",
+        """Configure 4-wire mode.
+
+        :type: bool
+            ``True``: enables 4-wire mode
+            ``False``: disables it.
+        """,
+        validator=strict_discrete_set,
+        values={False: "2W", True: "4W"},
+        map_values=True
+    )
 
     def shutdown(self):
         """ Ensures that the voltage is turned to zero

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -21,12 +21,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from pymeasure.instruments.instrument import Instrument
-from pymeasure.instruments.validators import strict_discrete_set
-from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDBase, SPDChannel
+from pymeasure.instruments.siglenttechnologies.siglent_spdbase import (SPDSingleChannelBase,
+                                                                       SPDChannel)
 
 
-class SPD1305X(SPDBase):
+class SPD1305X(SPDSingleChannelBase):
     """Represent the Siglent SPD1305X Power Supply.
     """
 
@@ -40,27 +39,7 @@ class SPD1305X(SPDBase):
         voltage_limits = [0, 30]
         current_limits = [0, 5]
 
-        self.ch = {}
         self.ch[1] = SPDChannel(self, 1, voltage_limits, current_limits)
 
         self.ch[1].voltage_setpoint_values = voltage_limits
         self.ch[1].current_limit_values = current_limits
-
-    enable_4W_mode = Instrument.setting(
-        "MODE:SET %s",
-        """Configure 4-wire mode.
-
-        :type: bool
-            ``True``: enables 4-wire mode
-            ``False``: disables it.
-        """,
-        validator=strict_discrete_set,
-        values={False: "2W", True: "4W"},
-        map_values=True
-    )
-
-    def shutdown(self):
-        """ Ensures that the voltage is turned to zero
-        and disables the output. """
-        self.ch[1].voltage_setpoint = 0
-        self.ch[1].enable_output(False)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -39,7 +39,7 @@ class SPD1305X(SPDBase):
         current_limits = [0, 5]
 
         self.ch = {}
-        self.ch[1] = SPDChannel(self, 1)
+        self.ch[1] = SPDChannel(self, 1, voltage_limits, current_limits)
 
         self.ch[1].voltage_setpoint_values = voltage_limits
         self.ch[1].current_limit_values = current_limits

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -153,6 +153,18 @@ class SPDBase(Instrument):
         super().shutdown()
 
 
+class SPDSingleChannelBase(SPDBase):
+
+    def enable_4W_mode(self, enable: bool = True):
+        """Enable 4-wire mode.
+
+        :type: bool
+            ``True``: enables 4-wire mode
+            ``False``: disables it.
+        """
+        self.write(f'MODE:SET {("2W","4W")[enable]}')
+
+
 class SPDChannel(object):
     """ The channel class for Siglent SPDxxxxX instruments.
     """

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -1,0 +1,275 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import logging
+from pymeasure.instruments.instrument import Instrument
+from pymeasure.instruments.validators import (strict_discrete_set,
+                                              truncated_range
+                                              )
+from enum import IntFlag
+
+log = logging.getLogger(__name__)  # https://docs.python.org/3/howto/logging.html#library-config
+log.addHandler(logging.NullHandler())
+
+
+class SystemStatusCode(IntFlag):
+    """System status enums based on ``IntFlag``
+
+    Used in conjunction with :attr:`~.system_status_code`.
+
+        ======  ======
+        Value   Enum
+        ======  ======
+        256     WAVEFORM_DISPLAY
+        64      TIMER_ENABLED
+        32      FOUR_WIRE
+        16      OUTPUT_ENABLED
+        1       CONSTANT_CURRENT
+        0       CONSTANT_VOLTAGE
+        ======  ======
+
+    """
+
+    WAVEFORM_DISPLAY = 256  # bit 8 -- waveform display enabled
+    TIMER_ENABLED = 64  # bit 6 -- timer enabled
+    FOUR_WIRE = 32  # bit 5 -- four-wire mode enabled
+    OUTPUT_ENABLED = 16  # bit 4 -- output enabled
+    CONSTANT_CURRENT = 1   # bit 0 -- constant current mode
+    CONSTANT_VOLTAGE = 0   # bit 0 -- constant voltage mode
+
+
+class SPDBase(Instrument):
+    """ The base class for Siglent SPDxxxxX instruments.
+    """
+
+    error = Instrument.measurement(
+        "SYST:ERR?",
+        """Read the error code and information of the instrument.
+
+        :type: str
+        """
+    )
+
+    fw_version = Instrument.measurement(
+        "SYST:VERS?",
+        """Read the software version of the instrument.
+
+        :type: str
+        """
+    )
+
+    system_status_code = Instrument.measurement(
+        "SYST:STAT?",
+        """Read the system status register.
+
+        :type: :class:`.SystemStatusCode`
+        """,
+        validator=truncated_range,
+        values=[0, 1024],
+        get_process=lambda v: SystemStatusCode(int(v, base=16)),
+    )
+
+    local_lockout = Instrument.setting(
+        "%s",
+        """``True`` disables local interface, ``False`` enables it.
+        """,
+        validator=strict_discrete_set,
+        values={True: "*LOCK", False: "*UNLOCK"},
+        map_values=True
+    )
+
+    save_settings = Instrument.measurement(
+        "*SAV %d",
+        """Save the current configuration in non-volatile memory.
+
+        :type: int
+        """,
+        validator=strict_discrete_set,
+        values=[1, 2, 3, 4, 5]
+    )
+
+    recall_settings = Instrument.measurement(
+        "*RCL %d",
+        """Recall the saved configuration from non-volatile memory.
+
+        :type: int
+        """,
+        validator=strict_discrete_set,
+        values=[1, 2, 3, 4, 5]
+    )
+
+    selected_channel = Instrument.control(
+        "INST?", "INST %s",
+        """Control the selected channel of the instrument.
+
+        :type: :class:`.SPDChannel`
+        """,
+        validator=strict_discrete_set,
+        values={1: "CH1"},
+        map_values=True,
+        dynamic=True
+    )
+
+    set_4W_mode = Instrument.setting(
+        "MODE:SET %s",
+        """Control the 4-Wire Sense Mode of the instrument.
+        """,
+        validator=strict_discrete_set,
+        values={False: "2W", True: "4W"},
+        map_values=True
+    )
+
+    def __init__(self, adapter, **kwargs):
+        super().__init__(
+            adapter,
+            usb=dict(write_termination='\n',
+                     read_termination='\n'),
+            tcpip=dict(write_termination='\n',
+                       read_termination='\n'),
+            **kwargs
+        )
+
+    def save_config(self, index):
+        """Save the current config to memory.
+
+        :param index:
+            string: index of the location to save the configuration
+        :returns: self
+        """
+        self.save_settings = index
+
+        return self
+
+    def recall_config(self, index):
+        """Recall a config from memory.
+
+        :param index:
+            string: index of the location from which to recall the configuration
+        :returns: self
+        """
+        self.recall_settings = index
+
+        return self
+
+
+class SPDChannel(object):
+    channel = 1
+
+    voltage = Instrument.measurement(
+        f"MEAS:VOLT? CH{channel}",
+        """Measure the channel output voltage.
+
+        :type: float
+        """
+    )
+
+    current = Instrument.measurement(
+        f"MEAS:CURR? CH{channel}",
+        """Measure the channel output voltage.
+
+        :type: float
+        """
+    )
+
+    power = Instrument.measurement(
+        f"MEAS:POWE? CH{channel}",
+        """Measure the channel output voltage.
+
+        :type: float
+        """
+    )
+
+    set_current = Instrument.control(
+        "CURR?", "CURR %g",
+        """Control the output current configuration of the channel.
+
+        :type: float
+        """,
+        validator=truncated_range,
+        values=[0, 8],
+        dynamic=True
+    )
+
+    set_voltage = Instrument.control(
+        "VOLT?", "VOLT %g",
+        """Control the output voltage configuration of the channel.
+
+        :type: float
+        """,
+        validator=truncated_range,
+        values=[0, 16],
+        dynamic=True
+    )
+
+    output = Instrument.setting(
+        f"OUTP CH{channel},%s",
+        """Configure the power supply output.
+
+        :type: bool
+        ``True`` disables local interface, ``False`` enables it.
+        """,
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True
+    )
+
+    enable_timer = Instrument.setting(
+        f"TIME CH{channel}",
+        """Enable the channel timer.
+
+        :type: bool
+        """,
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True
+    )
+
+    def __init__(self, instrument, channel: int = 1):
+        self.instrument = instrument
+        self.channel = channel
+
+    def ask(self, cmd):
+        if (cmd[0:3] == "VOLT") | (cmd[0:3] == "CURR"):
+            cmd = f'CH{self.channel}:{cmd}'
+        return self.instrument.ask(f'{cmd}')
+
+    def write(self, cmd):
+        if (cmd[0:3] == "VOLT") | (cmd[0:3] == "CURR"):
+            cmd = f'CH{self.channel}:{cmd}'
+        self.instrument.write(f'{cmd}')
+
+    def enable(self):
+        """Enable the channel output
+
+        :returns: self
+        """
+        self.output = True
+        return self
+
+    def disable(self):
+        """Disable the channel output
+
+        :returns: self
+        """
+        self.output = False
+        return self

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -173,7 +173,7 @@ class SPDChannel(object):
 
     current = Instrument.measurement(
         "MEAS:CURR? CH{channel}",
-        """Measure the channel output voltage.
+        """Measure the channel output current.
 
         :type: float
         """
@@ -181,62 +181,32 @@ class SPDChannel(object):
 
     power = Instrument.measurement(
         "MEAS:POWE? CH{channel}",
-        """Measure the channel output voltage.
+        """Measure the channel output power.
 
         :type: float
         """
     )
 
-    set_current = Instrument.control(
+    current_limit = Instrument.control(
         "CH{channel}:CURR?", "CH{channel}:CURR %g",
         """Control the output current configuration of the channel.
 
-        :type: float
-
+        :type : float
         """,
         validator=truncated_range,
         values=[0, 8],
         dynamic=True
     )
 
-    set_voltage = Instrument.control(
+    voltage_setpoint = Instrument.control(
         "CH{channel}:VOLT?", "CH{channel}:VOLT %g",
         """Control the output voltage configuration of the channel.
 
-        :type: float
-
+        :type : float
         """,
         validator=truncated_range,
         values=[0, 16],
         dynamic=True
-    )
-
-    output = Instrument.setting(
-        "OUTP CH{channel},%s",
-        """Configure the power supply output.
-
-        :type: bool
-            ``True``: enables the output
-            ``False``: disables the output
-
-        """,
-        validator=strict_discrete_set,
-        values={True: "ON", False: "OFF"},
-        map_values=True
-    )
-
-    enable_timer = Instrument.setting(
-        "TIME CH{channel},%s",
-        """Enable the channel timer.
-
-        :type: bool
-            ``True``: enables the timer
-            ``False``: disables it
-
-        """,
-        validator=strict_discrete_set,
-        values={True: "ON", False: "OFF"},
-        map_values=True
     )
 
     def ask(self, cmd):
@@ -254,14 +224,16 @@ class SPDChannel(object):
     def check_errors(self):
         return self.instrument.check_errors()
 
-    def enable(self):
-        """Enable the channel output
+    def enable_output(self, enable: bool = True):
+        """Enable the channel output.
 
-        :returns: self
+        :type: bool
+            ``True``: enables the output
+            ``False``: disables it
         """
         self.instrument.selected_channel = self.channel
-        self.output = True
-        return self
+        self.write(f'OUTP CH{self.channel},{("OFF","ON")[enable]}')
+
 
     def disable(self):
         """Disable the channel output

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -137,6 +137,7 @@ class SPDBase(Instrument):
         """Control the selected channel of the instrument.
 
         :type: int
+
         """,
         validator=strict_discrete_set,
         values={1: "CH1"},  # This dynamic property should be updated for multi-channel instruments
@@ -212,6 +213,7 @@ class SPDChannel(object):
         """Control the output current configuration of the channel.
 
         :type: float
+
         """,
         validator=truncated_range,
         values=[0, 8],
@@ -223,6 +225,7 @@ class SPDChannel(object):
         """Control the output voltage configuration of the channel.
 
         :type: float
+
         """,
         validator=truncated_range,
         values=[0, 16],

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -74,6 +74,8 @@ class SPDBase(Instrument):
             **kwargs
         )
 
+        self.ch = {}
+
     error = Instrument.measurement(
         "SYST:ERR?",
         """Read the error code and information of the instrument.
@@ -141,6 +143,14 @@ class SPDBase(Instrument):
         """
         index = strict_discrete_range(index, [1, 5], 1)
         self.write(f"*RCL {index:d}")
+
+    def shutdown(self):
+        """ Ensure that the voltage is turned to zero
+        and disable the output. """
+        for channel in self.ch:
+            channel.voltage_setpoint = 0
+            channel.enable_output(False)
+        super().shutdown()
 
 
 class SPDChannel(object):

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -277,6 +277,7 @@ class SPDChannel(object):
 
         :returns: self
         """
+        self.instrument.selected_channel = self.channel
         self.output = True
         return self
 
@@ -285,5 +286,6 @@ class SPDChannel(object):
 
         :returns: self
         """
+        self.instrument.selected_channel = self.channel
         self.output = False
         return self

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -178,7 +178,7 @@ class SPDChannel(object):
         self.channel = channel
 
     voltage = Instrument.measurement(
-        f"MEAS:VOLT? CH{channel}",
+        "MEAS:VOLT? CH{channel}",
         """Measure the channel output voltage.
 
         :type: float
@@ -186,7 +186,7 @@ class SPDChannel(object):
     )
 
     current = Instrument.measurement(
-        f"MEAS:CURR? CH{channel}",
+        "MEAS:CURR? CH{channel}",
         """Measure the channel output voltage.
 
         :type: float
@@ -194,7 +194,7 @@ class SPDChannel(object):
     )
 
     power = Instrument.measurement(
-        f"MEAS:POWE? CH{channel}",
+        "MEAS:POWE? CH{channel}",
         """Measure the channel output voltage.
 
         :type: float
@@ -202,7 +202,7 @@ class SPDChannel(object):
     )
 
     set_current = Instrument.control(
-        "CURR?", "CURR %g",
+        "CH{channel}:CURR?", "CH{channel}:CURR %g",
         """Control the output current configuration of the channel.
 
         :type: float
@@ -214,7 +214,7 @@ class SPDChannel(object):
     )
 
     set_voltage = Instrument.control(
-        "VOLT?", "VOLT %g",
+        "CH{channel}:VOLT?", "CH{channel}:VOLT %g",
         """Control the output voltage configuration of the channel.
 
         :type: float
@@ -226,7 +226,7 @@ class SPDChannel(object):
     )
 
     output = Instrument.setting(
-        f"OUTP CH{channel},%s",
+        "OUTP CH{channel},%s",
         """Configure the power supply output.
 
         :type: bool
@@ -240,7 +240,7 @@ class SPDChannel(object):
     )
 
     enable_timer = Instrument.setting(
-        f"TIME CH{channel},%s",
+        "TIME CH{channel},%s",
         """Enable the channel timer.
 
         :type: bool
@@ -250,25 +250,17 @@ class SPDChannel(object):
         map_values=True
     )
 
-    def __init__(self, instrument, channel: int = 1):
-        self.instrument = instrument
-        self.channel = channel
-
     def ask(self, cmd):
-        if (cmd[0:3] == "VOLT") | (cmd[0:3] == "CURR"):
-            cmd = f'CH{self.channel}:{cmd}'
-        return self.instrument.ask(f'{cmd}')
+        return self.instrument.ask(cmd.format(channel=self.channel))
 
     def write(self, cmd):
-        if (cmd[0:3] == "VOLT") | (cmd[0:3] == "CURR"):
-            cmd = f'CH{self.channel}:{cmd}'
-        self.instrument.write(f'{cmd}')
+        self.instrument.write(cmd.format(channel=self.channel))
 
     def values(self, cmd, **kwargs):
         """ Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.
         """
-        return self.instrument.values(f'{cmd}')
+        return self.instrument.values(cmd.format(channel=self.channel))
 
     def check_errors(self):
         return self.instrument.check_errors()

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -64,6 +64,7 @@ class SPDBase(Instrument):
     """
 
     def __init__(self, adapter, **kwargs):
+        kwargs.setdefault('name', 'Siglent SPDxxxxX instrument Base Class')
         super().__init__(
             adapter,
             usb=dict(write_termination='\n',

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -98,46 +98,24 @@ class SPDBase(Instrument):
         get_process=lambda v: SystemStatusCode(int(v, base=16)),
     )
 
-    local_lockout = Instrument.setting(
+    disable_local_interface = Instrument.setting(
         "%s",
-        """Set the local interface lockout.
+        """Configure the availability of the local interface.
 
         :type: bool
             ``True``: disables the local interface
             ``False``: enables it.
-
         """,
         validator=strict_discrete_set,
         values={True: "*LOCK", False: "*UNLOCK"},
         map_values=True
     )
 
-    save_settings = Instrument.setting(
-        "*SAV %d",
-        """Save the current configuration in non-volatile memory.
-
-        :type: int
-        """,
-        validator=strict_range,
-        values=[1, 5]
-    )
-
-    recall_settings = Instrument.setting(
-        "*RCL %d",
-        """Recall the saved configuration from non-volatile memory.
-
-        :type: int
-        """,
-        validator=strict_range,
-        values=[1, 5]
-    )
-
     selected_channel = Instrument.control(
         "INST?", "INST %s",
         """Control the selected channel of the instrument.
 
-        :type: int
-
+        :type : int
         """,
         validator=strict_discrete_set,
         values={1: "CH1"},  # This dynamic property should be updated for multi-channel instruments
@@ -145,14 +123,13 @@ class SPDBase(Instrument):
         dynamic=True
     )
 
-    set_4W_mode = Instrument.setting(
+    enable_4W_mode = Instrument.setting(
         "MODE:SET %s",
         """Configure 4-wire mode.
 
         :type: bool
             ``True``: enables 4-wire mode
             ``False``: disables it.
-
         """,
         validator=strict_discrete_set,
         values={False: "2W", True: "4W"},
@@ -163,17 +140,19 @@ class SPDBase(Instrument):
         """Save the current config to memory.
 
         :param index:
-            string: index of the location to save the configuration
+            int: index of the location to save the configuration
         """
-        self.save_settings = index
+        index = strict_discrete_range(index, [1, 5], 1)
+        self.write(f"*SAV {index:d}")
 
     def recall_config(self, index):
         """Recall a config from memory.
 
         :param index:
-            string: index of the location from which to recall the configuration
+            int: index of the location from which to recall the configuration
         """
-        self.recall_settings = index
+        index = strict_discrete_range(index, [1, 5], 1)
+        self.write(f"*RCL {index:d}")
 
 
 class SPDChannel(object):

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -143,7 +143,6 @@ class SPDBase(Instrument):
     def __init__(self, adapter, **kwargs):
         super().__init__(
             adapter,
-            name="Siglent Technologies SPDxxxxX Power Supply",
             usb=dict(write_termination='\n',
                      read_termination='\n'),
             tcpip=dict(write_termination='\n',
@@ -240,7 +239,7 @@ class SPDChannel(object):
     )
 
     enable_timer = Instrument.setting(
-        f"TIME CH{channel}",
+        f"TIME CH{channel},%s",
         """Enable the channel timer.
 
         :type: bool

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -123,19 +123,6 @@ class SPDBase(Instrument):
         dynamic=True
     )
 
-    enable_4W_mode = Instrument.setting(
-        "MODE:SET %s",
-        """Configure 4-wire mode.
-
-        :type: bool
-            ``True``: enables 4-wire mode
-            ``False``: disables it.
-        """,
-        validator=strict_discrete_set,
-        values={False: "2W", True: "4W"},
-        map_values=True
-    )
-
     def save_config(self, index):
         """Save the current config to memory.
 

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -94,8 +94,6 @@ class SPDBase(Instrument):
 
         :type: :class:`.SystemStatusCode`
         """,
-        validator=truncated_range,
-        values=[0, 1024],
         get_process=lambda v: SystemStatusCode(int(v, base=16)),
     )
 
@@ -114,8 +112,6 @@ class SPDBase(Instrument):
 
         :type: int
         """,
-        validator=strict_discrete_set,
-        values=[1, 2, 3, 4, 5]
     )
 
     recall_settings = Instrument.measurement(
@@ -124,8 +120,6 @@ class SPDBase(Instrument):
 
         :type: int
         """,
-        validator=strict_discrete_set,
-        values=[1, 2, 3, 4, 5]
     )
 
     selected_channel = Instrument.control(

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -101,19 +101,6 @@ class SPDBase(Instrument):
         get_process=lambda v: SystemStatusCode(int(v, base=16)),
     )
 
-    disable_local_interface = Instrument.setting(
-        "%s",
-        """Configure the availability of the local interface.
-
-        :type: bool
-            ``True``: disables the local interface
-            ``False``: enables it.
-        """,
-        validator=strict_discrete_set,
-        values={True: "*LOCK", False: "*UNLOCK"},
-        map_values=True
-    )
-
     selected_channel = Instrument.control(
         "INST?", "INST %s",
         """Control the selected channel of the instrument.
@@ -143,6 +130,15 @@ class SPDBase(Instrument):
         """
         index = strict_discrete_range(index, [1, 5], 1)
         self.write(f"*RCL {index:d}")
+
+    def enable_local_interface(self, enable: bool = True):
+        """Configure the availability of the local interface.
+
+        :type: bool
+            ``True``: enables the local interface
+            ``False``: disables it.
+        """
+        self.write(("*LOCK", "*UNLOCK")[enable])
 
     def shutdown(self):
         """ Ensure that the voltage is turned to zero

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -62,6 +62,16 @@ class SPDBase(Instrument):
     """ The base class for Siglent SPDxxxxX instruments.
     """
 
+    def __init__(self, adapter, **kwargs):
+        super().__init__(
+            adapter,
+            usb=dict(write_termination='\n',
+                     read_termination='\n'),
+            tcpip=dict(write_termination='\n',
+                       read_termination='\n'),
+            **kwargs
+        )
+
     error = Instrument.measurement(
         "SYST:ERR?",
         """Read the error code and information of the instrument.
@@ -140,16 +150,6 @@ class SPDBase(Instrument):
         map_values=True
     )
 
-    def __init__(self, adapter, **kwargs):
-        super().__init__(
-            adapter,
-            usb=dict(write_termination='\n',
-                     read_termination='\n'),
-            tcpip=dict(write_termination='\n',
-                       read_termination='\n'),
-            **kwargs
-        )
-
     def save_config(self, index):
         """Save the current config to memory.
 
@@ -158,8 +158,6 @@ class SPDBase(Instrument):
         :returns: self
         """
         self.save_settings = index
-
-        return self
 
     def recall_config(self, index):
         """Recall a config from memory.
@@ -170,11 +168,14 @@ class SPDBase(Instrument):
         """
         self.recall_settings = index
 
-        return self
-
 
 class SPDChannel(object):
-    channel = 1
+    """ The channel class for Siglent SPDxxxxX instruments.
+    """
+
+    def __init__(self, instrument, channel: int = 1):
+        self.instrument = instrument
+        self.channel = channel
 
     voltage = Instrument.measurement(
         f"MEAS:VOLT? CH{channel}",

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -123,6 +123,7 @@ class SPDBase(Instrument):
         """Control the selected channel of the instrument.
 
         :type: :class:`.SPDChannel`
+
         """,
         validator=strict_discrete_set,
         values={1: "CH1"},
@@ -142,6 +143,7 @@ class SPDBase(Instrument):
     def __init__(self, adapter, **kwargs):
         super().__init__(
             adapter,
+            name="Siglent Technologies SPDxxxxX Power Supply",
             usb=dict(write_termination='\n',
                      read_termination='\n'),
             tcpip=dict(write_termination='\n',
@@ -204,6 +206,7 @@ class SPDChannel(object):
         """Control the output current configuration of the channel.
 
         :type: float
+
         """,
         validator=truncated_range,
         values=[0, 8],
@@ -215,6 +218,7 @@ class SPDChannel(object):
         """Control the output voltage configuration of the channel.
 
         :type: float
+
         """,
         validator=truncated_range,
         values=[0, 16],
@@ -226,7 +230,9 @@ class SPDChannel(object):
         """Configure the power supply output.
 
         :type: bool
-        ``True`` disables local interface, ``False`` enables it.
+            ``True``: disable local interface
+            ``False``: enables local interface
+
         """,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
@@ -257,6 +263,15 @@ class SPDChannel(object):
         if (cmd[0:3] == "VOLT") | (cmd[0:3] == "CURR"):
             cmd = f'CH{self.channel}:{cmd}'
         self.instrument.write(f'{cmd}')
+
+    def values(self, cmd, **kwargs):
+        """ Reads a set of values from the instrument through the adapter,
+        passing on any key-word arguments.
+        """
+        return self.instrument.values(f'{cmd}')
+
+    def check_errors(self):
+        return self.instrument.check_errors()
 
     def enable(self):
         """Enable the channel output

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -1,0 +1,67 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.siglenttechnologies.siglent_spd1168x import SPD1168X
+
+
+def test_set_4W_mode():
+    with expected_protocol(
+        SPD1168X,
+        [("MODE:SET 4W", None)]
+    ) as inst:
+        inst.set_4W_mode = True
+
+
+def test_set_current():
+    with expected_protocol(
+        SPD1168X,
+        [("CH1:CURR 0.5", None),
+         ("CH1:CURR?", "0.5")]
+    ) as inst:
+        inst.ch[1].set_current = 0.5
+        assert inst.ch[1].set_current == 0.5
+
+
+def test_set_current_trunc():
+    with expected_protocol(
+        SPD1168X,
+        [("CH1:CURR 8", None),
+         ("CH1:CURR?", "0.5")]
+    ) as inst:
+        inst.ch[1].set_current = 10  # too large, gets truncated
+        assert inst.ch[1].set_current == 0.5
+
+
+def test_enable_output():
+    with expected_protocol(
+        SPD1168X,
+        [("INST CH1", None),
+         ("OUTP CH1,ON", None),
+         ("INST CH1", None),
+         ("OUTP CH1,OFF", None)]
+    ) as inst:
+        inst.ch[1].enable()
+        inst.ch[1].disable()

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -21,8 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import pytest
-
 from pymeasure.test import expected_protocol
 from pymeasure.instruments.siglenttechnologies.siglent_spd1168x import SPD1168X
 

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -83,3 +83,21 @@ def test_enable_output():
     ) as inst:
         inst.ch[1].enable_output()
         inst.ch[1].enable_output(False)
+
+
+def test_enable_timer():
+    with expected_protocol(
+        SPD1168X,
+        [("TIME CH1,ON", None),
+         ("TIME CH1,OFF", None)]
+    ) as inst:
+        inst.ch[1].enable_timer()
+        inst.ch[1].enable_timer(False)
+
+
+def test_configure_timer():
+    with expected_protocol(
+        SPD1168X,
+        [("TIME:SET CH1,1,5.001,8.000,30", None)]
+    ) as inst:
+        inst.ch[1].configure_timer(1, 5.001, 8.55, 30)

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -25,12 +25,32 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.siglenttechnologies.siglent_spd1168x import SPD1168X
 
 
-def test_set_4W_mode():
+def test_enable_4W_mode():
     with expected_protocol(
         SPD1168X,
         [("MODE:SET 4W", None)]
     ) as inst:
-        inst.set_4W_mode = True
+        inst.enable_4W_mode = True
+
+
+def test_save_config():
+    with expected_protocol(
+        SPD1168X,
+        [("*SAV 1", None),
+         ("*SAV 5", None)]
+    ) as inst:
+        inst.save_config(1)
+        inst.save_config(5)
+
+
+def test_recall_config():
+    with expected_protocol(
+        SPD1168X,
+        [("*RCL 1", None),
+         ("*RCL 5", None)]
+    ) as inst:
+        inst.recall_config(1)
+        inst.recall_config(5)
 
 
 def test_set_current():

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -59,18 +59,18 @@ def test_set_current():
         [("CH1:CURR 0.5", None),
          ("CH1:CURR?", "0.5")]
     ) as inst:
-        inst.ch[1].set_current = 0.5
-        assert inst.ch[1].set_current == 0.5
+        inst.ch[1].current_limit = 0.5
+        assert inst.ch[1].current_limit == 0.5
 
 
 def test_set_current_trunc():
     with expected_protocol(
         SPD1168X,
         [("CH1:CURR 8", None),
-         ("CH1:CURR?", "0.5")]
+         ("CH1:CURR?", "8")]
     ) as inst:
-        inst.ch[1].set_current = 10  # too large, gets truncated
-        assert inst.ch[1].set_current == 0.5
+        inst.ch[1].current_limit = 10  # too large, gets truncated
+        assert inst.ch[1].current_limit == 8
 
 
 def test_enable_output():
@@ -81,5 +81,5 @@ def test_enable_output():
          ("INST CH1", None),
          ("OUTP CH1,OFF", None)]
     ) as inst:
-        inst.ch[1].enable()
-        inst.ch[1].disable()
+        inst.ch[1].enable_output()
+        inst.ch[1].enable_output(False)

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -28,9 +28,11 @@ from pymeasure.instruments.siglenttechnologies.siglent_spd1168x import SPD1168X
 def test_enable_4W_mode():
     with expected_protocol(
         SPD1168X,
-        [("MODE:SET 4W", None)]
+        [("MODE:SET 4W", None),
+         ("MODE:SET 2W", None)]
     ) as inst:
-        inst.enable_4W_mode = True
+        inst.enable_4W_mode(True)
+        inst.enable_4W_mode(False)
 
 
 def test_save_config():

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -54,7 +54,7 @@ proper_adapters = ["IBeamSmart", "ANC300Controller"]
 init = ["ThorlabsPM100USB", "Keithley2700", "TC038", "Agilent34450A",
         "AWG401x_AWG", "AWG401x_AFG", "VARX", "HP8116A"]
 # Instruments which require more input arguments
-init.extend(["Instrument", "ATSBase", "SPDBase"])
+init.extend(["Instrument", "ATSBase"])
 
 
 @pytest.mark.parametrize("cls", devices)

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -54,7 +54,7 @@ proper_adapters = ["IBeamSmart", "ANC300Controller"]
 init = ["ThorlabsPM100USB", "Keithley2700", "TC038", "Agilent34450A",
         "AWG401x_AWG", "AWG401x_AFG", "VARX", "HP8116A"]
 # Instruments which require more input arguments
-init.extend(["Instrument", "ATSBase"])
+init.extend(["Instrument", "ATSBase", "SPDBase"])
 
 
 @pytest.mark.parametrize("cls", devices)


### PR DESCRIPTION
Add new instrument, SPD1168X power supply with base and channel class for the SPD power supply family. #718 would mean the channel implementation here could rely on a different base class but this works for now. The only unimplemented function is currently the ability to set the timer steps of the PSU, this requires setting a list of values in the same command which I couldn't find an example for. Any pointers to one would be great so I can add that last property