### PR TITLE
ProtocolAdapter can return empty string/bytes.

### DIFF
--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -61,7 +61,7 @@ def expected_protocol(instrument_cls, comm_pairs,
     assert protocol._index == len(comm_pairs), (
         "Unprocessed protocol definitions remain: "
         f"{comm_pairs[protocol._index:]}.")
-    assert protocol._write_buffer == b"", (
+    assert protocol._write_buffer is None, (
         f"Non-empty write buffer remains: '{protocol._write_buffer}'.")
-    assert protocol._read_buffer == b"", (
+    assert protocol._read_buffer is None, (
         f"Non-empty read buffer remains: '{protocol._read_buffer}'.")

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -183,7 +183,7 @@ class Test_read_bytes:
         a.read_bytes(7)
         assert a._read_buffer is None
 
-    def test_read_all_bytes__from_pairs_empties_read_buffer(self):
+    def test_read_all_bytes_from_pairs_empties_read_buffer(self):
         a = ProtocolAdapter([(None, b"jklasdf")])
         a.read_bytes(7)
         assert a._read_buffer is None


### PR DESCRIPTION
Previously, the ProtocolAdapter could not return an empty string/bytes, but continued to return the next message.
Some instruments return an empty line (just the terminators), therefore it is necessary.

This PR changes "no buffer" from `b""` to `None`. And adjusts the tests accordingly.