### PR TITLE
Deprecation warning texts improved

### DIFF
--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -58,7 +58,8 @@ class Adapter:
             self.log = log.getChild("Adapter")
         self.log.addHandler(logging.NullHandler())
         if preprocess_reply is not None:
-            warn("Deprecated in Adapter, implement it in the instrument instead.",
+            warn(("Parameter `preprocess_reply` is deprecated in Adapter. "
+                 "Implement it in the instrument instead."),
                  FutureWarning)
 
     def __del__(self):
@@ -150,8 +151,7 @@ class Adapter:
         :param command: SCPI command string to be sent to the instrument
         :returns: String ASCII response of the instrument
         """
-        warn("Deprecated, call `Instrument.ask` instead.",
-             FutureWarning)
+        warn("`Adapter.ask` is deprecated, call `Instrument.ask` instead.", FutureWarning)
         self.write(command)
         return self.read()
 
@@ -171,7 +171,7 @@ class Adapter:
             preprocessing is done.
         :returns: A list of the desired type, or strings where the casting fails
         """
-        warn("Deprecated, call `Instrument.values` instead.",
+        warn("`Adapter.values` is deprecated, call `Instrument.values` instead.",
              FutureWarning)
         results = str(self.ask(command)).strip()
         if callable(preprocess_reply):
@@ -202,7 +202,7 @@ class Adapter:
         :param dtype: The NumPy data type to format the values with
         :returns: NumPy array of values
         """
-        warn("Deprecated, call `Instrument.binary_values` instead.",
+        warn("`Adapter.binary_values` is deprecated, call `Instrument.binary_values` instead.",
              FutureWarning)
         self.write(command)
         binary = self.read()

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -90,10 +90,13 @@ class PrologixAdapter(VISAAdapter):
                  preprocess_reply=None, **kwargs):
         # for legacy rw_delay: prefer new style over old one.
         if rw_delay:
-            warn("Implement in Instrument's 'wait_until_read' instead.", FutureWarning)
+            warn(("Parameter `rw_delay` is deprecated. "
+                  "Implement in Instrument's `wait_until_read` instead."),
+                 FutureWarning)
             kwargs['query_delay'] = rw_delay
         if serial_timeout:
-            warn("Use 'timeout' in ms instead", FutureWarning)
+            warn("Parameter `serial_timeout` is deprecated. Use `timeout` in ms instead",
+                 FutureWarning)
             kwargs['timeout'] = serial_timeout
         super().__init__(resource_name,
                          asrl={
@@ -122,8 +125,7 @@ class PrologixAdapter(VISAAdapter):
 
         :param command: SCPI command string to be sent to instrument
         """
-        warn("Do not call `Adapter.ask`, but `Instrument.ask` instead.",
-             FutureWarning)
+        warn("`Adapter.ask` is deprecated, call `Instrument.ask` instead.", FutureWarning)
         self.write(command)
         return self.read()
 

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -87,7 +87,9 @@ class VISAAdapter(Adapter):
                  query_delay=0, log=None, **kwargs):
         super().__init__(preprocess_reply=preprocess_reply, log=log)
         if query_delay:
-            warn("Implement in Instrument's 'wait_until_read' instead.", FutureWarning)
+            warn(("Parameter `query_delay` is deprecated. "
+                  "Implement in Instrument's `wait_until_read` instead."),
+                 FutureWarning)
             kwargs.setdefault("query_delay", query_delay)
         self.query_delay = query_delay
         if isinstance(resource_name, ProtocolAdapter):
@@ -172,7 +174,7 @@ class VISAAdapter(Adapter):
         :param command: SCPI command string to be sent to the instrument
         :returns: String ASCII response of the instrument
         """
-        warn("Deprecated call `Instrument.ask` instead.", FutureWarning)
+        warn("`Adapter.ask` is deprecated, call `Instrument.ask` instead.", FutureWarning)
         return self.connection.query(command)
 
     def ask_values(self, command, **kwargs):
@@ -187,7 +189,8 @@ class VISAAdapter(Adapter):
         :param kwargs: Key-word arguments to pass onto `query_ascii_values`
         :returns: Formatted response of the instrument.
         """
-        warn("Deprecated, call `Instrument.values` instead.", FutureWarning)
+        warn("`Adapter.ask_values` is deprecated, call `Instrument.values` instead.",
+             FutureWarning)
 
         return self.connection.query_ascii_values(command, **kwargs)
 
@@ -202,7 +205,7 @@ class VISAAdapter(Adapter):
         :param dtype: The NumPy data type to format the values with
         :returns: NumPy array of values
         """
-        warn("Deprecated, call `Instrument.binary_values` instead.",
+        warn("`Adapter.binary_values` is deprecated, call `Instrument.binary_values` instead.",
              FutureWarning)
         self.connection.write(command)
         binary = self.connection.read_raw()


### PR DESCRIPTION
The adapters' deprecation warnings did not mention, what is deprecated. I fixed it.
See #672 