### PR TITLE
Drop str conversion in values

### DIFF
--- a/docs/dev/adding_instruments.rst
+++ b/docs/dev/adding_instruments.rst
@@ -1068,14 +1068,14 @@ Some devices do not expect ASCII strings but raw bytes. In those cases, you can 
             self.write_bytes(bytes(b))
     
         def read(self):
-            """Read the response and return the data as an integer, if applicable."""
+            """Read the response and return the data as a string, if applicable."""
             response = self.read_bytes(2)  # return type and payload
             if response[0] == 0x00:
                 raise ConnectionError(f"Device error of type {response[1]} occurred.")
             if response[0] == 0x03:
                 # read that many bytes and return them as an integer
                 data = self.read_bytes(response[1])
-                return int.from_bytes(data, byteorder="big", signed=True)
+                return str(int.from_bytes(data, byteorder="big", signed=True))
             if response[0] == 0x10 and response[1] != 0x00:
                 raise ConnectionError(f"Writing to the device failed with error {response[1]}")
     

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -303,7 +303,7 @@ class CommonBase:
         :param maxsplit: At most `maxsplit` splits are done. -1 (default) indicates no limit.
         :returns: A list of the desired type, or strings where the casting fails
         """
-        results = str(self.ask(command)).strip()
+        results = self.ask(command).strip()
         if callable(preprocess_reply):
             results = preprocess_reply(results)
         results = results.split(separator, maxsplit=maxsplit)

--- a/pymeasure/instruments/hcp/tc038d.py
+++ b/pymeasure/instruments/hcp/tc038d.py
@@ -99,7 +99,7 @@ class TC038D(Instrument):
         self.write_bytes(bytes(data))
 
     def read(self):
-        """Read response and interpret the number"""
+        """Read response and interpret the number, returning it as a string."""
         # Slave address, function
         got = self.read_bytes(2)
         if got[1] == Functions.R:
@@ -109,7 +109,7 @@ class TC038D(Instrument):
             read = self.read_bytes(length[0] + 2)
             if read[-2:] != bytes(CRC16(got + length + read[:-2])):
                 raise ConnectionError("Response CRC does not match.")
-            return int.from_bytes(read[:-2], byteorder="big", signed=True)
+            return str(int.from_bytes(read[:-2], byteorder="big", signed=True))
         elif got[1] == Functions.W:
             # start address, number elements, CRC; each 2 Bytes long
             got += self.read_bytes(2 + 2 + 2)
@@ -120,7 +120,7 @@ class TC038D(Instrument):
             got += self.read_bytes(2 + 2 + 2)
             if got[-2:] != bytes(CRC16(got[:-2])):
                 raise ConnectionError("Response CRC does not match.")
-            return int.from_bytes(got[-4:-2], "big")
+            return str(int.from_bytes(got[-4:-2], "big"))
         else:  # an error occurred
             # got[1] is functioncode + 0x80
             end = self.read_bytes(3)  # error code and CRC
@@ -138,7 +138,7 @@ class TC038D(Instrument):
 
     def ping(self, test_data=0):
         """Test the connection sending an integer up to 65535, checks the response."""
-        assert self.ask(f"ECHO,0,{test_data}") == test_data
+        assert int(self.ask(f"ECHO,0,{test_data}")) == test_data
 
     setpoint = Instrument.control(
         "R,0x106", "W,0x106,%i",


### PR DESCRIPTION
As discussed in #784 , the str conversion in the beginning of `values` is superfluous, as `read` returns strings on default. If you want to work with bytes, this string conversion raises Exceptions, therefore I removed it.

The TC038D relied on this conversion, therefore I fixed it.