### PR TITLE
Prologix settings are configurable.

### DIFF
--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -57,7 +57,7 @@ class PrologixAdapter(VISAAdapter):
 
     :param auto: Enable or disable read-after-write and address instrument to listen.
     :param eoi: Enable or disable EOI assertion.
-    :param eos: Set command termination string ("\r\n", "\r", "\n", or "")
+    :param eos: Set command termination string (CR+LF, CR, LF, or "")
     :param kwargs: Key-word arguments if constructing a new serial object
 
     :ivar address: Integer GPIB address of the desired instrument.
@@ -151,10 +151,10 @@ class PrologixAdapter(VISAAdapter):
         """Control GPIB termination characters (str).
 
         possible values:
-            - "\r\n": CR+LF
-            - \r": CR
-            - "\n": LF
-            - None
+            - CR+LF
+            - CR
+            - LF
+            - empty string
 
         When data from host is received, all non-escaped LF, CR and ESC characters are
         removed and GPIB terminators, as specified by this command, are appended before

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -36,6 +36,15 @@ def test_init():
         pass
 
 
+def test_init_different_config():
+    with expected_protocol(
+            PrologixAdapter,
+            [("++auto 1", None), ("++eoi 3", None), ("++eos 5", None)],
+            auto=1, eoi=3, eos=5,
+    ):
+        pass
+
+
 def test_write():
     with expected_protocol(
             PrologixAdapter,

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -28,10 +28,13 @@ from pymeasure.adapters import PrologixAdapter
 from pymeasure.test import expected_protocol
 
 
+init_comm = [("++auto 0", None), ("++eoi 1", None), ("++eos 2", None)]
+
+
 def test_init():
     with expected_protocol(
             PrologixAdapter,
-            [("++auto 0", None), ("++eoi 1", None), ("++eos 2", None)]
+            init_comm,
     ):
         pass
 
@@ -39,10 +42,19 @@ def test_init():
 def test_init_different_config():
     with expected_protocol(
             PrologixAdapter,
-            [("++auto 1", None), ("++eoi 3", None), ("++eos 5", None)],
-            auto=1, eoi=3, eos=5,
+            [("++auto 1", None), ("++eoi 0", None), ("++eos 0", None)],
+            auto=True, eoi=False, eos="\r\n",
     ):
         pass
+
+
+@pytest.mark.parametrize("message, value", (("1", True), ("0", False)))
+def test_auto(message, value):
+    with expected_protocol(
+            PrologixAdapter,
+            init_comm + [("++auto", message)],
+    ) as adapter:
+        assert adapter.auto is value
 
 
 def test_write():


### PR DESCRIPTION
Incorporate properties from https://github.com/thosou/pymeasure/blob/dev/prologix-ethernet/pymeasure/adapters/prologix.py by @thosou

given in #172 

Only the `read` methods differ (++read vs ++read eoi), could you shed light on this question @msmttchr ?