### PR TITLE
add T&C Power Conversion RF power supply

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -54,6 +54,7 @@ Instruments by manufacturer:
    siglenttechnologies/index
    signalrecovery/index
    srs/index
+   tcpowerconversion/index
    tektronix/index
    temptronic/index
    texio/index

--- a/docs/api/instruments/tcpowerconversion/index.rst
+++ b/docs/api/instruments/tcpowerconversion/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.tcpowerconversion
+
+####################
+T&C Power Conversion 
+####################
+
+This section contains specific documentation on the instruments from T&C Power Conversion that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   tccxn

--- a/docs/api/instruments/tcpowerconversion/tccxn.rst
+++ b/docs/api/instruments/tcpowerconversion/tccxn.rst
@@ -1,0 +1,7 @@
+###################################################
+T&C Power Conversion AG Series Plasma Generator CXN
+###################################################
+
+.. autoclass:: pymeasure.instruments.tcpowerconversion.CXN
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -62,6 +62,7 @@ from . import rohdeschwarz
 from . import siglenttechnologies
 from . import signalrecovery
 from . import srs
+from . import tcpowerconversion
 from . import tektronix
 from . import temptronic
 from . import texio

--- a/pymeasure/instruments/tcpowerconversion/__init__.py
+++ b/pymeasure/instruments/tcpowerconversion/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .tccxn import CXN

--- a/pymeasure/instruments/tcpowerconversion/tccxn.py
+++ b/pymeasure/instruments/tcpowerconversion/tccxn.py
@@ -141,7 +141,6 @@ class CXN(Instrument):
         datalength = int.from_bytes(header[2:], "big")
         data = super().read_bytes(datalength)
         chksum = super().read_bytes(2)
-        print(header+data+chksum)
         if chksum == self._checksum(header + data):
             return data
         else:
@@ -158,7 +157,6 @@ class CXN(Instrument):
         """
         fullcmd = self._prepend_cmdheader(command.encode())
         super().write_bytes(fullcmd + self._checksum(fullcmd))
-        print(fullcmd + self._checksum(fullcmd))
         self.check_acknowledgment()
 
     # could be removed if the split of values is put into CommonBase

--- a/pymeasure/instruments/tcpowerconversion/tccxn.py
+++ b/pymeasure/instruments/tcpowerconversion/tccxn.py
@@ -224,6 +224,13 @@ class CXN(Instrument):
         get_process=lambda d: d.decode()[2:-1].strip(),
     )
 
+    firmware_version = Instrument.measurement(
+        "Gf\x00\x00\x00\x00",
+        """ UI-processor and RF-processor firmware version numbers """,
+        preprocess_reply=lambda d: struct.unpack("BBBB", d),
+        get_process=lambda v: str.format("UI {}.{}, RF {}.{}", *v)
+    )
+
     pulse_params = Instrument.measurement(
         "GE\x00\x00\x00\x00",
         """ Get pulse on/off time of the pulse waveform """,

--- a/pymeasure/instruments/tcpowerconversion/tccxn.py
+++ b/pymeasure/instruments/tcpowerconversion/tccxn.py
@@ -381,21 +381,17 @@ class CXN(Instrument):
         values=(True, False),
     )
 
-    load_capacity1 = Instrument.control(
-        "GU\x00\x01\x00\x00", "TD\x01\x01\x00%c",
-        """ percentage of full-scale value of the load capacity preset """,
-        preprocess_reply=lambda d: struct.unpack(">H", d[2:4]),
-        validator=strict_discrete_set,
-        values=range(101),
-    )
-
     def request_control(self):
         self.write("BC\x55\x55\x00\x00")
-        print(int(struct.unpack(">H", self.read())[0]))
+        status = int(struct.unpack(">H", self.read())[0])
+        if status != 1:
+            print("error(CXN): control request denied!")
 
     def release_control(self):
         self.write("BC\x00\x00\x00\x00")
-        print(int(struct.unpack(">H", self.read())[0]))
+        status = int(struct.unpack(">H", self.read())[0])
+        if status != 0:
+            print("error(CXN): release of control unsuccessful!")
 
     def ping(self):
         self.write("BP\x00\x00\x00\x00")

--- a/pymeasure/instruments/tcpowerconversion/tccxn.py
+++ b/pymeasure/instruments/tcpowerconversion/tccxn.py
@@ -1,0 +1,326 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import struct
+
+from pymeasure.instruments.validators import strict_discrete_set
+from pymeasure.instruments import Instrument
+
+
+def int2char(value):
+    """
+    converts an integer (unsigned-16bit) to a tuple containing the values
+    of two representing characters.
+    """
+    return tuple(int(b) for b in value.to_bytes(2, "big"))
+
+
+class CXN(Instrument):
+    """T&C Power Conversion AG Series Plasma Generator CXN
+    (also rebranded by AJA International Inc as 0113 GTC or 0313 GTC)
+
+    Connection to the device is made through an RS232 serial connection.
+    The communication settings are fixed in the device at 38400, stopbit one,
+    parity none. The device uses a command response system where every receipt
+    of a command is acknowledged by returning a '*'. A '?' is returned to
+    indicates the command was not recognized by the device.
+
+    A command messages always consists of the following bytes (B):
+    1B - header (always 'C'),
+    1B - address (ignored),
+    2B - command id,
+    2B - parameter 1,
+    2B - parameter,
+    2B - checksum
+
+    A response message always consists of:
+    1B - header (always 'R'),
+    1B - address of the device,
+    2B - length of the data package,
+    variable length data,
+    2B - checksum
+    response messages are received after the acknowledge byte.
+
+    :param adapter: pyvisa resource name of the instrument or adapter instance
+    :param kwargs: Any valid key-word argument for Instrument
+
+    Note: In order to enable setting any parameters one has to request control
+    and periodically (at least once per 2s) poll any value from the device.
+    Failure to do so will mean loss of control and the device will reset
+    certain parameters (setpoint, disable RF, ...)
+    """
+
+    def __init__(self, adapter, address=0, **kwargs):
+        self.address = address
+        kwargs.setdefault("write_termination", "")
+        kwargs.setdefault("read_termination", "")
+        kwargs.setdefault("asrl", dict(baud_rate=38400))
+        super().__init__(adapter,
+                         "T&C RF sputtering power supply",
+                         includeSCPI=False,
+                         **kwargs)
+
+    @staticmethod
+    def _checksum(msg):
+        """
+        returns 2 bytes checksum calculated by a bytewise sum
+
+        Parameters
+        ----------
+        msg : bytes object corresponding to the message
+        """
+        return struct.pack(">H", sum(msg))
+
+    def _prepend_cmdheader(self, cmd):
+        """
+        prepends command start byte and address to the command
+
+        Parameters
+        ----------
+        msg : bytes object corresponding to the command id and parameters
+        """
+        return b"C" + self.address.to_bytes(1, "big") + cmd
+
+    def read(self):
+        """
+        Reads from the instrument and returns the data fields as bytes
+        """
+        header = super().read_bytes(4)
+        datalength = int.from_bytes(header[2:], "big")
+        data = super().read_bytes(datalength)
+        chksum = super().read_bytes(2)
+        if chksum == self._checksum(header + data):
+            return data
+        else:
+            raise ValueError(
+                f"checksum error in received message {header + data} "
+                f"with checksum {self._checksum(header + data)} "
+                f"but should be {chksum}")
+
+    def write(self, command):
+        """
+        Writes to the instrument and includes needed command header/address
+
+        :param command: command string to be sent to the instrument
+        """
+        fullcmd = self._prepend_cmdheader(command.encode())
+        super().write_bytes(fullcmd + self._checksum(fullcmd))
+        self.check_acknowledgment()
+
+    def values(self, command, cast=int, preprocess_reply=None):
+        """ Writes a command to the instrument and returns a list of formatted
+        values from the result.
+        :param command: command to be sent to the instrument
+        :param cast: A type to cast the result
+        :param preprocess_reply: optional callable used to preprocess values
+            received from the instrument. The callable returns the processed
+            string.
+        :returns: A list of the desired type, or bytes where the casting fails
+        """
+        results = self.ask(command)
+        if callable(preprocess_reply):
+            results = preprocess_reply(results)
+        for i, result in enumerate(results):
+            try:
+                if cast == bool:
+                    # Need to cast to float first since results are usually
+                    # strings and bool of a non-empty string is always True
+                    results[i] = bool(float(result))
+                else:
+                    results[i] = cast(result)
+            except Exception:
+                pass  # Keep as bytes
+        return results
+
+    def check_acknowledgment(self):
+        """
+        check reply string for acknowledgement string
+        """
+        ret = super().read_bytes(1)
+        if ret == b"*":
+            return
+        # no valid acknowledgement message found
+        raise ValueError(
+            f"invalid reply '{ret}' found in acknowledgement check")
+
+    id = Instrument.measurement(
+        "Gi\x00\x01\x00\x00",
+        """ Device identification string """,
+        cast=str,
+        get_process=lambda d: d.decode()[2:-1].strip(),
+    )
+
+    serial = Instrument.measurement(
+        "Gi\x00\x02\x00\x00",
+        """ Serial number of the instrument """,
+        cast=str,
+        get_process=lambda d: d.decode()[2:-1].strip(),
+    )
+
+    pulse_params = Instrument.measurement(
+        "GE\x00\x00\x00\x00",
+        """ Get pulse on/off time of the pulse waveform """,
+        preprocess_reply=lambda d: struct.unpack(">HH", d),
+    )
+
+    frequency = Instrument.measurement(
+        "GF\x00\x00\x00\x00",
+        """ Get operating frequency in Hz""",
+        preprocess_reply=lambda d: struct.unpack(">L", d),
+    )
+
+    power = Instrument.measurement(
+        "GP\x00\x00\x00\x00",
+        """ Get power readings for forward/reverse/load power in watts """,
+        preprocess_reply=lambda d: struct.unpack(">HHH", d),
+        get_process=lambda d: (float(d[0])/10, float(d[1])/10, float(d[2])/10),
+    )
+
+    status = Instrument.measurement(
+        "GS\x00\x00\x00\x00",
+        """ Get status field, where used bit correspond to:
+        bit 14: Analog interface enabled,
+        bit 11: Interlock open,
+        bit 10: Over temperature,
+        bit 9: Reverse power limit,
+        bit 8: Forward power limit,
+        bit 6: MCG mode active,
+        bit 5: load power leveling active,
+        bit 4, External RF source active,
+        bit 0: RF power on.
+        """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[:2]),
+        get_process=lambda d: f"{d:016b}",
+    )
+
+    temperature = Instrument.measurement(
+        "GS\x00\x00\x00\x00",
+        """ Get heat sink temperature in deg Celsius """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[2:4]),
+        get_process=lambda d: float(d)/10,
+    )
+
+    tuner = Instrument.measurement(
+        "GS\x00\x00\x00\x00",
+        """ Get type of tuning. """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[6:]),
+        values={"none": 1, "AFT generator": 2,
+                "analog tuner": 3, "digital tuner": 4},
+        map_values=True,
+    )
+
+    power_limit = Instrument.measurement(
+        "Gp\x00\x00\x00\x00",
+        """ Get maximum power of the power supply. """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[2:4]),
+        get_process=lambda d: float(d)/10,
+    )
+
+    reverse_power_limit = Instrument.measurement(
+        "Gp\x00\x00\x00\x00",
+        """ Get maximum power reverse power. """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[18:20]),
+        get_process=lambda d: float(d)/10,
+    )
+
+    dc_voltage = Instrument.measurement(
+        "GT\x00\x00\x00\x00",
+        """ chamber DC voltage in volts. """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[6:8]),
+    )
+
+    operation_mode = Instrument.control(
+        "GS\x00\x00\x00\x00", "SO\x00%c\x00\x00",
+        """ operation mode """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[4:6]),
+        values={"normal": 1, "<invalid>": 2, "pulse": 3, "ramp": 4},
+        map_values=True,
+    )
+
+    setpoint = Instrument.control(
+        "GL\x00\x00\x00\x00", "SA%c%c\x00\x00",
+        """ setpoint power level in watts """,
+        preprocess_reply=lambda d: struct.unpack(">H", d),
+        get_process=lambda d: float(d)/10,
+        set_process=int2char,
+        validator=strict_discrete_set,
+        values=range(4001),
+    )
+
+    ramp_start_power = Instrument.control(
+        "GR\x00\x00\x00\x00", "RP%c%c\x00\x00",
+        """ ramp starting power in watts""",
+        preprocess_reply=lambda d: struct.unpack(">H", d[:2]),
+        set_process=int2char,
+        validator=strict_discrete_set,
+        values=range(1, 4001),
+    )
+
+    ramp_rate = Instrument.control(
+        "GR\x00\x00\x00\x00", "RR%c%c\x00\x00",
+        """ ramp rate in watts/second""",
+        preprocess_reply=lambda d: struct.unpack(">H", d[2:]),
+        set_process=int2char,
+        validator=strict_discrete_set,
+        values=range(1, 99),
+    )
+
+    load_capacity = Instrument.control(
+        "GT\x00\x00\x00\x00", "TC\x00\x01\x00%c",
+        """ percentage of full-scale value of the load capacity """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[2:4]),
+        get_process=lambda d: float(d)/10,
+        validator=strict_discrete_set,
+        values=range(101),
+    )
+
+    tune_capacity = Instrument.control(
+        "GT\x00\x00\x00\x00", "TC\x00\x02\x00%c",
+        """ percentage of full-scale value of the tune capacity """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[4:6]),
+        get_process=lambda d: float(d)/10,
+        validator=strict_discrete_set,
+        values=range(101),
+    )
+
+    rf_enable = Instrument.control(
+        "GS\x00\x00\x00\x00", "BR%c%c\x00\x00",
+        """ enable or disable RF output """,
+        preprocess_reply=lambda d: struct.unpack(">H", d[:2]),
+        get_process=lambda v: bool(v & 1),
+        set_process=lambda v: (85, 85) if v else (0, 0),
+        validator=strict_discrete_set,
+        values=(True, False),
+    )
+
+    def request_control(self):
+        self.write("BC\x55\x55\x00\x00")
+        print(int(struct.unpack(">H", self.read())[0]))
+
+    def release_control(self):
+        self.write("BC\x00\x00\x00\x00")
+        print(int(struct.unpack(">H", self.read())[0]))
+
+    def ping(self):
+        self.write("BP\x00\x00\x00\x00")

--- a/tests/instruments/tcpowerconversion/test_cxn.py
+++ b/tests/instruments/tcpowerconversion/test_cxn.py
@@ -31,7 +31,12 @@ def test_id():
     """Verify the communication of the id property."""
     with expected_protocol(
         CXN,
-        [(b'C\x00Gi\x00\x01\x00\x00\x00\xf4', b'\x2aR\x00\x00\x10\x00\x01AG 0313 GTC  \x00\x03\x10'), ],
+        [
+            (
+                b"C\x00Gi\x00\x01\x00\x00\x00\xf4",
+                b"\x2aR\x00\x00\x10\x00\x01AG 0313 GTC  \x00\x03\x10",
+            ),
+        ],
     ) as inst:
         assert inst.id == "AG 0313 GTC"
 
@@ -40,7 +45,12 @@ def test_power():
     """Verify the processing the power measurement."""
     with expected_protocol(
         CXN,
-        [(b'C\x00GP\x00\x00\x00\x00\x00\xda', b'\x2aR\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x58'), ],
+        [
+            (
+                b"C\x00GP\x00\x00\x00\x00\x00\xda",
+                b"\x2aR\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x58",
+            ),
+        ],
     ) as inst:
         assert inst.power == (0.0, 0.0, 0.0)
 
@@ -49,7 +59,12 @@ def test_temperature():
     """Verify the processing the temperature measurement."""
     with expected_protocol(
         CXN,
-        [(b'C\x00GS\x00\x00\x00\x00\x00\xdd', b'\x2aR\x00\x00\x08\x00\x10\x00\xdd\x00\x04\x00\x03\x01\x4e'), ],
+        [
+            (
+                b"C\x00GS\x00\x00\x00\x00\x00\xdd",
+                b"\x2aR\x00\x00\x08\x00\x10\x00\xdd\x00\x04\x00\x03\x01\x4e",
+            ),
+        ],
     ) as inst:
         assert inst.temperature == pytest.approx(22.1)
 
@@ -58,7 +73,13 @@ def test_power_limit():
     """Verify the processing the power limit property"""
     with expected_protocol(
         CXN,
-        [(b'C\x00Gp\x00\x00\x00\x00\x00\xfa', b'\x2aR\x00\x00\x144\xf8\x0b\xb8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff4\xf8\x02\xbc\x10\x33'), ],
+        [
+            (
+                b"C\x00Gp\x00\x00\x00\x00\x00\xfa",
+                b"\x2aR\x00\x00\x144\xf8\x0b\xb8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+                b"4\xf8\x02\xbc\x10\x33",
+            ),
+        ],
     ) as inst:
         assert inst.power_limit == pytest.approx(300.0)
 
@@ -67,7 +88,12 @@ def test_manual_mode():
     """Verify the processing the manual mode property"""
     with expected_protocol(
         CXN,
-        [(b'C\x00GT\x00\x00\x00\x00\x00\xde', b'\x2aR\x00\x00\n\x00\x01\x01\xa9\x02v\x00\x00\x00\x00\x01\x7f'), ],
+        [
+            (
+                b"C\x00GT\x00\x00\x00\x00\x00\xde",
+                b"\x2aR\x00\x00\n\x00\x01\x01\xa9\x02v\x00\x00\x00\x00\x01\x7f",
+            ),
+        ],
     ) as inst:
         assert inst.manual_mode is True
 
@@ -77,12 +103,15 @@ def test_load_capacity_preset(channel):
     """Verify the processing the load capacity propert via a Channel"""
     # here we use '%' for formating since encoding from strings makes troubles
     # with some values (e.g. \xff)
-    cmd = b'C\x00GU\x00%c\x00\x00' % (channel)
+    cmd = b"C\x00GU\x00%c\x00\x00" % (channel)
     cmd += CXN._checksum(cmd)
-    response = b'R\x00\x00\n\x00%c\x00\x32\x00\x32\xff\xff\xff\xff' % (channel)
+    response = b"R\x00\x00\n\x00%c\x00\x32\x00\x32\xff\xff\xff\xff" % (channel)
     response += CXN._checksum(response)
     print(cmd, response)
     with expected_protocol(
-        CXN, [(cmd, b'\x2a' + response), ],
+        CXN,
+        [
+            (cmd, b"\x2a" + response),
+        ],
     ) as inst:
         assert inst.presets[channel].load_capacity == 50

--- a/tests/instruments/tcpowerconversion/test_cxn.py
+++ b/tests/instruments/tcpowerconversion/test_cxn.py
@@ -1,0 +1,90 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.tcpowerconversion import CXN
+
+
+def test_id():
+    """Verify the communication of the id property."""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00Gi\x00\x01\x00\x00\x00\xf4', b'\x2aR\x00\x00\x10\x00\x01AG 0313 GTC  \x00\x03\x10'), ],
+    ) as inst:
+        assert inst.id == "AG 0313 GTC"
+
+
+def test_power():
+    """Verify the processing the power measurement."""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00GP\x00\x00\x00\x00\x00\xda', b'\x2aR\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x58'), ],
+    ) as inst:
+        assert inst.power == (0.0, 0.0, 0.0)
+
+
+def test_temperature():
+    """Verify the processing the temperature measurement."""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00GS\x00\x00\x00\x00\x00\xdd', b'\x2aR\x00\x00\x08\x00\x10\x00\xdd\x00\x04\x00\x03\x01\x4e'), ],
+    ) as inst:
+        assert inst.temperature == pytest.approx(22.1)
+
+
+def test_power_limit():
+    """Verify the processing the power limit property"""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00Gp\x00\x00\x00\x00\x00\xfa', b'\x2aR\x00\x00\x144\xf8\x0b\xb8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff4\xf8\x02\xbc\x10\x33'), ],
+    ) as inst:
+        assert inst.power_limit == pytest.approx(300.0)
+
+
+def test_manual_mode():
+    """Verify the processing the manual mode property"""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00GT\x00\x00\x00\x00\x00\xde', b'\x2aR\x00\x00\n\x00\x01\x01\xa9\x02v\x00\x00\x00\x00\x01\x7f'), ],
+    ) as inst:
+        assert inst.manual_mode is True
+
+
+def test_load_capacity():
+    """Verify the processing the load capacity property"""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00GU\x00\x01\x00\x00\x00\xe0', b'\x2aR\x00\x00\n\x00\x01\x002\x002\xff\xff\xff\xff\x04\xbd'), ],
+    ) as inst:
+        assert inst.load_capacity1 == 50
+
+
+def test_load_capacity_preset():
+    """Verify the processing the load capacity propert via a Channel"""
+    with expected_protocol(
+        CXN,
+        [(b'C\x00GU\x00\x01\x00\x00\x00\xe0', b'\x2aR\x00\x00\n\x00\x01\x002\x002\xff\xff\xff\xff\x04\xbd'), ],
+    ) as inst:
+        assert inst.preset_1.load_capacity == 50

--- a/tests/instruments/tcpowerconversion/test_cxn.py
+++ b/tests/instruments/tcpowerconversion/test_cxn.py
@@ -72,19 +72,17 @@ def test_manual_mode():
         assert inst.manual_mode is True
 
 
-def test_load_capacity():
-    """Verify the processing the load capacity property"""
-    with expected_protocol(
-        CXN,
-        [(b'C\x00GU\x00\x01\x00\x00\x00\xe0', b'\x2aR\x00\x00\n\x00\x01\x002\x002\xff\xff\xff\xff\x04\xbd'), ],
-    ) as inst:
-        assert inst.load_capacity1 == 50
-
-
-def test_load_capacity_preset():
+@pytest.mark.parametrize("channel", range(1, 10))
+def test_load_capacity_preset(channel):
     """Verify the processing the load capacity propert via a Channel"""
+    # here we use '%' for formating since encoding from strings makes troubles
+    # with some values (e.g. \xff)
+    cmd = b'C\x00GU\x00%c\x00\x00' % (channel)
+    cmd += CXN._checksum(cmd)
+    response = b'R\x00\x00\n\x00%c\x00\x32\x00\x32\xff\xff\xff\xff' % (channel)
+    response += CXN._checksum(response)
+    print(cmd, response)
     with expected_protocol(
-        CXN,
-        [(b'C\x00GU\x00\x01\x00\x00\x00\xe0', b'\x2aR\x00\x00\n\x00\x01\x002\x002\xff\xff\xff\xff\x04\xbd'), ],
+        CXN, [(cmd, b'\x2a' + response), ],
     ) as inst:
-        assert inst.preset_1.load_capacity == 50
+        assert inst.presets[channel].load_capacity == 50

--- a/tests/instruments/tcpowerconversion/test_cxn.py
+++ b/tests/instruments/tcpowerconversion/test_cxn.py
@@ -42,7 +42,7 @@ def test_id():
 
 
 def test_power():
-    """Verify the processing the power measurement."""
+    """Verify processing the power measurement."""
     with expected_protocol(
         CXN,
         [
@@ -56,7 +56,7 @@ def test_power():
 
 
 def test_temperature():
-    """Verify the processing the temperature measurement."""
+    """Verify processing the temperature measurement."""
     with expected_protocol(
         CXN,
         [
@@ -69,8 +69,25 @@ def test_temperature():
         assert inst.temperature == pytest.approx(22.1)
 
 
+def test_status():
+    """Verify processing the status IntFlag."""
+    with expected_protocol(
+        CXN,
+        [
+            (
+                b"C\x00GS\x00\x00\x00\x00\x00\xdd",
+                b"\x2aR\x00\x00\x08\x00\x11\x00\xdd\x00\x04\x00\x03\x01\x4f",
+            ),
+        ],
+    ) as inst:
+        status = inst.status
+        assert CXN.Status.EXTERNAL_RFSOURCE in status
+        assert CXN.Status.RF_ENABLED in status
+        assert CXN.Status.RF_ENABLED | CXN.Status.EXTERNAL_RFSOURCE == status
+
+
 def test_power_limit():
-    """Verify the processing the power limit property"""
+    """Verify processing the power limit property"""
     with expected_protocol(
         CXN,
         [
@@ -85,7 +102,7 @@ def test_power_limit():
 
 
 def test_manual_mode():
-    """Verify the processing the manual mode property"""
+    """Verify processing the manual mode property"""
     with expected_protocol(
         CXN,
         [
@@ -100,14 +117,13 @@ def test_manual_mode():
 
 @pytest.mark.parametrize("channel", range(1, 10))
 def test_load_capacity_preset(channel):
-    """Verify the processing the load capacity propert via a Channel"""
+    """Verify processing the load capacity propert via a Channel"""
     # here we use '%' for formating since encoding from strings makes troubles
     # with some values (e.g. \xff)
     cmd = b"C\x00GU\x00%c\x00\x00" % (channel)
     cmd += CXN._checksum(cmd)
     response = b"R\x00\x00\n\x00%c\x00\x32\x00\x32\xff\xff\xff\xff" % (channel)
     response += CXN._checksum(response)
-    print(cmd, response)
     with expected_protocol(
         CXN,
         [


### PR DESCRIPTION
This adds a new Instrument. An RF power supply for magnetron sputtering. 

This instrument is largely based on binary communication, which makes overwriting `read/write/values` methods necessary. Every command sent to the instrument is acknowledged, and the response messages are quite structured: they use some header and checksum fields and do not use any terminator. The tests give a flavor of the kind of communication.

Additionally, due to the issue outlined in #784 I split `values` into two functions which allows using the `Channels` with the overwritten `values` method of the parent `Instrument`. This approach was suggested in #784.