### PR TITLE
dev/SPDxxxxX_channels

### DIFF
--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -36,4 +36,4 @@ class SPD1168X(SPDSingleChannelBase):
             **kwargs
         )
 
-        self.ch[1] = SPDChannel(self, 1)
+        self.add_child(SPDChannel, 1)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -21,8 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from pymeasure.instruments.siglenttechnologies.siglent_spdbase import (SPDSingleChannelBase,
-                                                                       SPDChannel)
+from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDSingleChannelBase
 
 
 class SPD1168X(SPDSingleChannelBase):
@@ -35,5 +34,3 @@ class SPD1168X(SPDSingleChannelBase):
             name="Siglent Technologies SPD1168X Power Supply",
             **kwargs
         )
-
-        self.add_child(SPDChannel, 1)

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -21,12 +21,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from pymeasure.instruments.siglenttechnologies.siglent_spdbase import SPDSingleChannelBase
+from pymeasure.instruments.instrument import Instrument
+from pymeasure.instruments.siglenttechnologies.siglent_spdbase import (SPDSingleChannelBase,
+                                                                       SPDChannel)
 
 
 class SPD1168X(SPDSingleChannelBase):
     """Represent the Siglent SPD1168X Power Supply.
     """
+
+    channels = Instrument.ChannelCreator(SPDChannel, 1)
 
     def __init__(self, adapter, **kwargs):
         super().__init__(

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -39,7 +39,7 @@ class SPD1305X(SPDSingleChannelBase):
         voltage_limits = [0, 30]
         current_limits = [0, 5]
 
-        self.ch[1] = SPDChannel(self, 1, voltage_limits, current_limits)
+        self.add_child(SPDChannel, 1)
 
-        self.ch[1].voltage_setpoint_values = voltage_limits
-        self.ch[1].current_limit_values = current_limits
+        self.ch_1.voltage_setpoint_values = voltage_limits
+        self.ch_1.current_limit_values = current_limits

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -30,6 +30,8 @@ class SPD1305X(SPDSingleChannelBase):
     """Represent the Siglent SPD1305X Power Supply.
     """
 
+    channels = Instrument.ChannelCreator(SPDChannel, 1)
+
     def __init__(self, adapter, **kwargs):
 
         super().__init__(

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -30,7 +30,11 @@ class SPD1305X(SPDSingleChannelBase):
     """Represent the Siglent SPD1305X Power Supply.
     """
 
-    channels = Instrument.ChannelCreator(SPDChannel, 1)
+    voltage_range = [0, 30]
+    current_range = [0, 5]
+    channels = Instrument.ChannelCreator(SPDChannel, 1,
+                                         voltage_range=voltage_range,
+                                         current_range=current_range)
 
     def __init__(self, adapter, **kwargs):
 
@@ -39,12 +43,6 @@ class SPD1305X(SPDSingleChannelBase):
             name="Siglent Technologies SPD1305X Power Supply",
             **kwargs
         )
-        voltages = [0, 30]
-        currents = [0, 5]
 
-        self.channels = Instrument.ChannelCreator(SPDChannel, 1,
-                                                  voltage_range=voltages,
-                                                  current_range=currents)
-
-        self.ch_1.voltage_setpoint_values = voltages
-        self.ch_1.current_limit_values = currents
+        self.ch_1.voltage_setpoint_values = self.voltage_range
+        self.ch_1.current_limit_values = self.current_range

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -36,10 +36,10 @@ class SPD1305X(SPDSingleChannelBase):
             name="Siglent Technologies SPD1305X Power Supply",
             **kwargs
         )
-        voltage_limits = [0, 30]
-        current_limits = [0, 5]
+        voltages = [0, 30]
+        currents = [0, 5]
 
-        self.add_child(SPDChannel, 1, voltage_limits, current_limits)
+        self.add_child(SPDChannel, 1, voltage_range=voltages, current_range=currents)
 
-        self.ch_1.voltage_setpoint_values = voltage_limits
-        self.ch_1.current_limit_values = current_limits
+        self.ch_1.voltage_setpoint_values = voltages
+        self.ch_1.current_limit_values = currents

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from pymeasure.instruments.instrument import Instrument
 from pymeasure.instruments.siglenttechnologies.siglent_spdbase import (SPDSingleChannelBase,
                                                                        SPDChannel)
 
@@ -39,7 +40,9 @@ class SPD1305X(SPDSingleChannelBase):
         voltages = [0, 30]
         currents = [0, 5]
 
-        self.add_child(SPDChannel, 1, voltage_range=voltages, current_range=currents)
+        self.channels = Instrument.ChannelCreator(SPDChannel, 1,
+                                                  voltage_range=voltages,
+                                                  current_range=currents)
 
         self.ch_1.voltage_setpoint_values = voltages
         self.ch_1.current_limit_values = currents

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -39,7 +39,7 @@ class SPD1305X(SPDSingleChannelBase):
         voltage_limits = [0, 30]
         current_limits = [0, 5]
 
-        self.add_child(SPDChannel, 1)
+        self.add_child(SPDChannel, 1, voltage_limits, current_limits)
 
         self.ch_1.voltage_setpoint_values = voltage_limits
         self.ch_1.current_limit_values = current_limits

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -142,7 +142,7 @@ class SPDBase(Instrument):
     def shutdown(self):
         """ Ensure that the voltage is turned to zero
         and disable the output. """
-        for ch in self.channels:
+        for ch in self.channels.values():
             ch.voltage_setpoint = 0
             ch.enable_output(False)
         super().shutdown()

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -232,7 +232,7 @@ class SPDBase(Instrument):
             ``True``: enables the local interface
             ``False``: disables it.
         """
-        self.write(("*UNLOCK" if enable else "*LOCK"))
+        self.write("*UNLOCK" if enable else "*LOCK")
 
     def shutdown(self):
         """ Ensure that the voltage is turned to zero
@@ -251,4 +251,4 @@ class SPDSingleChannelBase(SPDBase):
             ``True``: enables 4-wire mode
             ``False``: disables it.
         """
-        self.write(f'MODE:SET {("4W" if enable else "2W")}')
+        self.write(f'MODE:SET {"4W" if enable else "2W"}')

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -164,13 +164,10 @@ class SPDChannel(Channel):
     """ The channel class for Siglent SPDxxxxX instruments.
     """
 
-    def __init__(self, instrument,
-                 channel: int = 1,
+    def __init__(self, parent, id,
                  voltage_range: list = [0, 16],
                  current_range: list = [0, 8]):
-        self.instrument = instrument
-        self.channel = channel
-
+        super().__init__(parent, id)
         self.voltage_range = voltage_range
         self.current_range = current_range
 

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -244,8 +244,6 @@ class SPDBase(Instrument):
 
 
 class SPDSingleChannelBase(SPDBase):
-    channels = Instrument.ChannelCreator(SPDChannel, 1)
-
     def enable_4W_mode(self, enable: bool = True):
         """Enable 4-wire mode.
 

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1168x.py
@@ -61,8 +61,8 @@ def test_set_current():
         [("CH1:CURR 0.5", None),
          ("CH1:CURR?", "0.5")]
     ) as inst:
-        inst.ch[1].current_limit = 0.5
-        assert inst.ch[1].current_limit == 0.5
+        inst.ch_1.current_limit = 0.5
+        assert inst.ch_1.current_limit == 0.5
 
 
 def test_set_current_trunc():
@@ -71,8 +71,8 @@ def test_set_current_trunc():
         [("CH1:CURR 8", None),
          ("CH1:CURR?", "8")]
     ) as inst:
-        inst.ch[1].current_limit = 10  # too large, gets truncated
-        assert inst.ch[1].current_limit == 8
+        inst.ch_1.current_limit = 10  # too large, gets truncated
+        assert inst.ch_1.current_limit == 8
 
 
 def test_enable_output():
@@ -83,8 +83,8 @@ def test_enable_output():
          ("INST CH1", None),
          ("OUTP CH1,OFF", None)]
     ) as inst:
-        inst.ch[1].enable_output()
-        inst.ch[1].enable_output(False)
+        inst.ch_1.enable_output()
+        inst.ch_1.enable_output(False)
 
 
 def test_enable_timer():
@@ -93,8 +93,8 @@ def test_enable_timer():
         [("TIME CH1,ON", None),
          ("TIME CH1,OFF", None)]
     ) as inst:
-        inst.ch[1].enable_timer()
-        inst.ch[1].enable_timer(False)
+        inst.ch_1.enable_timer()
+        inst.ch_1.enable_timer(False)
 
 
 def test_configure_timer():
@@ -102,4 +102,4 @@ def test_configure_timer():
         SPD1168X,
         [("TIME:SET CH1,1,5.001,8.000,30", None)]
     ) as inst:
-        inst.ch[1].configure_timer(1, 5.001, 8.55, 30)
+        inst.ch_1.configure_timer(1, 5.001, 8.55, 30)

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1305x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1305x.py
@@ -1,0 +1,71 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.siglenttechnologies.siglent_spd1305x import SPD1305X
+
+
+def test_set_current():
+    with expected_protocol(
+        SPD1305X,
+        [("CH1:CURR 0.5", None),
+         ("CH1:CURR?", "0.5")]
+    ) as inst:
+        inst.ch_1.current_limit = 0.5
+        assert inst.ch_1.current_limit == 0.5
+
+
+def test_set_current_trunc():
+    with expected_protocol(
+        SPD1305X,
+        [("CH1:CURR 5", None),
+         ("CH1:CURR?", "5")]
+    ) as inst:
+        inst.ch_1.current_limit = 10  # too large, gets truncated
+        assert inst.ch_1.current_limit == 5
+
+def test_set_current():
+    with expected_protocol(
+        SPD1305X,
+        [("CH1:VOLT 0.5", None),
+         ("CH1:VOLT?", "0.5")]
+    ) as inst:
+        inst.ch_1.voltage_setpoint = 0.5
+        assert inst.ch_1.voltage_setpoint == 0.5
+
+def test_set_voltage_trunc():
+    with expected_protocol(
+        SPD1305X,
+        [("CH1:VOLT 30", None),
+         ("CH1:VOLT?", "30")]
+    ) as inst:
+        inst.ch_1.voltage_setpoint = 35  # too large, gets truncated
+        assert inst.ch_1.voltage_setpoint == 30
+
+
+def test_configure_timer():
+    with expected_protocol(
+        SPD1305X,
+        [("TIME:SET CH1,1,5.001,5.000,30", None)]
+    ) as inst:
+        inst.ch_1.configure_timer(1, 5.001, 8.55, 30)

--- a/tests/instruments/siglenttechnologies/test_siglent_spd1305x.py
+++ b/tests/instruments/siglenttechnologies/test_siglent_spd1305x.py
@@ -44,7 +44,8 @@ def test_set_current_trunc():
         inst.ch_1.current_limit = 10  # too large, gets truncated
         assert inst.ch_1.current_limit == 5
 
-def test_set_current():
+
+def test_set_voltage():
     with expected_protocol(
         SPD1305X,
         [("CH1:VOLT 0.5", None),
@@ -52,6 +53,7 @@ def test_set_current():
     ) as inst:
         inst.ch_1.voltage_setpoint = 0.5
         assert inst.ch_1.voltage_setpoint == 0.5
+
 
 def test_set_voltage_trunc():
     with expected_protocol(


### PR DESCRIPTION
Following on from #718 & #719, I thought I'd try converting the SPD PSU channels to see how it would go. In general, it seems to have gone quite smoothly and it should be possible with a few minor tweaks to the current `SPDChannel` class. The most challenging aspect of the change was what to do with the methods inside `SPDChannel`, can anyone else see a better way of writing these methods? @bmoneke, would you mind having a look over this to see if there are any points in the implementation you would suggest doing differently (on a channels specific basis). This should start ticking off things in #746 