### PR TITLE
Shutdown code unification

### DIFF
--- a/pymeasure/instruments/agilent/agilent8257D.py
+++ b/pymeasure/instruments/agilent/agilent8257D.py
@@ -340,3 +340,4 @@ class Agilent8257D(Instrument):
         """
         self.disable_modulation()
         self.disable()
+        super().shutdown()

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,4 +1,4 @@
-#
+/#
 # This file is part of the PyMeasure package.
 #
 # Copyright (c) 2013-2022 PyMeasure Developers
@@ -208,7 +208,6 @@ class Ametek7270(Instrument):
 
     def shutdown(self):
         """ Ensures the instrument in a safe state """
-        self.voltage = 0.
-        self.isShutdown = True
-        super().shutdown()
         log.info("Shutting down %s" % self.name)
+        self.voltage = 0.
+        super().shutdown()

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -210,4 +210,5 @@ class Ametek7270(Instrument):
         """ Ensures the instrument in a safe state """
         self.voltage = 0.
         self.isShutdown = True
+        super().shutdown()
         log.info("Shutting down %s" % self.name)

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,4 +1,4 @@
-/#
+#
 # This file is part of the PyMeasure package.
 #
 # Copyright (c) 2013-2022 PyMeasure Developers

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -53,7 +53,7 @@ class AMI430(Instrument):
 
         magnet.ramp_to_current(5)             # Ramps the current to 5 A
 
-        magnet.down()                     # Ramps the current to zero and disables output
+        magnet.shutdown()                     # Ramps the current to zero and disables output
 
     """
 

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -53,7 +53,7 @@ class AMI430(Instrument):
 
         magnet.ramp_to_current(5)             # Ramps the current to 5 A
 
-        magnet.shutdown()                     # Ramps the current to zero and disables output
+        magnet.down()                     # Ramps the current to zero and disables output
 
     """
 
@@ -220,3 +220,4 @@ class AMI430(Instrument):
         self.zero()
         self.wait_for_holding()
         self.disable_persistent_switch()
+        super().shutdown()

--- a/pymeasure/instruments/anritsu/anritsuMG3692C.py
+++ b/pymeasure/instruments/anritsu/anritsuMG3692C.py
@@ -76,3 +76,4 @@ class AnritsuMG3692C(Instrument):
         # TODO: Implement modulation
         self.modulation = False
         self.disable()
+        super().shutdown()

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -144,3 +144,4 @@ class SM7045D(Instrument):
         """
         self.ramp_to_zero()
         self.disable()
+        super().shutdown()

--- a/pymeasure/instruments/hp/hp8657b.py
+++ b/pymeasure/instruments/hp/hp8657b.py
@@ -217,7 +217,7 @@ class HP8657B(Instrument):
         self.adapter.connection.clear()
 
     def shutdown(self):
-        super().shutdown()
-        self.output_enabled = False
         self.adapter.connection.clear()
+        self.output_enabled = False
         self.adapter.connection.close()
+        super().shutdown()

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -580,7 +580,7 @@ class Instrument:
     def shutdown(self):
         """Brings the instrument to a safe and stable state"""
         self.isShutdown = True
-        log.info("Shutting down %s" % self.name)
+        log.info(f"Finished shutting down {self.name}")
 
     def check_errors(self):
         """ Read all errors from the instrument.

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -763,3 +763,4 @@ class Keithley2400(Instrument, KeithleyBuffer):
             self.ramp_to_voltage(0.0)
         self.stop_buffer()
         self.disable_source()
+        super().shutdown()

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -635,3 +635,4 @@ class Keithley2450(Instrument, KeithleyBuffer):
             self.ramp_to_voltage(0.0)
         self.stop_buffer()
         self.disable_source()
+        super().shutdown()

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -321,3 +321,4 @@ class Channel:
         else:
             self.ramp_to_voltage(0.0)
         self.source_output = 'OFF'
+        super().shutdown()

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -410,6 +410,7 @@ class Keithley6221(Instrument, KeithleyBuffer):
         """ Disables the output. """
         log.info("Shutting down %s." % self.name)
         self.disable_source()
+        super().shutdown()
 
     ###############
     # Status bits #

--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -347,3 +347,4 @@ class Keithley6517B(Instrument, KeithleyBuffer):
         self.ramp_to_voltage(0.0)
         self.stop_buffer()
         self.disable_source()
+        super().shutdown()

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -317,3 +317,4 @@ class ESP300(Instrument):
         """ Shuts down the controller by disabling all of the axes.
         """
         self.disable()
+        super().shutdown()

--- a/pymeasure/instruments/ni/daqmx.py
+++ b/pymeasure/instruments/ni/daqmx.py
@@ -168,3 +168,4 @@ class DAQmx:
     def shutdown(self):
         self.stop()
         self.terminated = True
+        super().shutdown()

--- a/pymeasure/instruments/ni/virtualbench.py
+++ b/pymeasure/instruments/ni/virtualbench.py
@@ -128,7 +128,6 @@ class VirtualBench():
         log.info("Shutting down %s" % self.name)
         self.vb.release()
         self.isShutdown = True
-        super().shutdown()
 
     def get_library_version(self):
         ''' Return the version of the VirtualBench runtime library
@@ -306,7 +305,6 @@ class VirtualBench():
             log.info("Shutting down %s" % self.name)
             self._instrument_handle.release()
             self.isShutdown = True
-            super().shutdown()
 
     class DigitalInputOutput(VirtualBenchInstrument):
         """ Represents Digital Input Output (DIO) Module of Virtual Bench

--- a/pymeasure/instruments/ni/virtualbench.py
+++ b/pymeasure/instruments/ni/virtualbench.py
@@ -128,6 +128,7 @@ class VirtualBench():
         log.info("Shutting down %s" % self.name)
         self.vb.release()
         self.isShutdown = True
+        super().shutdown()
 
     def get_library_version(self):
         ''' Return the version of the VirtualBench runtime library
@@ -305,6 +306,7 @@ class VirtualBench():
             log.info("Shutting down %s" % self.name)
             self._instrument_handle.release()
             self.isShutdown = True
+            super().shutdown()
 
     class DigitalInputOutput(VirtualBenchInstrument):
         """ Represents Digital Input Output (DIO) Module of Virtual Bench

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -589,3 +589,4 @@ class DSP7265(Instrument):
         log.info("Shutting down %s." % self.name)
         self.voltage = 0.
         self.isShutdown = True
+        super().shutdown()

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -588,5 +588,4 @@ class DSP7265(Instrument):
     def shutdown(self):
         log.info("Shutting down %s." % self.name)
         self.voltage = 0.
-        self.isShutdown = True
         super().shutdown()


### PR DESCRIPTION
[As mentioned](https://github.com/pymeasure/pymeasure/pull/732#discussion_r1016650307) #732  when instruments overwrite the `shutdown()` method, that method should contain `super().shutdown()`.

Topics for disucssion:

1. Some [instruments](https://github.com/LongnoseRob/pymeasure/blob/d639d925d41931458d5fc7abd6983919942e3c42/pymeasure/instruments/ametek/ametek7270.py#L212)  use `self.isShutdown = True`, would this still be required if we add `super().shutdown()` ?
2. `pymeasure/instruments/ni/virtualbench.py` has 2 definitions of `shutdown`, the influence of  adding `super().shutdown()` should be properly checked