### PR TITLE
fallback version of discarding the read buffer

### DIFF
--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -25,6 +25,8 @@
 import logging
 from unittest.mock import MagicMock
 
+import pyvisa
+
 from .adapter import Adapter
 
 log = logging.getLogger(__name__)
@@ -160,3 +162,12 @@ class ProtocolAdapter(Adapter):
             else:
                 self._read_buffer = p_read[count:]
                 return p_read[:count]
+
+    def flush_read_buffer(self):
+        """ Flush and discard the input buffer
+
+        As detailed by pyvisa, discard the read buffer contents and if data was present
+        in the read buffer and no END-indicator was present, read from the device until
+        encountering an END indicator (which causes loss of data).
+        """
+        self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -25,8 +25,6 @@
 import logging
 from unittest.mock import MagicMock
 
-import pyvisa
-
 from .adapter import Adapter
 
 log = logging.getLogger(__name__)
@@ -170,4 +168,4 @@ class ProtocolAdapter(Adapter):
         in the read buffer and no END-indicator was present, read from the device until
         encountering an END indicator (which causes loss of data).
         """
-        self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
+        self.connection.flush("pyvisa.constants.BufferOperation.discard_read_buffer")

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -228,7 +228,15 @@ class VISAAdapter(Adapter):
         in the read buffer and no END-indicator was present, read from the device until
         encountering an END indicator (which causes loss of data).
         """
-        self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
+        try:
+            self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
+        except NotImplementedError:
+            # fake discarding the read buffer by reading all available messages.
+            try:
+                while True:
+                    self.read()
+            except pyvisa.errors.VisaIOError:
+                pass
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resource_name

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -231,12 +231,15 @@ class VISAAdapter(Adapter):
         try:
             self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
         except NotImplementedError:
+            # NotImplementedError is raised when using resource types other than `asrl`
+            # in conjunction with pyvisa-py.
+            # Upstream issue: https://github.com/pyvisa/pyvisa-py/issues/348
             # fake discarding the read buffer by reading all available messages.
             timeout = self.connection.timeout
             self.connection.timeout = 0
             try:
                 while True:
-                    self.read()
+                    self.read_bytes(-1)
             except pyvisa.errors.VisaIOError:
                 pass
             self.connection.timeout = timeout

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -241,7 +241,8 @@ class VISAAdapter(Adapter):
                 self.read_bytes(-1)
             except pyvisa.errors.VisaIOError:
                 pass
-            self.connection.timeout = timeout
+            finally:
+                self.connection.timeout = timeout
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resource_name

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -232,11 +232,14 @@ class VISAAdapter(Adapter):
             self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
         except NotImplementedError:
             # fake discarding the read buffer by reading all available messages.
+            timeout = self.connection.timeout
+            self.connection.timeout = 0
             try:
                 while True:
                     self.read()
             except pyvisa.errors.VisaIOError:
                 pass
+            self.connection.timeout = timeout
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resource_name

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -238,8 +238,7 @@ class VISAAdapter(Adapter):
             timeout = self.connection.timeout
             self.connection.timeout = 0
             try:
-                while True:
-                    self.read_bytes(-1)
+                self.read_bytes(-1)
             except pyvisa.errors.VisaIOError:
                 pass
             self.connection.timeout = timeout


### PR DESCRIPTION
This PR shall implement a fallback method for `VisaAdapter.flush_read_buffer` which in pyvisa-py currently is supported only by the ASRL resource type and raises a `NotImplementedError` otherwise. 

This is related to issue #834 