### PR TITLE
Move coordinates label to the pyqtgraph PlotItem

### DIFF
--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -65,20 +65,16 @@ class PlotFrame(QtWidgets.QFrame):
         vbox = QtWidgets.QVBoxLayout(self)
 
         self.plot_widget = pg.PlotWidget(self, background='#ffffff')
-        self.coordinates = QtWidgets.QLabel(self)
-        self.coordinates.setMinimumSize(QtCore.QSize(0, 20))
-        self.coordinates.setStyleSheet("background: #fff")
-        self.coordinates.setText("")
-        self.coordinates.setAlignment(
-            QtCore.Qt.AlignmentFlag.AlignRight |
-            QtCore.Qt.AlignmentFlag.AlignTrailing |
-            QtCore.Qt.AlignmentFlag.AlignVCenter)
-
         vbox.addWidget(self.plot_widget)
-        vbox.addWidget(self.coordinates)
         self.setLayout(vbox)
 
         self.plot = self.plot_widget.getPlotItem()
+
+        style = dict(self.LABEL_STYLE | {'justify': 'right'})
+        if "font-size" in style:  # LabelItem wants the size as 'size' rather than 'font-size'
+            style["size"] = style.pop("font-size")
+        self.coordinates = pg.LabelItem("", parent=self.plot, **style)
+        self.coordinates.anchor(itemPos=(1, 1), parentPos=(1, 1), offset=(0, 3))
 
         self.crosshairs = Crosshairs(self.plot,
                                      pen=pg.mkPen(color='#AAAAAA',


### PR DESCRIPTION
In order to save room in the plotwidget (especially relevant for widgets such as the DockWidget that houses multiple PlotWidgets) I here propose to make the coordinates label (now positioned just below the PlotItem in a separate, otherwise empty, VBoxLayout) a part of the PlotItem.