### PR TITLE
Log widget colouring and format option

### DIFF
--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -70,7 +70,15 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
     :class:`ManagedWindowBase<pymeasure.display.windows.managed_window.ManagedWindowBase>`
     """
 
-    def __init__(self, name, parent=None):
+    fmt = '%(asctime)s : %(message)s (%(levelname)s)'
+    datefmt = '%m/%d/%Y %I:%M:%S %p'
+
+    def __init__(self, name, parent=None, fmt=None, datefmt=None):
+        if fmt is not None:
+            self.fmt = fmt
+        if datefmt is not None:
+            self.datefmt = datefmt
+
         super().__init__(name, parent)
         self._setup_ui()
         self._layout()
@@ -80,8 +88,8 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self.view.setReadOnly(True)
         self.handler = LogHandler()
         self.handler.setFormatter(HTMLFormatter(
-            fmt='%(asctime)s : %(message)s (%(levelname)s)',
-            datefmt='%m/%d/%Y %I:%M:%S %p'
+            fmt=self.fmt,
+            datefmt=self.datefmt,
         ))
         self.handler.connect(self.view.appendHtml)
 

--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -32,6 +32,37 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+class HTMLFormatter(logging.Formatter):
+    level_colors = {
+        "DEBUG": "DarkGray",
+        # "INFO": "Black",
+        "WARNING": "DarkOrange",
+        "ERROR": "Red",
+        "CRITICAL": "DarkRed",
+    }
+
+    html_replacements = {
+        "\r\n": "<br>  ",
+        "\n": "<br>  ",
+        "\r": "<br>  ",
+        "  ": "&nbsp;" * 2,
+        "\t": "&nbsp;" * 4,
+    }
+
+    def format(self, record):
+        formatted = super().format(record)
+
+        # Apply color if a level-color is defined
+        if record.levelname in self.level_colors:
+            formatted = f"<font color=\"{self.level_colors[record.levelname]}\">{formatted}</font>"
+
+        # ensure newlines and indents are preserved
+        for replacement in self.html_replacements.items():
+            formatted = formatted.replace(*replacement)
+
+        return formatted
+
+
 class LogWidget(TabWidget, QtWidgets.QWidget):
     """ Widget to display logging information in GUI
 
@@ -48,11 +79,11 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self.view = QtWidgets.QPlainTextEdit()
         self.view.setReadOnly(True)
         self.handler = LogHandler()
-        self.handler.setFormatter(logging.Formatter(
+        self.handler.setFormatter(HTMLFormatter(
             fmt='%(asctime)s : %(message)s (%(levelname)s)',
             datefmt='%m/%d/%Y %I:%M:%S %p'
         ))
-        self.handler.connect(self.view.appendPlainText)
+        self.handler.connect(self.view.appendHtml)
 
     def _layout(self):
         vbox = QtWidgets.QVBoxLayout(self)

--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -115,16 +115,10 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self.setLayout(vbox)
 
     def blink(self):
-        if self.blink_state:
-            self.tab_widget.tabBar().setTabTextColor(
-                self.tab_index,
-                QtGui.QColor("black")
-            )
-        else:
-            self.tab_widget.tabBar().setTabTextColor(
-                self.tab_index,
-                QtGui.QColor(self.blink_color)
-            )
+        self.tab_widget.tabBar().setTabTextColor(
+            self.tab_index,
+            QtGui.QColor("black" if self.blinking_state else self.blink_color)
+        )
 
         self.blink_state = not self.blink_state
 

--- a/pymeasure/display/windows/managed_dock_window.py
+++ b/pymeasure/display/windows/managed_dock_window.py
@@ -51,7 +51,8 @@ class ManagedDockWindow(ManagedWindowBase):
         :class:`~pymeasure.display.windows.managed_window.ManagedWindowBase`
     """
 
-    def __init__(self, procedure_class, x_axis=None, y_axis=None, log_fmt=None, log_datefmt=None, **kwargs):
+    def __init__(self, procedure_class, x_axis=None, y_axis=None,
+                 log_fmt=None, log_datefmt=None, **kwargs):
 
         self.x_axis = x_axis
         self.y_axis = y_axis

--- a/pymeasure/display/windows/managed_dock_window.py
+++ b/pymeasure/display/windows/managed_dock_window.py
@@ -45,11 +45,13 @@ class ManagedDockWindow(ManagedWindowBase):
     :param y_axis: the data column(s) for the y-axis of the plot. This may be a string or a list
         of strings from the data columns of the procedure. The list length determines the number of
         plots
+    :param log_fmt: formatting string for the log-widget
+    :param log_datefmt: formatting string for the date in the log-widget
     :param \\**kwargs: optional keyword arguments that will be passed to
         :class:`~pymeasure.display.windows.managed_window.ManagedWindowBase`
     """
 
-    def __init__(self, procedure_class, x_axis=None, y_axis=None, **kwargs):
+    def __init__(self, procedure_class, x_axis=None, y_axis=None, log_fmt=None, log_datefmt=None, **kwargs):
 
         self.x_axis = x_axis
         self.y_axis = y_axis
@@ -75,7 +77,7 @@ class ManagedDockWindow(ManagedWindowBase):
             self.y_axis_labels = [self.y_axis, ]
             measure_quantities.append(self.y_axis)
 
-        self.log_widget = LogWidget("Experiment Log")
+        self.log_widget = LogWidget("Experiment Log", fmt=log_fmt, datefmt=log_datefmt)
         self.dock_widget = DockWidget("Dock Tab", procedure_class, self.x_axis_labels,
                                       self.y_axis_labels)
 

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -592,15 +592,18 @@ class ManagedWindow(ManagedWindowBase):
     :param x_axis: the initial data-column for the x-axis of the plot
     :param y_axis: the initial data-column for the y-axis of the plot
     :param linewidth: linewidth for the displayed curves, default is 1
+    :param log_fmt: formatting string for the log-widget
+    :param log_datefmt: formatting string for the date in the log-widget
     :param \\**kwargs: optional keyword arguments that will be passed to
         :class:`~pymeasure.display.windows.managed_window.ManagedWindowBase`
 
     """
 
-    def __init__(self, procedure_class, x_axis=None, y_axis=None, linewidth=1, **kwargs):
+    def __init__(self, procedure_class, x_axis=None, y_axis=None, linewidth=1,
+                 log_fmt=None, log_datefmt=None, **kwargs):
         self.x_axis = x_axis
         self.y_axis = y_axis
-        self.log_widget = LogWidget("Experiment Log")
+        self.log_widget = LogWidget("Experiment Log", fmt=log_fmt, datefmt=log_datefmt)
         self.plot_widget = PlotWidget("Results Graph", procedure_class.DATA_COLUMNS, self.x_axis,
                                       self.y_axis, linewidth=linewidth)
         self.plot_widget.setMinimumSize(100, 200)


### PR DESCRIPTION
Triggered by #886, I quickly put in some effort to make available this modification to the logwidget that I had to make recently for a project.

This PR adds colouring to log messages, depending on the log-level (by utilizing the HTML functionality of the QPlainTextView).
Moreover, when a warning, error or critical message is logged, the tab starts blinking to attract attention (this blinking is stopped when the log tab is selected).
Finally, to (hopefully) help #886, I also added a way to pass fmt-string (and datefmt-string) to the formatted of the log-widget.