### PR TITLE
Removing Teledyne T3AFG check_set_errors

### DIFF
--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -79,7 +79,6 @@ class SignalChannel(Channel):
         values=[0, 350e6],
         get_process=get_process_generator_search('FRQ', 'HZ', float),
         dynamic=True,
-        check_set_errors=True,
     )
 
     amplitude = Channel.control(
@@ -93,7 +92,6 @@ class SignalChannel(Channel):
         values=[-5, 5],
         get_process=get_process_generator_search('AMP', 'V', float),
         dynamic=True,
-        check_set_errors=True,
     )
 
     offset = Channel.control(
@@ -107,7 +105,6 @@ class SignalChannel(Channel):
         values=[-5, 5],
         get_process=get_process_generator_search('OFST', 'V', float),
         dynamic=True,
-        check_set_errors=True,
     )
 
     max_output_amplitude = Channel.control(

--- a/tests/instruments/teledyne/test_teledyneT3AFG.py
+++ b/tests/instruments/teledyne/test_teledyneT3AFG.py
@@ -54,7 +54,6 @@ def test_frequency():
     with expected_protocol(
         TeledyneT3AFG,
         [("C1:BSWV FRQ,1000", None),
-         ("SYST:ERR?", "-0, No errors"),
          ("C1:BSWV?", "C1:BSWV WVTP,SINE,FRQ,0.3HZ,PERI,3.33333S,AMP,0.08V,"
           "AMPVRMS,0.02828Vrms,MAX_OUTPUT_AMP,4.6V,OFST,-2V,HLEV,-1.96V,LLEV,-2.04V,PHSE,0")],
     ) as inst:
@@ -76,7 +75,6 @@ def test_amplitude():
     with expected_protocol(
         TeledyneT3AFG,
         [("C1:BSWV AMP,1", None),
-         ("SYST:ERR?", "-0, No errors"),
          ("C1:BSWV?", "C1:BSWV WVTP,SINE,FRQ,0.3HZ,PERI,3.33333S,AMP,0.08V,"
           "AMPVRMS,0.02828Vrms,MAX_OUTPUT_AMP,4.6V,OFST,-2V,HLEV,-1.96V,LLEV,-2.04V,PHSE,0")],
     ) as inst:
@@ -89,7 +87,6 @@ def test_offset():
     with expected_protocol(
         TeledyneT3AFG,
         [("C1:BSWV OFST,1", None),
-         ("SYST:ERR?", "-0, No errors"),
          ("C1:BSWV?", "C1:BSWV WVTP,DC,MAX_OUT_AMP,4.6V,OFST,0V")],
     ) as inst:
         inst.ch_1.offset = 1


### PR DESCRIPTION
After testing with the instrument over the past few weeks I've repeatedly run into thread safety issues (see [833](https://github.com/pymeasure/pymeasure/issues/833) and [506](https://github.com/pymeasure/pymeasure/issues/506)). In this case, I don't think check_set_errors really adds anything to pymeasure implementation of this particular instrument. By removing it, I reduce the chance of a user getting an opaque fatal error associated with setting and measuring from the same instrument at the same time.

I also adjusted the tests to match. 