### PR TITLE
Fix broken documentation example.

### DIFF
--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -774,6 +774,7 @@ In this case you would update the specific class parameter range without rewriti
             """Set the frequency (float).""",
             validator=strict_range,
             values=[0, 1e9],
+            dynamic=True,
             # ... other possible parameters follow
         )
         #

--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -767,6 +767,13 @@ A common case is to have a family of similar instruments with some parameter ran
 In this case you would update the specific class parameter range without rewriting the entire property:
 
 .. testcode::
+    :hide:
+
+    # Behind the scene, load the real Instrument
+    from pymeasure.instruments import Instrument
+    from pymeasure.test import expected_protocol
+
+.. testcode::
 
     class FictionalInstrumentFamily(Instrument):
         frequency = Instrument.setting(
@@ -789,6 +796,12 @@ In this case you would update the specific class parameter range without rewriti
 
     class FictionalInstrument_9GHz(FictionalInstrumentFamily):
         frequency_values = [0, 9e9]
+
+.. testcode::
+    :hide:
+
+    with expected_protocol(FictionalInstrument_9GHz, [("FREQ 5e+09", None)], name="Test") as inst:
+        inst.frequency = 5e9
 
 Notice how easily you can derive the different family members from a common class, and the fact that the attribute is now defined at class level and not at instance level.
 
@@ -842,13 +855,6 @@ Adding a device address and adding delay
 
 Let's look at a simple example for a device, which requires its address as the first three characters and returns the same style. This is straightforward, as :meth:`write` just prepends the device address to the command, and :meth:`read` has to strip it again doing some error checking. Similarly, a checksum could be added.
 Additionally, the device needs some time after it received a command, before it responds, therefore :meth:`wait_for` waits always a certain time span.
-
-.. testcode::
-    :hide:
-
-    # Behind the scene, load the real Instrument
-    from pymeasure.instruments import Instrument
-    from pymeasure.test import expected_protocol
 
 .. testcode::
 


### PR DESCRIPTION
The example for creating a new instrument with dynamic properties missed a "dynamic=True". I added a test to catch that.