### PR TITLE
Add MKS Instruments 937B vacuum gauge controller.

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -43,6 +43,7 @@ Instruments by manufacturer:
    keysight/index
    lakeshore/index
    lecroy/index
+   mksinst/index
    newport/index
    ni/index
    oxfordinstruments/index

--- a/docs/api/instruments/mksinst/index.rst
+++ b/docs/api/instruments/mksinst/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.mksinst
+
+###############
+MKS Instruments
+###############
+
+This section contains specific documentation on the MKS Instruments devices that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   mks937b

--- a/docs/api/instruments/mksinst/mks937b.rst
+++ b/docs/api/instruments/mksinst/mks937b.rst
@@ -1,0 +1,7 @@
+############################################
+MKS Instruments 937B Vacuum Gauge Controller
+############################################
+
+.. autoclass:: pymeasure.instruments.mksinst.mks937b.MKS937B
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -52,6 +52,7 @@ from . import keithley
 from . import keysight
 from . import lakeshore
 from . import lecroy
+from . import mksinst
 from . import newport
 from . import ni
 from . import oxfordinstruments

--- a/pymeasure/instruments/mksinst/__init__.py
+++ b/pymeasure/instruments/mksinst/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .mks937b import MKS937B

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -1,0 +1,258 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import re
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_discrete_set
+
+
+_ion_gauge_status = {"Wait": "W",
+                     "Off": "O",
+                     "Protect": "P",
+                     "Degas": "D",
+                     "Control": "C",
+                     "Rear panel Ctrl off": "R",
+                     "HC filament fault": "H",
+                     "No gauge": "N",
+                     "Good": "G",
+                     "NOT_IONGAUGE": "NAK152",
+                     }
+
+
+class MKS937B(Instrument):
+    """ MKS 937B vacuum gauge controller
+
+    Connection to the device is made through an RS232/RS485 serial connection.
+    The communication protocol of this device is as follows:
+
+    Query: '@<aaa><Command>?;FF' with the response '@<aaa>ACK<Response>;FF'
+    Set command: '@<aaa><Command>!<parameter>;FF' with the response '@<aaa>ACK<Response>;FF'
+    Above <aaa> is an address from 001 to 254 which can be specified upon
+    initialization. Since ';FF' is not supported by pyvisa as terminator this
+    class overloads the device communication methods.
+
+    :param adapter: pyvisa resource name of the instrument or adapter instance
+    :param address: device address included in every message to the instrument
+                    (default=253)
+    :param kwargs: Any valid key-word argument for Instrument
+    """
+
+    def __init__(self, adapter, address=253, **kwargs):
+        kwargs.setdefault("write_termination", ";FF")
+        kwargs.setdefault("read_termination", ";")  # in reality its ";FF"
+        # which is, however, invalid for pyvisa. Therefore extra bytes have to
+        # be read in the read() method.
+        super().__init__(
+            adapter,
+            "MKS 937B vacuum gauge controller",
+            includeSCPI=False,
+            **kwargs
+        )
+        self.address = address
+        # compiled regular expression for finding numerical values in reply strings
+        self._re_response = re.compile(fr"@{self.address:03d}(?P<ack>ACK)?(?P<msg>.*)")
+
+    def _extract_reply(self, reply):
+        """ preprocess_reply function which tries to extract <Response> from
+        '@<aaa>ACK<Response>;FF'. If <Response> can not be identified the orignal string
+        is returned.
+        :param reply: reply string
+        :returns: string with only the response, or the original string
+        """
+        rvalue = self._re_response.search(reply)
+        if rvalue:
+            return rvalue.group('msg')
+        return reply
+
+    def _prepend_address(self, cmd):
+        """
+        create command string by including the device address
+        """
+        return f"@{self.address:03d}{cmd}"
+
+    def _check_extra_termination(self):
+        """
+        Check the read termination to correspond to the protocol
+        """
+        t = super().read_bytes(2)  # read extra termination chars 'FF'
+        if t != b'FF':
+            raise ValueError(f"unexpected termination string received {t}")
+
+    def read(self):
+        """
+        Reads from the instrument including the correct termination characters
+        """
+        ret = super().read()
+        self._check_extra_termination()
+        return self._extract_reply(ret)
+
+    def write(self, command):
+        """
+        Writes to the instrument including the device address
+
+        :param command: command string to be sent to the instrument
+        """
+        super().write(self._prepend_address(command))
+
+    def check_errors(self):
+        """
+        check reply string for acknowledgement string
+        """
+        ret = self.adapter.read()  # use adapter read to get raw reply
+        reply = self._re_response.search(ret)
+        if reply:
+            if reply.group('ack') == 'ACK':
+                return
+        # no valid acknowledgement message found
+        raise ValueError(f"invalid reply '{ret}' found in check_errors")
+
+    serial = Instrument.measurement(
+        "SN?", """ Serial number of the instrument """,
+        cast=str,
+    )
+
+    pressure1 = Instrument.measurement(
+        "PR1?", """ Pressure on channel 1 in selected units """,
+    )
+
+    pressure2 = Instrument.measurement(
+        "PR2?", """ Pressure on channel 2 in selected units """,
+    )
+
+    pressure3 = Instrument.measurement(
+        "PR3?", """ Pressure on channel 3 in selected units """,
+    )
+
+    pressure4 = Instrument.measurement(
+        "PR4?", """ Pressure on channel 4 in selected units """,
+    )
+
+    pressure5 = Instrument.measurement(
+        "PR5?", """ Pressure on channel 5 in selected units """,
+    )
+
+    pressure6 = Instrument.measurement(
+        "PR6?", """ Pressure on channel 6 in selected units """,
+    )
+
+    all_pressures = Instrument.measurement(
+        "PRZ?", """ Read pressures on all channels in selected units """,
+    )
+
+    combined_pressure1 = Instrument.measurement(
+        "PC1?", """ Read pressure on channel 1 and its combination sensor """,
+    )
+
+    combined_pressure2 = Instrument.measurement(
+        "PC2?", """ Read pressure on channel 2 and its combination sensor """,
+    )
+
+    ion_gauge_status1 = Instrument.measurement(
+        "T1?",
+        """Ion gauge status of channel 1""",
+        map_values=True,
+        values=_ion_gauge_status,
+    )
+
+    ion_gauge_status3 = Instrument.measurement(
+        "T3?",
+        """Ion gauge status of channel 3""",
+        map_values=True,
+        values=_ion_gauge_status,
+    )
+
+    ion_gauge_status5 = Instrument.measurement(
+        "T5?",
+        """Ion gauge status of channel 5""",
+        map_values=True,
+        values=_ion_gauge_status,
+    )
+
+    unit = Instrument.control(
+        "U?", "U!%s",
+        """Pressure unit used for all pressure readings from the instrument""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={"Torr": "TORR",
+                "mBar": "mBAR",
+                "Pascal": "PASCAL",
+                "Micron": "MICRON",
+                },
+        check_set_errors=True,
+    )
+
+    power1_enabled = Instrument.control(
+        "CP1?", "CP1!%s",
+        """Power status of channel 1""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )
+
+    power2_enabled = Instrument.control(
+        "CP2?", "CP2!%s",
+        """Power status of channel 2""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )
+
+    power3_enabled = Instrument.control(
+        "CP3?", "CP3!%s",
+        """Power status of channel 3""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )
+
+    power4_enabled = Instrument.control(
+        "CP4?", "CP4!%s",
+        """Power status of channel 4""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )
+
+    power5_enabled = Instrument.control(
+        "CP5?", "CP5!%s",
+        """Power status of channel 5""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )
+
+    power6_enabled = Instrument.control(
+        "CP6?", "CP6!%s",
+        """Power status of channel 6""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON", False: "OFF"},
+        check_set_errors=True,
+    )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -59,14 +59,14 @@ class MKS937B(Instrument):
     :param kwargs: Any valid key-word argument for Instrument
     """
 
-    def __init__(self, adapter, address=253, **kwargs):
+    def __init__(self, adapter, name="MKS 937B vacuum gauge controller", address=253, **kwargs):
         kwargs.setdefault("write_termination", ";FF")
         kwargs.setdefault("read_termination", ";")  # in reality its ";FF"
         # which is, however, invalid for pyvisa. Therefore extra bytes have to
         # be read in the read() method.
         super().__init__(
             adapter,
-            "MKS 937B vacuum gauge controller",
+            name,
             includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -80,6 +80,7 @@ class MKS937B(Instrument):
     class overloads the device communication methods.
 
     :param adapter: pyvisa resource name of the instrument or adapter instance
+    :param string name: The name of the instrument.
     :param address: device address included in every message to the instrument
                     (default=253)
     :param kwargs: Any valid key-word argument for Instrument

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -56,9 +56,12 @@ class PressureChannel(Channel):
         check_set_errors=True,
     )
 
+
+class IonGaugeAndPressureChannel(PressureChannel):
+    """Channel having both a pressure and an ion gauge sensor"""
     ion_gauge_status = Channel.measurement(
         "T{ch}?",
-        """Ion gauge status of the channel, only valid for channel 1, 3, and 5""",
+        """Ion gauge status of the channel""",
         map_values=True,
         values=_ion_gauge_status,
     )
@@ -81,7 +84,10 @@ class MKS937B(Instrument):
                     (default=253)
     :param kwargs: Any valid key-word argument for Instrument
     """
-    channels = Instrument.ChannelCreator(PressureChannel, ("1", "2", "3", "4", "5", "6"))
+    channels = Instrument.ChannelCreator(
+        (IonGaugeAndPressureChannel, PressureChannel) * 3,
+        ("1", "2", "3", "4", "5", "6"),
+    )  # Channels 1,3,5 have both an ion gauge and a pressure sensor, 2,4,6 only a pressure sensor
 
     def __init__(self, adapter, name="MKS 937B vacuum gauge controller", address=253, **kwargs):
         super().__init__(

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -1,0 +1,71 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.mksinst.mks937b import MKS937B
+
+
+def test_pressure():
+    """Verify the communication of the voltage getter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253PR1?", "@253ACK1.10e-9"),
+         (None, b"FF")],
+    ) as inst:
+        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
+        assert inst.pressure1 == pytest.approx(1.1e-9)
+
+
+def test_ion_gauge_status():
+    """Verify the communication of the voltage getter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253T1?", "@253ACKG"),
+         (None, b"FF")],
+    ) as inst:
+        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
+        assert inst.ion_gauge_status1 == "Good"
+
+
+def test_unit():
+    """Verify the communication of the voltage getter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253U?", "@253ACKTORR"),
+         (None, b"FF")],
+    ) as inst:
+        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
+        assert inst.unit == "Torr"
+
+
+def test_power_enabled():
+    """Verify the communication of the voltage getter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253CP1?", "@253ACKON"),
+         (None, b"FF")],
+    ) as inst:
+        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
+        assert inst.power1_enabled is True

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -28,7 +28,7 @@ from pymeasure.instruments.mksinst.mks937b import MKS937B
 
 
 def test_pressure():
-    """Verify the communication of the voltage getter."""
+    """Verify the communication of the pressure getter."""
     with expected_protocol(
         MKS937B,
         [("@253PR1?", "@253ACK1.10e-9"),
@@ -39,7 +39,7 @@ def test_pressure():
 
 
 def test_ion_gauge_status():
-    """Verify the communication of the voltage getter."""
+    """Verify the communication of the ion gauge status getter."""
     with expected_protocol(
         MKS937B,
         [("@253T1?", "@253ACKG"),
@@ -47,6 +47,17 @@ def test_ion_gauge_status():
     ) as inst:
         inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         assert inst.ch_1.ion_gauge_status == "Good"
+
+
+def test_ion_gauge_status_invalid_channel():
+    """Ion gauge status does not exist on all channels."""
+    with expected_protocol(
+        MKS937B,
+        [],
+    ) as inst:
+        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
+        with pytest.raises(AttributeError):
+            inst.ch_2.ion_gauge_status
 
 
 def test_unit():

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -34,7 +34,6 @@ def test_pressure():
         [("@253PR1?", "@253ACK1.10e-9"),
          (None, b"FF")],
     ) as inst:
-        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         assert inst.ch_1.pressure == pytest.approx(1.1e-9)
 
 
@@ -45,7 +44,6 @@ def test_ion_gauge_status():
         [("@253T1?", "@253ACKG"),
          (None, b"FF")],
     ) as inst:
-        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         assert inst.ch_1.ion_gauge_status == "Good"
 
 
@@ -55,7 +53,6 @@ def test_ion_gauge_status_invalid_channel():
         MKS937B,
         [],
     ) as inst:
-        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         with pytest.raises(AttributeError):
             inst.ch_2.ion_gauge_status
 
@@ -67,7 +64,6 @@ def test_unit():
         [("@253U?", "@253ACKTORR"),
          (None, b"FF")],
     ) as inst:
-        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         assert inst.unit == "Torr"
 
 
@@ -78,5 +74,4 @@ def test_power_enabled():
         [("@253CP1?", "@253ACKON"),
          (None, b"FF")],
     ) as inst:
-        inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
         assert inst.ch_1.power_enabled is True

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -35,7 +35,7 @@ def test_pressure():
          (None, b"FF")],
     ) as inst:
         inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
-        assert inst.pressure1 == pytest.approx(1.1e-9)
+        assert inst.ch_1.pressure == pytest.approx(1.1e-9)
 
 
 def test_ion_gauge_status():
@@ -46,7 +46,7 @@ def test_ion_gauge_status():
          (None, b"FF")],
     ) as inst:
         inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
-        assert inst.ion_gauge_status1 == "Good"
+        assert inst.ch_1.ion_gauge_status == "Good"
 
 
 def test_unit():
@@ -68,4 +68,4 @@ def test_power_enabled():
          (None, b"FF")],
     ) as inst:
         inst.adapter.preprocess_reply = inst._extract_reply  # needed to workaround a bug
-        assert inst.power1_enabled is True
+        assert inst.ch_1.power_enabled is True


### PR DESCRIPTION
This adds the instrument from #637 by @dkriegner, with the sensor types properties and the associated needed change to pymeasure core mechanics removed.
I'll replay the mechanics change later, but it's challenging to extract/rebase, I'll probably do it manually (#740).