### PR TITLE
Adding tolerance for opening result files with missing parameters

### DIFF
--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -398,7 +398,7 @@ class Results:
                 setattr(procedure, name, value)
             else:
                 log.warning(
-                    f"Parameter \"{parameter.name}\" not found when loading" +
+                    f"Parameter \"{parameter.name}\" not found when loading " +
                     f"'{procedure_class}', setting default value")
                 setattr(procedure, name, parameter.default)
 

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -397,8 +397,10 @@ class Results:
                 value = parameters[parameter.name]
                 setattr(procedure, name, value)
             else:
-                raise Exception("Missing '{}' parameter when loading '{}' class".format(
-                    parameter.name, procedure_class))
+                log.warning(
+                    f"Parameter \"{parameter.name}\" not found when loading" +
+                    f"'{procedure_class}', setting default value")
+                setattr(procedure, name, parameter.default)
 
         procedure.refresh_parameters()  # Enforce update of meta data
 


### PR DESCRIPTION
It is quite common to write experiment and store csv results and it is also common that the experiment set of parameters is changed over time.
This situation will lead to a situation where the old csv file cannot be loaded on the updated experiment.
This is caused by the fact that an exception is raised by the code.
This PR addresses this problem making the loading process of csv more tolerant, that is: instead of an exception a warning is logged, and the parameter is set with its default value.