### PR TITLE
[WIP] adding proper shutdown sequence to many non-SCPI instruments

### DIFF
--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -337,3 +337,8 @@ class DPSeriesMotorController(Instrument):
         """
         while self.busy:
             sleep(interval)
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -255,3 +255,8 @@ class ANC300Controller(Instrument):
             attribute = getattr(self, attr)
             if isinstance(attribute, Axis):
                 attribute.stop()
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -364,3 +364,8 @@ class Danfysik8500(Instrument):
         :param stack: A stack number between 0-15
         """
         return re.search("R%i," % stack, self.ask("S2")) is not None
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/edwards/nxds.py
+++ b/pymeasure/instruments/edwards/nxds.py
@@ -45,3 +45,8 @@ class Nxds(Instrument):
             includeSCPI=False,
             **kwargs
         )
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -143,3 +143,8 @@ class TC038(Instrument):
         """The information about the device and its capabilites.""",
         get_process=lambda got: got[7:-1],
         )
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/heidenhain/nd287.py
+++ b/pymeasure/instruments/heidenhain/nd287.py
@@ -111,3 +111,8 @@ class ND287(Instrument):
             log.error("Heidenhain ND287 error message received: %s" % err_str)
 
         return err_str
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/hp/hp8657b.py
+++ b/pymeasure/instruments/hp/hp8657b.py
@@ -220,3 +220,5 @@ class HP8657B(Instrument):
         self.output_enabled = False
         self.adapter.connection.clear()
         self.adapter.connection.close()
+        super.shutdown()
+        

--- a/pymeasure/instruments/ni/nidaq.py
+++ b/pymeasure/instruments/ni/nidaq.py
@@ -69,3 +69,8 @@ class NIDAQ(Instrument):
     def set_chan(self, chan, value):
         setattr(self, '_%s' % chan, value)
         getattr(self._daq, chan).write('%sV' % value)
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/oxfordinstruments/ips120_10.py
+++ b/pymeasure/instruments/oxfordinstruments/ips120_10.py
@@ -503,3 +503,8 @@ class IPS120_10(Instrument):
             self.set_field(field, rate, persistent_mode_control=False)
 
         self.set_field(0)
+
+        def shutdown(self):
+            self.adapter.connection.clear()
+            self.adapter.connection.close()
+            super.shutdown()

--- a/pymeasure/instruments/oxfordinstruments/itc503.py
+++ b/pymeasure/instruments/oxfordinstruments/itc503.py
@@ -573,3 +573,8 @@ class ITC503(Instrument):
     def wipe_sweep_table(self):
         """ Wipe the currently programmed sweep table. """
         self.write("w")
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -589,3 +589,5 @@ class DSP7265(Instrument):
         log.info("Shutting down %s." % self.name)
         self.voltage = 0.
         self.isShutdown = True
+        super.shutdown()
+

--- a/pymeasure/instruments/srs/sr510.py
+++ b/pymeasure/instruments/srs/sr510.py
@@ -85,3 +85,8 @@ class SR510(Instrument):
             includeSCPI=False,
             **kwargs,
         )
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/thermotron/thermotron3800.py
+++ b/pymeasure/instruments/thermotron/thermotron3800.py
@@ -139,3 +139,8 @@ class Thermotron3800(Instrument):
         mode = Thermotron3800.Thermotron3800Mode(int(mode_coded_integer))
 
         return mode
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()

--- a/pymeasure/instruments/toptica/ibeamsmart.py
+++ b/pymeasure/instruments/toptica/ibeamsmart.py
@@ -118,3 +118,8 @@ class IBeamSmart(Instrument):
         self.write('di ext')
         self.channel2_enabled = False
         self.laser_enabled = False
+
+    def shutdown(self):
+        self.adapter.connection.clear()
+        self.adapter.connection.close()
+        super.shutdown()


### PR DESCRIPTION
after #732 was merged, it was found that the `shutdown()` definition did not contan the recommended `super.shutdown()`
The initial commit includes many instruments with `includeSCPI=False`, however a _proper_ review of the codebase still might be recommended.