### PR TITLE
Add maxsplit parameter to values.

### DIFF
--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -290,7 +290,7 @@ class CommonBase:
         self.wait_for(query_delay)
         return self.read()
 
-    def values(self, command, separator=',', cast=float, preprocess_reply=None):
+    def values(self, command, separator=',', cast=float, preprocess_reply=None, maxsplit=-1):
         """Write a command to the instrument and return a list of formatted
         values from the result.
 
@@ -300,12 +300,13 @@ class CommonBase:
         :param preprocess_reply: optional callable used to preprocess values
             received from the instrument. The callable returns the processed
             string.
+        :param maxsplit: At most `maxsplit` splits are done. -1 (default) indicates no limit.
         :returns: A list of the desired type, or strings where the casting fails
         """
         results = str(self.ask(command)).strip()
         if callable(preprocess_reply):
             results = preprocess_reply(results)
-        results = results.split(separator)
+        results = results.split(separator, maxsplit=maxsplit)
         for i, result in enumerate(results):
             try:
                 if cast == bool:

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -327,7 +327,9 @@ def test_ask_writes_and_reads():
                           ("X,Y,Z", {'cast': str}, ['X', 'Y', 'Z']),
                           ("X.Y.Z", {'separator': '.'}, ['X', 'Y', 'Z']),
                           ("0,5,7.1", {'cast': bool}, [False, True, True]),
-                          ("x5x", {'preprocess_reply': lambda v: v.strip("x")}, [5])
+                          ("x5x", {'preprocess_reply': lambda v: v.strip("x")}, [5]),
+                          ("X,Y,Z", {'maxsplit': 1}, ["X", "Y,Z"]),
+                          ("X,Y,Z", {'maxsplit': 0}, ["X,Y,Z"]),
                           ))
 def test_values(value, kwargs, result):
     cb = CommonBaseTesting(FakeAdapter(), "test")


### PR DESCRIPTION
I added the `maxsplit` parameter to values to hand it to the split function.

With that, you can deactivate it (`maxsplit=0`) and get a single value, such that mapping works (see #791 ) even with a single result.

It is also good to deactivate splitting, if you expect binary data (i.e. any character).

Tests are expanded accordingly.