### PR TITLE
Prologix adapter documentation adjusted to recent changes

### DIFF
--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -79,8 +79,8 @@ Therefore, new :class:`PrologixAdapter <pymeasure.adapters.PrologixAdapter>` ins
     from pymeasure.adapters import PrologixAdapter
 
     adapter = PrologixAdapter('ASRL/dev/ttyUSB0::INSTR', address=7)
-    sourcemeter1 = Keithley2400(adapter)  # at GPIB address 7
-    sourcemeter2 = Keithley2400(adapter.gpib(9))  # at GPIB address 9
+    sourcemeter = Keithley2400(adapter)  # at GPIB address 7
+    multimeter = Keithley2000(adapter.gpib(9))  # at GPIB address 9
 
 Some equipment may require the vxi-11 protocol for communication. An example would be a Agilent E5810B ethernet to GPIB bridge.
 To use this type equipment the python-vxi11 library has to be installed which is part of the extras package requirements. ::

--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -72,12 +72,15 @@ Instead of passing a string, you could equally pass an adapter object. ::
     adapter = VISAAdapter("GPIB::4")
     sourcemeter = Keithely2400(adapter)
 
-To instead use a Prologix GPIB device connected on :code:`/dev/ttyUSB0` (proper permissions are needed in Linux, see :class:`PrologixAdapter <pymeasure.adapters.PrologixAdapter>`), the adapter is constructed in a similar way. Unlike the VISA adapter which is specific to each instrument, the Prologix adapter can be shared by many instruments. Therefore, they are addressed separately based on the GPIB address number when passing the adapter into the instrument construction. ::
+To instead use a Prologix GPIB device connected on :code:`/dev/ttyUSB0` (proper permissions are needed in Linux, see :class:`PrologixAdapter <pymeasure.adapters.PrologixAdapter>`), the adapter is constructed in a similar way.
+The Prologix adapter can be shared by many instruments.
+Therefore, new :class:`PrologixAdapter <pymeasure.adapters.PrologixAdapter>` instances with different GPIB addresses can be generated from an already existing instance. ::
 
     from pymeasure.adapters import PrologixAdapter
 
-    adapter = PrologixAdapter('/dev/ttyUSB0')
-    sourcemeter = Keithley2400(adapter.gpib(4))
+    adapter = PrologixAdapter('ASRL/dev/ttyUSB0::INSTR', address=7)
+    sourcemeter1 = Keithley2400(adapter)  # at GPIB address 7
+    sourcemeter2 = Keithley2400(adapter.gpib(9))  # at GPIB address 9
 
 Some equipment may require the vxi-11 protocol for communication. An example would be a Agilent E5810B ethernet to GPIB bridge.
 To use this type equipment the python-vxi11 library has to be installed which is part of the extras package requirements. ::

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -29,17 +29,18 @@ from pymeasure.adapters import VISAAdapter
 
 class PrologixAdapter(VISAAdapter):
     """ Encapsulates the additional commands necessary
-    to communicate over a Prologix GPIB-USB Adapter,
+    to communicate over a Prologix GPIB Adapter,
     using the :class:`VISAAdapter`.
 
-    Each PrologixAdapter is constructed based on a serial port or
-    connection and the GPIB address to be communicated to.
-    Serial connection sharing is achieved by using the :meth:`.gpib`
+    Each PrologixAdapter is constructed based on a connection to the Prologix device
+    itself and the GPIB address of the instrument to be communicated to.
+    Connection sharing is achieved by using the :meth:`.gpib`
     method to spawn new PrologixAdapters for different GPIB addresses.
 
     :param resource_name: A
         `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
-        that identifies the target of the connection.
+        that identifies the connection to the Prologix device itself, for example
+        "ASRL5" for the 5th COM port.
     :param address: Integer GPIB address of the desired instrument.
     :param rw_delay: An optional delay to set between a write and read call for
         slow to respond instruments.
@@ -63,10 +64,10 @@ class PrologixAdapter(VISAAdapter):
     .. code::
 
         adapter = PrologixAdapter("ASRL5::INSTR", 7)
+        sourcemeter = Keithley2400(adapter)  # at GPIB address 7
         # generate another instance with a different GPIB address:
         adapter2 = adapter.gpib(9)
-        sourcemeter1 = Keithley2400(adapter)  # at GPIB address 7
-        sourcemeter2 = Keithley2400(adapter2)  # at GPIB address 9
+        multimeter = Keithley2000(adapter2)  # at GPIB address 9
 
 
     To allow user access to the Prologix adapter in Linux, create the file:

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -29,7 +29,7 @@ from pymeasure.adapters import VISAAdapter
 
 class PrologixAdapter(VISAAdapter):
     """ Encapsulates the additional commands necessary
-    to communicate over a Prologix GPIB Adapter,
+    to communicate over a Prologix GPIB-USB Adapter,
     using the :class:`VISAAdapter`.
 
     Each PrologixAdapter is constructed based on a connection to the Prologix device

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -37,8 +37,10 @@ class PrologixAdapter(VISAAdapter):
     Serial connection sharing is achieved by using the :meth:`.gpib`
     method to spawn new PrologixAdapters for different GPIB addresses.
 
-    :param port: The Serial port name or a connection object
-    :param address: Integer GPIB address of the desired instrument
+    :param resource_name: A
+        `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
+        that identifies the target of the connection.
+    :param address: Integer GPIB address of the desired instrument.
     :param rw_delay: An optional delay to set between a write and read call for
         slow to respond instruments.
 
@@ -54,7 +56,18 @@ class PrologixAdapter(VISAAdapter):
 
     :param kwargs: Key-word arguments if constructing a new serial object
 
-    :ivar address: Integer GPIB address of the desired instrument
+    :ivar address: Integer GPIB address of the desired instrument.
+
+    Usage example:
+
+    .. code::
+
+        adapter = PrologixAdapter("ASRL5::INSTR", 7)
+        # generate another instance with a different GPIB address:
+        adapter2 = adapter.gpib(9)
+        sourcemeter1 = Keithley2400(adapter)  # at GPIB address 7
+        sourcemeter2 = Keithley2400(adapter2)  # at GPIB address 9
+
 
     To allow user access to the Prologix adapter in Linux, create the file:
     :code:`/etc/udev/rules.d/51-prologix.rules`, with contents:


### PR DESCRIPTION
The Prologix adapter documentation (and tutorial) is adjusted to the recent change of the base adapter (serial to visa).

Closes #807 