### PR TITLE
Fix issue with ImageWidget

### DIFF
--- a/pymeasure/display/curves.py
+++ b/pymeasure/display/curves.py
@@ -26,7 +26,7 @@ import logging
 
 import numpy as np
 import pyqtgraph as pg
-from .Qt import QtCore
+from .Qt import QtCore, QtGui
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -82,11 +82,13 @@ class ResultsImage(pg.ImageItem):
 
         super().__init__(image=self.img_data)
 
-        # Scale and translate image so that the pixels are in the coorect
+        # Scale and translate image so that the pixels are in the correct
         # position in "data coordinates"
-        self.scale(self.xstep, self.ystep)
-        self.translate(int(self.xstart / self.xstep) - 0.5,
-                       int(self.ystart / self.ystep) - 0.5)  # 0.5 so pixels centered
+        tr = QtGui.QTransform()
+        tr.scale(self.xstep, self.ystep)
+        tr.translate(int(self.xstart / self.xstep) - 0.5,
+                     int(self.ystart / self.ystep) - 0.5)  # 0.5 so pixels centered
+        self.setTransform(tr)
 
     def update_data(self):
         if self.force_reload:


### PR DESCRIPTION
When playing around with another PR, I came  across an issue with the ImageWidget: when a new measurement is queued, it crashes because the initialization of the `ResultsImage` class calls the `scale` and `translate`, methods, which does (nowadays) only return the scaling or translation values.