### PR TITLE
 dsp7265: Move preprocess_reply functionality to instrument read() method

### DIFF
--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -193,7 +193,6 @@ class DSP7265(Instrument):
 
         # Check and map the value
         value = truncated_discrete_set(value, sensitivities)
-        print(value)
         value = sensitivities.index(value)
 
         # Set sensitivity

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -68,10 +68,12 @@ class DSP7265(Instrument):
             adapter,
             "Signal Recovery DSP 7265",
             includeSCPI=False,
-            # Remove extra unicode character
-            preprocess_reply=lambda r: r.replace('\x00', ''),
             **kwargs
         )
+
+    def read(self, **kwargs):
+        """Remove extra unicode character from instrument readings"""
+        return super().read(**kwargs).replace('\x00', '')
 
     voltage = Instrument.control(
         "OA.", "OA. %g",
@@ -371,7 +373,7 @@ class DSP7265(Instrument):
 
         bits = 0
         for q in quantities:
-            bits += 2**self.CURVE_BITS.index(q)
+            bits += 2 ** self.CURVE_BITS.index(q)
 
         self.curve_buffer_bits = bits
         self.curve_buffer_length = points

--- a/tests/instruments/signalrecovery/test_dsp7265.py
+++ b/tests/instruments/signalrecovery/test_dsp7265.py
@@ -1,0 +1,71 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.test import expected_protocol
+
+from pymeasure.instruments.signalrecovery.dsp7265 import DSP7265
+
+
+@pytest.mark.parametrize("index, reference", [(idx, i) for idx, i in enumerate(DSP7265.REFERENCES)])
+def test_reference(index, reference):
+    with expected_protocol(
+            DSP7265,
+            [(f"IE {index}", None)],
+    ) as instr:
+        instr.reference = reference
+
+
+@pytest.mark.parametrize("index, imode", [(idx, i) for idx, i in enumerate(DSP7265.IMODES)])
+def test_imode(index, imode):
+    with expected_protocol(
+            DSP7265,
+            [(f"IMODE {index}", None)],
+    ) as instr:
+        instr.imode = imode
+
+
+@pytest.mark.parametrize("reading, value",
+                         [(b"-12\x00", -12), (b"0\x00", 0), (b"5", 5), (b"12", 12)])
+def test_dac1(reading, value):
+    with expected_protocol(
+            DSP7265,
+            [("DAC. 1", reading)],
+    ) as instr:
+        assert instr.dac1 == value
+
+
+@pytest.mark.parametrize("reading, value",
+                         [(b'-2.14E-07\r\n', -2.14e-07),
+                          (b'-0.0E+00\x00\r\n', 0.0),
+                          (b'1.2E-07\r\n', 1.2e-07),
+                          (b'6.44E-07\r\n', 6.44e-07),
+                          ])
+def test_x(reading, value):
+    with expected_protocol(
+            DSP7265,
+            [('X.', reading)],
+    ) as instr:
+        assert instr.x == value


### PR DESCRIPTION
This fixes the DSP 7265 instrument driver referenced in issue https://github.com/pymeasure/pymeasure/issues/872
