### PR TITLE
VisaAdapter: close manager only when using pyvisa-sim

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -140,7 +140,7 @@ class VISAAdapter(Adapter):
         try:
             if self.manager.visalib.library_path == "unset":
                 # if using the pyvisa-sim library the manager has to be also closed.
-                # this works around pyvisa/pyvisa-sim#68
+                # this works around https://github.com/pyvisa/pyvisa-sim/issues/82
                 self.manager.close()
         except AttributeError:
             # AttributeError can occur during __del__ calling close

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -138,9 +138,13 @@ class VISAAdapter(Adapter):
         """
         super().close()
         try:
-            self.manager.close()
+            if self.manager.visalib.library_path == "unset":
+                # if using the pyvisa-sim library the manager has to be also closed.
+                # this works around pyvisa/pyvisa-sim#68
+                self.manager.close()
         except AttributeError:
-            pass  # Closed from another adapter using the same connection.
+            # AttributeError can occur during __del__ calling close
+            pass
 
     def _write(self, command, **kwargs):
         """Write a string command to the instrument appending `write_termination`.


### PR DESCRIPTION
As outlined in #894 closing the `VisaAdapter.manager` has the unwanted side effect of also closing all other pyvisa connections (even those of devices not related to this Visa resource). The reason for this is that the pyvisa ResourceManager shares the hardware session between all its instances (pyvisa/pyvisa#742). 

Closing the resource manager should therefore generally not be done when closing a device connection. It is however required when using pyvisa-sim due to a bug in this package (pyvisa/pyvisa-sim#68). 

I therefore propose these code changes which trigger the close only when using pyvisa-sim. 