### PR TITLE
Keysight e36232a

### DIFF
--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -26,3 +26,4 @@ from .keysightDSOX1102G import KeysightDSOX1102G
 from .keysightN5767A import KeysightN5767A
 from .keysightN7776C import KeysightN7776C
 from .keysightE36312A import KeysightE36312A
+from .keysightE36232A import KeysightE36232A

--- a/pymeasure/instruments/keysight/keysightE36232A.py
+++ b/pymeasure/instruments/keysight/keysightE36232A.py
@@ -1,0 +1,109 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2022 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+import logging
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import truncated_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class KeysightE36232A(Instrument):
+    """ Represents the Keysight N5767A Power supply
+    interface for interacting with the instrument.
+
+    .. code-block:: python
+
+    """
+    ###############
+    # Current (A) #
+    ###############
+    _max_current = Instrument.measurement(":CURR? MAX", 
+										  """ Gets the unit's max current """
+										  )
+	
+    current_range = Instrument.control(
+        ":CURR?", ":CURR %g",
+        """ A floating point property that controls the DC current range in
+        Amps, which can take values from 0 to 10 A.
+        Auto-range is disabled when this property is set. """,
+        validator=truncated_range,
+        values=[0, 10],
+    )
+
+    current = Instrument.measurement(":MEAS:CURR?",
+                                     """ Reads a measured current in Amps. """
+                                     )
+
+    ###############
+    # Voltage (V) #
+    ###############
+    _max_voltage = Instrument.measurement(":VOLT? MAX", 
+										 """ Gets the unit's max voltage """
+										 )
+	
+    voltage_range = Instrument.control(
+        ":VOLT?", ":VOLT %g V",
+        """ A floating point property that controls the DC voltage range in
+        Volts, which can take values from 0 to 60 V.
+        Auto-range is disabled when this property is set. """,
+        validator=truncated_range,
+        values=[0, 60],
+    )
+
+    voltage = Instrument.measurement("MEAS:VOLT?",
+                                     """ Reads a DC voltage measurement in Volts. """
+                                     )
+	
+
+    #################
+    # _status (0/1) #
+    #################
+    _status = Instrument.measurement(":OUTP?",
+                                     """ Read power supply current output status. """,
+                                     )
+
+    def enable(self):
+        """ Enables the flow of current.
+        """
+        self.write(":OUTP 1")
+
+    def disable(self):
+        """ Disables the flow of current.
+        """
+        self.write(":OUTP 0")
+
+    def is_enabled(self):
+        """ Returns True if the current supply is enabled.
+        """
+        return bool(self._status)
+
+    def __init__(self, adapter, **kwargs):
+        super().__init__(
+            adapter, "Keysight E36232A power supply", **kwargs
+        )
+		


### PR DESCRIPTION
I've added the Keysight E36232A power supply.  The code is based HEAVILY on other keysight devices already on pymeasure.  

This is my first pull request ever.  Please be gentle.  

I did not use pytest because it would require the physical instrument to be present to whoever runs the test (which is unlikely).  

Once we get this relatively simple instrument successfully merged, I plan to develop a good deal more instruments.  