### PR TITLE
Mock connection for ProtocolAdapter

### DIFF
--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -23,6 +23,7 @@
 #
 
 import logging
+from unittest.mock import MagicMock
 
 from .adapter import Adapter
 
@@ -50,15 +51,29 @@ class ProtocolAdapter(Adapter):
 
     This adapter is primarily meant for use within :func:`pymeasure.test.expected_protocol()`.
 
+    The :attr:`connection` attribute is a :class:`unittest.mock.MagicMock` such
+    that every call returns. If you want to set a return value, you can use
+    :code:`adapter.connection.some_method.return_value = 7`,
+    such that a call to :code:`adapter.connection.some_method()` will return `7`.
+    Similarly, you can verify that this call to the connection method happened
+    with :code:`assert adapter.connection.some_method.called is True`.
+    You can specify dictionaries with return values of attributes and methods.
+
     :param list comm_pairs: List of "reference" message pair tuples. The first element is
         what is sent to the instrument, the second one is the returned message.
         'None' indicates that a pair member (write or read) does not exist.
         The messages do **not** include the termination characters.
+    :param dict connection_attributes: Dictionary of attributes of the connection.
+    :param dict connection_methods: Pairs of method names and return values.
     """
 
-    def __init__(self, comm_pairs=[], preprocess_reply=None, **kwargs):
+    def __init__(self, comm_pairs=[], preprocess_reply=None,
+                 connection_attributes={},
+                 connection_methods={},
+                 **kwargs):
         """Generate the adapter and initialize internal buffers."""
         super().__init__(preprocess_reply=preprocess_reply, **kwargs)
+        # Setup communication
         assert isinstance(comm_pairs, (list, tuple)), (
             "Parameter comm_pairs has to be a list or tuple.")
         for pair in comm_pairs:
@@ -68,6 +83,15 @@ class ProtocolAdapter(Adapter):
         self._write_buffer = b""
         self.comm_pairs = comm_pairs
         self._index = 0
+        # Setup attributes
+        self._setup_connection(connection_attributes, connection_methods)
+
+    def _setup_connection(self, connection_attributes, connection_methods):
+        self.connection = MagicMock()
+        for key, value in connection_attributes.items():
+            setattr(self.connection, key, value)
+        for key, value in connection_methods.items():
+            getattr(self.connection, key).return_value = value
 
     def _write(self, command, **kwargs):
         """Compare the command with the expected one and fill the read."""

--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -28,7 +28,9 @@ from pymeasure.adapters.protocol import ProtocolAdapter
 
 
 @contextmanager
-def expected_protocol(instrument_cls, comm_pairs, **kwargs):
+def expected_protocol(instrument_cls, comm_pairs,
+                      connection_attributes={}, connection_methods={},
+                      **kwargs):
     """Context manager that checks sent/received instrument commands without a
     device connected.
 
@@ -47,10 +49,13 @@ def expected_protocol(instrument_cls, comm_pairs, **kwargs):
         'None' indicates that a pair member (command or response) does not
         exist, e.g. `(None, 'RESP1')`. Commands and responses are without
         termination characters.
+    :param dict connection_attributes: Dictionary of attributes of the connection.
+    :param dict connection_methods: Pairs of method names and return values.
     :param \\**kwargs:
         Keyword arguments for the instantiation of the instrument.
     """
-    protocol = ProtocolAdapter(comm_pairs)
+    protocol = ProtocolAdapter(comm_pairs, connection_attributes=connection_attributes,
+                               connection_methods=connection_methods)
     instr = instrument_cls(protocol, **kwargs)
     yield instr
     assert protocol._index == len(comm_pairs), (

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -22,9 +22,17 @@
 # THE SOFTWARE.
 #
 
+from unittest.mock import call
+import pytest
+
 from pymeasure.adapters.protocol import to_bytes, ProtocolAdapter
 
 from pytest import mark, raises, fixture
+
+
+@pytest.fixture
+def adapter():
+    return ProtocolAdapter()
 
 
 @mark.parametrize("input, output", (("superXY", b"superXY"),
@@ -44,6 +52,27 @@ def test_to_bytes_invalid():
 def test_protocol_instantiation():
     a = ProtocolAdapter([("write", "read"), ("write_only", None)])
     assert a.comm_pairs == [("write", "read"), ("write_only", None)]
+
+
+@pytest.fixture
+def mockAdapter():
+    adapter = ProtocolAdapter(connection_attributes={'timeout': 100},
+                              connection_methods={'stb': 17})
+    return adapter
+
+
+def test_connection_call(mockAdapter):
+    """Test whether a call to the connection is registered."""
+    mockAdapter.connection.clear(7)
+    assert mockAdapter.connection.clear.call_args_list == [call(7)]
+
+
+def test_connection_attribute(mockAdapter):
+    assert mockAdapter.connection.timeout == 100
+
+
+def test_connection_method(mockAdapter):
+    assert mockAdapter.connection.stb() == 17
 
 
 class Test_write:

--- a/tests/instruments/lecroy/test_lecroyT3DSO1204.py
+++ b/tests/instruments/lecroy/test_lecroyT3DSO1204.py
@@ -259,7 +259,8 @@ def test_download_one_point():
              (b"C1:VDIV?", b"5.00E-02"),
              (b"C1:OFST?", b"-1.50E-01"),
              (b"C1:UNIT?", b"V")
-             ]
+             ],
+            connection_attributes={'chunk_size': 0},
     ) as instr:
         y, x, preamble = instr.download_waveform(source="c1", requested_points=1, sparsing=1)
         assert preamble == {
@@ -308,7 +309,8 @@ def test_download_two_points():
              (b"C1:VDIV?", b"5.00E-02"),
              (b"C1:OFST?", b"-1.50E-01"),
              (b"C1:UNIT?", b"V")
-             ]
+             ],
+            connection_attributes={'chunk_size': 0},
     ) as instr:
         y, x, preamble = instr.download_waveform(source="c1", requested_points=2, sparsing=1)
         assert preamble == {

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -22,7 +22,6 @@
 # THE SOFTWARE.
 #
 
-import pytest
 from pytest import raises
 
 from pymeasure.test import expected_protocol
@@ -142,17 +141,3 @@ class TestConnectionCalls:
                 connection_attributes={'timeout': 100}
         ) as inst:
             assert inst.adapter.connection.timeout == 100
-
-
-@pytest.mark.xfail
-def test_preprocess_reply_on_init():
-    # TODO: For now preprocess_reply at init level is nonfunctional because this
-    #  lives in the real adapter, should be fixed with #567
-    class InstrumentWithPreprocess(BasicTestInstrument):
-        def __init__(self, adapter, **kwargs):
-            super().__init__(adapter, preprocess_reply=lambda v: v + "2345", **kwargs)
-    with expected_protocol(
-        InstrumentWithPreprocess,
-        [("VOLT?", "3.1")]
-    ) as instr:
-        assert instr.simple == 3.12345

--- a/tests/test_expected_protocol.py
+++ b/tests/test_expected_protocol.py
@@ -126,6 +126,24 @@ def test_preprocess_reply_on_values():
         assert instr.simple == 3.12345
 
 
+class TestConnectionCalls:
+    def test_connection_method_call(self):
+        with expected_protocol(
+                BasicTestInstrument,
+                [],
+                connection_methods={'stb': 17}
+        ) as inst:
+            assert inst.adapter.connection.stb() == 17
+
+    def test_connection_attribute(self):
+        with expected_protocol(
+                BasicTestInstrument,
+                [],
+                connection_attributes={'timeout': 100}
+        ) as inst:
+            assert inst.adapter.connection.timeout == 100
+
+
 @pytest.mark.xfail
 def test_preprocess_reply_on_init():
     # TODO: For now preprocess_reply at init level is nonfunctional because this
@@ -133,7 +151,6 @@ def test_preprocess_reply_on_init():
     class InstrumentWithPreprocess(BasicTestInstrument):
         def __init__(self, adapter, **kwargs):
             super().__init__(adapter, preprocess_reply=lambda v: v + "2345", **kwargs)
-
     with expected_protocol(
         InstrumentWithPreprocess,
         [("VOLT?", "3.1")]


### PR DESCRIPTION
Closes #742 

The connection of the ProtocolAdapter is a MagicMock.
You can set attribute return values and method return values via a dictionary (which you can set from `expected_protocol` as well).
Such that you can preset your connection in order to let tests pass (see Lecroy test).