### PR TITLE
VISAAdapter fix read_bytes(-1)

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -181,6 +181,9 @@ class VISAAdapter(Adapter):
         elif break_on_termchar:
             return self.connection.read_raw(None, **kwargs)
         else:
+            # pyvisa's `read_raw` reads until newline, if no termination_character defined
+            # and if not configured to stop at a termination lane etc.
+            # see https://github.com/pyvisa/pyvisa/issues/728
             result = bytearray()
             while True:
                 try:

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -154,6 +154,13 @@ class TestReadBytes:
         # `break_on_termchar=False` is default value
         assert adapterR.read_bytes(-1) == b"SCPI,MOCK,VERSION_1.0\n"
 
+    def test_read_no_break_on_newline(self, adapter):
+        # write twice to have two newline characters in the read buffer
+        adapter.write("*IDN?")
+        adapter.write("*IDN?")
+        # `break_on_termchar=False` is default value
+        assert adapter.read_bytes(-1) == b"SCPI,MOCK,VERSION_1.0\nSCPI,MOCK,VERSION_1.0\n"
+
 
 def test_visa_adapter(adapter):
     assert repr(adapter) == f"<VISAAdapter(resource='{SIM_RESOURCE}')>"


### PR DESCRIPTION
Fixes #863 

Goal: test expected `read_bytes(-1)` behaviour and make it work.

- First commit is a test (which should be added anyways).
- Second commit is a fail proof (though not very elegant) solution to read the whole buffer.

Drawback of the solution: It takes at least one timeout period.