### PR TITLE
Update Flake8 version

### DIFF
--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -320,8 +320,8 @@ class Agilent34450A(Instrument):
     ###################
 
     temperature = Instrument.measurement(":READ?",
-                                         """ Reads a temperature measurement in Celsius, based on the
-                                         active :attr:`~.Agilent34450A.mode`. """
+                                         """ Reads a temperature measurement in Celsius, based on
+                                         the active :attr:`~.Agilent34450A.mode`. """
                                          )
 
     #############

--- a/pymeasure/instruments/agilent/agilent4156.py
+++ b/pymeasure/instruments/agilent/agilent4156.py
@@ -624,7 +624,7 @@ class SMU(Instrument):
     def __validate_cons(self):
         """Validates the instrument settings for operation in constant mode.
         """
-        if not((self.channel_mode != 'COMM') and (
+        if not ((self.channel_mode != 'COMM') and (
                 self.channel_function == 'CONS')):
             raise ValueError(
                 'Cannot set constant SMU function when SMU mode is COMMON, '
@@ -637,7 +637,7 @@ class SMU(Instrument):
     def __validate_compl(self):
         """Validates the instrument compliance for operation in constant mode.
         """
-        if not((self.channel_mode != 'COMM') and (
+        if not ((self.channel_mode != 'COMM') and (
                 self.channel_function == 'CONS')):
             raise ValueError(
                 'Cannot set constant SMU parameters when SMU mode is COMMON, '

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -154,8 +154,9 @@ class DPSeriesMotorController(Instrument):
 
     encoder_window = Instrument.control(
         "VEW", "EW%i",
-        """An integer property that represents the allowable error in encoder pulses from the desired
-           position before the encoder auto-correct function runs. This property can be set.""",
+        """An integer property that represents the allowable error in encoder pulses from the
+        desired position before the encoder auto-correct function runs. This property can be set.
+        """,
         validator=truncated_range,
         values=[0, 255],
         cast=int,
@@ -330,7 +331,8 @@ class DPSeriesMotorController(Instrument):
         super().write(cmd_str)
 
     def wait_for_completion(self, interval=0.5):
-        """ Block until the controller is not "busy" (i.e. block until the motor is no longer moving.)
+        """ Block until the controller is not "busy" (i.e. block until the motor is no longer
+        moving.)
 
         :param interval: (float) seconds between queries to the "busy" flag.
         :return: None

--- a/pymeasure/instruments/anritsu/anritsuMS9710C.py
+++ b/pymeasure/instruments/anritsu/anritsuMS9710C.py
@@ -303,7 +303,7 @@ class AnritsuMS9710C(Instrument):
         log.info("Wait for OPC")
         res = self.ask("*OPC?")
         n_attempts = n
-        while(res == ''):
+        while res == '':
             log.debug(f"Empty OPC Response. {n_attempts} remaining")
             if n_attempts == 0:
                 break
@@ -320,7 +320,7 @@ class AnritsuMS9710C(Instrument):
         """
         log.debug("Waiting for spectrum sweep")
 
-        while(self.esr2 != 3 and n > 0):
+        while self.esr2 != 3 and n > 0:
             log.debug(f"Wait for sweep [{n}]")
             # log.debug("ESR2: {}".format(esr2))
             sleep(delay)

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -230,7 +230,8 @@ class HP8116A(Instrument):
         self._wait_for_commands_processed()
 
     def ask(self, command, num_bytes=None):
-        """ Write a command to the instrument, read the response, and return the response as ASCII text.
+        """ Write a command to the instrument, read the response, and return the response as ASCII
+        text.
 
         :param command: The command to send to the instrument.
         :param num_bytes: The number of bytes to read from the instrument. If not specified,

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -92,8 +92,8 @@ class Instrument(CommonBase):
     # SCPI default properties
     @property
     def complete(self):
-        """ This property allows synchronization between a controller and a device. The Operation Complete
-        query places an ASCII character 1 into the device's Output Queue when all pending
+        """ This property allows synchronization between a controller and a device. The Operation
+        Complete query places an ASCII character 1 into the device's Output Queue when all pending
         selected device operations have been finished.
         """
         if self.SCPI:

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -216,8 +216,8 @@ class Keithley2450(Instrument, KeithleyBuffer):
     ####################
 
     resistance = Instrument.measurement(":READ?",
-                                        """ Reads the resistance in Ohms, if configured for this reading.
-        """
+                                        """ Reads the resistance in Ohms, if configured for this
+                                        reading. """
                                         )
     resistance_range = Instrument.control(
         ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",

--- a/pymeasure/instruments/keysight/keysightDSOX1102G.py
+++ b/pymeasure/instruments/keysight/keysightDSOX1102G.py
@@ -394,7 +394,8 @@ class KeysightDSOX1102G(Instrument):
 
     @property
     def waveform_preamble(self):
-        """ Get preamble information for the selected waveform source as a dict with the following keys:
+        """ Get preamble information for the selected waveform source as a dict with the following
+        keys:
             - "format": byte, word, or ascii (str)
             - "type": normal, peak detect, or average (str)
             - "points": nb of data points transferred (int)

--- a/pymeasure/instruments/keysight/keysightN7776C.py
+++ b/pymeasure/instruments/keysight/keysightN7776C.py
@@ -75,12 +75,12 @@ class KeysightN7776C(Instrument):
                                           get_process=lambda v: v*1e3)
 
     _output_power_dBm = Instrument.control('SOUR0:POW?', 'SOUR0:POW %f dBm',
-                                           """ Floating point value indicating the laser output power
-                                           in dBm.""")
+                                           """ Floating point value indicating the laser output
+                                           power in dBm.""")
 
     _output_power_unit = Instrument.control('SOUR0:POW:UNIT?', 'SOUR0:POW:UNIT %g',
-                                            """ String parameter controlling the power unit used internally
-                                            by the laser.""",
+                                            """ String parameter controlling the power unit used
+                                            internally by the laser.""",
                                             map_values=True,
                                             values={'dBm': 0, 'mW': 1})
 
@@ -103,8 +103,8 @@ class KeysightN7776C(Instrument):
         self._output_power_dBm = new_power
 
     trigger_out = Instrument.control('TRIG0:OUTP?', 'TRIG0:OUTP %s',
-                                     """ Specifies if and at which point in a sweep cycle an output trigger
-                                     is generated and arms the module. """,
+                                     """ Specifies if and at which point in a sweep cycle an output
+                                     trigger is generated and arms the module. """,
                                      validator=strict_discrete_set,
                                      values=['DIS', 'STF', 'SWF', 'SWST'])
 
@@ -158,8 +158,8 @@ class KeysightN7776C(Instrument):
         able to pass a wavelength sweep.""")
 
     sweep_points = Instrument.measurement('sour0:read:points? llog',
-                                          """Returns the number of datapoints that the :READout:DATA?
-                                          command will return.""")
+                                          """Returns the number of datapoints that the
+                                          :READout:DATA? command will return.""")
 
     sweep_state = Instrument.control('sour0:wav:swe?', 'sour0:wav:swe %g',
                                      """ State of the wavelength sweep. Stops, starts, pauses

--- a/pymeasure/instruments/srs/sr510.py
+++ b/pymeasure/instruments/srs/sr510.py
@@ -46,16 +46,16 @@ class SR510(Instrument):
                                )
 
     time_constant = Instrument.control("T1", "T1,%d",
-                                       """A float property that represents the SR510 PRE filter time constant.
-                                          This property can be set.""",
+                                       """A float property that represents the SR510 PRE filter time
+                                       constant. This property can be set.""",
                                        validator=truncated_discrete_set,
                                        values=TIME_CONSTANTS,
                                        map_values=True,
                                        )
 
     sensitivity = Instrument.control("G", "G%d",
-                                     """A float property that represents the SR510 sensitivity value.
-                                        This property can be set.""",
+                                     """A float property that represents the SR510 sensitivity
+                                     value. This property can be set.""",
                                      validator=truncated_discrete_set,
                                      values=SENSITIVITIES,
                                      map_values=True,

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -279,28 +279,32 @@ class SR860(Instrument):
     )
     sine_amplitudepreset1 = Instrument.control(
         "PSTA? 0", "PSTA0, %0.9e",
-        """Floating point property representing the preset sine out amplitude, for the A1 preset button.
+        """Floating point property representing the preset sine out amplitude, for the A1 preset
+        button.
         This property can be set.""",
         validator=truncated_range,
         values=[1e-9, 2]
     )
     sine_amplitudepreset2 = Instrument.control(
         "PSTA? 1", "PSTA1, %0.9e",
-        """Floating point property representing the preset sine out amplitude, for the A2 preset button.
+        """Floating point property representing the preset sine out amplitude, for the A2 preset
+        button.
         This property can be set.""",
         validator=truncated_range,
         values=[1e-9, 2]
     )
     sine_amplitudepreset3 = Instrument.control(
         "PSTA? 2", "PSTA2, %0.9e",
-        """Floating point property representing the preset sine out amplitude, for the A3 preset button.
+        """Floating point property representing the preset sine out amplitude, for the A3 preset
+        button.
         This property can be set.""",
         validator=truncated_range,
         values=[1e-9, 2]
     )
     sine_amplitudepreset4 = Instrument.control(
         "PSTA? 3", "PSTA 3, %0.9e",
-        """Floating point property representing the preset sine out amplitude, for the A3 preset button.
+        """Floating point property representing the preset sine out amplitude, for the A3 preset
+        button.
         This property can be set.""",
         validator=truncated_range,
         values=[1e-9, 2]
@@ -520,7 +524,8 @@ class SR860(Instrument):
     )
     strip_chart_dat1 = Instrument.control(
         "CGRF? 0", "CGRF 0, %i",
-        """A integer property that turns the strip chart graph of data channel 1 off(i=0) or on(i=1).
+        """A integer property that turns the strip chart graph of data channel 1 off(i=0) or
+        on(i=1).
         """,
         validator=strict_discrete_set,
         values=ON_OFF_VALUES,
@@ -528,7 +533,8 @@ class SR860(Instrument):
     )
     strip_chart_dat2 = Instrument.control(
         "CGRF? 1", "CGRF 1, %i",
-        """A integer property that turns the strip chart graph of data channel 2 off(i=0) or on(i=1).
+        """A integer property that turns the strip chart graph of data channel 2 off(i=0) or
+        on(i=1).
         """,
         validator=strict_discrete_set,
         values=ON_OFF_VALUES,
@@ -536,7 +542,8 @@ class SR860(Instrument):
     )
     strip_chart_dat3 = Instrument.control(
         "CGRF? 2", "CGRF 2, %i",
-        """A integer property that turns the strip chart graph of data channel 1 off(i=0) or on(i=1).
+        """A integer property that turns the strip chart graph of data channel 1 off(i=0) or
+        on(i=1).
         """,
         validator=strict_discrete_set,
         values=ON_OFF_VALUES,
@@ -544,7 +551,8 @@ class SR860(Instrument):
     )
     strip_chart_dat4 = Instrument.control(
         "CGRF? 3", "CGRF 3, %i",
-        """A integer property that turns the strip chart graph of data channel 4 off(i=0) or on(i=1).
+        """A integer property that turns the strip chart graph of data channel 4 off(i=0) or
+        on(i=1).
         """,
         validator=strict_discrete_set,
         values=ON_OFF_VALUES,

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -725,7 +725,7 @@ class ATSBase(Instrument):
         time.sleep(1)
         t = 0
         t_start = time.time()
-        while(not self.at_temperature()):  # assert at temperature
+        while not self.at_temperature():  # assert at temperature
             time.sleep(1)
             t = time.time() - t_start
 

--- a/requirements/pymeasure.yml
+++ b/requirements/pymeasure.yml
@@ -16,7 +16,7 @@ dependencies:
   - pytest-qt=3.3.0
   - pytest-runner=5.2
   - pytest=6.2.5
-  - flake8=4.0.1
+  - flake8=6.0.0
   - setuptools_scm # don't pin, to get newest features
   - sphinx=4.3.1
   - sphinx_rtd_theme=1.0.0

--- a/tests/adapters/test_serial.py
+++ b/tests/adapters/test_serial.py
@@ -69,4 +69,4 @@ def test_read_bytes(adapter):
 def test_adapter_write_binary_values(adapter, test_input, expected):
     adapter.write_binary_values("OUTP", test_input, datatype='B')
     # Add 10 bytes more, just to check that no extra bytes are present
-    assert(adapter.connection.read(len(expected) + 10) == expected)
+    assert adapter.connection.read(len(expected) + 10) == expected

--- a/tests/experiment/test_procedure.py
+++ b/tests/experiment/test_procedure.py
@@ -67,12 +67,12 @@ def test_procedure_properties():
     class TestProcedure(Procedure):
         @property
         def a(self):
-            assert(isinstance(self.x, int))
+            assert isinstance(self.x, int)
             return self.x
 
         @property
         def z(self):
-            assert(isinstance(self.x, int))
+            assert isinstance(self.x, int)
             return self.x
         x = Parameter('X', default=5)
 


### PR DESCRIPTION
The current flake8 version is missing line-too-long issues when a line is part of a triple-quoted string.
This is solved for flake8>5.0.0, I propose to update the version to the latest version (6.0.0) and fix the issues that now surface; i.e. the triple-quoted string issues, and "E275 missing whitespace after keyword" issues that are added by the updated pycodestyle dependency of flake8.