### PR TITLE
Added `flush_read_buffer` to SerialAdapter

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -60,3 +60,4 @@ Scott Candey
 Tom Verbeure
 Max Herbold
 Alexander Wichers
+Robert Roos

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -141,6 +141,10 @@ class Adapter:
         """Read bytes from the instrument. Implement in subclass."""
         raise NotImplementedError("Adapter class has not implemented reading bytes.")
 
+    def flush_read_buffer(self):
+        """Flush and discard the input buffer. Implement in subclass."""
+        raise NotImplementedError("Adapter class has not implemented input flush.")
+
     # Deprecated methods.
     def ask(self, command):
         """ Write the command to the instrument and returns the resulting

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -107,5 +107,9 @@ class SerialAdapter(Adapter):
             # At -1 we read a very large number of bytes, which can be considered the whole buffer.
             return self.connection.read(1e99 if count == -1 else count, **kwargs)
 
+    def flush_read_buffer(self):
+        """Flush and discard the input buffer."""
+        self.connection.reset_input_buffer()
+
     def __repr__(self):
         return "<SerialAdapter(port='%s')>" % self.connection.port


### PR DESCRIPTION
and added stub in `Adapter` base class. Fixes #864 

I am not sure we need to declare the method in the base class. Not every adapter has a (meaningful) implementation, but to keep instruments agnostic of their adapters, it should be a base definition.