### PR TITLE
Add name kwarg to all instruments

### DIFF
--- a/pymeasure/instruments/activetechnologies/AWG401x.py
+++ b/pymeasure/instruments/activetechnologies/AWG401x.py
@@ -352,7 +352,9 @@ class ChannelAWG(ChannelBase):
 class AWG401x_base(Instrument):
     """AWG-401x base class"""
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter,
+                 name="Active Technologies AWG-4014 1.2GS/s Arbitrary Waveform Generator",
+                 **kwargs):
 
         # Insert an higher timeout because, often, when starting the
         # instrument, can pass some time and the adapted goes in timeout
@@ -360,8 +362,7 @@ class AWG401x_base(Instrument):
 
         super().__init__(
             adapter,
-            """Active Technologies AWG-4014 1.2GS/s Arbitrary Waveform
-            Generator""",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/advantest/advantestR3767CG.py
+++ b/pymeasure/instruments/advantest/advantestR3767CG.py
@@ -67,10 +67,10 @@ class AdvantestR3767CG(Instrument):
         "TRAC:DATA? FDAT1", """ Reads the Data array from trace 1 after formatting """
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Advantest R3767CG", **kwargs):
         super().__init__(
             adapter,
-            "Advantest R3767CG",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilent33220A.py
+++ b/pymeasure/instruments/agilent/agilent33220A.py
@@ -69,10 +69,10 @@ class Agilent33220A(Instrument):
 
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent 33220A Arbitrary Waveform generator", **kwargs):
         super().__init__(
             adapter,
-            "Agilent 33220A Arbitrary Waveform generator",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -391,9 +391,10 @@ class Agilent33500(Instrument):
 
     ch = Instrument.ChannelCreator(Agilent33500Channel, (1, 2))
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent 33500 Function/Arbitrary Waveform generator family",
+                 **kwargs):
         super().__init__(
-            adapter, "Agilent 33500 Function/Arbitrary Waveform generator family", **kwargs
+            adapter, name, **kwargs
         )
 
     def beep(self):

--- a/pymeasure/instruments/agilent/agilent34410A.py
+++ b/pymeasure/instruments/agilent/agilent34410A.py
@@ -46,7 +46,7 @@ class Agilent34410A(Instrument):
     resistance_4w = Instrument.measurement(
         "MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms")
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="HP/Agilent/Keysight 34410A Multimeter", **kwargs):
         super().__init__(
-            adapter, "HP/Agilent/Keysight 34410A Multimeter", **kwargs
+            adapter, name, **kwargs
         )

--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -370,9 +370,9 @@ class Agilent34450A(Instrument):
                                         based on the active :attr:`~.Agilent34450A.mode`. """
                                         )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="HP/Agilent/Keysight 34450A Multimeter", **kwargs):
         super().__init__(
-            adapter, "HP/Agilent/Keysight 34450A Multimeter", timeout=10000, **kwargs
+            adapter, name, timeout=10000, **kwargs
         )
         # Configuration changes can necessitate up to 8.8 secs (per datasheet)
         self.check_errors()

--- a/pymeasure/instruments/agilent/agilent4156.py
+++ b/pymeasure/instruments/agilent/agilent4156.py
@@ -130,10 +130,11 @@ class Agilent4156(Instrument):
 
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent 4155/4156 Semiconductor Parameter Analyzer",
+                 **kwargs):
         super().__init__(
             adapter,
-            "Agilent 4155/4156 Semiconductor Parameter Analyzer",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilent8257D.py
+++ b/pymeasure/instruments/agilent/agilent8257D.py
@@ -249,9 +249,9 @@ class Agilent8257D(Instrument):
         map_values=True
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent 8257D RF Signal Generator", **kwargs):
         super().__init__(
-            adapter, "Agilent 8257D RF Signal Generator", **kwargs
+            adapter, name, **kwargs
         )
 
     def enable(self):

--- a/pymeasure/instruments/agilent/agilent8722ES.py
+++ b/pymeasure/instruments/agilent/agilent8722ES.py
@@ -73,10 +73,10 @@ class Agilent8722ES(Instrument):
         cast=bool
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent 8722ES Vector Network Analyzer", **kwargs):
         super().__init__(
             adapter,
-            "Agilent 8722ES Vector Network Analyzer",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -49,10 +49,10 @@ class AgilentB1500(Instrument):
     measurements.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent B1500 Semiconductor Parameter Analyzer", **kwargs):
         super().__init__(
             adapter,
-            "Agilent B1500 Semiconductor Parameter Analyzer",
+            name,
             **kwargs
         )
         self._smu_names = {}

--- a/pymeasure/instruments/agilent/agilentE4408B.py
+++ b/pymeasure/instruments/agilent/agilentE4408B.py
@@ -76,10 +76,10 @@ class AgilentE4408B(Instrument):
         """
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent E4408B Spectrum Analyzer", **kwargs):
         super().__init__(
             adapter,
-            "Agilent E4408B Spectrum Analyzer",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -98,9 +98,9 @@ Select trigger source; accept the values:
                                         validator=strict_discrete_set,
                                         values=["HOLD", "INT", "BUS", "EXT"])
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Agilent E4980A/AL LCR meter", **kwargs):
         super().__init__(
-            adapter, "Agilent E4980A/AL LCR meter", **kwargs
+            adapter, name, **kwargs
         )
         self.timeout = 30000
         # format: output ascii

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -175,10 +175,10 @@ class Ametek7270(Instrument):
                                 """ Reads the instrument identification """
                                 )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Ametek DSP 7270", **kwargs):
         super().__init__(
             adapter,
-            "Ametek DSP 7270",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -57,11 +57,11 @@ class AMI430(Instrument):
 
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="AMI superconducting magnet power supply.", **kwargs):
         kwargs.setdefault('read_termination', '\n')
         super().__init__(
             adapter,
-            "AMI superconducting magnet power supply.",
+            name,
             includeSCPI=True,
             **kwargs
         )

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -183,7 +183,8 @@ class DPSeriesMotorController(Instrument):
             logging.error("DP-Series motor controller error detected: %s" % current_errors)
         return current_errors
 
-    def __init__(self, adapter, address=0, encoder_enabled=False, **kwargs):
+    def __init__(self, adapter, name="Anaheim Automation Stepper Motor Controller",
+                 address=0, encoder_enabled=False, **kwargs):
         """
         Initialize communication with the motor controller with the address given by `address`.
 
@@ -202,7 +203,7 @@ class DPSeriesMotorController(Instrument):
 
         super().__init__(
             adapter,
-            "Anaheim Automation Stepper Motor Controller",
+            name,
             includeSCPI=False,
             asrl={'baud_rate': 38400},
             **kwargs

--- a/pymeasure/instruments/anapico/apsin12G.py
+++ b/pymeasure/instruments/anapico/apsin12G.py
@@ -62,10 +62,10 @@ class APSIN12G(Instrument):
         values=['ON', 'OFF']
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Anapico APSIN12G Signal Generator", **kwargs):
         super().__init__(
             adapter,
-            "Anapico APSIN12G Signal Generator",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/anritsu/anritsuMG3692C.py
+++ b/pymeasure/instruments/anritsu/anritsuMG3692C.py
@@ -39,10 +39,10 @@ class AnritsuMG3692C(Instrument):
         in Hz. This property can be set. """
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Anritsu MG3692C Signal Generator", **kwargs):
         super().__init__(
             adapter,
-            "Anritsu MG3692C Signal Generator",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/anritsu/anritsuMS9740A.py
+++ b/pymeasure/instruments/anritsu/anritsuMS9740A.py
@@ -37,11 +37,11 @@ log.addHandler(logging.NullHandler())
 class AnritsuMS9740A(AnritsuMS9710C):
     """Anritsu MS9740A Optical Spectrum Analyzer."""
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Anritsu MS9740A Optical Spectrum Analyzer", **kwargs):
         """Constructor."""
         self.analysis_mode = None
         super().__init__(
-            adapter, name="Anritsu MS9740A Optical Spectrum Analyzer", **kwargs)
+            adapter, name, **kwargs)
 
     ####################################
     # Spectrum Parameters - Wavelength #

--- a/pymeasure/instruments/bkprecision/bkprecision9130b.py
+++ b/pymeasure/instruments/bkprecision/bkprecision9130b.py
@@ -60,9 +60,9 @@ class BKPrecision9130B(Instrument):
         get_process=lambda x: int(x[2])
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="BK Precision 9130B Source", **kwargs):
         super().__init__(
-            adapter, "BK Precision 9130B Source", **kwargs
+            adapter, name, **kwargs
         )
 
     @property

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -56,10 +56,10 @@ class Danfysik8500(Instrument):
         "PRINT", """ Reads the idenfitication information. """
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Danfysik 8500 Current Supply", **kwargs):
         super().__init__(
             adapter,
-            "Danfysik 8500 Current Supply",
+            name,
             includeSCPI=False,
             write_termination="\r",
             read_termination="\r",

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -94,10 +94,10 @@ class SM7045D(Instrument):
         output of the power supply is disabled/enabled. """,
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Delta Elektronika SM 70-45 D", **kwargs):
         super().__init__(
             adapter,
-            "Delta Elektronika SM 70-45 D",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/edwards/nxds.py
+++ b/pymeasure/instruments/edwards/nxds.py
@@ -38,10 +38,10 @@ class Nxds(Instrument):
                                 validator=strict_discrete_set,
                                 values=(0, 1),)
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Edwards NXDS Vacuum Pump", **kwargs):
         super().__init__(
             adapter,
-            "Edwards NXDS Vacuum Pump",
+            name,
             includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/eurotest/eurotestHPP120256.py
+++ b/pymeasure/instruments/eurotest/eurotestHPP120256.py
@@ -96,6 +96,7 @@ class EurotestHPP120256(Instrument):
 
     def __init__(self,
                  adapter,
+                 name="Euro Test High Voltage DC Source model HPP-120-256",
                  query_delay=0.1,
                  write_delay=0.4,
                  timeout=5000,
@@ -103,7 +104,7 @@ class EurotestHPP120256(Instrument):
 
         super().__init__(
             adapter,
-            "Euro Test High Voltage DC Source model HPP-120-256",
+            name,
             write_termination="\n",
             read_termination="",
             send_end=True,

--- a/pymeasure/instruments/fluke/fluke7341.py
+++ b/pymeasure/instruments/fluke/fluke7341.py
@@ -30,12 +30,12 @@ class Fluke7341(Instrument):
     """ Represents the compact constant temperature bath from Fluke.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Fluke 7341", **kwargs):
         kwargs.setdefault('timeout', 2000)
         kwargs.setdefault('write_termination', '\r\n')
         super().__init__(
             adapter,
-            "Fluke 7341",
+            name,
             includeSCPI=False,
             asrl={'baud_rate': 2400},
             **kwargs

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -48,12 +48,12 @@ class FWBell5080(Instrument):
 
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="F.W. Bell 5080 Handheld Gaussmeter", **kwargs):
         kwargs.setdefault('timeout', 500)
         kwargs.setdefault('baudrate', 2400)
         super().__init__(
             adapter,
-            "F.W. Bell 5080 Handheld Gaussmeter",
+            name,
             includeSCPI=True,
             **kwargs
         )

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -76,10 +76,10 @@ class TC038(Instrument):
     :param int timeout: Timeout in ms.
     """
 
-    def __init__(self, adapter, address=1, timeout=1000,
+    def __init__(self, adapter, name="TC038", address=1, timeout=1000,
                  includeSCPI=False, **kwargs):
 
-        super().__init__(adapter, "TC038", timeout=timeout,
+        super().__init__(adapter, name, timeout=timeout,
                          write_termination="\r", read_termination="\r",
                          parity=Parity.even, **kwargs)
         self.address = address

--- a/pymeasure/instruments/heidenhain/nd287.py
+++ b/pymeasure/instruments/heidenhain/nd287.py
@@ -42,8 +42,8 @@ class ND287(Instrument):
 
     # get_process lambda functions used in the position property
     position_get_process_map = {
-        "mm": lambda p: float(p.split("\x02")[-1])*1e-4,
-        "inch": lambda p: float(p.split("\x02")[-1])*1e-5
+        "mm": lambda p: float(p.split("\x02")[-1]) * 1e-4,
+        "inch": lambda p: float(p.split("\x02")[-1]) * 1e-5
     }
 
     position = Instrument.measurement(
@@ -56,7 +56,7 @@ class ND287(Instrument):
         dynamic=True
     )
 
-    def __init__(self, adapter, units="mm", **kwargs):
+    def __init__(self, adapter, name="Heidenhain ND287", units="mm", **kwargs):
         """ Initialize the nd287 with a carriage return write termination.
 
         :param: units: Specify the units that the gauge is working in.
@@ -66,7 +66,7 @@ class ND287(Instrument):
 
         super().__init__(
             adapter,
-            "Heidenhain ND287",
+            name,
             includeSCPI=False,
             write_termination="\r",
             **kwargs

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -105,10 +105,10 @@ class HP33120A(Instrument):
         map_values=True
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett Packard 33120A Function Generator", **kwargs):
         super().__init__(
             adapter,
-            "Hewlett Packard 33120A Function Generator",
+            name,
             **kwargs
         )
         self.amplitude_units = 'Vpp'

--- a/pymeasure/instruments/hp/hp3437A.py
+++ b/pymeasure/instruments/hp/hp3437A.py
@@ -174,13 +174,12 @@ class HP3437A(HPLegacyInstrument):
     status_desc = Status
     pb_desc = PackedBits
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett-Packard HP3437A", **kwargs):
         super().__init__(
             adapter,
-            "Hewlett-Packard HP3437A",
+            name,
             **kwargs,
         )
-        log.info("Initialized HP3437A")
 
     # Definitions for different specifics of this instrument
     RANGE = {

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -70,10 +70,10 @@ class HP34401A(Instrument):
 
     BOOL_MAPPINGS = {True: 1, False: 0}
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="HP 34401A", **kwargs):
         super().__init__(
             adapter,
-            "HP 34401A",
+            name,
             asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},
             **kwargs
         )

--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -113,12 +113,12 @@ class HP3478A(HPLegacyInstrument):
     """
     status_desc = Status
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett-Packard HP3478A", **kwargs):
         kwargs.setdefault('read_termination', '\r\n')
         kwargs.setdefault('send_end', True)
         super().__init__(
             adapter,
-            "Hewlett-Packard HP3478A",
+            name,
             **kwargs,
         )
 

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -56,13 +56,13 @@ class HP8116A(Instrument):
     The resolution for all floating point instrument parameters is 3 digits.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett-Packard 8116A", **kwargs):
         kwargs.setdefault('read_termination', '\r\n')
         kwargs.setdefault('write_termination', '\r\n')
         kwargs.setdefault('send_end', True)
         super().__init__(
             adapter,
-            'Hewlett-Packard 8116A',
+            name,
             includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/hp/hp8657b.py
+++ b/pymeasure/instruments/hp/hp8657b.py
@@ -37,10 +37,10 @@ class HP8657B(Instrument):
     with the instrument.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett-Packard HP8657B", **kwargs):
         super().__init__(
             adapter,
-            "Hewlett-Packard HP8657B",
+            name,
             includeSCPI=False,
             send_end=True,
             **kwargs,

--- a/pymeasure/instruments/hp/hpsystempsu.py
+++ b/pymeasure/instruments/hp/hpsystempsu.py
@@ -74,12 +74,12 @@ class HP6632A(HPLegacyInstrument):
     """
     status_desc = Status
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Hewlett-Packard HP6632A", **kwargs):
         kwargs.setdefault('read_termination', '\r\n')
         kwargs.setdefault('send_end', True)
         super().__init__(
             adapter,
-            "Hewlett-Packard HP6632A",
+            name,
             **kwargs,
         )
 
@@ -314,7 +314,9 @@ class HP6633A(HP6632A):
     with the instrument.
     """
 
-    name = "Hewlett Packard HP6633A"
+    def __init__(self, adapter, name="Hewlett Packard HP6633A", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
     current_values = [0, limits["HP6633A"]["Cur_lim"]]
     OVP_values = [0, limits["HP6633A"]["OVP_lim"]]
     voltage_values = [0, limits["HP6633A"]["Volt_lim"]]
@@ -326,7 +328,9 @@ class HP6634A(HP6632A):
     with the instrument.
     """
 
-    name = "Hewlett Packard HP6634A"
+    def __init__(self, adapter, name="Hewlett Packard HP6634A", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
     current_values = [0, limits["HP6634A"]["Cur_lim"]]
     OVP_values = [0, limits["HP6634A"]["OVP_lim"]]
     voltage_values = [0, limits["HP6634A"]["Volt_lim"]]

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -436,9 +436,9 @@ class Keithley2000(Instrument, KeithleyBuffer):
         values=[0, 999999.999]
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2000 Multimeter", **kwargs):
         super().__init__(
-            adapter, "Keithley 2000 Multimeter", **kwargs
+            adapter, name, **kwargs
         )
 
     def measure_voltage(self, max_voltage=1, ac=False):

--- a/pymeasure/instruments/keithley/keithley2260B.py
+++ b/pymeasure/instruments/keithley/keithley2260B.py
@@ -51,10 +51,11 @@ class Keithley2260B(Instrument):
         print(source.applied)
     """
 
-    def __init__(self, adapter, read_termination="\n", **kwargs):
-        kwargs.setdefault('name', "Keithley 2260B DC Power Supply")
+    def __init__(self, adapter, name="Keithley 2260B DC Power Supply",
+                 read_termination="\n", **kwargs):
         super().__init__(
             adapter,
+            name,
             read_termination=read_termination,
             **kwargs
         )

--- a/pymeasure/instruments/keithley/keithley2306.py
+++ b/pymeasure/instruments/keithley/keithley2306.py
@@ -602,10 +602,10 @@ class Keithley2306(Instrument):
     """ Represents the Keithley 2306 Dual Channel Battery/Charger Simulator.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2306", **kwargs):
         super().__init__(
             adapter,
-            "Keithley 2306",
+            name,
             **kwargs
         )
         self.ch1 = BatteryChannel(self, 1)

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -369,9 +369,9 @@ class Keithley2400(Instrument, KeithleyBuffer):
     # Methods        #
     ####################
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2400 SourceMeter", **kwargs):
         super().__init__(
-            adapter, "Keithley 2400 SourceMeter", **kwargs
+            adapter, name, **kwargs
         )
 
     def enable_source(self):

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -365,9 +365,9 @@ class Keithley2450(Instrument, KeithleyBuffer):
     # Methods        #
     ####################
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2450 SourceMeter", **kwargs):
         super().__init__(
-            adapter, "Keithley 2450 SourceMeter", **kwargs
+            adapter, name, **kwargs
         )
 
     def enable_source(self):

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -35,10 +35,10 @@ log.addHandler(logging.NullHandler())
 class Keithley2600(Instrument):
     """Represents the Keithley 2600 series (channel A and B) SourceMeter"""
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2600 SourceMeter", **kwargs):
         super().__init__(
             adapter,
-            "Keithley 2600 SourceMeter",
+            name,
             **kwargs
         )
         self.ChA = Channel(self, 'a')

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -139,9 +139,9 @@ class Keithley2700(Instrument, KeithleyBuffer):
         """
         self.write(":ROUTe:OPEN:ALL")
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2700 MultiMeter/Switch System", **kwargs):
         super().__init__(
-            adapter, "Keithley 2700 MultiMeter/Switch System", **kwargs
+            adapter, name, **kwargs
         )
 
         self.check_errors()

--- a/pymeasure/instruments/keithley/keithley2750.py
+++ b/pymeasure/instruments/keithley/keithley2750.py
@@ -59,9 +59,9 @@ class Keithley2750(Instrument):
                                              "Reads the list of closed channels",
                                              get_process=clean_closed_channels)
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 2750 Multimeter/Switch System", **kwargs):
         super().__init__(
-            adapter, "Keithley 2750 Multimeter/Switch System", **kwargs
+            adapter, name, **kwargs
         )
 
     def open(self, channel):

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -283,9 +283,9 @@ class Keithley6221(Instrument, KeithleyBuffer):
         # Select the newly made arbitrary waveform as waveform function
         self.waveform_function = "arbitrary%d" % location
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 6221 SourceMeter", **kwargs):
         super().__init__(
-            adapter, "Keithley 6221 SourceMeter", **kwargs
+            adapter, name, **kwargs
         )
 
     def enable_source(self):

--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -192,9 +192,9 @@ class Keithley6517B(Instrument, KeithleyBuffer):
     # Methods        #
     ####################
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keithley 6517B Electrometer/High Resistance Meter", **kwargs):
         super().__init__(
-            adapter, "Keithley 6517B Electrometer/High Resistance Meter",
+            adapter, name,
             **kwargs
         )
 

--- a/pymeasure/instruments/keysight/keysightDSOX1102G.py
+++ b/pymeasure/instruments/keysight/keysightDSOX1102G.py
@@ -243,9 +243,9 @@ class KeysightDSOX1102G(Instrument):
 
     BOOLS = {True: 1, False: 0}
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keysight DSOX1102G Oscilloscope", **kwargs):
         super().__init__(
-            adapter, "Keysight DSOX1102G Oscilloscope", timeout=6000, **kwargs
+            adapter, name, timeout=6000, **kwargs
         )
         # Account for setup time for timebase_mode, waveform_points_mode
         self.ch1 = Channel(self, 1)

--- a/pymeasure/instruments/keysight/keysightN5767A.py
+++ b/pymeasure/instruments/keysight/keysightN5767A.py
@@ -95,9 +95,9 @@ class KeysightN5767A(Instrument):
         """
         return bool(self._status)
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Keysight N5767A power supply", **kwargs):
         super().__init__(
-            adapter, "Keysight N5767A power supply", **kwargs
+            adapter, name, **kwargs
         )
         # Set up data transfer format
         if isinstance(self.adapter, VISAAdapter):

--- a/pymeasure/instruments/keysight/keysightN7776C.py
+++ b/pymeasure/instruments/keysight/keysightN7776C.py
@@ -51,9 +51,10 @@ class KeysightN7776C(Instrument):
         laser.output_enabled = 0
 
     """
-    def __init__(self, adapter, **kwargs):
-        super(KeysightN7776C, self).__init__(
-            adapter, "N7776C Tunable Laser Source", **kwargs)
+
+    def __init__(self, adapter, name="N7776C Tunable Laser Source", **kwargs):
+        super().__init__(
+            adapter, name, **kwargs)
 
     locked = Instrument.control(
         ':LOCK?', ':LOCK %g,'+str(LOCK_PW),

--- a/pymeasure/instruments/keysight/keysightN7776C.py
+++ b/pymeasure/instruments/keysight/keysightN7776C.py
@@ -57,7 +57,7 @@ class KeysightN7776C(Instrument):
             adapter, name, **kwargs)
 
     locked = Instrument.control(
-        ':LOCK?', ':LOCK %g,'+str(LOCK_PW),
+        ':LOCK?', ':LOCK %g,' + str(LOCK_PW),
         """ Boolean property controlling the lock state (True/False) of the laser source""",
         validator=strict_discrete_set,
         map_values=True,
@@ -75,7 +75,7 @@ class KeysightN7776C(Instrument):
     _output_power_mW = Instrument.control(
         'SOUR0:POW?', 'SOUR0:POW %f mW',
         """ Floating point value indicating the laser output power in mW.""",
-        get_process=lambda v: v*1e3
+        get_process=lambda v: v * 1e3
     )
 
     _output_power_dBm = Instrument.control(
@@ -125,29 +125,29 @@ class KeysightN7776C(Instrument):
                                     """ Absolute wavelength of the output light (in nanometers)""",
                                     validator=strict_range,
                                     values=WL_RANGE,
-                                    get_process=lambda v: v*1e9)
+                                    get_process=lambda v: v * 1e9)
 
     sweep_wl_start = Instrument.control('sour0:wav:swe:star?', 'sour0:wav:swe:star %fnm',
                                         """ Start Wavelength (in nanometers) for a sweep.""",
                                         validator=strict_range,
                                         values=WL_RANGE,
-                                        get_process=lambda v: v*1e9)
+                                        get_process=lambda v: v * 1e9)
     sweep_wl_stop = Instrument.control('sour0:wav:swe:stop?', 'sour0:wav:swe:stop %fnm',
                                        """ End Wavelength (in nanometers) for a sweep.""",
                                        validator=strict_range,
                                        values=WL_RANGE,
-                                       get_process=lambda v: v*1e9)
+                                       get_process=lambda v: v * 1e9)
 
     sweep_step = Instrument.control('sour0:wav:swe:step?', 'sour0:wav:swe:step %fnm',
                                     """ Step width of the sweep (in nanometers).""",
                                     validator=strict_range,
-                                    values=[0.0001, WL_RANGE[1]-WL_RANGE[0]],
-                                    get_process=lambda v: v*1e9)
+                                    values=[0.0001, WL_RANGE[1] - WL_RANGE[0]],
+                                    get_process=lambda v: v * 1e9)
     sweep_speed = Instrument.control('sour0:wav:swe:speed?', 'sour0:wav:swe:speed %fnm/s',
                                      """ Speed of the sweep (in nanometers per second).""",
                                      validator=strict_discrete_set,
                                      values=[0.5, 1, 50, 80, 200],
-                                     get_process=lambda v: v*1e9)
+                                     get_process=lambda v: v * 1e9)
     sweep_mode = Instrument.control('sour0:wav:swe:mode?', 'sour0:wav:swe:mode %s',
                                     """ Sweep mode of the swept laser source """,
                                     validator=strict_discrete_set,

--- a/pymeasure/instruments/lakeshore/lakeshore224.py
+++ b/pymeasure/instruments/lakeshore/lakeshore224.py
@@ -49,14 +49,10 @@ class LakeShore224(Instrument):
                                       'D1', 'D2', 'D3', 'D4', 'D5'],
                                      prefix='input_')
 
-    def __init__(self, adapter, **kwargs):
-        name = 'Lakeshore Model 224 Temperature Controller' if 'name' not in kwargs.keys() \
-            else kwargs.pop('name')
-        read_termination = '\r\n' if 'read_termination' not in kwargs.keys() \
-            else kwargs.pop('read_termination')
+    def __init__(self, adapter, name="Lakeshore Model 224 Temperature Controller", **kwargs):
+        kwargs.setdefault('read_termination', "\r\n")
         super().__init__(
             adapter,
             name,
-            read_termination=read_termination,
             **kwargs
         )

--- a/pymeasure/instruments/lakeshore/lakeshore331.py
+++ b/pymeasure/instruments/lakeshore/lakeshore331.py
@@ -51,14 +51,10 @@ class LakeShore331(Instrument):
     i_ch = Instrument.ChannelCreator(LakeShoreTemperatureChannel, ('A', 'B'), prefix='input_')
     o_ch = Instrument.ChannelCreator(LakeShoreHeaterChannel, (1, 2), prefix='output_')
 
-    def __init__(self, adapter, **kwargs):
-        name = 'Lakeshore Model 336 Temperature Controller' if 'name' not in kwargs.keys() \
-            else kwargs.pop('name')
-        read_termination = '\r\n' if 'read_termination' not in kwargs.keys() \
-            else kwargs.pop('read_termination')
+    def __init__(self, adapter, name="Lakeshore Model 336 Temperature Controller", **kwargs):
+        kwargs.setdefault('read_termination', "\r\n")
         super().__init__(
             adapter,
             name,
-            read_termination=read_termination,
             **kwargs
         )

--- a/pymeasure/instruments/lakeshore/lakeshore421.py
+++ b/pymeasure/instruments/lakeshore/lakeshore421.py
@@ -60,11 +60,7 @@ class LakeShore421(Instrument):
         super().__init__(
             adapter,
             name,
-            "Lake Shore 421 Gaussmeter",
-            baud_rate=baud_rate,
-            data_bits=7,
-            stop_bits=10,
-            parity=1,
+            asrl={'baud_rate': baud_rate, 'data_bits': 7, 'stop_bits': 10, 'parity': 1},
             read_termination='\r',
             write_termination='\n',
             **kwargs

--- a/pymeasure/instruments/lakeshore/lakeshore421.py
+++ b/pymeasure/instruments/lakeshore/lakeshore421.py
@@ -56,9 +56,10 @@ class LakeShore421(Instrument):
     UNITS = ['G', 'T']
     WRITE_DELAY = 0.05
 
-    def __init__(self, adapter, baud_rate=9600, **kwargs):
-        super(LakeShore421, self).__init__(
+    def __init__(self, adapter, name="Lake Shore 421 Gaussmeter", baud_rate=9600, **kwargs):
+        super().__init__(
             adapter,
+            name,
             "Lake Shore 421 Gaussmeter",
             baud_rate=baud_rate,
             data_bits=7,

--- a/pymeasure/instruments/lakeshore/lakeshore425.py
+++ b/pymeasure/instruments/lakeshore/lakeshore425.py
@@ -73,10 +73,10 @@ class LakeShore425(Instrument):
         map_values=True
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="LakeShore 425 Gaussmeter", **kwargs):
         super().__init__(
             adapter,
-            "LakeShore 425 Gaussmeter",
+            name,
             asrl={'write_termination': "\n",
                   'read_termination': "\n",  # from manual
                   'baud_rate': 57600,

--- a/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
+++ b/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
@@ -493,8 +493,8 @@ class LeCroyT3DSO1204(Instrument):
 
     channels = Instrument.ChannelCreator(ScopeChannel, (1, 2, 3, 4))
 
-    def __init__(self, adapter, **kwargs):
-        super().__init__(adapter, "LeCroy T3DSO1204 Oscilloscope", **kwargs)
+    def __init__(self, adapter, name="LeCroy T3DSO1204 Oscilloscope", **kwargs):
+        super().__init__(adapter, name, **kwargs)
         if self.adapter.connection is not None:
             self.adapter.connection.timeout = 3000
         self._grid_number = 14  # Number of grids in the horizontal direction

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -249,10 +249,10 @@ class ESP300(Instrument):
         cast=int
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Newport ESP 300 Motion Controller", **kwargs):
         super().__init__(
             adapter,
-            "Newport ESP 300 Motion Controller",
+            name,
             **kwargs
         )
         # Defines default axes, which can be overwritten

--- a/pymeasure/instruments/parker/parkerGV6.py
+++ b/pymeasure/instruments/parker/parkerGV6.py
@@ -35,10 +35,10 @@ class ParkerGV6(Instrument):
 
     degrees_per_count = 0.00045  # 90 deg per 200,000 count
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Parker GV6 Motor Controller", **kwargs):
         super().__init__(
             adapter,
-            "Parker GV6 Motor Controller",
+            name,
             asrl={'baud_rate': 9600,
                   'timeout': 500,
                   },

--- a/pymeasure/instruments/pendulum/cnt91.py
+++ b/pymeasure/instruments/pendulum/cnt91.py
@@ -46,12 +46,12 @@ class CNT91(Instrument):
     CHANNELS = {"A": 1, "B": 2, "C": 3, "E": 4, "INTREF": 6}
     MAX_BUFFER_SIZE = 32000  # User Manual 8-38
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Pendulum CNT-91", **kwargs):
         kwargs.setdefault('timeout', 120000)
         kwargs.setdefault('read_termination', '\n')
         super().__init__(
             adapter,
-            "Pendulum CNT-91",
+            name,
             **kwargs,
         )
 

--- a/pymeasure/instruments/razorbill/razorbillRP100.py
+++ b/pymeasure/instruments/razorbill/razorbillRP100.py
@@ -107,8 +107,8 @@ class razorbillRP100(Instrument):
         """Returns the current in amps present at the front panel output of channel 2"""
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Razorbill RP100 Piezo Stack Powersupply", **kwargs):
         super().__init__(
-            adapter, "Razorbill RP100 Piezo Stack Powersupply", **kwargs
+            adapter, name, **kwargs
         )
         self.timeout = 20

--- a/pymeasure/instruments/rohdeschwarz/fsl.py
+++ b/pymeasure/instruments/rohdeschwarz/fsl.py
@@ -50,9 +50,9 @@ class FSL(Instrument):
     dBm, etc.).
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Rohde&Schwarz FSL", **kwargs):
         super().__init__(
-            adapter, "Rohde&Schwarz FSL", includeSCPI=True, **kwargs
+            adapter, name, includeSCPI=True, **kwargs
         )
 
     # Frequency settings ------------------------------------------------------

--- a/pymeasure/instruments/rohdeschwarz/sfm.py
+++ b/pymeasure/instruments/rohdeschwarz/sfm.py
@@ -202,10 +202,10 @@ class SFM(Instrument):
 
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Rohde&Schwarz SFM", **kwargs):
         super().__init__(
             adapter,
-            "Rohde&Schwarz SFM",
+            name,
             includeSCPI=True,
             **kwargs
         )

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1168x.py
@@ -32,9 +32,9 @@ class SPD1168X(SPDSingleChannelBase):
 
     channels = Instrument.ChannelCreator(SPDChannel, 1)
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Siglent Technologies SPD1168X Power Supply", **kwargs):
         super().__init__(
             adapter,
-            name="Siglent Technologies SPD1168X Power Supply",
+            name,
             **kwargs
         )

--- a/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spd1305x.py
@@ -36,11 +36,11 @@ class SPD1305X(SPDSingleChannelBase):
                                          voltage_range=voltage_range,
                                          current_range=current_range)
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Siglent Technologies SPD1305X Power Supply", **kwargs):
 
         super().__init__(
             adapter,
-            name="Siglent Technologies SPD1305X Power Supply",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_spdbase.py
@@ -161,10 +161,10 @@ class SPDBase(Instrument):
     Uses :class:`SPDChannel` for measurement channels.
     """
 
-    def __init__(self, adapter, **kwargs):
-        kwargs.setdefault('name', 'Siglent SPDxxxxX instrument Base Class')
+    def __init__(self, adapter, name="Siglent SPDxxxxX instrument Base Class", **kwargs):
         super().__init__(
             adapter,
+            name,
             usb=dict(write_termination='\n',
                      read_termination='\n'),
             tcpip=dict(write_termination='\n',

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -63,10 +63,10 @@ class DSP7265(Instrument):
                   # Dual modes
                   'x2', 'y2', 'magnitude2', 'phase2', 'sensitivity2']
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Signal Recovery DSP 7265", **kwargs):
         super().__init__(
             adapter,
-            "Signal Recovery DSP 7265",
+            name,
             includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/srs/sg380.py
+++ b/pymeasure/instruments/srs/sg380.py
@@ -50,10 +50,11 @@ class SG380(Instrument):
         in Hz. This property can be set. """
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Stanford Research Systems SG380 RF Signal Generator",
+                 **kwargs):
         super().__init__(
             adapter,
-            "Stanford Research Systems SG380 RF Signal Generator",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/srs/sr510.py
+++ b/pymeasure/instruments/srs/sr510.py
@@ -80,11 +80,12 @@ class SR510(Instrument):
         """A float property that represents the SR510 output voltage in Volts.""",
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Stanford Research Systems SR510 Lock-in amplifier",
+                 **kwargs):
         kwargs.setdefault('write_termination', '\r')
         super().__init__(
             adapter,
-            "Stanford Research Systems SR510 Lock-in amplifier",
+            name,
             includeSCPI=False,
             **kwargs,
         )

--- a/pymeasure/instruments/srs/sr570.py
+++ b/pymeasure/instruments/srs/sr570.py
@@ -29,10 +29,11 @@ from pymeasure.instruments.validators import strict_discrete_set, \
 
 class SR570(Instrument):
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Stanford Research Systems SR570 Lock-in amplifier",
+                 **kwargs):
         super().__init__(
             adapter,
-            "Stanford Research Systems SR570 Lock-in amplifier",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -342,10 +342,11 @@ class SR830(Instrument):
     # For consistency with other lock-in instrument classes
     adc4 = aux_in_4
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Stanford Research Systems SR830 Lock-in amplifier",
+                 **kwargs):
         super().__init__(
             adapter,
-            "Stanford Research Systems SR830 Lock-in amplifier",
+            name,
             **kwargs
         )
 

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -559,9 +559,10 @@ class SR860(Instrument):
         values=range(0, 16)
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Stanford Research Systems SR860 Lock-in amplifier",
+                 **kwargs):
         super().__init__(
             adapter,
-            "Stanford Research Systems SR860 Lock-in amplifier",
+            name,
             **kwargs
         )

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -197,10 +197,10 @@ class AFG3152C(Instrument):
         afg.ch1.enable()               # Enables the output from CH1
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Tektronix AFG3152C arbitrary function generator", **kwargs):
         super().__init__(
             adapter,
-            "Tektronix AFG3152C arbitrary function generator",
+            name,
             **kwargs
         )
         self.ch1 = Channel(self, 1)

--- a/pymeasure/instruments/tektronix/tds2000.py
+++ b/pymeasure/instruments/tektronix/tds2000.py
@@ -85,10 +85,10 @@ class TDS2000(Instrument):
                 raise ValueError("Invalid unit ('{}') provided to {}".format(
                                  self.parent, value))
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Tektronix TDS 2000 Oscilliscope", **kwargs):
         super().__init__(
             adapter,
-            "Tektronix TDS 2000 Oscilliscope",
+            name,
             **kwargs
         )
         self.measurement = TDS2000.Measurement(self)

--- a/pymeasure/instruments/temptronic/temptronic_ats525.py
+++ b/pymeasure/instruments/temptronic/temptronic_ats525.py
@@ -47,5 +47,5 @@ class ATS525(ATSBase):
         """,
     )
 
-    def __init__(self, adapter, **kwargs):
-        super().__init__(adapter, name="Temptronic ATS-525 Thermostream", **kwargs)
+    def __init__(self, adapter, name="Temptronic ATS-525 Thermostream", **kwargs):
+        super().__init__(adapter, name, **kwargs)

--- a/pymeasure/instruments/temptronic/temptronic_ats545.py
+++ b/pymeasure/instruments/temptronic/temptronic_ats545.py
@@ -64,5 +64,5 @@ class ATS545(ATSBase):
         """
         raise NotImplementedError
 
-    def __init__(self, adapter, **kwargs):
-        super().__init__(adapter, name="Temptronic ATS-545 Thermostream", **kwargs)
+    def __init__(self, adapter, name="Temptronic ATS-545 Thermostream", **kwargs):
+        super().__init__(adapter, name, **kwargs)

--- a/pymeasure/instruments/temptronic/temptronic_eco560.py
+++ b/pymeasure/instruments/temptronic/temptronic_eco560.py
@@ -90,11 +90,11 @@ class ECO560(ATSBase):
     copy_active_setup_file = None
     # Not Implemented in ECO-560
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Temptronic ECO-560 Thermostream", **kwargs):
         kwargs.setdefault('timeout', 3000)
         super().__init__(
             adapter,
-            name="Temptronic ECO-560 Thermostream",
+            name,
             tcpip={'write_termination': '\n',
                    'read_termination': '\n'},
             **kwargs

--- a/pymeasure/instruments/texio/texioPSW360L30.py
+++ b/pymeasure/instruments/texio/texioPSW360L30.py
@@ -64,9 +64,8 @@ class TexioPSW360L30(Keithley2260B):
         print(source.applied)
     """
 
-    def __init__(self, adapter, **kwargs):
-        kwargs['name'] = "TEXIO PSW-360L30 Power Supply"
-        super().__init__(adapter, **kwargs)
+    def __init__(self, adapter, name="TEXIO PSW-360L30 Power Supply", **kwargs):
+        super().__init__(adapter, name, **kwargs)
 
     def check_errors(self):
         """ Logs any system errors reported by the instrument.

--- a/pymeasure/instruments/thermotron/thermotron3800.py
+++ b/pymeasure/instruments/thermotron/thermotron3800.py
@@ -33,10 +33,10 @@ class Thermotron3800(Instrument):
     There is a 1000ms built in wait time after all write commands.
     """
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Thermotron 3800", **kwargs):
         super().__init__(
             adapter,
-            "Thermotron 3800",
+            name,
             includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -34,9 +34,9 @@ log.addHandler(logging.NullHandler())
 class ThorlabsPM100USB(Instrument):
     """Represents Thorlabs PM100USB powermeter."""
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="ThorlabsPM100USB powermeter", **kwargs):
         super().__init__(
-            adapter, "ThorlabsPM100USB powermeter", **kwargs
+            adapter, name, **kwargs
         )
         self.timout = 3000
         self._set_flags()

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -38,7 +38,6 @@ class ThorlabsPM100USB(Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
-        self.timout = 3000  # TODO what is this for?
         self._set_flags()
 
     wavelength_min = Instrument.measurement(

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -38,7 +38,7 @@ class ThorlabsPM100USB(Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
-        self.timout = 3000
+        self.timout = 3000  # TODO what is this for?
         self._set_flags()
 
     wavelength_min = Instrument.measurement(

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -32,10 +32,10 @@ class ThorlabsPro8000(Instrument):
     LDC_POLARITIES = ['AG', 'CG']
     STATUS = ['ON', 'OFF']
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Thorlabs Pro 8000", **kwargs):
         super().__init__(
             adapter,
-            "Thorlabs Pro 8000",
+            name,
             **kwargs
         )
         self.write(':SYST:ANSW VALUE')

--- a/pymeasure/instruments/yokogawa/yokogawa7651.py
+++ b/pymeasure/instruments/yokogawa/yokogawa7651.py
@@ -131,9 +131,9 @@ class Yokogawa7651(Instrument):
         set_process=lambda v: v * 1e3,  # converts mA to A
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Yokogawa 7651 Programmable DC Source", **kwargs):
         super().__init__(
-            adapter, "Yokogawa 7651 Programmable DC Source", **kwargs
+            adapter, name, **kwargs
         )
 
         self.write("H0;E")  # Set no header in output data

--- a/pymeasure/instruments/yokogawa/yokogawags200.py
+++ b/pymeasure/instruments/yokogawa/yokogawags200.py
@@ -86,9 +86,9 @@ class YokogawaGS200(Instrument):
         values=[1e-3, 200e-3]
     )
 
-    def __init__(self, adapter, **kwargs):
+    def __init__(self, adapter, name="Yokogawa GS200 Source", **kwargs):
         super().__init__(
-            adapter, "Yokogawa GS200 Source", **kwargs
+            adapter, name, **kwargs
         )
 
     @property

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -78,90 +78,11 @@ def test_adapter_arg(cls):
     cls(adapter=MagicMock())
 
 
-# Instruments which do not yet accept "name" argument
-nameless_instruments = [
-    "AdvantestR3767CG",
-    "Agilent33220A",
-    "Agilent33500",
-    "Agilent33521A",
-    "Agilent34410A",
-    "Agilent4156",
-    "Agilent8257D",
-    "Agilent8722ES",
-    "AgilentB1500",
-    "AgilentE4408B",
-    "AgilentE4980",
-    "Ametek7270",
-    "AMI430",
-    "DPSeriesMotorController",
-    "APSIN12G",
-    "AnritsuMG3692C",
-    "AnritsuMS9740A",
-    "BKPrecision9130B",
-    "Danfysik8500",
-    "SM7045D",  # deltaelektronika
-    "Nxds",  # edwards
-    "EurotestHPP120256",
-    "Fluke7341",
-    "FWBell5080",
-    "ND287",
-    "HP33120A",
-    "HP3437A",
-    "HP34401A",
-    "HP3478A",
-    "HP6632A",
-    "HP6633A",
-    "HP6634A",
-    "HP8657B",
-    "Keithley2000",
-    "Keithley2306",
-    "Keithley2400",
-    "Keithley2450",
-    "Keithley2600",
-    "Keithley2750",
-    "Keithley6221",
-    "Keithley6517B",
-    "KeysightDSOX1102G",
-    "KeysightN5767A",
-    "KeysightN7776C",
-    "LakeShore331",
-    "LakeShore421",
-    "LakeShore425",
-    "LeCroyT3DSO1204",
-    "ESP300",
-    "ParkerGV6",
-    "CNT91",  # pendulum
-    "razorbillRP100",
-    "FSL",
-    "SFM",
-    "SPD1168X",  # siglenttechnologies
-    "SPD1305X",  # siglenttechnologies
-    "DSP7265",
-    "SG380",
-    "SR510",
-    "SR570",
-    "SR830",
-    "SR860",
-    "AFG3152C",
-    "TDS2000",  # tectronix
-    "ATS525",  # temptronic
-    "ATS545",  # temptronic
-    "ECO560",  # temptronic
-    "TexioPSW360L30",
-    "Thermotron3800",
-    "ThorlabsPro8000",
-    "Yokogawa7651",
-    "YokogawaGS200",
-]
-
-
 @pytest.mark.parametrize("cls", devices)
 def test_name_argument(cls):
     "Test that every instrument accepts a name argument"
     if cls.__name__ in (*proper_adapters, *need_init_communication):
         pytest.skip(f"{cls.__name__} cannot be tested without communication.")
-    elif cls.__name__ in nameless_instruments:
-        pytest.skip(f"{cls.__name__} does not accept a name argument yet.")
     inst = cls(adapter=MagicMock(), name="Name_Test")
     assert inst.name == "Name_Test"
 


### PR DESCRIPTION
All instruments have a default `name` kwarg. `test_all_instruments` is adjusted accordingly.

Closes #658 