### PR TITLE
Fix ChannelCreator resolution broken #759

### DIFF
--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -118,9 +118,10 @@ class CommonBase:
     # Prefix used to store reserved variables
     __reserved_prefix = "___"
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._special_names = self._setup_special_names()
         self._create_channels()
+        super().__init__(**kwargs)
 
     class ChannelCreator:
         """Add channels to the parent class.

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -119,12 +119,8 @@ class CommonBase:
 
     def __init__(self):
         self._special_names = self._setup_special_names()
-        # Add children from ChildDescriptors.
-        for item, value in self.__class__.__dict__.items():
-            if isinstance(value, self.ChannelCreator):
-                for cls, id in value.pairs:
-                    child = self.add_child(cls, id, collection=item, **value.kwargs)
-                    child._protected = True
+        # Add children from ChannelCreators.
+        self._create_channels()
 
     class ChannelCreator:
         """Add channels to the parent class.
@@ -192,6 +188,14 @@ class CommonBase:
                     # Copy class special variable at instance level, prefixing reserved_prefix
                     setattr(self, self.__reserved_prefix + attr, obj.__dict__[attr])
         return special_names
+
+    def _create_channels(self):
+        """Create channels according to the ChannelCreator objects."""
+        for item, value in self.__class__.__dict__.items():
+            if isinstance(value, self.ChannelCreator):
+                for cls, id in value.pairs:
+                    child = self.add_child(cls, id, collection=item, **value.kwargs)
+                    child._protected = True
 
     def __setattr__(self, name, value):
         """ Add reserved_prefix in front of special variables."""

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -114,7 +114,14 @@ def fake():
 
 class ExtendedBase(FakeBase):
     # Keep values unchanged, just derive another instrument, e.g. to add more properties
-    pass
+    fake_ctrl2 = CommonBase.control(
+        "", "%d", "docs",
+        validator=truncated_range,
+        values=(1, 10),
+        dynamic=True,
+    )
+
+    fake_ctrl2.values = (2, 20)
 
 
 class StrictExtendedBase(ExtendedBase):
@@ -662,6 +669,7 @@ def test_dynamic_property_unchanged_by_inheritance():
 
 
 def test_dynamic_property_strict_raises():
+    # Tests also that dynamic properties can be changed at class level.
     strict = StrictExtendedBase()
 
     with pytest.raises(ValueError):
@@ -711,3 +719,18 @@ def test_dynamic_property_values_update_in_one_instance_leaves_other_unchanged()
 def test_dynamic_property_reading_special_attributes_forbidden(fake):
     with pytest.raises(AttributeError):
         fake.fake_ctrl_validator
+
+
+def test_dynamic_property_with_inheritance():
+    inst = ExtendedBase()
+    # Test for inherited attribute
+    with pytest.raises(AttributeError):
+        inst.fake_ctrl_validator
+    # Test for new attribute
+    with pytest.raises(AttributeError):
+        inst.fake_ctrl2_validator
+
+
+def test_dynamic_property_values_defined_at_superclass_level():
+    inst = StrictExtendedBase()
+    inst.fake_ctrl2 = 17  # outside original values (1, 10)

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -121,7 +121,7 @@ class ExtendedBase(FakeBase):
         dynamic=True,
     )
 
-    fake_ctrl2.values = (2, 20)
+    fake_ctrl2_values = (2, 20)
 
 
 class StrictExtendedBase(ExtendedBase):

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -255,7 +255,25 @@ class TestRemoveChild:
         assert getattr(parent_without_children, "function", None) is None
 
 
-# Test ChildDescriptor
+class TestInheritanceWithChildren:
+    class InstrumentSubclass(Parent):
+        """Override one channel group, inherit other groups."""
+        function = CommonBase.ChannelCreator(GenericBase, "overridden", prefix=None)
+
+    def test_inherited_children_present(self):
+        parent = self.InstrumentSubclass(ProtocolAdapter())
+        assert isinstance(parent.ch_A, GenericBase)
+
+    def test_ChannelCreator_is_replaced(self):
+        parent = self.InstrumentSubclass(ProtocolAdapter())
+        assert not isinstance(parent.channels, CommonBase.ChannelCreator)
+
+    def test_overridden_children(self):
+        parent = self.InstrumentSubclass(ProtocolAdapter())
+        assert parent.function.id == "overridden"
+
+
+# Test ChannelCreator
 @pytest.mark.parametrize("args, pairs, kwargs", (
     ((Child, ["A", "B"]), [(Child, "A"), (Child, "B")], {'prefix': "ch_"}),
     (((Child, GenericBase, Child), (1, 2, 3)),

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -260,16 +260,17 @@ class TestInheritanceWithChildren:
         """Override one channel group, inherit other groups."""
         function = CommonBase.ChannelCreator(GenericBase, "overridden", prefix=None)
 
-    def test_inherited_children_present(self):
-        parent = self.InstrumentSubclass(ProtocolAdapter())
+    @pytest.fixture()
+    def parent(self):
+        return self.InstrumentSubclass(ProtocolAdapter())
+
+    def test_inherited_children_are_present(self, parent):
         assert isinstance(parent.ch_A, GenericBase)
 
-    def test_ChannelCreator_is_replaced(self):
-        parent = self.InstrumentSubclass(ProtocolAdapter())
+    def test_ChannelCreator_is_replaced(self, parent):
         assert not isinstance(parent.channels, CommonBase.ChannelCreator)
 
-    def test_overridden_children(self):
-        parent = self.InstrumentSubclass(ProtocolAdapter())
+    def test_overridden_child_is_present(self, parent):
         assert parent.function.id == "overridden"
 
 

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -267,7 +267,7 @@ class TestInheritanceWithChildren:
     def test_inherited_children_are_present(self, parent):
         assert isinstance(parent.ch_A, GenericBase)
 
-    def test_ChannelCreator_is_replaced(self, parent):
+    def test_ChannelCreator_is_replaced_by_channel_collection(self, parent):
         assert not isinstance(parent.channels, CommonBase.ChannelCreator)
 
     def test_overridden_child_is_present(self, parent):

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -116,12 +116,12 @@ class ExtendedBase(FakeBase):
     # Keep values unchanged, just derive another instrument, e.g. to add more properties
     fake_ctrl2 = CommonBase.control(
         "", "%d", "docs",
-        validator=truncated_range,
+        validator=strict_range,
         values=(1, 10),
         dynamic=True,
     )
 
-    fake_ctrl2_values = (2, 20)
+    fake_ctrl2_values = (5, 20)
 
 
 class StrictExtendedBase(ExtendedBase):
@@ -732,5 +732,9 @@ def test_dynamic_property_with_inheritance():
 
 
 def test_dynamic_property_values_defined_at_superclass_level():
+    """Test whether a dynamic property can be changed a superclass level"""
     inst = StrictExtendedBase()
-    inst.fake_ctrl2 = 17  # outside original values (1, 10)
+    # Test whether the change of values from (1, 10) to (5, 20) succeeded:
+    inst.fake_ctrl2 = 17  # should raise an error if change unsuccessful
+    with pytest.raises(ValueError):
+        inst.fake_ctrl2 = 2  # should not raise an error if change unsuccessful


### PR DESCRIPTION
Fixes #759 

- adds a test to ensure that inheritance (and overriding as expected) works
- outsources the channel creation to its own method
- fixes the problem

Fix description:

1. Look through the MRO (in reverse order) and collect all `ChannelCreator` objects in a dictionary, the key is the variable name of the object. The reverse order ensures, that the `ChannelCreator` assigned to `channels` in a subclass replaces that of a superclass assigned also to `channels`.
2. Create the children according to that collected dictionary.


Not working possibilites:

- `inspect.getmembers` fails, because it tries to read all the attributes, even `Instrument.setting`, which is not possible.