### PR TITLE
HP8657B - GHz fix

### DIFF
--- a/pymeasure/instruments/hp/hp8657b.py
+++ b/pymeasure/instruments/hp/hp8657b.py
@@ -171,7 +171,7 @@ class HP8657B(Instrument):
         )
 
     frequency = Instrument.setting(
-        "FR %9.1f HZ",
+        "FR %10.0f HZ",
         """
         Set the output frequency of the instrument in Hz.
 

--- a/tests/instruments/hp/test_hp8657b.py
+++ b/tests/instruments/hp/test_hp8657b.py
@@ -31,11 +31,11 @@ from pymeasure.instruments.hp import HP8657B
 def test_frequency():
     with expected_protocol(
             HP8657B,
-            [(b"FR 1234567890.0 HZ", None),
-             (b"FR 12345678.9 HZ", None)],
+            [(b"FR 1234567890 HZ", None),
+             (b"FR   12345678 HZ", None)],
     ) as instr:
         instr.frequency = 1.23456789e9
-        instr.frequency = 1.23456789e7
+        instr.frequency = 1.2345678e7
 
 
 def test_level():


### PR DESCRIPTION
This PR fixes a small error in the format string for `hp8657b.frequency` made it impossible to set frequencies higger 999.999999 MHz.
Tested for fucntionality with real hardware.