### PR TITLE
34401A driver improvement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,18 @@ New adapter and instrument mechanics
 - Channel class added. Instrument.channels and Instrument.ch_X (X is any channel name) are reserved for channel implementations.
 - All instruments are required to accept a :code:`name` argument.
 
+Deprecated features
+-------------------
+- HP 34401A: :code:`voltage_ac`, :code:`current_dc`, :code:`current_ac`, :code:`resistance`, :code:`resistance_4w` properties,
+  use :code:`function_` and :code:`reading` properties instead.
+
+
 Version 0.11.0 (2022-11-19)
 ===========================
 Main items of this new release:
 
 - 11 new instrument drivers have been added
-- A method for testing instrument communication **without** hardware present has been added, see `the documentation <https://pymeasure.readthedocs.io/en/latest/dev/adding_instruments.html#protocol-tests>`__. 
+- A method for testing instrument communication **without** hardware present has been added, see `the documentation <https://pymeasure.readthedocs.io/en/latest/dev/adding_instruments.html#protocol-tests>`__.
 - The separation between :code:`Instrument` and :code:`Adapter` has been improved to make future modifications easier. Adapters now focus on the hardware communication, and the communication *protocol* should be defined in the Instruments. Details in a section below.
 - The GUI is now compatible with Qt6.
 - We have started to clean up our API in preparation for a future version 1.0. There will be deprecations and subsequent removals, which will be prominently listed in the changelog.

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -36,6 +36,22 @@ def _deprecation_warning(property_name):
 
 
 class HP34401A(Instrument):
+    """ Represents the HP / Agilent / Keysight 34401A Multimeter and
+    provides a high-level interface for interacting with the instrument.
+
+    .. code-block:: python
+
+        dmm = HP34401A("GPIB::1")
+        dmm.function_ = "DCV"
+        print(dmm.reading)  # -> Single float reading
+
+        dmm.nplc = 0.02
+        dmm.autozero_enabled = False
+        dmm.trigger_count = 100
+        dmm.trigger_delay = "MIN"
+        print(dmm.reading)  # -> Array of 100 very fast readings
+
+    """
     FUNCTIONS = {"DCV": "VOLT", "DCV_RATIO": "VOLT:RAT",
                  "ACV": "VOLT:AC", "DCI": "CURR", "ACI": "CURR:AC",
                  "R2W": "RES", "R4W": "FRES", "FREQ": "FREQ",

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -82,7 +82,8 @@ class HP34401A(Instrument):
         validator=strict_discrete_set,
         values=FUNCTIONS,
         map_values=True,
-        get_process=lambda v: v.strip('"'))
+        get_process=lambda v: v.strip('"')
+    )
 
     range_ = Instrument.control(
         "<function_prefix_for_range>:RANG?", "<function_prefix_for_range>:RANG %s",
@@ -107,8 +108,9 @@ class HP34401A(Instrument):
         Not valid for frequency, period, or ratio.
         Specify the resolution in the same units as the
         measurement function, not in number of digits.
+        Results in a "Settings Conflict" error if autorange is enabled.
         MIN selects the smallest value accepted, which gives the most resolution.
-        MAX selects the largest value accepted which gives the least resolution.""",
+        MAX selects the largest value accepted which gives the least resolution."""
     )
 
     nplc = Instrument.control(
@@ -119,7 +121,7 @@ class HP34401A(Instrument):
         This command is valid only for dc volts, ratio, dc current,
         2-wire ohms, and 4-wire ohms.""",
         validator=strict_discrete_set,
-        values=[0.02, 0.2, 1, 10, 100, "MIN", "MAX"],
+        values=[0.02, 0.2, 1, 10, 100, "MIN", "MAX"]
     )
 
     gate_time = Instrument.control(
@@ -130,7 +132,7 @@ class HP34401A(Instrument):
         Specifically:  10 ms (4.5 digits), 100 ms (default; 5.5 digits),
         or 1 second (6.5 digits).""",
         validator=strict_discrete_set,
-        values=[0.01, 0.1, 1, "MIN", "MAX"],
+        values=[0.01, 0.1, 1, "MIN", "MAX"]
     )
 
     detector_bandwidth = Instrument.control(
@@ -139,14 +141,16 @@ class HP34401A(Instrument):
 
         Valid values: 3, 20, 200, "MIN", "MAX".""",
         validator=strict_discrete_set,
-        values=[3, 20, 200, "MIN", "MAX"])
+        values=[3, 20, 200, "MIN", "MAX"]
+    )
 
     autozero_enabled = Instrument.control(
         "ZERO:AUTO?", "ZERO:AUTO %s",
         """Control the autozero state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True)
+        map_values=True
+    )
 
     def trigger_single_autozero(self):
         """Trigger an autozero measurement.
@@ -164,7 +168,8 @@ class HP34401A(Instrument):
         >10 GOhms for the 100 mV, 1 V, and 10 V ranges.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True)
+        map_values=True
+    )
 
     terminals_used = Instrument.measurement(
         "ROUT:TERM?",
@@ -173,7 +178,8 @@ class HP34401A(Instrument):
 
         Returns "FRONT" or "REAR".""",
         values={"FRONT": "FRON", "REAR": "REAR"},
-        map_values=True)
+        map_values=True
+    )
 
     # Trigger related commands
     def init_trigger(self):
@@ -188,7 +194,8 @@ class HP34401A(Instrument):
         """Take a measurement of the currently selected function.
 
         Reading this property is equivalent to calling `init_trigger()`,
-        waiting for completion and fetching the reading(s).""")
+        waiting for completion and fetching the reading(s)."""
+    )
 
     trigger_source = Instrument.control(
         "TRIG:SOUR?", "TRIG:SOUR %s",
@@ -199,15 +206,15 @@ class HP34401A(Instrument):
         an immediate internal trigger (this is the default source),
         or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""",
         validator=strict_discrete_set,
-        values=["IMM", "BUS", "EXT"])
+        values=["IMM", "BUS", "EXT"]
+    )
 
     trigger_delay = Instrument.control(
         "TRIG:DEL?", "TRIG:DEL %s",
         """Control the trigger delay in seconds.
 
-        Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX".""",
-        # Use check_set_errors instead of strict_range validator to allow "MIN" and "MAX"
-        check_set_errors=True)
+        Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX"."""
+    )
 
     trigger_auto_delay_enabled = Instrument.control(
         "TRIG:DEL:AUTO?", "TRIG:DEL:AUTO %s",
@@ -218,14 +225,15 @@ class HP34401A(Instrument):
         automatically turns off the automatic trigger delay.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True)
+        map_values=True
+    )
 
     sample_count = Instrument.control(
         "SAMP:COUN?", "SAMP:COUN %s",
         """Controls the number of samples per trigger event.
 
-        Valid values: 1 to 50000, "MIN", "MAX".""",
-        check_set_errors=True)
+        Valid values: 1 to 50000, "MIN", "MAX"."""
+    )
 
     trigger_count = Instrument.control(
         "TRIG:COUN?", "TRIG:COUN %s",
@@ -233,15 +241,16 @@ class HP34401A(Instrument):
 
         Valid values: 1 to 50000, "MIN", "MAX", "INF".
         The INFinite parameter instructs the multimeter to continuously accept triggers
-        (you must send a device clear to return to the "idle" state).""",
-        check_set_errors=True)
+        (you must send a device clear to return to the "idle" state)."""
+    )
 
     stored_reading = Instrument.measurement(
         "FETC?",
         """Measure the reading(s) currently stored in the multimeter's internal memory.
 
         Reading this property will NOT initialize a trigger.
-        If you need that, use the `reading` property instead.""")
+        If you need that, use the `reading` property instead."""
+    )
 
     # Display related commands
     display_enabled = Instrument.control(
@@ -249,7 +258,8 @@ class HP34401A(Instrument):
         """Control the display state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True)
+        map_values=True
+    )
 
     displayed_text = Instrument.control(
         "DISP:TEXT?", "DISP:TEXT \"%s\"",
@@ -257,7 +267,8 @@ class HP34401A(Instrument):
 
         The text can be up to 12 characters long;
         any additional characters are truncated my the multimeter.""",
-        get_process=lambda x: x.strip('"'))
+        get_process=lambda x: x.strip('"')
+    )
 
     # System related commands
     def beep(self):
@@ -269,22 +280,26 @@ class HP34401A(Instrument):
         """Control whether the beeper is enabled.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True)
+        map_values=True
+    )
 
     scpi_version = Instrument.measurement(
         "SYST:VERS?",
-        """The SCPI version of the multimeter.""")
+        """The SCPI version of the multimeter."""
+    )
 
     stored_readings_count = Instrument.measurement(
         "DATA:POIN?",
-        """The number of readings currently stored in the multimeter's internal memory.""")
+        """The number of readings currently stored in the multimeter's internal memory."""
+    )
 
     self_test_result = Instrument.measurement(
         "*TST?",
         """Initiate a self-test of the multimeter and return the result.
 
         Be sure to set an appropriate connection timeout,
-        otherwise the command will fail.""")
+        otherwise the command will fail."""
+    )
 
     def write(self, command):
         """Write a command to the instrument."""

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -23,24 +23,24 @@
 #
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_discrete_set
 
 
 class HP34401A(Instrument):
     """ Represents the HP 34401A instrument.
     """
 
-    voltage_dc = Instrument.measurement("MEAS:VOLT:DC? DEF,DEF", "DC voltage, in Volts")
+    FUNCTIONS = {"DCV": "VOLT", "DCV_RATIO": "VOLT:RAT",
+                 "ACV": "VOLT:AC", "DCI": "CURR", "ACI": "CURR:AC",
+                 "R2W": "RES", "R4W": "FRES", "FREQ": "FREQ",
+                 "PERIOD": "PER", "CONTINUITY": "CONT", "DIODE": "DIOD"}
 
-    voltage_ac = Instrument.measurement("MEAS:VOLT:AC? DEF,DEF", "AC voltage, in Volts")
+    FUNCTIONS_WITH_RANGE = {
+        "DCV": "VOLT", "ACV": "VOLT:AC", "DCI": "CURR",
+        "ACI": "CURR:AC", "R2W": "RES", "R4W": "FRES",
+        "FREQ": "FREQ", "PERIOD": "PER"}
 
-    current_dc = Instrument.measurement("MEAS:CURR:DC? DEF,DEF", "DC current, in Amps")
-
-    current_ac = Instrument.measurement("MEAS:CURR:AC? DEF,DEF", "AC current, in Amps")
-
-    resistance = Instrument.measurement("MEAS:RES? DEF,DEF", "Resistance, in Ohms")
-
-    resistance_4w = Instrument.measurement(
-        "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms")
+    BOOL_MAPPINGS = {True: 1, False: 0}
 
     def __init__(self, adapter, **kwargs):
         super().__init__(
@@ -49,3 +49,141 @@ class HP34401A(Instrument):
             asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},
             **kwargs
         )
+
+    function_ = Instrument.control(
+        "FUNC?", "FUNC \"%s\"",
+        """ A string property that controls the measurement function,
+        which can take the values: DCV, DCV_RATIO, ACV, DCI, ACI,
+        R2W, R4W, FREQ, PERIOD, CONTINUITY, DIODE. """,
+        validator=strict_discrete_set,
+        values=FUNCTIONS,
+        map_values=True,
+        get_process=lambda v: v.strip('"'))
+
+    @property
+    def range_(self):
+        """ A float property that sets the range for the currently active function.
+        For frequency and period measurements, ranging applies to
+        the signal's input voltage, not its frequency"""
+        command = f"{self._get_function_range_prefix()}:RANG?"
+        return float(self.ask(command))
+
+    @range_.setter
+    def range_(self, value):
+        command = f"{self._get_function_range_prefix()}:RANG {value}"
+        self.write(command)
+
+    @property
+    def auto_range_enabled(self):
+        """ A boolean property that controls the autorange state
+        for the currently active function. """
+        command = f"{self._get_function_range_prefix()}:RANG:AUTO?"
+        return self.ask(command).strip() == "1"
+
+    @auto_range_enabled.setter
+    def auto_range_enabled(self, value):
+        command = f"{self._get_function_range_prefix()}:RANG:AUTO {HP34401A.BOOL_MAPPINGS[value]}"
+        self.write(command)
+
+    @property
+    def resolution(self):
+        """ A property that controls the measurement resolution.
+        Not valid for frequency, period, or ratio.
+        Specify the resolution in the same units as the
+        measurement function, not in number of digits.
+        MIN selects the smallest value accepted, which gives the most resolution.
+        MAX selects the largest value accepted which gives the least resolution. """
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:RES?"
+        return float(self.ask(command))
+
+    @resolution.setter
+    def resolution(self, value):
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:RES {value}"
+        self.write(command)
+
+    @property
+    def nplc(self):
+        """ A float / string property that controls the integration time in
+        number of power line cycles for the currently active function
+        (the default is 10 PLC).
+        Valid values: 0.02, 0.2, 1, 10, 100
+        The strings "MIN" for 0.02 and "MAX" = 100 are also valid.
+        This command is valid only for dc volts, ratio, dc current,
+        2-wire ohms, and 4-wire ohms.
+        """
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:NPLC?"
+        return float(self.ask(command))
+
+    @nplc.setter
+    def nplc(self, value):
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:NPLC {value}"
+        self.write(command)
+
+    @property
+    def gate_time(self):
+        """ Select the gate time (or aperture time)
+        for frequency or period measurements (the default is 0.1 seconds).
+        Valid values: 0.01, 0.1, 1.
+        Specifically:  10 ms (4.5 digits), 100 ms (default; 5.5 digits),
+        or 1 second (6.5 digits). MIN = 0.01 seconds. MAX = 1 second. """
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:APER?"
+        return float(self.ask(command))
+
+    @gate_time.setter
+    def gate_time(self, value):
+        command = f"{HP34401A.FUNCTIONS[self.function_]}:APER {value}"
+        self.write(command)
+
+    detector_bandwidth = Instrument.control(
+        "DET:BAND?", "DET:BAND %s",
+        """ A float / string property that controls the lowest frequency
+        expected in the input signal in Hertz.
+        Valid values: 3, 20, 200, MIN, MAX
+        """)
+
+    autozero_enabled = Instrument.control(
+        "ZERO:AUTO?", "ZERO:AUTO %s",
+        """ A boolean property that controls the autozero state. """,
+        validator=strict_discrete_set,
+        values=BOOL_MAPPINGS,
+        map_values=True)
+
+    def trigger_single_autozero(self):
+        """ Triggers an autozero measurement.
+        Consequent autozero measurements are disabled. """
+        self.write("ZERO:AUTO ONCE")
+
+    auto_input_impedance_enabled = Instrument.control(
+        "INP:IMP:AUTO?", "INP:IMP:AUTO %s",
+        """ A boolean property to enable or disable the automatic
+        input resistance mode for dc voltage measurements.
+        With AUTO OFF (default), the input resistance is fixed
+        at 10 MΩ for all ranges. With AUTO ON, the input resistance is set to
+        >10 GOhms for the 100 mV, 1 V, and 10 V ranges. """,
+        validator=strict_discrete_set,
+        values=BOOL_MAPPINGS,
+        map_values=True)
+
+    terminals_used = Instrument.measurement(
+        "ROUT:TERM?",
+        """ Query the multimeter to determine if the front or rear input terminals
+            are selected. Returns "FRONT" or "REAR". """,
+        values={"FRONT": "FRON", "REAR": "REAR"},
+        map_values=True)
+
+    reading = Instrument.measurement(
+        "READ?",
+        """ The reading of the currently selected function. """)
+
+    display_enabled = Instrument.control(
+        "DISP?", "DISP %s",
+        """ A boolean property that controls the display state. """,
+        validator=strict_discrete_set,
+        values=BOOL_MAPPINGS,
+        map_values=True)
+
+    def _get_function_range_prefix(self):
+        function_prefix = HP34401A.FUNCTIONS_WITH_RANGE[self.function_]
+        if function_prefix in ["FREQ", "PER"]:
+            function_prefix += ":VOLT"
+        return function_prefix

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -266,7 +266,9 @@ class HP34401A(Instrument):
     self_test_result = Instrument.measurement(
         "*TST?",
         """ A boolean property that, if read,
-        initiates a self-test of the multimeter and returns the result. """)
+        initiates a self-test of the multimeter and returns the result.
+        Be sure to set an appropriate connection timeout,
+        otherwise the command will fail. """)
 
     def _get_function_range_prefix(self):
         function_prefix = HP34401A.FUNCTIONS_WITH_RANGE[self.function_]

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -27,9 +27,6 @@ from pymeasure.instruments.validators import strict_discrete_set
 
 
 class HP34401A(Instrument):
-    """ Represents the HP 34401A instrument.
-    """
-
     FUNCTIONS = {"DCV": "VOLT", "DCV_RATIO": "VOLT:RAT",
                  "ACV": "VOLT:AC", "DCI": "CURR", "ACI": "CURR:AC",
                  "R2W": "RES", "R4W": "FRES", "FREQ": "FREQ",
@@ -52,9 +49,10 @@ class HP34401A(Instrument):
 
     function_ = Instrument.control(
         "FUNC?", "FUNC \"%s\"",
-        """ A string property that controls the measurement function,
-        which can take the values: DCV, DCV_RATIO, ACV, DCI, ACI,
-        R2W, R4W, FREQ, PERIOD, CONTINUITY, DIODE. """,
+        """Control the measurement function.
+
+        Allowed values: "DCV", "DCV_RATIO", "ACV", "DCI", "ACI",
+        "R2W", "R4W", "FREQ", "PERIOD", "CONTINUITY", "DIODE".""",
         validator=strict_discrete_set,
         values=FUNCTIONS,
         map_values=True,
@@ -62,7 +60,8 @@ class HP34401A(Instrument):
 
     @property
     def range_(self):
-        """ A float property that sets the range for the currently active function.
+        """Control the range for the currently active function.
+
         For frequency and period measurements, ranging applies to
         the signal's input voltage, not its frequency"""
         command = f"{self._get_function_range_prefix()}:RANG?"
@@ -75,8 +74,7 @@ class HP34401A(Instrument):
 
     @property
     def autorange(self):
-        """ A boolean property that controls the autorange state
-        for the currently active function. """
+        """Control the autorange state for the currently active function."""
         command = f"{self._get_function_range_prefix()}:RANG:AUTO?"
         return self.ask(command).strip() == "1"
 
@@ -87,12 +85,13 @@ class HP34401A(Instrument):
 
     @property
     def resolution(self):
-        """ A property that controls the measurement resolution.
+        """Control the resolution of the measurements.
+
         Not valid for frequency, period, or ratio.
         Specify the resolution in the same units as the
         measurement function, not in number of digits.
         MIN selects the smallest value accepted, which gives the most resolution.
-        MAX selects the largest value accepted which gives the least resolution. """
+        MAX selects the largest value accepted which gives the least resolution."""
         command = f"{HP34401A.FUNCTIONS[self.function_]}:RES?"
         return float(self.ask(command))
 
@@ -103,14 +102,11 @@ class HP34401A(Instrument):
 
     @property
     def nplc(self):
-        """ A float / string property that controls the integration time in
-        number of power line cycles for the currently active function
-        (the default is 10 PLC).
-        Valid values: 0.02, 0.2, 1, 10, 100
-        The strings "MIN" for 0.02 and "MAX" = 100 are also valid.
+        """Control the integration time in number of power line cycles (NPLC).
+
+        Valid values: 0.02, 0.2, 1, 10, 100, "MIN", "MAX".
         This command is valid only for dc volts, ratio, dc current,
-        2-wire ohms, and 4-wire ohms.
-        """
+        2-wire ohms, and 4-wire ohms."""
         command = f"{HP34401A.FUNCTIONS[self.function_]}:NPLC?"
         return float(self.ask(command))
 
@@ -121,11 +117,11 @@ class HP34401A(Instrument):
 
     @property
     def gate_time(self):
-        """ Select the gate time (or aperture time)
-        for frequency or period measurements (the default is 0.1 seconds).
-        Valid values: 0.01, 0.1, 1.
+        """Control the gate time (or aperture time) for frequency or period measurements.
+
+        Valid values: 0.01, 0.1, 1, "MIN", "MAX".
         Specifically:  10 ms (4.5 digits), 100 ms (default; 5.5 digits),
-        or 1 second (6.5 digits). MIN = 0.01 seconds. MAX = 1 second. """
+        or 1 second (6.5 digits)."""
         command = f"{HP34401A.FUNCTIONS[self.function_]}:APER?"
         return float(self.ask(command))
 
@@ -136,139 +132,148 @@ class HP34401A(Instrument):
 
     detector_bandwidth = Instrument.control(
         "DET:BAND?", "DET:BAND %s",
-        """ A float / string property that controls the lowest frequency
-        expected in the input signal in Hertz.
-        Valid values: 3, 20, 200, MIN, MAX
-        """)
+        """Control the lowest frequency expected in the input signal in Hertz.
+
+        Valid values: 3, 20, 200, "MIN", "MAX".""")
 
     autozero_enabled = Instrument.control(
         "ZERO:AUTO?", "ZERO:AUTO %s",
-        """ A boolean property that controls the autozero state. """,
+        """Control the autozero state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
         map_values=True)
 
     def trigger_single_autozero(self):
-        """ Triggers an autozero measurement.
-        Consequent autozero measurements are disabled. """
+        """Trigger an autozero measurement.
+
+        Consequent autozero measurements are disabled."""
         self.write("ZERO:AUTO ONCE")
 
     auto_input_impedance_enabled = Instrument.control(
         "INP:IMP:AUTO?", "INP:IMP:AUTO %s",
-        """ A boolean property to enable or disable the automatic
-        input resistance mode for dc voltage measurements.
-        With AUTO OFF (default), the input resistance is fixed
-        at 10 MΩ for all ranges. With AUTO ON, the input resistance is set to
-        >10 GOhms for the 100 mV, 1 V, and 10 V ranges. """,
+        """Control if automatic input resistance mode is enabled.
+
+        Only valid for dc voltage measurements.
+        When disabled (default), the input resistance is fixed
+        at 10 MOhms for all ranges. With AUTO ON, the input resistance is set to
+        >10 GOhms for the 100 mV, 1 V, and 10 V ranges.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
         map_values=True)
 
     terminals_used = Instrument.measurement(
         "ROUT:TERM?",
-        """ Query the multimeter to determine if the front or rear input terminals
-            are selected. Returns "FRONT" or "REAR". """,
+        """Query the multimeter to determine if the front or rear input terminals
+        are selected.
+
+        Returns "FRONT" or "REAR".""",
         values={"FRONT": "FRON", "REAR": "REAR"},
         map_values=True)
 
     # Trigger related commands
     def init_trigger(self):
-        """ This command changes the state of the triggering system
-        from the "idle" state to the "wait-for-trigger" state.
+        """Set the state of the triggering system to "wait-for-trigger".
+
         Measurements will begin when the specified trigger conditions
-        are satisfied after this command is received """
+        are satisfied after this command is received."""
         self.write("INIT")
 
     reading = Instrument.measurement(
         "READ?",
-        """ The reading(s) of the currently selected function.
+        """Take a measurement of the currently selected function.
+
         Reading this property is equivalent to calling `init_trigger()`,
-        waiting for completion and fetching the reading(s). """)
+        waiting for completion and fetching the reading(s).""")
 
     trigger_source = Instrument.control(
         "TRIG:SOUR?", "TRIG:SOUR %s",
-        """ A string property that controls the trigger source.
-        Valid values: IMM, BUS, EXT
+        """Control the trigger source.
+
+        Valid values: "IMM", "BUS", "EXT"
         The multimeter will accept a software (bus) trigger,
         an immediate internal trigger (this is the default source),
-        or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal. """)
+        or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""")
 
     trigger_delay = Instrument.control(
         "TRIG:DEL?", "TRIG:DEL %s",
-        """ A float / string property that controls the trigger delay in seconds.
-        Valid values: 0 to 3600 seconds, "MIN" or "MAX". """)
+        """Control the trigger delay in seconds.
+
+        Valid values: 0 to 3600 seconds, "MIN", "MAX".""")
 
     trigger_auto_delay_enabled = Instrument.control(
         "TRIG:DEL:AUTO?", "TRIG:DEL:AUTO %s",
-        """ A boolean property that controls the automatic trigger delay state.
+        """Control the automatic trigger delay state.
+
         If enabled, the delay is determined by function, range, integration time,
         and ac filter setting. Selecting a specific trigger delay value
-        automatically turns off the automatic trigger delay. """,
+        automatically turns off the automatic trigger delay.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
         map_values=True)
 
     sample_count = Instrument.control(
         "SAMP:COUN?", "SAMP:COUN %s",
-        """ A integer property that controls the number of samples to be taken
-        for each trigger event. Valid values: 1 to 50000, "MIN" or "MAX". """)
+        """Controls the number of samples per trigger event.
+
+        Valid values: 1 to 50000, "MIN", "MAX".""")
 
     trigger_count = Instrument.control(
         "TRIG:COUN?", "TRIG:COUN %s",
-        """ A integer property that controls the number of triggers the multimeter
-        will accept before returning to the "idle" state.
-        Valid values: 1 to 50000, "MIN", "MAX" or "INF".
+        """Control the number of triggers accepted before returning to the "idle" state.
+
+        Valid values: 1 to 50000, "MIN", "MAX", "INF".
         The INFinite parameter instructs the multimeter to continuously accept triggers
-        (you must send a device clear to return to the "idle" state). """)
+        (you must send a device clear to return to the "idle" state).""")
 
     stored_reading = Instrument.measurement(
         "FETC?",
-        """ This property returns the reading(s) currently stored in the
-        multimeter's internal memory. Reading this property will NOT initialize a trigger.
-        If you need that, use the `reading` property instead. """)
+        """Measure the reading(s) currently stored in the multimeter's internal memory.
+
+        Reading this property will NOT initialize a trigger.
+        If you need that, use the `reading` property instead.""")
 
     # Display related commands
     display_enabled = Instrument.control(
         "DISP?", "DISP %s",
-        """ A boolean property that controls the display state. """,
+        """Control the display state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
         map_values=True)
 
     displayed_text = Instrument.control(
         "DISP:TEXT?", "DISP:TEXT \"%s\"",
-        """ A string property that controls the text that is displayed on the
-        multimeter's display. The text can be up to 12 characters long;
-        any additional characters are truncated my the multimeter. """,
+        """Control the text displayed on the multimeter's display.
+
+        The text can be up to 12 characters long;
+        any additional characters are truncated my the multimeter.""",
         get_process=lambda x: x.strip('"'))
 
     # System related commands
     def beep(self):
-        """ This command causes the multimeter to beep once. """
+        """This command causes the multimeter to beep once."""
         self.write("SYST:BEEP")
 
     beeper_enabled = Instrument.control(
         "SYST:BEEP:STAT?", "SYST:BEEP:STAT %s",
-        """ A boolean property that controls if the beeper is enabled. """,
+        """Control whether the beeper is enabled.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
         map_values=True)
 
     scpi_version = Instrument.measurement(
         "SYST:VERS?",
-        """ Query the SCPI version of the multimeter. """)
+        """The SCPI version of the multimeter.""")
 
     stored_readings_count = Instrument.measurement(
         "DATA:POIN?",
-        """ Query the number of readings currently stored
-        in the multimeter's internal memory. """)
+        """The number of readings currently stored in the multimeter's internal memory.""")
 
     self_test_result = Instrument.measurement(
         "*TST?",
-        """ A boolean property that, if read,
-        initiates a self-test of the multimeter and returns the result.
+        """Initiate a self-test of the multimeter and return the result.
+
         Be sure to set an appropriate connection timeout,
-        otherwise the command will fail. """)
+        otherwise the command will fail.""")
 
     def _get_function_range_prefix(self):
         function_prefix = HP34401A.FUNCTIONS_WITH_RANGE[self.function_]

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -27,10 +27,16 @@ from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
 
+deprecated_text = """
+
+.. deprecated:: 0.12 Use the :code:`function_` and :code:`reading` properties instead.
+"""
+
+
 def _deprecation_warning(property_name):
     def func(x):
         warn(f'Deprecated property name "{property_name}", use the "function_" '
-             'and "reading" properties instead.', DeprecationWarning)
+             'and "reading" properties instead.', FutureWarning)
         return x
     return func
 
@@ -73,20 +79,25 @@ class HP34401A(Instrument):
         )
 
     # Log a deprecated warning for the old function property
-    voltage_ac = Instrument.measurement("MEAS:VOLT:AC? DEF,DEF", "AC voltage, in Volts",
+    voltage_ac = Instrument.measurement("MEAS:VOLT:AC? DEF,DEF",
+                                        "AC voltage, in Volts" + deprecated_text,
                                         get_process=_deprecation_warning('voltage_ac'))
 
-    current_dc = Instrument.measurement("MEAS:CURR:DC? DEF,DEF", "DC current, in Amps",
+    current_dc = Instrument.measurement("MEAS:CURR:DC? DEF,DEF",
+                                        "DC current, in Amps" + deprecated_text,
                                         get_process=_deprecation_warning('current_dc'))
 
-    current_ac = Instrument.measurement("MEAS:CURR:AC? DEF,DEF", "AC current, in Amps",
+    current_ac = Instrument.measurement("MEAS:CURR:AC? DEF,DEF",
+                                        "AC current, in Amps" + deprecated_text,
                                         get_process=_deprecation_warning('current_ac'))
 
-    resistance = Instrument.measurement("MEAS:RES? DEF,DEF", "Resistance, in Ohms",
+    resistance = Instrument.measurement("MEAS:RES? DEF,DEF",
+                                        "Resistance, in Ohms" + deprecated_text,
                                         get_process=_deprecation_warning('resistance'))
 
     resistance_4w = Instrument.measurement(
-        "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms",
+        "MEAS:FRES? DEF,DEF",
+        "Four-wires (remote sensing) resistance, in Ohms" + deprecated_text,
         get_process=_deprecation_warning('resistance_4w'))
 
     function_ = Instrument.control(
@@ -110,7 +121,8 @@ class HP34401A(Instrument):
     )
 
     autorange = Instrument.control(
-        "{function_prefix_for_range}:RANG:AUTO?", "{function_prefix_for_range}:RANG:AUTO %d",
+        "{function_prefix_for_range}:RANG:AUTO?",
+        "{function_prefix_for_range}:RANG:AUTO %d",
         """Control the autorange state for the currently active function.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
@@ -220,7 +232,8 @@ class HP34401A(Instrument):
         Valid values: "IMM", "BUS", "EXT"
         The multimeter will accept a software (bus) trigger,
         an immediate internal trigger (this is the default source),
-        or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""",
+        or a hardware trigger from the rear-panel
+        Ext Trig (external trigger) terminal.""",
         validator=strict_discrete_set,
         values=["IMM", "BUS", "EXT"],
     )

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -22,8 +22,20 @@
 # THE SOFTWARE.
 #
 
+import logging
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+def _deprecation_warning(property_name):
+    def func(x):
+        log.warning(f'Deprecated property name "{property_name}", use the "function_" '
+                    'and "reading" properties instead.')
+        return x
+    return func
 
 
 class HP34401A(Instrument):
@@ -46,6 +58,23 @@ class HP34401A(Instrument):
             asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},
             **kwargs
         )
+
+    # Log a deprecated warning for the old function property
+    voltage_ac = Instrument.measurement("MEAS:VOLT:AC? DEF,DEF", "AC voltage, in Volts",
+                                        get_process=_deprecation_warning('voltage_ac'))
+
+    current_dc = Instrument.measurement("MEAS:CURR:DC? DEF,DEF", "DC current, in Amps",
+                                        get_process=_deprecation_warning('current_dc'))
+
+    current_ac = Instrument.measurement("MEAS:CURR:AC? DEF,DEF", "AC current, in Amps",
+                                        get_process=_deprecation_warning('current_ac'))
+
+    resistance = Instrument.measurement("MEAS:RES? DEF,DEF", "Resistance, in Ohms",
+                                        get_process=_deprecation_warning('resistance'))
+
+    resistance_4w = Instrument.measurement(
+        "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms",
+        get_process=_deprecation_warning('resistance_4w'))
 
     function_ = Instrument.control(
         "FUNC?", "FUNC \"%s\"",

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -74,14 +74,14 @@ class HP34401A(Instrument):
         self.write(command)
 
     @property
-    def auto_range_enabled(self):
+    def autorange(self):
         """ A boolean property that controls the autorange state
         for the currently active function. """
         command = f"{self._get_function_range_prefix()}:RANG:AUTO?"
         return self.ask(command).strip() == "1"
 
-    @auto_range_enabled.setter
-    def auto_range_enabled(self, value):
+    @autorange.setter
+    def autorange(self, value):
         command = f"{self._get_function_range_prefix()}:RANG:AUTO {HP34401A.BOOL_MAPPINGS[value]}"
         self.write(command)
 
@@ -222,7 +222,7 @@ class HP34401A(Instrument):
         (you must send a device clear to return to the "idle" state). """)
 
     stored_reading = Instrument.measurement(
-        "FETCh?",
+        "FETC?",
         """ This property returns the reading(s) currently stored in the
         multimeter's internal memory. Reading this property will NOT initialize a trigger.
         If you need that, use the `reading` property instead. """)

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -98,27 +98,27 @@ class HP34401A(Instrument):
         validator=strict_discrete_set,
         values=FUNCTIONS,
         map_values=True,
-        get_process=lambda v: v.strip('"')
+        get_process=lambda v: v.strip('"'),
     )
 
     range_ = Instrument.control(
-        "<function_prefix_for_range>:RANG?", "<function_prefix_for_range>:RANG %s",
+        "{function_prefix_for_range}:RANG?", "{function_prefix_for_range}:RANG %s",
         """Control the range for the currently active function.
 
         For frequency and period measurements, ranging applies to
-        the signal's input voltage, not its frequency"""
+        the signal's input voltage, not its frequency""",
     )
 
     autorange = Instrument.control(
-        "<function_prefix_for_range>:RANG:AUTO?", "<function_prefix_for_range>:RANG:AUTO %d",
+        "{function_prefix_for_range}:RANG:AUTO?", "{function_prefix_for_range}:RANG:AUTO %d",
         """Control the autorange state for the currently active function.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     resolution = Instrument.control(
-        "<function>:RES?", "<function>:RES %g",
+        "{function}:RES?", "{function}:RES %g",
         """Control the resolution of the measurements.
 
         Not valid for frequency, period, or ratio.
@@ -126,29 +126,29 @@ class HP34401A(Instrument):
         measurement function, not in number of digits.
         Results in a "Settings Conflict" error if autorange is enabled.
         MIN selects the smallest value accepted, which gives the most resolution.
-        MAX selects the largest value accepted which gives the least resolution."""
+        MAX selects the largest value accepted which gives the least resolution.""",
     )
 
     nplc = Instrument.control(
-        "<function>:NPLC?", "<function>:NPLC %s",
+        "{function}:NPLC?", "{function}:NPLC %s",
         """Control the integration time in number of power line cycles (NPLC).
 
         Valid values: 0.02, 0.2, 1, 10, 100, "MIN", "MAX".
         This command is valid only for dc volts, ratio, dc current,
         2-wire ohms, and 4-wire ohms.""",
         validator=strict_discrete_set,
-        values=[0.02, 0.2, 1, 10, 100, "MIN", "MAX"]
+        values=[0.02, 0.2, 1, 10, 100, "MIN", "MAX"],
     )
 
     gate_time = Instrument.control(
-        "<function>:APER?", "<function>:APER %s",
+        "{function}:APER?", "{function}:APER %s",
         """Control the gate time (or aperture time) for frequency or period measurements.
 
         Valid values: 0.01, 0.1, 1, "MIN", "MAX".
         Specifically:  10 ms (4.5 digits), 100 ms (default; 5.5 digits),
         or 1 second (6.5 digits).""",
         validator=strict_discrete_set,
-        values=[0.01, 0.1, 1, "MIN", "MAX"]
+        values=[0.01, 0.1, 1, "MIN", "MAX"],
     )
 
     detector_bandwidth = Instrument.control(
@@ -157,7 +157,7 @@ class HP34401A(Instrument):
 
         Valid values: 3, 20, 200, "MIN", "MAX".""",
         validator=strict_discrete_set,
-        values=[3, 20, 200, "MIN", "MAX"]
+        values=[3, 20, 200, "MIN", "MAX"],
     )
 
     autozero_enabled = Instrument.control(
@@ -165,7 +165,7 @@ class HP34401A(Instrument):
         """Control the autozero state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     def trigger_single_autozero(self):
@@ -184,7 +184,7 @@ class HP34401A(Instrument):
         >10 GOhms for the 100 mV, 1 V, and 10 V ranges.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     terminals_used = Instrument.measurement(
@@ -194,7 +194,7 @@ class HP34401A(Instrument):
 
         Returns "FRONT" or "REAR".""",
         values={"FRONT": "FRON", "REAR": "REAR"},
-        map_values=True
+        map_values=True,
     )
 
     # Trigger related commands
@@ -203,14 +203,14 @@ class HP34401A(Instrument):
 
         Measurements will begin when the specified trigger conditions
         are satisfied after this command is received."""
-        self.write("INIT")
+        self.write("INIT"),
 
     reading = Instrument.measurement(
         "READ?",
         """Take a measurement of the currently selected function.
 
         Reading this property is equivalent to calling `init_trigger()`,
-        waiting for completion and fetching the reading(s)."""
+        waiting for completion and fetching the reading(s).""",
     )
 
     trigger_source = Instrument.control(
@@ -222,14 +222,14 @@ class HP34401A(Instrument):
         an immediate internal trigger (this is the default source),
         or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""",
         validator=strict_discrete_set,
-        values=["IMM", "BUS", "EXT"]
+        values=["IMM", "BUS", "EXT"],
     )
 
     trigger_delay = Instrument.control(
         "TRIG:DEL?", "TRIG:DEL %s",
         """Control the trigger delay in seconds.
 
-        Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX"."""
+        Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX".""",
     )
 
     trigger_auto_delay_enabled = Instrument.control(
@@ -241,14 +241,14 @@ class HP34401A(Instrument):
         automatically turns off the automatic trigger delay.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     sample_count = Instrument.control(
         "SAMP:COUN?", "SAMP:COUN %s",
         """Controls the number of samples per trigger event.
 
-        Valid values: 1 to 50000, "MIN", "MAX"."""
+        Valid values: 1 to 50000, "MIN", "MAX".""",
     )
 
     trigger_count = Instrument.control(
@@ -257,7 +257,7 @@ class HP34401A(Instrument):
 
         Valid values: 1 to 50000, "MIN", "MAX", "INF".
         The INFinite parameter instructs the multimeter to continuously accept triggers
-        (you must send a device clear to return to the "idle" state)."""
+        (you must send a device clear to return to the "idle" state).""",
     )
 
     stored_reading = Instrument.measurement(
@@ -265,7 +265,7 @@ class HP34401A(Instrument):
         """Measure the reading(s) currently stored in the multimeter's internal memory.
 
         Reading this property will NOT initialize a trigger.
-        If you need that, use the `reading` property instead."""
+        If you need that, use the `reading` property instead.""",
     )
 
     # Display related commands
@@ -274,7 +274,7 @@ class HP34401A(Instrument):
         """Control the display state.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     displayed_text = Instrument.control(
@@ -283,7 +283,7 @@ class HP34401A(Instrument):
 
         The text can be up to 12 characters long;
         any additional characters are truncated my the multimeter.""",
-        get_process=lambda x: x.strip('"')
+        get_process=lambda x: x.strip('"'),
     )
 
     # System related commands
@@ -296,17 +296,17 @@ class HP34401A(Instrument):
         """Control whether the beeper is enabled.""",
         validator=strict_discrete_set,
         values=BOOL_MAPPINGS,
-        map_values=True
+        map_values=True,
     )
 
     scpi_version = Instrument.measurement(
         "SYST:VERS?",
-        """The SCPI version of the multimeter."""
+        """The SCPI version of the multimeter.""",
     )
 
     stored_readings_count = Instrument.measurement(
         "DATA:POIN?",
-        """The number of readings currently stored in the multimeter's internal memory."""
+        """The number of readings currently stored in the internal memory.""",
     )
 
     self_test_result = Instrument.measurement(
@@ -314,16 +314,16 @@ class HP34401A(Instrument):
         """Initiate a self-test of the multimeter and return the result.
 
         Be sure to set an appropriate connection timeout,
-        otherwise the command will fail."""
+        otherwise the command will fail.""",
     )
 
     def write(self, command):
         """Write a command to the instrument."""
-        if "<function_prefix_for_range>" in command:
-            command = command.replace("<function_prefix_for_range>",
+        if "{function_prefix_for_range}" in command:
+            command = command.replace("{function_prefix_for_range}",
                                       self._get_function_prefix_for_range())
-        elif "<function>" in command:
-            command = command.replace("<function>", HP34401A.FUNCTIONS[self.function_])
+        elif "{function}" in command:
+            command = command.replace("{function}", HP34401A.FUNCTIONS[self.function_])
         super().write(command)
 
     def _get_function_prefix_for_range(self):

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -109,6 +109,7 @@ class HP34401A(Instrument):
 
     @autorange.setter
     def autorange(self, value):
+        value = strict_discrete_set(value, HP34401A.BOOL_MAPPINGS.keys())
         command = f"{self._get_function_range_prefix()}:RANG:AUTO {HP34401A.BOOL_MAPPINGS[value]}"
         self.write(command)
 
@@ -141,6 +142,7 @@ class HP34401A(Instrument):
 
     @nplc.setter
     def nplc(self, value):
+        value = strict_discrete_set(value, [0.02, 0.2, 1, 10, 100, "MIN", "MAX"])
         command = f"{HP34401A.FUNCTIONS[self.function_]}:NPLC {value}"
         self.write(command)
 
@@ -156,6 +158,7 @@ class HP34401A(Instrument):
 
     @gate_time.setter
     def gate_time(self, value):
+        value = strict_discrete_set(value, [0.01, 0.1, 1, "MIN", "MAX"])
         command = f"{HP34401A.FUNCTIONS[self.function_]}:APER {value}"
         self.write(command)
 
@@ -163,7 +166,9 @@ class HP34401A(Instrument):
         "DET:BAND?", "DET:BAND %s",
         """Control the lowest frequency expected in the input signal in Hertz.
 
-        Valid values: 3, 20, 200, "MIN", "MAX".""")
+        Valid values: 3, 20, 200, "MIN", "MAX".""",
+        validator=strict_discrete_set,
+        values=[3, 20, 200, "MIN", "MAX"])
 
     autozero_enabled = Instrument.control(
         "ZERO:AUTO?", "ZERO:AUTO %s",
@@ -221,13 +226,17 @@ class HP34401A(Instrument):
         Valid values: "IMM", "BUS", "EXT"
         The multimeter will accept a software (bus) trigger,
         an immediate internal trigger (this is the default source),
-        or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""")
+        or a hardware trigger from the rear-panel Ext Trig (external trigger) terminal.""",
+        validator=strict_discrete_set,
+        values=["IMM", "BUS", "EXT"])
 
     trigger_delay = Instrument.control(
         "TRIG:DEL?", "TRIG:DEL %s",
         """Control the trigger delay in seconds.
 
-        Valid values: 0 to 3600 seconds, "MIN", "MAX".""")
+        Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX".""",
+        # Use check_set_errors instead of strict_range validator to allow "MIN" and "MAX"
+        check_set_errors=True)
 
     trigger_auto_delay_enabled = Instrument.control(
         "TRIG:DEL:AUTO?", "TRIG:DEL:AUTO %s",
@@ -244,7 +253,8 @@ class HP34401A(Instrument):
         "SAMP:COUN?", "SAMP:COUN %s",
         """Controls the number of samples per trigger event.
 
-        Valid values: 1 to 50000, "MIN", "MAX".""")
+        Valid values: 1 to 50000, "MIN", "MAX".""",
+        check_set_errors=True)
 
     trigger_count = Instrument.control(
         "TRIG:COUN?", "TRIG:COUN %s",
@@ -252,7 +262,8 @@ class HP34401A(Instrument):
 
         Valid values: 1 to 50000, "MIN", "MAX", "INF".
         The INFinite parameter instructs the multimeter to continuously accept triggers
-        (you must send a device clear to return to the "idle" state).""")
+        (you must send a device clear to return to the "idle" state).""",
+        check_set_errors=True)
 
     stored_reading = Instrument.measurement(
         "FETC?",

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2022 PyMeasure Developers
+# Copyright (c) 2013-2023 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -162,12 +162,12 @@ def test_detector_bandwidth():
     with expected_protocol(
             HP34401A,
             [
-                ("DET:BAND?", "1"),
-                ("DET:BAND 1", None),
+                ("DET:BAND?", "3"),
+                ("DET:BAND 3", None),
             ],
     ) as inst:
-        assert 1 == inst.detector_bandwidth
-        inst.detector_bandwidth = 1
+        assert 3 == inst.detector_bandwidth
+        inst.detector_bandwidth = 3
 
 
 @pytest.mark.parametrize("enabled", [True, False])
@@ -255,6 +255,7 @@ def test_trigger_delay():
             [
                 ("TRIG:DEL?", "1"),
                 ("TRIG:DEL 1", None),
+                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.trigger_delay
@@ -280,6 +281,7 @@ def test_sample_count():
             [
                 ("SAMP:COUN?", "1"),
                 ("SAMP:COUN 1", None),
+                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.sample_count
@@ -292,6 +294,7 @@ def test_trigger_count():
             [
                 ("TRIG:COUN?", "1"),
                 ("TRIG:COUN 1", None),
+                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.trigger_count

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -23,12 +23,11 @@
 #
 
 import pytest
-import math
 import time
 import logging
 from pymeasure.instruments.hp import HP34401A
 
-# pytest.skip('Only work with connected hardware', allow_module_level=True)
+pytest.skip('Only work with connected hardware', allow_module_level=True)
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -65,142 +64,142 @@ class TestHP8116A:
         self.instr.reset()
         return self.instr
 
-    # def test_correct_model_by_idn(self, make_resetted_instr):
-    #     instr = make_resetted_instr
-    #     assert "34401a" in instr.id.lower()
+    def test_correct_model_by_idn(self, make_resetted_instr):
+        instr = make_resetted_instr
+        assert "34401a" in instr.id.lower()
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS)
-    # def test_given_function_when_set_then_function_is_set(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.function_ == function_
+    @pytest.mark.parametrize("function_", FUNCTIONS)
+    def test_given_function_when_set_then_function_is_set(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.function_ == function_
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS)
-    # def test_given_function_is_set_then_reading_avaliable(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.reading is not None
+    @pytest.mark.parametrize("function_", FUNCTIONS)
+    def test_given_function_is_set_then_reading_avaliable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.reading is not None
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    # def test_given_function_is_set_then_range_avaliable(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.range_ is not None
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_function_is_set_then_range_avaliable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ is not None
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    # def test_given_function_is_set_then_auto_range_is_enabled(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.auto_range_enabled == True
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_function_set_then_auto_range_enabled(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled is True
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    # def test_given_function_and_range_when_set_then_ratio_correct(self, make_resetted_instr, function_):
-    #     for range in self.TEST_RANGES[function_]:
-    #         instr = make_resetted_instr
-    #         instr.function_ = function_
-    #         instr.range_ = range
-    #         assert len(instr.check_errors()) == 0
-    #         assert instr.range_ == range
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_range_set_then_range_correct(self, make_resetted_instr, function_):
+        for range in self.TEST_RANGES[function_]:
+            instr = make_resetted_instr
+            instr.function_ = function_
+            instr.range_ = range
+            assert len(instr.check_errors()) == 0
+            assert instr.range_ == range
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    # def test_autorange_enable(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     instr.auto_range_enabled = True
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.auto_range_enabled == True
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_autorange_enable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.auto_range_enabled = True
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled is True
 
-    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    # def test_autorange_disable(self, make_resetted_instr, function_):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     instr.auto_range_enabled = False
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.auto_range_enabled == False
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_autorange_disable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.auto_range_enabled = False
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled is False
 
-    # def test_dcv_range_min_max(self, make_resetted_instr):
-    #     instr = make_resetted_instr
-    #     instr.function_ = "DCV"
-    #     instr.range_ = "MIN"
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.range_ == 0.1
-    #     instr.range_ = "MAX"
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.range_ == 1000
+    def test_dcv_range_min_max(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.function_ = "DCV"
+        instr.range_ = "MIN"
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ == 0.1
+        instr.range_ = "MAX"
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ == 1000
 
-    # @pytest.mark.parametrize("enabled", [True, False])
-    # def test_display_enabled(self, make_resetted_instr, enabled):
-    #     instr = make_resetted_instr
-    #     instr.display_enabled = enabled
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.display_enabled == enabled
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_display_enabled(self, make_resetted_instr, enabled):
+        instr = make_resetted_instr
+        instr.display_enabled = enabled
+        assert len(instr.check_errors()) == 0
+        assert instr.display_enabled == enabled
 
-    # @pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
-    # def test_resolution(self, make_resetted_instr, function_):
-    #     instr: HP34401A = make_resetted_instr
-    #     instr.function_ = function_
-    #     instr.range_ = 1
-    #     instr.resolution = 0.0001
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.resolution == 0.0001
+    @pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
+    def test_resolution(self, make_resetted_instr, function_):
+        instr: HP34401A = make_resetted_instr
+        instr.function_ = function_
+        instr.range_ = 1
+        instr.resolution = 0.0001
+        assert len(instr.check_errors()) == 0
+        assert instr.resolution == 0.0001
 
-    # @pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
-    # @pytest.mark.parametrize("nplc", [0.02, 1, 100])
-    # def test_nplc(self, make_resetted_instr, function_, nplc):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     instr.nplc = nplc
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.nplc == nplc
+    @pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
+    @pytest.mark.parametrize("nplc", [0.02, 1, 100])
+    def test_nplc(self, make_resetted_instr, function_, nplc):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.nplc = nplc
+        assert len(instr.check_errors()) == 0
+        assert instr.nplc == nplc
 
-    # @pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
-    # @pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
-    # def test_gate_time(self, make_resetted_instr, function_, gate_time):
-    #     instr = make_resetted_instr
-    #     instr.function_ = function_
-    #     instr.gate_time = gate_time
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.gate_time == gate_time
+    @pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
+    @pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
+    def test_gate_time(self, make_resetted_instr, function_, gate_time):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.gate_time = gate_time
+        assert len(instr.check_errors()) == 0
+        assert instr.gate_time == gate_time
 
-    # @pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
-    # def test_detector_bandwidth(self, make_resetted_instr, detector_bandwidth):
-    #     instr = make_resetted_instr
-    #     instr.function_ = "FREQ"
-    #     instr.detector_bandwidth = detector_bandwidth
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.detector_bandwidth == detector_bandwidth
+    @pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
+    def test_detector_bandwidth(self, make_resetted_instr, detector_bandwidth):
+        instr = make_resetted_instr
+        instr.function_ = "FREQ"
+        instr.detector_bandwidth = detector_bandwidth
+        assert len(instr.check_errors()) == 0
+        assert instr.detector_bandwidth == detector_bandwidth
 
-    # @pytest.mark.parametrize("enable", [True, False])
-    # def test_autozero(self, make_resetted_instr, enable):
-    #     instr = make_resetted_instr
-    #     instr.autozero_enabled = enable
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.autozero_enabled == enable
+    @pytest.mark.parametrize("enable", [True, False])
+    def test_autozero(self, make_resetted_instr, enable):
+        instr = make_resetted_instr
+        instr.autozero_enabled = enable
+        assert len(instr.check_errors()) == 0
+        assert instr.autozero_enabled == enable
 
-    # def test_single_autozero(self, make_resetted_instr):
-    #     instr = make_resetted_instr
-    #     instr.autozero_enabled = True
-    #     instr.trigger_single_autozero()
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.autozero_enabled == False
+    def test_single_autozero(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.autozero_enabled = True
+        instr.trigger_single_autozero()
+        assert len(instr.check_errors()) == 0
+        assert instr.autozero_enabled is False
 
-    # def test_auto_input_impedance(self, make_resetted_instr):
-    #     instr = make_resetted_instr
-    #     instr.auto_input_impedance_enabled = True
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.auto_input_impedance_enabled == True
-    #     instr.auto_input_impedance_enabled = False
-    #     assert len(instr.check_errors()) == 0
-    #     assert instr.auto_input_impedance_enabled == False
+    def test_auto_input_impedance(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.auto_input_impedance_enabled = True
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_input_impedance_enabled is True
+        instr.auto_input_impedance_enabled = False
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_input_impedance_enabled is False
 
-    # def test_terminals_used(self, make_resetted_instr):
-    #     instr = make_resetted_instr
-    #     assert instr.terminals_used in ["FRONT", "REAR"]
-    #     assert len(instr.check_errors()) == 0
+    def test_terminals_used(self, make_resetted_instr):
+        instr = make_resetted_instr
+        assert instr.terminals_used in ["FRONT", "REAR"]
+        assert len(instr.check_errors()) == 0
 
     def test_when_init_trigger_called_then_no_error(self, make_resetted_instr):
         instr = make_resetted_instr
@@ -242,7 +241,6 @@ class TestHP8116A:
         assert instr.trigger_count == 10
 
     def test_read_stored_readings(self, make_resetted_instr):
-        # TODO: Under construction...
         instr: HP34401A = make_resetted_instr
         instr.sample_count = 10
         instr.trigger_source = "IMM"

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -65,144 +65,230 @@ class TestHP8116A:
         self.instr.reset()
         return self.instr
 
-    def test_correct_model_by_idn(self, make_resetted_instr):
+    # def test_correct_model_by_idn(self, make_resetted_instr):
+    #     instr = make_resetted_instr
+    #     assert "34401a" in instr.id.lower()
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS)
+    # def test_given_function_when_set_then_function_is_set(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.function_ == function_
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS)
+    # def test_given_function_is_set_then_reading_avaliable(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.reading is not None
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    # def test_given_function_is_set_then_range_avaliable(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.range_ is not None
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    # def test_given_function_is_set_then_auto_range_is_enabled(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.auto_range_enabled == True
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    # def test_given_function_and_range_when_set_then_ratio_correct(self, make_resetted_instr, function_):
+    #     for range in self.TEST_RANGES[function_]:
+    #         instr = make_resetted_instr
+    #         instr.function_ = function_
+    #         instr.range_ = range
+    #         assert len(instr.check_errors()) == 0
+    #         assert instr.range_ == range
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    # def test_autorange_enable(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     instr.auto_range_enabled = True
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.auto_range_enabled == True
+
+    # @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    # def test_autorange_disable(self, make_resetted_instr, function_):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     instr.auto_range_enabled = False
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.auto_range_enabled == False
+
+    # def test_dcv_range_min_max(self, make_resetted_instr):
+    #     instr = make_resetted_instr
+    #     instr.function_ = "DCV"
+    #     instr.range_ = "MIN"
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.range_ == 0.1
+    #     instr.range_ = "MAX"
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.range_ == 1000
+
+    # @pytest.mark.parametrize("enabled", [True, False])
+    # def test_display_enabled(self, make_resetted_instr, enabled):
+    #     instr = make_resetted_instr
+    #     instr.display_enabled = enabled
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.display_enabled == enabled
+
+    # @pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
+    # def test_resolution(self, make_resetted_instr, function_):
+    #     instr: HP34401A = make_resetted_instr
+    #     instr.function_ = function_
+    #     instr.range_ = 1
+    #     instr.resolution = 0.0001
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.resolution == 0.0001
+
+    # @pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
+    # @pytest.mark.parametrize("nplc", [0.02, 1, 100])
+    # def test_nplc(self, make_resetted_instr, function_, nplc):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     instr.nplc = nplc
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.nplc == nplc
+
+    # @pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
+    # @pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
+    # def test_gate_time(self, make_resetted_instr, function_, gate_time):
+    #     instr = make_resetted_instr
+    #     instr.function_ = function_
+    #     instr.gate_time = gate_time
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.gate_time == gate_time
+
+    # @pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
+    # def test_detector_bandwidth(self, make_resetted_instr, detector_bandwidth):
+    #     instr = make_resetted_instr
+    #     instr.function_ = "FREQ"
+    #     instr.detector_bandwidth = detector_bandwidth
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.detector_bandwidth == detector_bandwidth
+
+    # @pytest.mark.parametrize("enable", [True, False])
+    # def test_autozero(self, make_resetted_instr, enable):
+    #     instr = make_resetted_instr
+    #     instr.autozero_enabled = enable
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.autozero_enabled == enable
+
+    # def test_single_autozero(self, make_resetted_instr):
+    #     instr = make_resetted_instr
+    #     instr.autozero_enabled = True
+    #     instr.trigger_single_autozero()
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.autozero_enabled == False
+
+    # def test_auto_input_impedance(self, make_resetted_instr):
+    #     instr = make_resetted_instr
+    #     instr.auto_input_impedance_enabled = True
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.auto_input_impedance_enabled == True
+    #     instr.auto_input_impedance_enabled = False
+    #     assert len(instr.check_errors()) == 0
+    #     assert instr.auto_input_impedance_enabled == False
+
+    # def test_terminals_used(self, make_resetted_instr):
+    #     instr = make_resetted_instr
+    #     assert instr.terminals_used in ["FRONT", "REAR"]
+    #     assert len(instr.check_errors()) == 0
+
+    def test_when_init_trigger_called_then_no_error(self, make_resetted_instr):
         instr = make_resetted_instr
-        assert "34401a" in instr.id.lower()
+        instr.init_trigger()
+        assert len(instr.check_errors()) == 0
 
-    @pytest.mark.parametrize("function_", FUNCTIONS)
-    def test_given_function_when_set_then_function_is_set(self, make_resetted_instr, function_):
+    @pytest.mark.parametrize("trigger_source", ["IMM", "BUS", "EXT"])
+    def test_trigger_source(self, make_resetted_instr, trigger_source):
         instr = make_resetted_instr
-        instr.function_ = function_
+        instr.trigger_source = trigger_source
         assert len(instr.check_errors()) == 0
-        assert instr.function_ == function_
+        assert instr.trigger_source == trigger_source
 
-    @pytest.mark.parametrize("function_", FUNCTIONS)
-    def test_given_function_is_set_then_reading_avaliable(self, make_resetted_instr, function_):
+    def test_trigger_delay(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.function_ = function_
+        instr.trigger_delay = 10.5
+        trigger_delay = instr.trigger_delay
         assert len(instr.check_errors()) == 0
-        assert instr.reading is not None
+        assert trigger_delay == 10.5
 
-    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    def test_given_function_is_set_then_range_avaliable(self, make_resetted_instr, function_):
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_trigger_auto_delay_enabled(self, make_resetted_instr, enabled):
         instr = make_resetted_instr
-        instr.function_ = function_
+        instr.trigger_auto_delay_enabled = enabled
+        trigger_auto_delay_enabled = instr.trigger_auto_delay_enabled
         assert len(instr.check_errors()) == 0
-        assert instr.range_ is not None
+        assert trigger_auto_delay_enabled == enabled
 
-    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    def test_given_function_is_set_then_auto_range_is_enabled(self, make_resetted_instr, function_):
+    def test_sample_count(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.function_ = function_
+        instr.sample_count = 10
+        assert instr.sample_count == 10
         assert len(instr.check_errors()) == 0
-        assert instr.auto_range_enabled == True
 
-    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    def test_given_function_and_range_when_set_then_ratio_correct(self, make_resetted_instr, function_):
-        for range in self.TEST_RANGES[function_]:
-            instr = make_resetted_instr
-            instr.function_ = function_
-            instr.range_ = range
-            assert len(instr.check_errors()) == 0
-            assert instr.range_ == range
-
-    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    def test_autorange_enable(self, make_resetted_instr, function_):
+    def test_trigger_count(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.function_ = function_
-        instr.auto_range_enabled = True
+        instr.trigger_count = 10
         assert len(instr.check_errors()) == 0
-        assert instr.auto_range_enabled == True
+        assert instr.trigger_count == 10
 
-    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
-    def test_autorange_disable(self, make_resetted_instr, function_):
-        instr = make_resetted_instr
-        instr.function_ = function_
-        instr.auto_range_enabled = False
-        assert len(instr.check_errors()) == 0
-        assert instr.auto_range_enabled == False
-
-    def test_dcv_range_min_max(self, make_resetted_instr):
-        instr = make_resetted_instr
-        instr.function_ = "DCV"
-        instr.range_ = "MIN"
-        assert len(instr.check_errors()) == 0
-        assert instr.range_ == 0.1
-        instr.range_ = "MAX"
-        assert len(instr.check_errors()) == 0
-        assert instr.range_ == 1000
-
-    def test_display_enable(self, make_resetted_instr):
-        instr = make_resetted_instr
-        instr.display_enabled = True
-        assert len(instr.check_errors()) == 0
-        assert instr.display_enabled == True
-
-    def test_display_disable(self, make_resetted_instr):
-        instr = make_resetted_instr
-        instr.display_enabled = False
-        assert len(instr.check_errors()) == 0
-        assert instr.display_enabled == False
-
-    @pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
-    def test_resolution(self, make_resetted_instr, function_):
+    def test_read_stored_readings(self, make_resetted_instr):
+        # TODO: Under construction...
         instr: HP34401A = make_resetted_instr
-        instr.function_ = function_
-        instr.range_ = 1
-        instr.resolution = 0.0001
+        instr.sample_count = 10
+        instr.trigger_source = "IMM"
+        instr.nplc = 0.02
+        instr.init_trigger()
+        instr.complete
+        readings = instr.stored_readings
+        print(readings)
         assert len(instr.check_errors()) == 0
-        assert instr.resolution == 0.0001
+        assert len(readings) == 10
 
-    @pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
-    @pytest.mark.parametrize("nplc", [0.02, 1, 100])
-    def test_nplc(self, make_resetted_instr, function_, nplc):
+    def test_displayed_text(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.function_ = function_
-        instr.nplc = nplc
+        instr.displayed_text = "Hello World"
+        assert instr.displayed_text == "Hello World"
         assert len(instr.check_errors()) == 0
-        assert instr.nplc == nplc
 
-    @pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
-    @pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
-    def test_gate_time(self, make_resetted_instr, function_, gate_time):
+    def test_beep(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.function_ = function_
-        instr.gate_time = gate_time
+        instr.beep()
         assert len(instr.check_errors()) == 0
-        assert instr.gate_time == gate_time
 
-    @pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
-    def test_detector_bandwidth(self, make_resetted_instr, detector_bandwidth):
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_beeper_enabled(self, make_resetted_instr, enabled):
         instr = make_resetted_instr
-        instr.function_ = "FREQ"
-        instr.detector_bandwidth = detector_bandwidth
+        instr.beeper_enabled = enabled
+        assert instr.beeper_enabled == enabled
         assert len(instr.check_errors()) == 0
-        assert instr.detector_bandwidth == detector_bandwidth
 
-    @pytest.mark.parametrize("enable", [True, False])
-    def test_autozero(self, make_resetted_instr, enable):
+    def test_scpi_version(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.autozero_enabled = enable
+        assert len(str(instr.scpi_version)) > 0
         assert len(instr.check_errors()) == 0
-        assert instr.autozero_enabled == enable
 
-    def test_single_autozero(self, make_resetted_instr):
+    def test_stored_readings_count(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.autozero_enabled = True
-        instr.trigger_single_autozero()
+        instr.nplc = 0.02
+        instr.sample_count = 10
+        instr.trigger_source = "IMM"
+        instr.init_trigger()
+        time.sleep(1)
+        assert instr.stored_readings_count == 10
         assert len(instr.check_errors()) == 0
-        assert instr.autozero_enabled == False
 
-    def test_auto_input_impedance(self, make_resetted_instr):
+    def test_self_test_result(self, make_resetted_instr):
         instr = make_resetted_instr
-        instr.auto_input_impedance_enabled = True
-        assert len(instr.check_errors()) == 0
-        assert instr.auto_input_impedance_enabled == True
-        instr.auto_input_impedance_enabled = False
-        assert len(instr.check_errors()) == 0
-        assert instr.auto_input_impedance_enabled == False
-
-    def test_terminals_used(self, make_resetted_instr):
-        instr = make_resetted_instr
-        assert instr.terminals_used in ["FRONT", "REAR"]
+        instr.adapter.connection.timeout = 60000
+        assert instr.self_test_result in [True, False]
         assert len(instr.check_errors()) == 0

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -45,11 +45,11 @@ def test_range_dcv():
     with expected_protocol(
             HP34401A,
             [
-                (f"FUNC \"VOLT\"", None),
+                ("FUNC \"VOLT\"", None),
                 ("FUNC?", "VOLT"),
-                (f"VOLT:RANG?", "1"),
+                ("VOLT:RANG?", "1"),
                 ("FUNC?", "VOLT"),
-                (f"VOLT:RANG 1", None),
+                ("VOLT:RANG 1", None),
             ],
     ) as inst:
         inst.function_ = "DCV"
@@ -61,11 +61,11 @@ def test_range_freq():
     with expected_protocol(
             HP34401A,
             [
-                (f"FUNC \"FREQ\"", None),
+                ("FUNC \"FREQ\"", None),
                 ("FUNC?", "FREQ"),
-                (f"FREQ:VOLT:RANG?", "1"),
+                ("FREQ:VOLT:RANG?", "1"),
                 ("FUNC?", "FREQ"),
-                (f"FREQ:VOLT:RANG 1", None),
+                ("FREQ:VOLT:RANG 1", None),
             ],
     ) as inst:
         inst.function_ = "FREQ"
@@ -78,9 +78,9 @@ def test_autorange_dcv(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"FUNC \"VOLT\"", None),
+                ("FUNC \"VOLT\"", None),
                 ("FUNC?", "VOLT"),
-                (f"VOLT:RANG:AUTO?", "1" if enabled else "0"),
+                ("VOLT:RANG:AUTO?", "1" if enabled else "0"),
                 ("FUNC?", "VOLT"),
                 (f"VOLT:RANG:AUTO {1 if enabled else 0}", None),
             ],
@@ -95,9 +95,9 @@ def test_autorange_freq(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"FUNC \"FREQ\"", None),
+                ("FUNC \"FREQ\"", None),
                 ("FUNC?", "FREQ"),
-                (f"FREQ:VOLT:RANG:AUTO?", "1" if enabled else "0"),
+                ("FREQ:VOLT:RANG:AUTO?", "1" if enabled else "0"),
                 ("FUNC?", "FREQ"),
                 (f"FREQ:VOLT:RANG:AUTO {1 if enabled else 0}", None),
             ],
@@ -162,8 +162,8 @@ def test_detector_bandwidth():
     with expected_protocol(
             HP34401A,
             [
-                (f"DET:BAND?", "1"),
-                (f"DET:BAND 1", None),
+                ("DET:BAND?", "1"),
+                ("DET:BAND 1", None),
             ],
     ) as inst:
         assert 1 == inst.detector_bandwidth
@@ -175,7 +175,7 @@ def test_autozero_enabled(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"ZERO:AUTO?", "1" if enabled else "0"),
+                ("ZERO:AUTO?", "1" if enabled else "0"),
                 (f"ZERO:AUTO {1 if enabled else 0}", None),
             ],
     ) as inst:
@@ -187,7 +187,7 @@ def test_trigger_single_autozero():
     with expected_protocol(
             HP34401A,
             [
-                (f"ZERO:AUTO ONCE", None),
+                ("ZERO:AUTO ONCE", None),
             ],
     ) as inst:
         inst.trigger_single_autozero()
@@ -198,7 +198,7 @@ def test_auto_input_impedance_enabled(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"INP:IMP:AUTO?", "1" if enabled else "0"),
+                ("INP:IMP:AUTO?", "1" if enabled else "0"),
                 (f"INP:IMP:AUTO {1 if enabled else 0}", None),
             ],
     ) as inst:
@@ -210,7 +210,7 @@ def test_terminals_used():
     with expected_protocol(
             HP34401A,
             [
-                (f"ROUT:TERM?", "FRON"),
+                ("ROUT:TERM?", "FRON"),
             ],
     ) as inst:
         assert "FRONT" == inst.terminals_used
@@ -220,7 +220,7 @@ def test_init_trigger():
     with expected_protocol(
             HP34401A,
             [
-                (f"INIT", None)
+                ("INIT", None)
             ],
     ) as inst:
         inst.init_trigger()
@@ -230,7 +230,7 @@ def test_reading():
     with expected_protocol(
             HP34401A,
             [
-                (f"READ?", "1")
+                ("READ?", "1")
             ],
     ) as inst:
         assert 1 == inst.reading
@@ -241,7 +241,7 @@ def test_trigger_source(trigger_source):
     with expected_protocol(
             HP34401A,
             [
-                (f"TRIG:SOUR?", trigger_source),
+                ("TRIG:SOUR?", trigger_source),
                 (f"TRIG:SOUR {trigger_source}", None),
             ],
     ) as inst:
@@ -253,8 +253,8 @@ def test_trigger_delay():
     with expected_protocol(
             HP34401A,
             [
-                (f"TRIG:DEL?", "1"),
-                (f"TRIG:DEL 1", None),
+                ("TRIG:DEL?", "1"),
+                ("TRIG:DEL 1", None),
             ],
     ) as inst:
         assert 1 == inst.trigger_delay
@@ -266,7 +266,7 @@ def test_trigger_auto_delay_enabled(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"TRIG:DEL:AUTO?", "1" if enabled else "0"),
+                ("TRIG:DEL:AUTO?", "1" if enabled else "0"),
                 (f"TRIG:DEL:AUTO {1 if enabled else 0}", None),
             ],
     ) as inst:
@@ -278,8 +278,8 @@ def test_sample_count():
     with expected_protocol(
             HP34401A,
             [
-                (f"SAMP:COUN?", "1"),
-                (f"SAMP:COUN 1", None),
+                ("SAMP:COUN?", "1"),
+                ("SAMP:COUN 1", None),
             ],
     ) as inst:
         assert 1 == inst.sample_count
@@ -290,8 +290,8 @@ def test_trigger_count():
     with expected_protocol(
             HP34401A,
             [
-                (f"TRIG:COUN?", "1"),
-                (f"TRIG:COUN 1", None),
+                ("TRIG:COUN?", "1"),
+                ("TRIG:COUN 1", None),
             ],
     ) as inst:
         assert 1 == inst.trigger_count
@@ -302,7 +302,7 @@ def test_stored_reading():
     with expected_protocol(
             HP34401A,
             [
-                (f"FETC?", "1"),
+                ("FETC?", "1"),
             ],
     ) as inst:
         assert 1 == inst.stored_reading
@@ -313,7 +313,7 @@ def test_display_enabled(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"DISP?", "1" if enabled else "0"),
+                ("DISP?", "1" if enabled else "0"),
                 (f"DISP {1 if enabled else 0}", None),
             ],
     ) as inst:
@@ -325,8 +325,8 @@ def test_displayed_text():
     with expected_protocol(
             HP34401A,
             [
-                (f"DISP:TEXT?", "HELLO"),
-                (f"DISP:TEXT \"HELLO\"", None),
+                ("DISP:TEXT?", "HELLO"),
+                ("DISP:TEXT \"HELLO\"", None),
             ],
     ) as inst:
         assert "HELLO" == inst.displayed_text
@@ -337,7 +337,7 @@ def test_beep():
     with expected_protocol(
             HP34401A,
             [
-                (f"SYST:BEEP", None),
+                ("SYST:BEEP", None),
             ],
     ) as inst:
         inst.beep()
@@ -348,7 +348,7 @@ def test_beeper_enabled(enabled):
     with expected_protocol(
             HP34401A,
             [
-                (f"SYST:BEEP:STAT?", "1" if enabled else "0"),
+                ("SYST:BEEP:STAT?", "1" if enabled else "0"),
                 (f"SYST:BEEP:STAT {1 if enabled else 0}", None),
             ],
     ) as inst:
@@ -360,7 +360,7 @@ def test_scpi_version():
     with expected_protocol(
             HP34401A,
             [
-                (f"SYST:VERS?", "1-2-3"),
+                ("SYST:VERS?", "1-2-3"),
             ],
     ) as inst:
         assert "1-2-3" == inst.scpi_version
@@ -370,7 +370,7 @@ def test_stored_readings_count():
     with expected_protocol(
         HP34401A,
         [
-            (f"DATA:POIN?", "1"),
+            ("DATA:POIN?", "1"),
         ],
     ) as inst:
         assert 1 == inst.stored_readings_count
@@ -380,7 +380,7 @@ def test_self_test_result():
     with expected_protocol(
         HP34401A,
         [
-            (f"*TST?", "0"),
+            ("*TST?", "0"),
         ],
     ) as inst:
         assert 0 == inst.self_test_result

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -1,0 +1,208 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import math
+import time
+import logging
+from pymeasure.instruments.hp import HP34401A
+
+# pytest.skip('Only work with connected hardware', allow_module_level=True)
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class TestHP8116A:
+    """
+    Unit tests for HP34401A class.
+
+    This test suite, needs the following setup to work properly:
+        - A HP34401A device should be connected to the computer;
+        - The device's address must be set in the RESOURCE constant.
+    """
+
+    RESOURCE = 'GPIB0::16'
+    instr = HP34401A(RESOURCE)
+
+    FUNCTIONS = ["DCV", "DCV_RATIO", "ACV", "DCI", "ACI", "R2W",
+                 "R4W", "FREQ", "PERIOD", "CONTINUITY", "DIODE"]
+
+    FUNCTIONS_WITH_RANGE = ["DCV", "ACV", "DCI", "ACI",
+                            "R2W", "R4W", "FREQ", "PERIOD"]
+
+    TEST_RANGES = {
+        "DCV": [0.1, 1, 10], "ACV": [0.1, 1, 10], "DCI": [0.1, 1, 3],
+        "ACI": [1, 3], "R2W": [100, 1e3, 10e3], "R4W": [100, 1e3, 10e3],
+        "FREQ": [0.1, 1, 10], "PERIOD": [0.1, 1, 10]}
+
+    @pytest.fixture
+    def make_resetted_instr(self):
+        self.instr.reset()
+        self.instr.check_errors()
+        self.instr.write("*RST")
+        self.instr.reset()
+        return self.instr
+
+    def test_correct_model_by_idn(self, make_resetted_instr):
+        instr = make_resetted_instr
+        assert "34401a" in instr.id.lower()
+
+    @pytest.mark.parametrize("function_", FUNCTIONS)
+    def test_given_function_when_set_then_function_is_set(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.function_ == function_
+
+    @pytest.mark.parametrize("function_", FUNCTIONS)
+    def test_given_function_is_set_then_reading_avaliable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.reading is not None
+
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_function_is_set_then_range_avaliable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ is not None
+
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_function_is_set_then_auto_range_is_enabled(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled == True
+
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_given_function_and_range_when_set_then_ratio_correct(self, make_resetted_instr, function_):
+        for range in self.TEST_RANGES[function_]:
+            instr = make_resetted_instr
+            instr.function_ = function_
+            instr.range_ = range
+            assert len(instr.check_errors()) == 0
+            assert instr.range_ == range
+
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_autorange_enable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.auto_range_enabled = True
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled == True
+
+    @pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+    def test_autorange_disable(self, make_resetted_instr, function_):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.auto_range_enabled = False
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_range_enabled == False
+
+    def test_dcv_range_min_max(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.function_ = "DCV"
+        instr.range_ = "MIN"
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ == 0.1
+        instr.range_ = "MAX"
+        assert len(instr.check_errors()) == 0
+        assert instr.range_ == 1000
+
+    def test_display_enable(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.display_enabled = True
+        assert len(instr.check_errors()) == 0
+        assert instr.display_enabled == True
+
+    def test_display_disable(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.display_enabled = False
+        assert len(instr.check_errors()) == 0
+        assert instr.display_enabled == False
+
+    @pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
+    def test_resolution(self, make_resetted_instr, function_):
+        instr: HP34401A = make_resetted_instr
+        instr.function_ = function_
+        instr.range_ = 1
+        instr.resolution = 0.0001
+        assert len(instr.check_errors()) == 0
+        assert instr.resolution == 0.0001
+
+    @pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
+    @pytest.mark.parametrize("nplc", [0.02, 1, 100])
+    def test_nplc(self, make_resetted_instr, function_, nplc):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.nplc = nplc
+        assert len(instr.check_errors()) == 0
+        assert instr.nplc == nplc
+
+    @pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
+    @pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
+    def test_gate_time(self, make_resetted_instr, function_, gate_time):
+        instr = make_resetted_instr
+        instr.function_ = function_
+        instr.gate_time = gate_time
+        assert len(instr.check_errors()) == 0
+        assert instr.gate_time == gate_time
+
+    @pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
+    def test_detector_bandwidth(self, make_resetted_instr, detector_bandwidth):
+        instr = make_resetted_instr
+        instr.function_ = "FREQ"
+        instr.detector_bandwidth = detector_bandwidth
+        assert len(instr.check_errors()) == 0
+        assert instr.detector_bandwidth == detector_bandwidth
+
+    @pytest.mark.parametrize("enable", [True, False])
+    def test_autozero(self, make_resetted_instr, enable):
+        instr = make_resetted_instr
+        instr.autozero_enabled = enable
+        assert len(instr.check_errors()) == 0
+        assert instr.autozero_enabled == enable
+
+    def test_single_autozero(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.autozero_enabled = True
+        instr.trigger_single_autozero()
+        assert len(instr.check_errors()) == 0
+        assert instr.autozero_enabled == False
+
+    def test_auto_input_impedance(self, make_resetted_instr):
+        instr = make_resetted_instr
+        instr.auto_input_impedance_enabled = True
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_input_impedance_enabled == True
+        instr.auto_input_impedance_enabled = False
+        assert len(instr.check_errors()) == 0
+        assert instr.auto_input_impedance_enabled == False
+
+    def test_terminals_used(self, make_resetted_instr):
+        instr = make_resetted_instr
+        assert instr.terminals_used in ["FRONT", "REAR"]
+        assert len(instr.check_errors()) == 0

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -255,7 +255,6 @@ def test_trigger_delay():
             [
                 ("TRIG:DEL?", "1"),
                 ("TRIG:DEL 1", None),
-                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.trigger_delay
@@ -281,7 +280,6 @@ def test_sample_count():
             [
                 ("SAMP:COUN?", "1"),
                 ("SAMP:COUN 1", None),
-                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.sample_count
@@ -294,7 +292,6 @@ def test_trigger_count():
             [
                 ("TRIG:COUN?", "1"),
                 ("TRIG:COUN 1", None),
-                ("SYST:ERR?", "+0,\"No error\"")
             ],
     ) as inst:
         assert 1 == inst.trigger_count

--- a/tests/instruments/hp/test_hp34401a.py
+++ b/tests/instruments/hp/test_hp34401a.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2022 PyMeasure Developers
+# Copyright (c) 2013-2023 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/instruments/hp/test_hp34401a_with_device.py
+++ b/tests/instruments/hp/test_hp34401a_with_device.py
@@ -1,0 +1,283 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import time
+import logging
+from pymeasure.instruments.hp.hp34401A import HP34401A
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+FUNCTIONS = ["DCV", "DCV_RATIO", "ACV", "DCI", "ACI", "R2W",
+             "R4W", "FREQ", "PERIOD", "CONTINUITY", "DIODE"]
+
+FUNCTIONS_WITH_RANGE = ["DCV", "ACV", "DCI", "ACI",
+                        "R2W", "R4W", "FREQ", "PERIOD"]
+
+TEST_RANGES = {
+    "DCV": [0.1, 1, 10], "ACV": [0.1, 1, 10], "DCI": [0.1, 1, 3],
+    "ACI": [1, 3], "R2W": [100, 1e3, 10e3], "R4W": [100, 1e3, 10e3],
+    "FREQ": [0.1, 1, 10], "PERIOD": [0.1, 1, 10]}
+
+
+@pytest.fixture(scope="module")
+def hp34401a(connected_device_address):
+    instr = HP34401A(connected_device_address)
+    return instr
+
+
+@pytest.fixture
+def resetted_hp34401a(hp34401a):
+    hp34401a.clear()
+    hp34401a.write("*RST")
+    return hp34401a
+
+
+def test_correct_model_by_idn(resetted_hp34401a):
+    assert "34401a" in resetted_hp34401a.id.lower()
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS)
+def test_given_function_when_set_then_function_is_set(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.function_ == function_
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS)
+def test_given_function_is_set_then_reading_avaliable(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.reading is not None
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+def test_given_function_is_set_then_range_avaliable(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.range_ is not None
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+def test_given_function_set_then_autorange_enabled(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.autorange is True
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+def test_given_range_set_then_range_correct(resetted_hp34401a, function_):
+    for range in TEST_RANGES[function_]:
+        resetted_hp34401a.function_ = function_
+        resetted_hp34401a.range_ = range
+        assert len(resetted_hp34401a.check_errors()) == 0
+        assert resetted_hp34401a.range_ == range
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+def test_autorange_enable(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    resetted_hp34401a.autorange = True
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.autorange is True
+
+
+@pytest.mark.parametrize("function_", FUNCTIONS_WITH_RANGE)
+def test_autorange_disable(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    resetted_hp34401a.autorange = False
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.autorange is False
+
+
+def test_dcv_range_min_max(resetted_hp34401a):
+    resetted_hp34401a.function_ = "DCV"
+    resetted_hp34401a.range_ = "MIN"
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.range_ == 0.1
+    resetted_hp34401a.range_ = "MAX"
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.range_ == 1000
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_display_enabled(resetted_hp34401a, enabled):
+    resetted_hp34401a.display_enabled = enabled
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.display_enabled == enabled
+
+
+@pytest.mark.parametrize("function_", ["DCV", "ACV", "DCI", "R2W"])
+def test_resolution(resetted_hp34401a, function_):
+    resetted_hp34401a.function_ = function_
+    resetted_hp34401a.range_ = 1
+    resetted_hp34401a.resolution = 0.0001
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.resolution == 0.0001
+
+
+@pytest.mark.parametrize("function_", ["DCV", "DCI", "R2W"])
+@pytest.mark.parametrize("nplc", [0.02, 1, 100])
+def test_nplc(resetted_hp34401a, function_, nplc):
+    resetted_hp34401a.function_ = function_
+    resetted_hp34401a.nplc = nplc
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.nplc == nplc
+
+
+@pytest.mark.parametrize("function_", ["FREQ", "PERIOD"])
+@pytest.mark.parametrize("gate_time", [0.01, 0.01, 1])
+def test_gate_time(resetted_hp34401a, function_, gate_time):
+    resetted_hp34401a.function_ = function_
+    resetted_hp34401a.gate_time = gate_time
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.gate_time == gate_time
+
+
+@pytest.mark.parametrize("detector_bandwidth", [3, 20, 200])
+def test_detector_bandwidth(resetted_hp34401a, detector_bandwidth):
+    resetted_hp34401a.function_ = "FREQ"
+    resetted_hp34401a.detector_bandwidth = detector_bandwidth
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.detector_bandwidth == detector_bandwidth
+
+
+@pytest.mark.parametrize("enable", [True, False])
+def test_autozero(resetted_hp34401a, enable):
+    resetted_hp34401a.autozero_enabled = enable
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.autozero_enabled == enable
+
+
+def test_single_autozero(resetted_hp34401a):
+    resetted_hp34401a.autozero_enabled = True
+    resetted_hp34401a.trigger_single_autozero()
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.autozero_enabled is False
+
+
+def test_auto_input_impedance(resetted_hp34401a):
+    resetted_hp34401a.auto_input_impedance_enabled = True
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.auto_input_impedance_enabled is True
+    resetted_hp34401a.auto_input_impedance_enabled = False
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.auto_input_impedance_enabled is False
+
+
+def test_terminals_used(resetted_hp34401a):
+    assert resetted_hp34401a.terminals_used in ["FRONT", "REAR"]
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_when_init_trigger_called_then_no_error(resetted_hp34401a):
+    resetted_hp34401a.init_trigger()
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+@pytest.mark.parametrize("trigger_source", ["IMM", "BUS", "EXT"])
+def test_trigger_source(resetted_hp34401a, trigger_source):
+    resetted_hp34401a.trigger_source = trigger_source
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.trigger_source == trigger_source
+
+
+def test_trigger_delay(resetted_hp34401a):
+    resetted_hp34401a.trigger_delay = 10.5
+    trigger_delay = resetted_hp34401a.trigger_delay
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert trigger_delay == 10.5
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_trigger_auto_delay_enabled(resetted_hp34401a, enabled):
+    resetted_hp34401a.trigger_auto_delay_enabled = enabled
+    trigger_auto_delay_enabled = resetted_hp34401a.trigger_auto_delay_enabled
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert trigger_auto_delay_enabled == enabled
+
+
+def test_sample_count(resetted_hp34401a):
+    resetted_hp34401a.sample_count = 10
+    assert resetted_hp34401a.sample_count == 10
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_trigger_count(resetted_hp34401a):
+    resetted_hp34401a.trigger_count = 10
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert resetted_hp34401a.trigger_count == 10
+
+
+def test_read_stored_reading_multiple_readings(resetted_hp34401a):
+    resetted_hp34401a: HP34401A = resetted_hp34401a
+    resetted_hp34401a.sample_count = 10
+    resetted_hp34401a.trigger_source = "IMM"
+    resetted_hp34401a.nplc = 0.02
+    resetted_hp34401a.init_trigger()
+    resetted_hp34401a.complete
+    readings = resetted_hp34401a.stored_reading
+    print(readings)
+    assert len(resetted_hp34401a.check_errors()) == 0
+    assert len(readings) == 10
+
+
+def test_displayed_text(resetted_hp34401a):
+    resetted_hp34401a.displayed_text = "Hello World"
+    assert resetted_hp34401a.displayed_text == "Hello World"
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_beep(resetted_hp34401a):
+    resetted_hp34401a.beep()
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_beeper_enabled(resetted_hp34401a, enabled):
+    resetted_hp34401a.beeper_enabled = enabled
+    assert resetted_hp34401a.beeper_enabled == enabled
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_scpi_version(resetted_hp34401a):
+    assert len(str(resetted_hp34401a.scpi_version)) > 0
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_stored_readings_count(resetted_hp34401a):
+    resetted_hp34401a.nplc = 0.02
+    resetted_hp34401a.sample_count = 10
+    resetted_hp34401a.trigger_source = "IMM"
+    resetted_hp34401a.init_trigger()
+    time.sleep(1)
+    assert resetted_hp34401a.stored_readings_count == 10
+    assert len(resetted_hp34401a.check_errors()) == 0
+
+
+def test_self_test_result(resetted_hp34401a):
+    resetted_hp34401a.adapter.connection.timeout = 60000
+    assert resetted_hp34401a.self_test_result in [True, False]
+    assert len(resetted_hp34401a.check_errors()) == 0


### PR DESCRIPTION
The previous implementation of the 34401A driver was very basic there were no controls for essential parameters like range, resolution or NPLC. So I've expanded the driver to support all relevant SCPI commands.