### PR TITLE
Add support for TDK Lambda Genesys power supplies

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -57,6 +57,7 @@ Instruments by manufacturer:
    signalrecovery/index
    srs/index
    tcpowerconversion/index
+   tdk/index
    tektronix/index
    teledyne/index
    temptronic/index

--- a/docs/api/instruments/tdk/index.rst
+++ b/docs/api/instruments/tdk/index.rst
@@ -1,0 +1,14 @@
+.. module:: pymeasure.instruments.tdk
+
+##########
+TDK Lambda
+##########
+
+This section contains specific documentation on the TDK Lambda instruments that are implemented. If you are interested
+in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   tdk_gen40_38
+   tdk_gen80_65

--- a/docs/api/instruments/tdk/tdk_gen40_38.rst
+++ b/docs/api/instruments/tdk/tdk_gen40_38.rst
@@ -1,0 +1,8 @@
+########################################
+TDK Lambda Genesys 40-38 DC power supply
+########################################
+
+.. autoclass:: pymeasure.instruments.tdk.tdk_gen40_38.TDK_Gen40_38
+    :members:
+    :show-inheritance:
+    :inherited-members: Instrument

--- a/docs/api/instruments/tdk/tdk_gen80_65.rst
+++ b/docs/api/instruments/tdk/tdk_gen80_65.rst
@@ -1,0 +1,8 @@
+########################################
+TDK Lambda Genesys 80-65 DC power supply
+########################################
+
+.. autoclass:: pymeasure.instruments.tdk.tdk_gen80_65.TDK_Gen80_65
+    :members:
+    :show-inheritance:
+    :inherited-members: Instrument

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -200,7 +200,7 @@ class PrologixAdapter(VISAAdapter):
     def write(self, command, **kwargs):
         """Write a string command to the instrument appending `write_termination`.
 
-        If the GPIB address in :attr:`.address` is defined, it is sent first.
+        If the GPIB address in :attr:`self.address` is defined, it is sent first.
 
         :param str command: Command string to be sent to the instrument
             (without termination).

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -200,7 +200,7 @@ class PrologixAdapter(VISAAdapter):
     def write(self, command, **kwargs):
         """Write a string command to the instrument appending `write_termination`.
 
-        If the GPIB address in :attr:`self.address` is defined, it is sent first.
+        If the GPIB address in :attr:`address` is defined, it is sent first.
 
         :param str command: Command string to be sent to the instrument
             (without termination).

--- a/pymeasure/instruments/tdk/__init__.py
+++ b/pymeasure/instruments/tdk/__init__.py
@@ -1,0 +1,26 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .tdk_gen40_38 import TDK_Gen40_38
+from .tdk_gen80_65 import TDK_Gen80_65

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -69,31 +69,21 @@ class TDK_Lambda_Base(Instrument):
         )
         self.address = address
 
-    def write(self, command):
-        """Replace the ``Instrument.write()`` method to strip out an "OK" reply
-        that the instrument returns for any non-querying commands.
-
-        By default, any non-querying commands (i.e., a command that does NOT
-        have the "?" symbol in it like the instrument command "PV 10") will
-        automatically return an "OK" reply. This is done to confirm that the
-        instrument has received the command. Any querying commands (i.e., a
-        command that does have the "?" symbol in it like the instrument command
-        "PV?") will return the requested value. The returned value itself is
-        confirmation that the command was received.
-
-        The default, the ``Instrument.write()`` method is not set up to
-        automatically strip out instrument confirmations. If the command
-        string does not contain a "?", then ``self.read()`` once to clear the
-        "OK" from the read buffer. If this is not done, the adapter read buffer
-        will hold the "OK" reply until the next read command is given.
-
-        :param command: Command string to be sent to the instrument.
+    def check_errors(self):
         """
+        Only use this command for setting commands, i.e. non-querying commands.
 
-        super().write(command)
-        if '?' not in command:
-            # clear response from the adapter read buffer
-            self.read()
+        Any non-querying commands (i.e., a command that does NOT
+        have the "?" symbol in it like the instrument command "PV 10") will
+        automatically return an "OK" reply for valid command or an error code.
+        This is done to confirm that the instrument has received the command.
+        Any querying commands (i.e., a command that does have the "?" symbol
+        in it like the instrument command "PV?") will return the requested value,
+        not the confirmation.
+        """
+        response = self.read()
+        if response != "OK":
+            log.error(f"Received error: {response}")
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Properties
@@ -104,6 +94,7 @@ class TDK_Lambda_Base(Instrument):
         """Set the address of the power supply.
 
         Valid values are integers between 0 - 30 (inclusive).""",
+        check_set_errors=True,
         validator=strict_discrete_set,
         values=range(0, 31)
     )
@@ -115,6 +106,7 @@ class TDK_Lambda_Base(Instrument):
         Valid values are ``'LOC'`` for local mode, ``'REM'`` for remote mode,
         and ``'LLO'`` for local lockout mode.
         """,
+        check_set_errors=True,
         validator=strict_discrete_set,
         values=["LOC", "REM", "LLO"]
     )
@@ -182,6 +174,7 @@ class TDK_Lambda_Base(Instrument):
     voltage = Instrument.control(
         "PV?", "PV %g",
         """Control the programmed (set) output voltage.""",
+        check_set_errors=True,
         validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
         values=[0, 40],
         dynamic=True
@@ -195,6 +188,7 @@ class TDK_Lambda_Base(Instrument):
     current = Instrument.control(
         "PC?", "PC %g",
         """Control the programmed (set) output current.""",
+        check_set_errors=True,
         validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
         values=[0, 38],
         dynamic=True
@@ -246,6 +240,7 @@ class TDK_Lambda_Base(Instrument):
 
         Valid frequency values are 18, 23, or 46 Hz. Default value is 18 Hz.
         """,
+        check_set_errors=True,
         validator=strict_discrete_set,
         values=[18, 23, 46]
     )
@@ -256,6 +251,7 @@ class TDK_Lambda_Base(Instrument):
 
         Valid values are ``True`` and ``False``.
         """,
+        check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True
@@ -268,6 +264,7 @@ class TDK_Lambda_Base(Instrument):
         Valid values are ``True`` to arm the fold back protection and ``False``
         to cancel the fold back protection.
         """,
+        check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True
@@ -281,6 +278,7 @@ class TDK_Lambda_Base(Instrument):
         multiplying the set value by 0.1. Valid values are integers between
         0 to 255.
         """,
+        check_set_errors=True,
         validator=strict_range,
         values=[0, 255],
         cast=int
@@ -290,6 +288,7 @@ class TDK_Lambda_Base(Instrument):
         "OVP?", "OVP %g",
         """Control the over voltage protection.
         """,
+        check_set_errors=True,
         validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
         values=[2, 44],
         dynamic=True
@@ -301,6 +300,7 @@ class TDK_Lambda_Base(Instrument):
 
         Property is UNTESTED.
         """,
+        check_set_errors=True,
         validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
         values=[0, 38],
         dynamic=True
@@ -312,6 +312,7 @@ class TDK_Lambda_Base(Instrument):
 
         Valid values are ``True`` and ``False``.
         """,
+        check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True
@@ -324,10 +325,12 @@ class TDK_Lambda_Base(Instrument):
     def clear(self):
         """Clear FEVE and SEVE registers to zero."""
         self.write("CLS")
+        self.check_errors()
 
     def reset(self):
         """Reset the instrument to default values."""
         self.write("RST")
+        self.check_errors()
 
     def foldback_reset(self):
         """Reset the fold back delay to 0 s, restoring the standard 250 ms
@@ -336,20 +339,24 @@ class TDK_Lambda_Base(Instrument):
         Property is UNTESTED.
         """
         self.write("FDBRST")
+        self.check_errors()
 
     def save(self):
         """Save current instrument settings."""
         self.write("SAV")
+        self.check_errors()
 
     def recall(self):
         """Recall last saved instrument settings."""
         self.write("RCL")
+        self.check_errors()
 
     def set_max_over_voltage(self):
         """Set the over voltage protection to the maximum level for the power
         supply.
         """
         self.write("OVM")
+        self.check_errors()
 
     def ramp_to_current(self, target_current, steps=20, pause=0.2):
         """Ramps to a target current from the set current value over
@@ -374,5 +381,5 @@ class TDK_Lambda_Base(Instrument):
         """
         log.info("Shutting down %s." % self.name)
         self.ramp_to_current(0.0)
-        self.source_output = False
+        self.output_enabled = False
         super().shutdown()

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -115,7 +115,7 @@ class TDK_Lambda_Base(Instrument):
 
     multidrop_capability = Instrument.measurement(
         "MDAV?",
-        """Get the multi-drop option is available on the power supply.
+        """Get whether the multi-drop option is available on the power supply.
 
         If return value is ``False``, the option is not available, if ``True`` it is available.
 
@@ -252,7 +252,8 @@ class TDK_Lambda_Base(Instrument):
         "OUT?", "OUT %s",
         """Control the output of the power supply.
 
-        Valid values are ``True`` and ``False``.
+        Valid values are ``True`` to turn output on and ``False`` to turn output off, shutting down
+        any voltage or current.
         """,
         check_set_errors=True,
         validator=strict_discrete_set,
@@ -260,7 +261,7 @@ class TDK_Lambda_Base(Instrument):
         map_values=True
     )
 
-    foldback = Instrument.control(
+    foldback_enabled = Instrument.control(
         "FLD?", "FLD %s",
         """Control the fold back protection of the power supply.
 
@@ -309,11 +310,13 @@ class TDK_Lambda_Base(Instrument):
         dynamic=True
     )
 
-    auto_restart = Instrument.control(
+    auto_restart_enabled = Instrument.control(
         "AST?", "AST %s",
-        """Control the auto restart mode.
+        """Control the auto restart mode, which restores the power supply to the last
+        output voltage and current settings with output enabled on startup.
 
-        Valid values are ``True`` and ``False``.
+        Valid values are ``True`` to restore output settings with output enabled on startup
+        and ``False`` to disable restoration of settings and output disabled on startup.
         """,
         check_set_errors=True,
         validator=strict_discrete_set,

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -69,7 +69,7 @@ class TDK_Lambda_Base(Instrument):
         )
         self.address = address
 
-    def check_errors(self):
+    def check_set_errors(self):
         """
         Only use this command for setting commands, i.e. non-querying commands.
 
@@ -82,8 +82,10 @@ class TDK_Lambda_Base(Instrument):
         not the confirmation.
         """
         response = self.read()
+        error_list = []
         if response != "OK":
-            log.error(f"Received error: {response}")
+            error_list.append(f"Received error: {response}")
+        return error_list
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Properties

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -50,12 +50,9 @@ log.addHandler(logging.NullHandler())
 class TDK_Lambda_Base(Instrument):
     """
     This is the base class for TDK Lambda Genesys Series DC power supplies.
-
     Do not directly instantiate an object with this class. Use one of the
     TDK-Lambda power supply instrument classes that inherit from this parent
-    class.
-
-    Untested commands are noted in docstrings.
+    class. Untested commands are noted in docstrings.
     """
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,14 +60,6 @@ class TDK_Lambda_Base(Instrument):
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     def __init__(self, adapter, name="TDK-Lambda Base", address=6, **kwargs):
-        """
-        The initialization of a TDK instrument requires the current address
-        of the TDK power supply. The default address for the TDK Lambda is 6.
-
-        :param adapter: VISAAdapter instance
-        :param name: Instrument name
-        :param address: Serial port daisy chain number. Default is 6.
-        """
         super().__init__(
             adapter,
             name,
@@ -103,7 +92,7 @@ class TDK_Lambda_Base(Instrument):
 
         super().write(command)
         if '?' not in command:
-            # clear "OK" from the adapter read buffer
+            # clear response from the adapter read buffer
             self.read()
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,7 +110,7 @@ class TDK_Lambda_Base(Instrument):
 
     remote = Instrument.control(
         "RMT?", "RMT %s",
-        """Get the current remote operation of the power supply.
+        """Control the current remote operation of the power supply.
 
         Valid values are ``'LOC'`` for local mode, ``'REM'`` for remote mode,
         and ``'LLO'`` for local lockout mode.
@@ -261,25 +250,27 @@ class TDK_Lambda_Base(Instrument):
         values=[18, 23, 46]
     )
 
-    source_output = Instrument.control(
+    output_enabled = Instrument.control(
         "OUT?", "OUT %s",
         """Control the output of the power supply.
 
-        Valid values are ``'ON'`` and ``'OFF'``.
+        Valid values are ``True`` and ``False``.
         """,
         validator=strict_discrete_set,
-        values=["ON", "OFF"]
+        values={True: "ON", False: "OFF"},
+        map_values=True
     )
 
     foldback = Instrument.control(
         "FLD?", "FLD %s",
         """Control the fold back protection of the power supply.
 
-        Valid values are ``'ON'`` to arm the fold back protection and ``'OFF'``
+        Valid values are ``True`` to arm the fold back protection and ``False``
         to cancel the fold back protection.
         """,
         validator=strict_discrete_set,
-        values=["ON", "OFF"]
+        values={True: "ON", False: "OFF"},
+        map_values=True
     )
 
     foldback_delay = Instrument.control(
@@ -319,10 +310,11 @@ class TDK_Lambda_Base(Instrument):
         "AST?", "AST %s",
         """Control the auto restart mode.
 
-        Valid values are ``'ON'`` and ``'OFF'``.
+        Valid values are ``True`` and ``False``.
         """,
         validator=strict_discrete_set,
-        values=["ON", "OFF"]
+        values={True: "ON", False: "OFF"},
+        map_values=True
     )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -382,6 +374,5 @@ class TDK_Lambda_Base(Instrument):
         """
         log.info("Shutting down %s." % self.name)
         self.ramp_to_current(0.0)
-        self.source_output = "OFF"
-        log.info("%s has been shut down." % self.name)
+        self.source_output = False
         super().shutdown()

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -115,10 +115,11 @@ class TDK_Lambda_Base(Instrument):
         "MDAV?",
         """Get the multi-drop option is available on the power supply.
 
-        If return value is 0, the option is not available, if 1 it is available.
+        If return value is ``False``, the option is not available, if ``True`` it is available.
 
         Property is UNTESTED.
-        """
+        """,
+        cast=bool
     )
 
     master_slave_setting = Instrument.measurement(
@@ -171,7 +172,7 @@ class TDK_Lambda_Base(Instrument):
         """
     )
 
-    voltage = Instrument.control(
+    voltage_setpoint = Instrument.control(
         "PV?", "PV %g",
         """Control the programmed (set) output voltage.""",
         check_set_errors=True,
@@ -180,12 +181,12 @@ class TDK_Lambda_Base(Instrument):
         dynamic=True
     )
 
-    actual_voltage = Instrument.measurement(
+    voltage = Instrument.measurement(
         "MV?",
         """Measure the the actual output voltage."""
     )
 
-    current = Instrument.control(
+    current_setpoint = Instrument.control(
         "PC?", "PC %g",
         """Control the programmed (set) output current.""",
         check_set_errors=True,
@@ -194,7 +195,7 @@ class TDK_Lambda_Base(Instrument):
         dynamic=True
     )
 
-    actual_current = Instrument.measurement(
+    current = Instrument.measurement(
         "MC?",
         """Measure the actual output current.
 

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -1,0 +1,387 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# =============================================================================
+# Libraries / modules
+# =============================================================================
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_range
+from pymeasure.instruments.validators import strict_discrete_set
+from pymeasure.instruments.validators import strict_discrete_range
+import logging
+from time import sleep
+import numpy as np
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+# =============================================================================
+# Instrument file
+# =============================================================================
+
+
+class TDK_Lambda_Base(Instrument):
+    """
+    This is the base class for TDK Lambda Genesys Series DC power supplies.
+
+    Do not directly instantiate an object with this class. Use one of the
+    TDK-Lambda power supply instrument classes that inherit from this parent
+    class.
+
+    Untested commands are noted in docstrings.
+    """
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Initializer and important communication methods
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    def __init__(self, adapter, name="TDK-Lambda Base", address=6, **kwargs):
+        """
+        The initialization of a TDK instrument requires the current address
+        of the TDK power supply. The default address for the TDK Lambda is 6.
+
+        :param adapter: VISAAdapter instance
+        :param name: Instrument name
+        :param address: Serial port daisy chain number. Default is 6.
+        """
+        super().__init__(
+            adapter,
+            name,
+            includeSCPI=False,
+            asrl={'read_termination': "\r", 'write_termination': "\r"},
+            **kwargs
+        )
+        self.address = address
+
+    def write(self, command):
+        """Replace the ``Instrument.write()`` method to strip out an "OK" reply
+        that the instrument returns for any non-querying commands.
+
+        By default, any non-querying commands (i.e., a command that does NOT
+        have the "?" symbol in it like the instrument command "PV 10") will
+        automatically return an "OK" reply. This is done to confirm that the
+        instrument has received the command. Any querying commands (i.e., a
+        command that does have the "?" symbol in it like the instrument command
+        "PV?") will return the requested value. The returned value itself is
+        confirmation that the command was received.
+
+        The default, the ``Instrument.write()`` method is not set up to
+        automatically strip out instrument confirmations. If the command
+        string does not contain a "?", then ``self.read()`` once to clear the
+        "OK" from the read buffer. If this is not done, the adapter read buffer
+        will hold the "OK" reply until the next read command is given.
+
+        :param command: Command string to be sent to the instrument.
+        """
+
+        super().write(command)
+        if '?' not in command:
+            # clear "OK" from the adapter read buffer
+            self.read()
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Properties
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    address = Instrument.setting(
+        "ADR %d",
+        """Set the address of the power supply.
+
+        Valid values are integers between 0 - 30 (inclusive).""",
+        validator=strict_discrete_set,
+        values=range(0, 31)
+    )
+
+    remote = Instrument.control(
+        "RMT?", "RMT %s",
+        """Get the current remote operation of the power supply.
+
+        Valid values are ``'LOC'`` for local mode, ``'REM'`` for remote mode,
+        and ``'LLO'`` for local lockout mode.
+        """,
+        validator=strict_discrete_set,
+        values=["LOC", "REM", "LLO"]
+    )
+
+    multidrop_capability = Instrument.measurement(
+        "MDAV?",
+        """Get the multi-drop option is available on the power supply.
+
+        If return value is 0, the option is not available, if 1 it is available.
+
+        Property is UNTESTED.
+        """
+    )
+
+    master_slave_setting = Instrument.measurement(
+        "MS?",
+        """Get the master and slave settings.
+
+        Possible master return values are 1, 2, 3, and 4. The slave value is 0.
+
+        Property is UNTESTED.
+        """
+    )
+
+    repeat = Instrument.measurement(
+        "\\",
+        """Measure the last command again.
+
+        Returns output of the last command.
+        """
+    )
+
+    id = Instrument.measurement(
+        "IDN?",
+        """Get the identity of the instrument.
+
+        Returns a list of instrument manufacturer and model in the format: ``["LAMBDA", "GENX-Y"]``
+        """
+    )
+
+    version = Instrument.measurement(
+        "REV?",
+        """Get the software version on instrument.
+
+        Returns the software version as an ASCII string.
+        """
+    )
+
+    serial = Instrument.measurement(
+        "SN?",
+        """Get the serial number of the instrument.
+
+        Returns the serial number of of the instrument as an ASCII string.
+        """
+    )
+
+    last_test_date = Instrument.measurement(
+        "DATE?",
+        """Get the date of the last test, possibly calibration date.
+
+        Returns a string in the format: yyyy/mm/dd.
+        """
+    )
+
+    voltage = Instrument.control(
+        "PV?", "PV %g",
+        """Control the programmed (set) output voltage.""",
+        validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
+        values=[0, 40],
+        dynamic=True
+    )
+
+    actual_voltage = Instrument.measurement(
+        "MV?",
+        """Measure the the actual output voltage."""
+    )
+
+    current = Instrument.control(
+        "PC?", "PC %g",
+        """Control the programmed (set) output current.""",
+        validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
+        values=[0, 38],
+        dynamic=True
+    )
+
+    actual_current = Instrument.measurement(
+        "MC?",
+        """Measure the actual output current.
+
+        Returns a float with five digits of precision.
+        """
+    )
+
+    mode = Instrument.measurement(
+        "MODE?",
+        """Measure the output mode of the power supply.
+
+        When power supply is on, the returned value will be either ``'CV'`` for
+        control voltage or ``'CC'`` for or control current. If the power supply
+        is off, the returned value will be ``'OFF'``.
+        """
+    )
+
+    display = Instrument.measurement(
+        "DVC?",
+        """Get the displayed voltage and current.
+
+        Returns a list of floating point numbers in the order of [ measured voltage,
+        programmed voltage, measured current, programmed current, over voltage set point,
+        under voltage set point ].
+        """
+    )
+
+    status = Instrument.measurement(
+        "STT?",
+        """Get the power supply status.
+
+        Returns a list in the order of [ actual voltage
+        (MV), the programmed voltage (PV), the actual current (MC), the
+        programmed current (PC), the status register (SR), and the fault
+        register (FR) ].
+        """
+    )
+
+    pass_filter = Instrument.control(
+        "FILTER?", "FILTER %d",
+        """Control the low pass filter frequency of the A to D converter
+        for voltage and current measurement.
+
+        Valid frequency values are 18, 23, or 46 Hz. Default value is 18 Hz.
+        """,
+        validator=strict_discrete_set,
+        values=[18, 23, 46]
+    )
+
+    source_output = Instrument.control(
+        "OUT?", "OUT %s",
+        """Control the output of the power supply.
+
+        Valid values are ``'ON'`` and ``'OFF'``.
+        """,
+        validator=strict_discrete_set,
+        values=["ON", "OFF"]
+    )
+
+    foldback = Instrument.control(
+        "FLD?", "FLD %s",
+        """Control the fold back protection of the power supply.
+
+        Valid values are ``'ON'`` to arm the fold back protection and ``'OFF'``
+        to cancel the fold back protection.
+        """,
+        validator=strict_discrete_set,
+        values=["ON", "OFF"]
+    )
+
+    foldback_delay = Instrument.control(
+        "FBD?", "FBD %g",
+        """Control the fold back delay.
+
+        Adds an additional delay to the standard fold back delay (250 ms) by
+        multiplying the set value by 0.1. Valid values are integers between
+        0 to 255.
+        """,
+        validator=strict_range,
+        values=[0, 255],
+        cast=int
+    )
+
+    over_voltage = Instrument.control(
+        "OVP?", "OVP %g",
+        """Control the over voltage protection.
+        """,
+        validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
+        values=[2, 44],
+        dynamic=True
+    )
+
+    under_voltage = Instrument.control(
+        "UVL?", "UVL %g",
+        """Control the under voltage limit.
+
+        Property is UNTESTED.
+        """,
+        validator=lambda v, vs: strict_discrete_range(v, vs, step=0.01),
+        values=[0, 38],
+        dynamic=True
+    )
+
+    auto_restart = Instrument.control(
+        "AST?", "AST %s",
+        """Control the auto restart mode.
+
+        Valid values are ``'ON'`` and ``'OFF'``.
+        """,
+        validator=strict_discrete_set,
+        values=["ON", "OFF"]
+    )
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Methods
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    def clear(self):
+        """Clear FEVE and SEVE registers to zero."""
+        self.write("CLS")
+
+    def reset(self):
+        """Reset the instrument to default values."""
+        self.write("RST")
+
+    def foldback_reset(self):
+        """Reset the fold back delay to 0 s, restoring the standard 250 ms
+        delay.
+
+        Property is UNTESTED.
+        """
+        self.write("FDBRST")
+
+    def save(self):
+        """Save current instrument settings."""
+        self.write("SAV")
+
+    def recall(self):
+        """Recall last saved instrument settings."""
+        self.write("RCL")
+
+    def set_max_over_voltage(self):
+        """Set the over voltage protection to the maximum level for the power
+        supply.
+        """
+        self.write("OVM")
+
+    def ramp_to_current(self, target_current, steps=20, pause=0.2):
+        """Ramps to a target current from the set current value over
+        a certain number of linear steps, each separated by a pause duration.
+
+        :param target_current: Target current in amps
+        :param steps: Integer number of steps
+        :param pause: Pause duration in seconds to wait between steps
+        """
+
+        currents = [round(i, 2) for i in np.linspace(self.current,
+                                                     target_current, steps)]
+        for current in currents:
+            self.current = current
+            sleep(pause)
+
+    def shutdown(self):
+        """Safety shutdown the power supply.
+
+        Ramps the power supply down to zero current using the
+        ``self.ramp_to_current(0.0)`` method and turns the output off.
+        """
+        log.info("Shutting down %s." % self.name)
+        self.ramp_to_current(0.0)
+        self.source_output = "OFF"
+        log.info("%s has been shut down." % self.name)
+        super().shutdown()

--- a/pymeasure/instruments/tdk/tdk_gen40_38.py
+++ b/pymeasure/instruments/tdk/tdk_gen40_38.py
@@ -50,6 +50,12 @@ class TDK_Gen40_38(TDK_Lambda_Base):
         print(psu.actual_voltage)           # Measure actual PSU voltage
         psu.shutdown()                      # Run shutdown command
 
+    The initialization of a TDK instrument requires the current address
+    of the TDK power supply. The default address for the TDK Lambda is 6.
+
+    :param adapter: VISAAdapter instance
+    :param name: Instrument name. Default is "TDK Lambda Gen40-38"
+    :param address: Serial port daisy chain number. Default is 6.
     """
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pymeasure/instruments/tdk/tdk_gen40_38.py
+++ b/pymeasure/instruments/tdk/tdk_gen40_38.py
@@ -1,0 +1,75 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# =============================================================================
+# Libraries / modules
+# =============================================================================
+
+from .tdk_base import TDK_Lambda_Base
+
+
+# =============================================================================
+# Instrument file
+# =============================================================================
+
+
+class TDK_Gen40_38(TDK_Lambda_Base):
+    """
+    Represents the TDK Lambda Genesys 40-38 DC power supply. Class inherits
+    commands from the TDK_Lambda_Base parent class and utilizes dynamic
+    properties adjust valid values on various properties.
+
+    .. code-block:: python
+
+        psu = TDK_Gen40_38("COM3", 6)       # COM port and daisy-chain address
+        psu.remote = "REM"                  # PSU in remote mode
+        psu.source_output = "ON"            # Turn on output
+        psu.ramp_to_current(2.0)            # Ramp to 2.0 A of current
+        print(psu.actual_current)           # Measure actual PSU current
+        print(psu.actual_voltage)           # Measure actual PSU voltage
+        psu.shutdown()                      # Run shutdown command
+
+    """
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Dynamic values - Overrides base class validator values
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    voltage_values = [0, 40]
+    current_values = [0, 38]
+    over_voltage_values = [2, 44]
+    under_voltage_values = [0, 38]
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Initializer
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    def __init__(self, adapter, name="TDK Lambda Gen40-38", address=6,
+                 **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            address,
+            **kwargs
+        )

--- a/pymeasure/instruments/tdk/tdk_gen80_65.py
+++ b/pymeasure/instruments/tdk/tdk_gen80_65.py
@@ -1,0 +1,75 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# =============================================================================
+# Libraries / modules
+# =============================================================================
+
+from .tdk_base import TDK_Lambda_Base
+
+
+# =============================================================================
+# Instrument file
+# =============================================================================
+
+
+class TDK_Gen80_65(TDK_Lambda_Base):
+    """
+    Represents the TDK Lambda Genesys 80-65 DC power supply. Class inherits
+    commands from the TDK_Lambda_Base parent class and utilizes dynamic
+    properties adjust valid values on various properties.
+
+    .. code-block:: python
+
+        psu = TDK_Gen80_65("COM3", 6)       # COM port and daisy-chain address
+        psu.remote = "REM"                  # PSU in remote mode
+        psu.source_output = "ON"            # Turn on output
+        psu.ramp_to_current(2.0)            # Ramp to 2.0 A of current
+        print(psu.actual_current)           # Measure actual PSU current
+        print(psu.actual_voltage)           # Measure actual PSU voltage
+        psu.shutdown()                      # Run shutdown command
+
+    """
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Dynamic values - Overrides base class validator values
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    voltage_values = [0, 80]
+    current_values = [0, 65]
+    over_voltage_values = [5, 88]
+    under_voltage_values = [0, 76]
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # Initializer
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    def __init__(self, adapter, name="TDK Lambda Gen80-65", address=6,
+                 **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            address,
+            **kwargs
+        )

--- a/pymeasure/instruments/tdk/tdk_gen80_65.py
+++ b/pymeasure/instruments/tdk/tdk_gen80_65.py
@@ -50,6 +50,12 @@ class TDK_Gen80_65(TDK_Lambda_Base):
         print(psu.actual_voltage)           # Measure actual PSU voltage
         psu.shutdown()                      # Run shutdown command
 
+    The initialization of a TDK instrument requires the current address
+    of the TDK power supply. The default address for the TDK Lambda is 6.
+
+    :param adapter: VISAAdapter instance
+    :param name: Instrument name. Default is "TDK Lambda Gen80-65"
+    :param address: Serial port daisy chain number. Default is 6.
     """
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/instruments/tdk/test_tdk_base.py
+++ b/tests/instruments/tdk/test_tdk_base.py
@@ -50,8 +50,7 @@ def test_multidrop_capability():
             [(b"ADR 6", b"OK"),
              (b"MDAV?", b'1')]
     ) as instr:
-        value = instr.multidrop_capability
-        assert isinstance(value, bool) and value
+        assert instr.multidrop_capability is True
 
 
 def test_remote():

--- a/tests/instruments/tdk/test_tdk_base.py
+++ b/tests/instruments/tdk/test_tdk_base.py
@@ -44,6 +44,15 @@ def test_identity():
         assert instr.version == "REV:1U:4.3"
 
 
+def test_multidrop_capability():
+    with expected_protocol(
+            TDK_Lambda_Base,
+            [(b"ADR 6", b"OK"),
+             (b"MDAV?", b'1')]
+    ) as instr:
+        assert instr.multidrop_capability == True
+
+
 def test_remote():
     with expected_protocol(
             TDK_Lambda_Base,

--- a/tests/instruments/tdk/test_tdk_base.py
+++ b/tests/instruments/tdk/test_tdk_base.py
@@ -1,0 +1,57 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.tdk.tdk_base import TDK_Lambda_Base
+
+
+def test_init():
+    with expected_protocol(
+            TDK_Lambda_Base,
+            [(b"ADR 6", b"OK")],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_identity():
+    with expected_protocol(
+            TDK_Lambda_Base,
+            [(b"ADR 6", b"OK"),
+             (b"IDN?", b'LAMBDA,GENX-Y'),
+             (b"REV?", b"REV:1U:4.3")]
+    ) as instr:
+        assert instr.id == ["LAMBDA", "GENX-Y"]
+        assert instr.version == "REV:1U:4.3"
+
+
+def test_remote():
+    with expected_protocol(
+            TDK_Lambda_Base,
+            [(b"ADR 6", b"OK"),
+             (b"RMT?", b"REM"),
+             (b"RMT LOC", b"OK"),
+             (b"RMT?", b"LOC"), ]
+    ) as instr:
+        assert instr.remote == "REM"
+        instr.remote = 'LOC'
+        assert instr.remote == "LOC"

--- a/tests/instruments/tdk/test_tdk_base.py
+++ b/tests/instruments/tdk/test_tdk_base.py
@@ -50,7 +50,8 @@ def test_multidrop_capability():
             [(b"ADR 6", b"OK"),
              (b"MDAV?", b'1')]
     ) as instr:
-        assert instr.multidrop_capability == True
+        value = instr.multidrop_capability
+        assert isinstance(value, bool) and value
 
 
 def test_remote():

--- a/tests/instruments/tdk/test_tdk_gen40-38.py
+++ b/tests/instruments/tdk/test_tdk_gen40-38.py
@@ -38,15 +38,15 @@ def test_init():
 
 @pytest.mark.parametrize("volt",
                          (b"10", b"20", b"40"))
-def test_voltages(volt):
+def test_voltage_setpoint(volt):
     with expected_protocol(
             TDK_Gen40_38,
             [(b"ADR 6", b"OK"),
              (b"PV " + volt, b"OK"),
              (b"PV?", volt)]
     ) as instr:
-        instr.voltage = float(volt)
-        assert instr.voltage == float(volt)
+        instr.voltage_setpoint = float(volt)
+        assert instr.voltage_setpoint == float(volt)
 
 
 def test_invalid_voltage():
@@ -56,14 +56,14 @@ def test_invalid_voltage():
                 [(b"ADR 6", b"OK"),
                  (b"PV 60", b"OK"), ]
         ) as instr:
-            instr.voltage = 60
+            instr.voltage_setpoint = 60
 
 
-def test_invalid_current():
+def test_invalid_current_setpoint():
     with pytest.raises(ValueError):
         with expected_protocol(
                 TDK_Gen40_38,
                 [(b"ADR 6", b"OK"),
                  (b"PC 50", b"OK"), ]
         ) as instr:
-            instr.current = 50
+            instr.current_setpoint = 50

--- a/tests/instruments/tdk/test_tdk_gen40-38.py
+++ b/tests/instruments/tdk/test_tdk_gen40-38.py
@@ -1,0 +1,69 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.tdk.tdk_gen40_38 import TDK_Gen40_38
+
+
+def test_init():
+    with expected_protocol(
+            TDK_Gen40_38,
+            [(b"ADR 6", b"OK")],
+    ):
+        pass  # Verify the expected communication.
+
+
+@pytest.mark.parametrize("volt",
+                         (b"10", b"20", b"40"))
+def test_voltages(volt):
+    with expected_protocol(
+            TDK_Gen40_38,
+            [(b"ADR 6", b"OK"),
+             (b"PV " + volt, b"OK"),
+             (b"PV?", volt)]
+    ) as instr:
+        instr.voltage = float(volt)
+        assert instr.voltage == float(volt)
+
+
+def test_invalid_voltage():
+    with pytest.raises(ValueError):
+        with expected_protocol(
+                TDK_Gen40_38,
+                [(b"ADR 6", b"OK"),
+                 (b"PV 60", b"OK"), ]
+        ) as instr:
+            instr.voltage = 60
+
+
+def test_invalid_current():
+    with pytest.raises(ValueError):
+        with expected_protocol(
+                TDK_Gen40_38,
+                [(b"ADR 6", b"OK"),
+                 (b"PC 50", b"OK"), ]
+        ) as instr:
+            instr.current = 50

--- a/tests/instruments/tdk/test_tdk_gen80-65.py
+++ b/tests/instruments/tdk/test_tdk_gen80-65.py
@@ -38,32 +38,32 @@ def test_init():
 
 @pytest.mark.parametrize("volt",
                          (b"10", b"20", b"40"))
-def test_voltages(volt):
+def test_voltage_setpoint(volt):
     with expected_protocol(
             TDK_Gen80_65,
             [(b"ADR 6", b"OK"),
              (b"PV " + volt, b"OK"),
              (b"PV?", volt)]
     ) as instr:
-        instr.voltage = float(volt)
-        assert instr.voltage == float(volt)
+        instr.voltage_setpoint = float(volt)
+        assert instr.voltage_setpoint == float(volt)
 
 
-def test_invalid_voltage():
+def test_invalid_voltage_setpoint():
     with pytest.raises(ValueError):
         with expected_protocol(
                 TDK_Gen80_65,
                 [(b"ADR 6", b"OK"),
                  (b"PV 160", b"OK"), ]
         ) as instr:
-            instr.voltage = 160
+            instr.voltage_setpoint = 160
 
 
-def test_invalid_current():
+def test_invalid_current_setpoint():
     with pytest.raises(ValueError):
         with expected_protocol(
                 TDK_Gen80_65,
                 [(b"ADR 6", b"OK"),
                  (b"PC 150", b"OK"), ]
         ) as instr:
-            instr.current = 150
+            instr.current_setpoint = 150

--- a/tests/instruments/tdk/test_tdk_gen80-65.py
+++ b/tests/instruments/tdk/test_tdk_gen80-65.py
@@ -1,0 +1,69 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.tdk.tdk_gen80_65 import TDK_Gen80_65
+
+
+def test_init():
+    with expected_protocol(
+            TDK_Gen80_65,
+            [(b"ADR 6", b"OK")],
+    ):
+        pass  # Verify the expected communication.
+
+
+@pytest.mark.parametrize("volt",
+                         (b"10", b"20", b"40"))
+def test_voltages(volt):
+    with expected_protocol(
+            TDK_Gen80_65,
+            [(b"ADR 6", b"OK"),
+             (b"PV " + volt, b"OK"),
+             (b"PV?", volt)]
+    ) as instr:
+        instr.voltage = float(volt)
+        assert instr.voltage == float(volt)
+
+
+def test_invalid_voltage():
+    with pytest.raises(ValueError):
+        with expected_protocol(
+                TDK_Gen80_65,
+                [(b"ADR 6", b"OK"),
+                 (b"PV 160", b"OK"), ]
+        ) as instr:
+            instr.voltage = 160
+
+
+def test_invalid_current():
+    with pytest.raises(ValueError):
+        with expected_protocol(
+                TDK_Gen80_65,
+                [(b"ADR 6", b"OK"),
+                 (b"PC 150", b"OK"), ]
+        ) as instr:
+            instr.current = 150


### PR DESCRIPTION
This adds supports for the TDK Lambda Genesys 80-65 DC power supply and TDK Lambda Genesys 40-38 DC power supply.

This is implemented with a shared base class `pymeasure.instruments.tdk.tdk_base.TDK_Lambda_Base`. The only difference between the two models is their voltage and current ranges, which are both dynamic properties for the two instrument classes.

Tests and documentation are added as well.