### PR TITLE
Fix keithley2600.py shutdown()

### DIFF
--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -321,4 +321,3 @@ class Channel:
         else:
             self.ramp_to_voltage(0.0)
         self.source_output = 'OFF'
-        self.instrument.shutdown()

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -321,4 +321,4 @@ class Channel:
         else:
             self.ramp_to_voltage(0.0)
         self.source_output = 'OFF'
-        super().shutdown()
+        self.instrument.shutdown()


### PR DESCRIPTION
The `Channel` is not a subclass of `Instrument`, so calling super().shutdown() doesn't do anything.

Fixed to call instrument.shutdown() instead.
