### PR TITLE
Add TeledyneT3AFG waveform generator instrument

### DIFF
--- a/docs/api/instruments/teledyne/index.rst
+++ b/docs/api/instruments/teledyne/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.teledyne
+
+#########
+Teledyne
+#########
+
+This section contains specific documentation on the Teledyne instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   teledyneT3AFG

--- a/docs/api/instruments/teledyne/teledyneT3AFG.rst
+++ b/docs/api/instruments/teledyne/teledyneT3AFG.rst
@@ -1,0 +1,18 @@
+##############################################
+Teledyne T3AFG Arbitrary Waveform Generator
+##############################################
+
+*******************
+General Information
+*******************
+
+All internal limits assume the fancier set of waveform generators. Commands may fail silently on T3AFG5 or T3AFG10. 
+
+****************
+Instrument Class
+****************
+
+.. autoclass:: pymeasure.instruments.teledyne.teledyneT3AFG
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/api/instruments/teledyne/teledyneT3AFG.rst
+++ b/docs/api/instruments/teledyne/teledyneT3AFG.rst
@@ -6,7 +6,11 @@ Teledyne T3AFG Arbitrary Waveform Generator
 General Information
 *******************
 
-All internal limits assume the fancier set of waveform generators. Commands may fail silently on T3AFG5 or T3AFG10. 
+Initial implementation is aimed at T3AFG80 and is very limited even for target device.
+
+Some commands may fail silently or with error on T3AFG5 or T3AFG10. Features avalible on fancier models are not implemented.
+
+Eventually this may be a good use-case for a base class and inheritance for other models.
 
 ****************
 Instrument Class

--- a/pymeasure/instruments/teledyne/__init__.py
+++ b/pymeasure/instruments/teledyne/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .teledyneT3AFG import TeledyneT3AFG

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -25,14 +25,24 @@
 import logging
 
 from pymeasure.instruments import Instrument, Channel
-from pymeasure.instruments.validators import strict_range
+from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
 class SignalChannel(Channel):
-    pass
+    
+    output_enabled = Channel.control(
+        "C{ch}:OUTPut?",
+        "C{ch}:OUTPut %s",
+        """Control whether the channel output is enabled (boolean).""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: 'ON', False: 'OFF'},
+        get_process=lambda x: x[0].split(' ')[1],
+        # Not sure why "OFF" doesn't get transformed into False
+    )
 
 
 class TeledyneT3AFG(Instrument):
@@ -47,7 +57,7 @@ class TeledyneT3AFG(Instrument):
     generator=TeledyneT3AFG(resource)
     """
 
-    channels = Instrument.ChannelCreator(SignalChannel)
+    channels = Instrument.ChannelCreator(SignalChannel, (1,2))
 
     def __init__(self, adapter, name="Teledyne T3AFG", **kwargs):
         super().__init__(

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -38,8 +38,11 @@ class SignalChannel(Channel):
 class TeledyneT3AFG(Instrument):
     """Represents the Teledyne T3AFG series of arbitrary waveform
     generator interface for interacting with the instrument.
-    Limits are not accurate for T3AFG5, T3AFG10.
-    
+
+    Intially targeting T3AFG80, some features may not be avalible on
+    lower end models and features from higher end models are not 
+    included here intially. 
+
     .. code-block: python
     generator=TeledyneT3AFG(resource)
     """

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -44,6 +44,57 @@ class SignalChannel(Channel):
         # Not sure why "OFF" doesn't get transformed into False
     )
 
+    # TODO: Add other OUTPut related controls like Load and Polarity
+
+    wavetype = Channel.control(
+        "C{ch}:BSWV?",
+        "C{ch}:BSWV WVTP,%s",
+        """Control the type of waveform to be output.
+        Options are: {SINE, SQUARE, RAMP, PULSE, NOISE, ARB, DC, PRBS, IQ}
+        """,
+        validator=strict_discrete_set,
+        # TODO: make ENUM for more descriptive names?
+        values=['SINE', 'SQUARE', 'RAMP', 'PULSE', 'NOISE', 'ARB', 'DC', 'PRBS', 'IQ'],
+        get_process=lambda x: x[1],
+    )
+
+    # TODO: Wavetype dependent processing with errors
+    # For example, DC wavetype does not return frequency
+
+    # TODO: Add frequency ranges per model?
+    frequency = Channel.control(
+        "C{ch}:BSWV?",
+        "C{ch}:BSWV FRQ,%g",
+        """Control the frequency of waveform to be output in Hertz.""",
+        validator=strict_range,
+        values=[0,350e6],
+        get_process=lambda x: x,
+        #get_process=lambda x: x[1].split(',')[2].split('HZ'),
+    )
+
+    # TODO: Add range of outputs per model? Tricky without knowing offset
+    amplitude = Channel.control(
+        "C{ch}:BSWV?",
+        "C{ch}:BSWV AMP,%g",
+        """Control the amplitude of waveform to be output in volts peak-to-peak.""",
+        validator=strict_range,
+        values=[0,5],
+        get_process=lambda x: x[1].split(',')[6].split('V'),
+    )
+
+    # TODO: Add range of offset per model? Tricky without knowing amplitude
+    offset = Channel.control(
+        "C{ch}:BSWV?",
+        "C{ch}:BSWV OFST,%g",
+        """Control the offset of waveform to be output in volts.""",
+        validator=strict_range,
+        values=[0,5],
+        get_process=lambda x: x[1].split(',')[8].split('V'),
+    )
+
+    # TODO: Add other Basic Waveform parameters like period
+
+    # TODO: Add odd parameter like MAX_OUTPUT_AMP
 
 class TeledyneT3AFG(Instrument):
     """Represents the Teledyne T3AFG series of arbitrary waveform
@@ -63,3 +114,5 @@ class TeledyneT3AFG(Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
+
+    # TODO: Add channel coupling control

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -1,0 +1,52 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from pymeasure.instruments import Instrument, Channel
+from pymeasure.instruments.validators import strict_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class SignalChannel(Channel):
+    pass
+
+
+class TeledyneT3AFG(Instrument):
+    """Represents the Teledyne T3AFG series of arbitrary waveform
+    generator interface for interacting with the instrument.
+    Limits are not accurate for T3AFG5, T3AFG10.
+    
+    .. code-block: python
+    generator=TeledyneT3AFG(resource)
+    """
+
+    channels = Instrument.ChannelCreator(SignalChannel)
+
+    def __init__(self, adapter, name="Teledyne T3AFG", **kwargs):
+        super().__init__(
+            adapter, name, **kwargs
+        )

--- a/tests/instruments/teledyne/test_teledyneT3AFG.py
+++ b/tests/instruments/teledyne/test_teledyneT3AFG.py
@@ -34,3 +34,11 @@ def test_output_enabled():
     ) as inst:
         inst.ch_1.output_enabled = True
         assert inst.ch_1.output_enabled is False
+
+    # TODO: Test Wavetype control
+
+    # TODO: Test Frequency control
+
+    # TODO: Test Amplitude control
+
+    # TODO: Test Offset control

--- a/tests/instruments/teledyne/test_teledyneT3AFG.py
+++ b/tests/instruments/teledyne/test_teledyneT3AFG.py
@@ -30,7 +30,7 @@ def test_output_enabled():
     with expected_protocol(
         TeledyneT3AFG,
         [("C1:OUTPut ON", None),
-         ("C1:OUTPut?", "OFF")],
+         ("C1:OUTPut?", "C1:OUTP OFF,LOAD,HZ,PLRT,NOR")],
     ) as inst:
         inst.ch_1.output_enabled = True
         assert inst.ch_1.output_enabled is False

--- a/tests/instruments/teledyne/test_teledyneT3AFG.py
+++ b/tests/instruments/teledyne/test_teledyneT3AFG.py
@@ -1,0 +1,36 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.teledyne.TeledyneT3AFG import TeledyneT3AFG
+
+def test_output_enabled():
+    """Verify the output enable setter and getter."""
+    with expected_protocol(
+        TeledyneT3AFG,
+        [("C1:OUTPut ON", None),
+         ("C1:OUTPut?", "OFF")],
+    ) as inst:
+        inst.ch_1.output_enabled = True
+        assert inst.ch_1.output_enabled is False


### PR DESCRIPTION
In progress instrument for the T3AFG signal generator family of instruments. I only have access to the T3AFG80, but I wanted to start with a general implementation and the ranges could be adjusted later in inheritance if other people want to make interfaces for other models. 

My big question for this instrument is how to handle the strings that are returned by the instrument in get_process in a way that is dependent on the current waveform type. For instance, the frequency control doesn't make any sense if the wavetype is DC so the instrument doesn't even return it when the waveform info is query'd. 

https://cdn.teledynelecroy.com/files/manuals/t3afg-programming-guide.pdf