### PR TITLE
Adapters' read_bytes reworked

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ New adapter and instrument mechanics
 ------------------------------------
 - Channel class added. Instrument.channels and Instrument.ch_X (X is any channel name) are reserved for channel implementations.
 - All instruments are required to accept a :code:`name` argument.
+- :code:`read_bytes` of all Adapters does not break on a termination character, unless :code:`break_on_termchar` is set to `True`.
 
 Deprecated features
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ New adapter and instrument mechanics
 ------------------------------------
 - Channel class added. Instrument.channels and Instrument.ch_X (X is any channel name) are reserved for channel implementations.
 - All instruments are required to accept a :code:`name` argument.
-- :code:`read_bytes` of all Adapters does not break on a termination character, unless :code:`break_on_termchar` is set to `True`.
+- Changed: :code:`read_bytes` of all Adapters by default does not stop reading on a termination character, unless the new argument :code:`break_on_termchar` is set to `True`.
 
 Deprecated features
 -------------------

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -45,7 +45,7 @@ class Adapter:
             Implement it in the instrument's `read` method instead.
 
     :param log: Parent logger of the 'Adapter' logger.
-    :param kwargs: Keyword arguments just to be cooperative.
+    :param \\**kwargs: Keyword arguments just to be cooperative.
     """
 
     def __init__(self, preprocess_reply=None, log=None, **kwargs):
@@ -81,7 +81,7 @@ class Adapter:
 
         :param str command: Command string to be sent to the instrument
             (without termination).
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         self.log.debug("WRITE:%s", command)
         self._write(command, **kwargs)
@@ -92,7 +92,7 @@ class Adapter:
         Do not override in a subclass!
 
         :param bytes content: The bytes to write to the instrument.
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         self.log.debug("WRITE:%s", content)
         self._write_bytes(content, **kwargs)
@@ -102,7 +102,7 @@ class Adapter:
 
         Do not override in a subclass!
 
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         :returns str: ASCII response of the instrument (excluding read_termination).
         """
         read = self._read(**kwargs)
@@ -219,7 +219,7 @@ class Adapter:
         :param int header_bytes: Number of bytes to ignore in header.
         :param int termination_bytes: Number of bytes to strip at end of message or None.
         :param dtype: The NumPy data type to format the values with.
-        :param kwargs: Further arguments for the NumPy fromstring method.
+        :param \\**kwargs: Further arguments for the NumPy fromstring method.
         :returns: NumPy array of values
         """
         binary = self.read_bytes(-1)
@@ -253,7 +253,7 @@ class Adapter:
         :param command: command string to be sent to the instrument
         :param values: iterable representing the binary values
         :param termination: String added afterwards to terminate the message.
-        :param kwargs: Key-word arguments to pass onto :meth:`Adapter._format_binary_values`
+        :param \\**kwargs: Key-word arguments to pass onto :meth:`Adapter._format_binary_values`
         :returns: number of bytes written
         """
         block = self._format_binary_values(values, **kwargs)

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -63,7 +63,7 @@ class Adapter:
                  FutureWarning)
 
     def __del__(self):
-        """Close connection upon garbage collection of the device"""
+        """Close connection upon garbage collection of the device."""
         self.close()
 
     def close(self):

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -109,17 +109,18 @@ class Adapter:
         self.log.debug("READ:%s", read)
         return read
 
-    def read_bytes(self, count=-1, **kwargs):
+    def read_bytes(self, count=-1, break_on_termchar=False, **kwargs):
         """Read a certain number of bytes from the instrument.
 
         Do not override in a subclass!
 
         :param int count: Number of bytes to read. A value of -1 indicates to
-            read the whole read buffer.
-        :param kwargs: Keyword arguments for the connection itself.
+            read from the whole read buffer.
+        :param bool break_on_termchar: Stop reading at a termination character.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         :returns bytes: Bytes response of the instrument (including termination).
         """
-        read = self._read_bytes(count, **kwargs)
+        read = self._read_bytes(count, break_on_termchar, **kwargs)
         self.log.debug("READ:%s", read)
         return read
 
@@ -136,7 +137,7 @@ class Adapter:
         """Read string from the instrument. Implement in subclass."""
         raise NotImplementedError("Adapter class has not implemented reading.")
 
-    def _read_bytes(self, count, **kwargs):
+    def _read_bytes(self, count, break_on_termchar, **kwargs):
         """Read bytes from the instrument. Implement in subclass."""
         raise NotImplementedError("Adapter class has not implemented reading bytes.")
 
@@ -287,7 +288,7 @@ class FakeAdapter(Adapter):
         self._buffer = ""
         return result
 
-    def _read_bytes(self, count):
+    def _read_bytes(self, count, break_on_termchar):
         """ Return the last commands given after the
         last read call.
         """

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -46,7 +46,7 @@ class PrologixAdapter(VISAAdapter):
         slow to respond instruments.
 
         .. deprecated:: 0.11
-            Implement it in the instrument's `wait_until_read` method instead.
+            Implement it in the instrument's `wait_for` method instead.
 
     :param preprocess_reply: optional callable used to preprocess
         strings received from the instrument. The callable returns the
@@ -91,7 +91,7 @@ class PrologixAdapter(VISAAdapter):
         # for legacy rw_delay: prefer new style over old one.
         if rw_delay:
             warn(("Parameter `rw_delay` is deprecated. "
-                  "Implement in Instrument's `wait_until_read` instead."),
+                  "Implement in Instrument's `wait_for` instead."),
                  FutureWarning)
             kwargs['query_delay'] = rw_delay
         if serial_timeout:

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -24,6 +24,7 @@
 
 import logging
 from unittest.mock import MagicMock
+from warnings import warn
 
 from .adapter import Adapter
 
@@ -134,6 +135,10 @@ class ProtocolAdapter(Adapter):
 
         :param int count: Number of bytes to read. If -1, return the buffer.
         """
+        if break_on_termchar:
+            warn(("Breaking on termination character in `read_bytes` cannot be tested. "
+                  "You have to separate the message parts in the com_pairs."),
+                 UserWarning)
         if self._read_buffer is not None:
             if count == -1 or count >= len(self._read_buffer):
                 read = self._read_buffer

--- a/pymeasure/adapters/protocol.py
+++ b/pymeasure/adapters/protocol.py
@@ -129,7 +129,7 @@ class ProtocolAdapter(Adapter):
         """Return an already present or freshly fetched read buffer as a string."""
         return self._read_bytes(-1).decode("utf-8")
 
-    def _read_bytes(self, count, **kwargs):
+    def _read_bytes(self, count, break_on_termchar=False, **kwargs):
         """Read `count` number of bytes from the buffer.
 
         :param int count: Number of bytes to read. If -1, return the buffer.

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -104,8 +104,8 @@ class SerialAdapter(Adapter):
                                               count if count > 0 else None,
                                               **kwargs)
         else:
-            # At negative count, we read up to one GB, which can be considered the whole buffer.
-            return self.connection.read(count if count >= 0 else 1e9, **kwargs)
+            # At -1 we read a very large number of bytes, which can be considered the whole buffer.
+            return self.connection.read(1e99 if count == -1 else count, **kwargs)
 
     def __repr__(self):
         return "<SerialAdapter(port='%s')>" % self.connection.port

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -103,10 +103,9 @@ class SerialAdapter(Adapter):
             return self.connection.read_until(self.read_termination.encode(),
                                               count if count > 0 else None,
                                               **kwargs)
-        elif count == -1:
-            return b"\n".join(self.connection.readlines(**kwargs))
         else:
-            return self.connection.read(count, **kwargs)
+            # At negative count, we read up to one GB, which can be considered the whole buffer.
+            return self.connection.read(count if count >= 0 else 1e9, **kwargs)
 
     def __repr__(self):
         return "<SerialAdapter(port='%s')>" % self.connection.port

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -44,7 +44,7 @@ class SerialAdapter(Adapter):
 
     :param write_termination: String appended to messages before writing them.
     :param read_termination: String expected at end of read message and removed.
-    :param kwargs: Any valid key-word argument for serial.Serial
+    :param \\**kwargs: Any valid key-word argument for serial.Serial
     """
 
     def __init__(self, port, preprocess_reply=None,
@@ -63,7 +63,7 @@ class SerialAdapter(Adapter):
 
         :param str command: Command string to be sent to the instrument
             (without termination).
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         command += self.write_termination
         self._write_bytes(command.encode(), **kwargs)
@@ -72,7 +72,7 @@ class SerialAdapter(Adapter):
         """Write the bytes `content` to the instrument.
 
         :param bytes content: The bytes to write to the instrument.
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         self.connection.write(content, **kwargs)
 

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -55,7 +55,7 @@ class VISAAdapter(Adapter):
     :param float query_delay: Time in s to wait after writing and before reading.
 
         .. deprecated:: 0.11
-            Implement it in the instrument's `wait_until_read` method instead.
+            Implement it in the instrument's `wait_for` method instead.
 
     :param log: Parent logger of the 'Adapter' logger.
     :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
@@ -88,7 +88,7 @@ class VISAAdapter(Adapter):
         super().__init__(preprocess_reply=preprocess_reply, log=log)
         if query_delay:
             warn(("Parameter `query_delay` is deprecated. "
-                  "Implement in Instrument's `wait_until_read` instead."),
+                  "Implement in Instrument's `wait_for` instead."),
                  FutureWarning)
             kwargs.setdefault("query_delay", query_delay)
         self.query_delay = query_delay
@@ -131,7 +131,7 @@ class VISAAdapter(Adapter):
 
         :param str command: Command string to be sent to the instrument
             (without termination).
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         self.connection.write(command, **kwargs)
 
@@ -139,14 +139,14 @@ class VISAAdapter(Adapter):
         """Write the bytes `content` to the instrument.
 
         :param bytes content: The bytes to write to the instrument.
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         """
         self.connection.write_raw(content, **kwargs)
 
     def _read(self, **kwargs):
         """Read up to (excluding) `read_termination` or the whole read buffer.
 
-        :param kwargs: Keyword arguments for the connection itself.
+        :param \\**kwargs: Keyword arguments for the connection itself.
         :returns str: ASCII response of the instrument (excluding read_termination).
         """
         return self.connection.read(**kwargs)
@@ -196,7 +196,7 @@ class VISAAdapter(Adapter):
             Call `Instrument.values` instead.
 
         :param command: SCPI command to be sent to the instrument
-        :param kwargs: Key-word arguments to pass onto `query_ascii_values`
+        :param \\**kwargs: Key-word arguments to pass onto `query_ascii_values`
         :returns: Formatted response of the instrument.
         """
         warn("`Adapter.ask_values` is deprecated, call `Instrument.values` instead.",

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -160,9 +160,11 @@ class VISAAdapter(Adapter):
         :param \\**kwargs: Keyword arguments for the connection itself.
         :returns bytes: Bytes response of the instrument (including termination).
         """
-        if break_on_termchar:
-            return self.connection.read_raw(size=count if count >= 0 else None, **kwargs)
-        elif count == -1:
+        if count >= 0:
+            return self.connection.read_bytes(count, break_on_termchar=break_on_termchar, **kwargs)
+        elif break_on_termchar:
+            return self.connection.read_raw(None, **kwargs)
+        else:
             read_termination = self.connection.read_termination
             self.connection.read_termination = None
             # Try except allows to set the read_termination even after an error.
@@ -170,8 +172,6 @@ class VISAAdapter(Adapter):
                 return self.connection.read_raw(**kwargs)
             finally:
                 self.connection.read_termination = read_termination
-        else:
-            return self.connection.read_bytes(count, **kwargs)
 
     def ask(self, command):
         """ Writes the command to the instrument and returns the resulting

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -160,19 +160,18 @@ class VISAAdapter(Adapter):
         :param \\**kwargs: Keyword arguments for the connection itself.
         :returns bytes: Bytes response of the instrument (including termination).
         """
-        if count == -1:
-            if break_on_termchar:
+        if break_on_termchar:
+            return self.connection.read_raw(size=count if count >= 0 else None, **kwargs)
+        elif count == -1:
+            read_termination = self.connection.read_termination
+            self.connection.read_termination = None
+            # Try except allows to set the read_termination even after an error.
+            try:
                 return self.connection.read_raw(**kwargs)
-            else:
-                read_termination = self.connection.read_termination
-                self.connection.read_termination = None
-                # Try except allows to set the read_termination even after an error.
-                try:
-                    return self.connection.read_raw(**kwargs)
-                finally:
-                    self.connection.read_termination = read_termination
+            finally:
+                self.connection.read_termination = read_termination
         else:
-            return self.connection.read_bytes(count, break_on_termchar, **kwargs)
+            return self.connection.read_bytes(count, **kwargs)
 
     def ask(self, command):
         """ Writes the command to the instrument and returns the resulting

--- a/pymeasure/adapters/vxi11.py
+++ b/pymeasure/adapters/vxi11.py
@@ -125,15 +125,24 @@ class VXI11Adapter(Adapter):
         warn("Use `read_bytes` instead.", FutureWarning)
         return self.read_bytes(-1)
 
-    def _read_bytes(self, count, **kwargs):
+    def _read_bytes(self, count, break_on_termchar=False, **kwargs):
         """Read a certain number of bytes from the instrument.
 
         :param int count: Number of bytes to read. A value of -1 indicates to
             read the whole read buffer.
+        :param bool break_on_termchar: Stop reading at a termination character.
         :param kwargs: Keyword arguments for the connection itself.
         :returns bytes: Bytes response of the instrument (including termination).
         """
-        return self.connection.read_raw(count, **kwargs)
+        if self.connection.term_char and not break_on_termchar:
+            read_termination = self.connection.term_char
+            self.connection.term_char = None
+            try:
+                return self.connection.read_raw(count, **kwargs)
+            finally:
+                self.connection.term_char = read_termination
+        else:
+            return self.connection.read_raw(count, **kwargs)
 
     def ask_raw(self, command):
         """ Wrapper function for the ask_raw command using the

--- a/tests/adapters/test_adapter.py
+++ b/tests/adapters/test_adapter.py
@@ -85,7 +85,7 @@ def test_read_bytes(fake):
 @pytest.mark.parametrize("method, args", (['_write', ['5']],
                                           ['_read', []],
                                           ['_write_bytes', ['8']],
-                                          ['_read_bytes', ['5']],
+                                          ['_read_bytes', ['5', False]],
                                           ))
 def test_not_implemented_methods(adapter, method, args):
     with pytest.raises(NotImplementedError):

--- a/tests/adapters/test_protocol.py
+++ b/tests/adapters/test_protocol.py
@@ -27,7 +27,7 @@ import pytest
 
 from pymeasure.adapters.protocol import to_bytes, ProtocolAdapter
 
-from pytest import mark, raises, fixture
+from pytest import mark, raises, fixture, warns
 
 
 @pytest.fixture
@@ -212,6 +212,11 @@ class Test_read_bytes:
         a = ProtocolAdapter([(None, None)])
         with raises(AssertionError, match="None, None"):
             a.read_bytes(1)
+
+    def test_break_on_termchar_raises_warning(self):
+        a = ProtocolAdapter([(None, b"Response")])
+        with warns(UserWarning, match="cannot be tested"):
+            assert a.read_bytes(10, break_on_termchar=True) == b"Response"
 
 
 def test_read_write_sequence():

--- a/tests/adapters/test_serial.py
+++ b/tests/adapters/test_serial.py
@@ -64,6 +64,17 @@ def test_read_bytes(adapter):
     assert adapter.read_bytes(11) == b"basd\x02fasdf\n"
 
 
+def test_read_bytes_unlimited(adapter):
+    adapter.write_bytes(b"basd\x02fasdf\n")
+    assert adapter.read_bytes(-1) == b"basd\x02fasdf\n"
+
+
+def test_read_bytes_break_on_termchar(adapter):
+    adapter.read_termination = "\n"
+    adapter.write_bytes(b"basd\x02\nfasdf\n")
+    assert adapter.read_bytes(-1, break_on_termchar=True) == b"basd\x02\n"
+
+
 @pytest.mark.parametrize("test_input,expected", [([1, 2, 3], b'OUTP#13\x01\x02\x03'),
                                                  (range(100), b'OUTP#3100' + bytes(range(100)))])
 def test_adapter_write_binary_values(adapter, test_input, expected):

--- a/tests/adapters/test_serial.py
+++ b/tests/adapters/test_serial.py
@@ -60,19 +60,24 @@ def test_write_bytes(adapter, msg):
 
 
 def test_read_bytes(adapter):
-    adapter.write_bytes(b"basd\x02fasdf\n")
-    assert adapter.read_bytes(11) == b"basd\x02fasdf\n"
+    """Test whether `count` bytes are returned, even though a term char is defined."""
+    adapter.read_termination = "\n"
+    adapter.write_bytes(b"basd\x02\nfasdf\n")
+    assert adapter.read_bytes(9) == b"basd\x02\nfas"
 
 
 def test_read_bytes_unlimited(adapter):
-    adapter.write_bytes(b"basd\x02fasdf\n")
-    assert adapter.read_bytes(-1) == b"basd\x02fasdf\n"
-
-
-def test_read_bytes_break_on_termchar(adapter):
+    """Test whether all bytes are returned, even though a term char is defined."""
     adapter.read_termination = "\n"
     adapter.write_bytes(b"basd\x02\nfasdf\n")
-    assert adapter.read_bytes(-1, break_on_termchar=True) == b"basd\x02\n"
+    assert adapter.read_bytes(-1) == b"basd\x02\nfasdf\n"
+
+
+@pytest.mark.parametrize("count", (-1, 8))
+def test_read_bytes_break_on_termchar(adapter, count):
+    adapter.read_termination = "\n"
+    adapter.write_bytes(b"basd\x02\nfasdf\n")
+    assert adapter.read_bytes(count, break_on_termchar=True) == b"basd\x02\n"
 
 
 @pytest.mark.parametrize("test_input,expected", [([1, 2, 3], b'OUTP#13\x01\x02\x03'),

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -98,6 +98,14 @@ def test_write_read_all_bytes(adapter):
     assert adapter.read_bytes(-1) == b"SCPI,MOCK,VERSION_1.0\n"
 
 
+def test_write_read_break_on_termchar(adapter):
+    """Test read_bytes breaks or does not break on termchar."""
+    adapter.write("*IDN?")
+    adapter.connection.read_termination = ","
+    assert adapter.read_bytes(-1, break_on_termchar=True) == b"SCPI,"
+    assert adapter.read_bytes(-1, break_on_termchar=False) == b"MOCK,VERSION_1.0\n"
+
+
 def test_visa_adapter(adapter):
     assert repr(adapter) == f"<VISAAdapter(resource='{SIM_RESOURCE}')>"
 


### PR DESCRIPTION
Closes #837 

As discussed: Default is to **not** break at a term char, but the option remains. Changes are implemented in all adapters, which have `read_bytes`: VISA, Fake, Serial, VXI11.

Tests are added accordingly.

The first commit contains the changes.
The second commit contains some cosmetic docstring changes.