### PR TITLE
Fix query_delay usage in VISAAdapter, closes #760

### DIFF
--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -45,10 +45,11 @@ class Adapter:
             Implement it in the instrument's `read` method instead.
 
     :param log: Parent logger of the 'Adapter' logger.
-    :param kwargs: all other keyword arguments are ignored.
+    :param kwargs: Keyword arguments just to be cooperative.
     """
 
     def __init__(self, preprocess_reply=None, log=None, **kwargs):
+        super().__init__(**kwargs)
         self.preprocess_reply = preprocess_reply
         self.connection = None
         if log is None:

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -85,9 +85,11 @@ class VISAAdapter(Adapter):
 
     def __init__(self, resource_name, visa_library='', preprocess_reply=None,
                  query_delay=0, log=None, **kwargs):
-        super().__init__(preprocess_reply=preprocess_reply, log=log, query_delay=query_delay)
+        super().__init__(preprocess_reply=preprocess_reply, log=log)
         if query_delay:
             warn("Implement in Instrument's 'wait_until_read' instead.", FutureWarning)
+            kwargs.setdefault("query_delay", query_delay)
+        self.query_delay = query_delay
         if isinstance(resource_name, ProtocolAdapter):
             self.connection = resource_name
             self.connection.write_raw = self.connection.write_bytes

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -42,12 +42,14 @@ def adapter():
                        read_termination="\n")
 
 
-def test_nested_adapter(adapter):
-    adapter.query_delay = 10
-    a = VISAAdapter(adapter)
+@pytest.mark.parametrize("query_delay", (0, 10))
+def test_nested_adapter(query_delay):
+    a0 = VISAAdapter(SIM_RESOURCE, visa_library='@sim', read_termination="\n",
+                     query_delay=query_delay)
+    a = VISAAdapter(a0)
     assert a.resource_name == SIM_RESOURCE
-    assert a.connection == adapter.connection
-    assert a.query_delay == 10
+    assert a.connection == a0.connection
+    assert a.query_delay == query_delay
 
 
 def test_ProtocolAdapter():


### PR DESCRIPTION
Fixes #760 

- Adjusted test to cover this parameter (enabled or not enabled)
- `Adapter` calls `super` (docstring adjusted accordingly).
- Right usage of `query_delay` (store it always as `self.query_delay` in order to "nest" adapters. Hand it via kwargs to PyVISA).
