### PR TITLE
Add valid values automatically to the end of a driver docstring.

### DIFF
--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -104,11 +104,12 @@ class Ametek7270(Instrument):
                                  )
     harmonic = Instrument.control(
         "REFN", "REFN %d",
-        """ An integer property that represents the reference
+        """An integer property that represents the reference
         harmonic mode control, taking values from 1 to 127.
-        This property can be set. """,
+        This property can be set.
+        """,
         validator=truncated_discrete_set,
-        values=list(range(1, 128))
+        values=range(1, 128)
     )
     phase = Instrument.control(
         "REFP.", "REFP. %g",

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -530,8 +530,45 @@ class CommonBase:
         # Add the specified document string to the getter
         fget.__doc__ = docs
 
+        # If dynamic, add (dynamic) to the docstring
         if dynamic:
             fget.__doc__ += "(dynamic)"
+
+        def format_docstring_value(value):
+            if isinstance(value, str):
+                return "``'" + value + "'``"
+            elif isinstance(value, bool):
+                return "``" + str(value) + "``"
+            else:
+                return str(value)
+
+        if values != ():
+            valid_values = "\n\n        "
+            if isinstance(values, (list, tuple, dict)):
+                # If the validator has "range" in the function name
+                # format values as a range string: "value - value"
+                if isinstance(values, (list, tuple)) and 'range' in validator.__name__:
+                    valid_values += "**Valid Values in range:** "
+                    valid_values += format_docstring_value(values[0])
+                    valid_values += " - " + format_docstring_value(values[-1])
+                else:
+                    valid_values += "**Valid Values:** "
+                    valid_values += ", ".join(
+                        [format_docstring_value(i) for i in values]).strip()
+            elif isinstance(values, range):
+                valid_values += "**Valid Values in range:** "
+                valid_values += format_docstring_value(values.start)
+                valid_values += " - " + format_docstring_value(values.stop)
+            elif isinstance(values, (int, float)):
+                valid_values += "**Valid Value:** "
+                valid_values += format_docstring_value(values)
+            else:
+                # If values is another type, like np.arange, don't add values into docstring
+                valid_values = ""
+
+            fget.__doc__ += valid_values
+
+        if dynamic:
             return DynamicProperty(fget=fget, fset=fset,
                                    fget_params_list=CommonBase._fget_params_list,
                                    fset_params_list=CommonBase._fset_params_list,

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -96,7 +96,7 @@ class Keithley2700(Instrument, KeithleyBuffer):
 
     """
 
-    CLIST_VALUES = list(range(101, 300))
+    CLIST_VALUES = range(101, 300)
 
     # Routing commands
     closed_channels = Instrument.control(


### PR DESCRIPTION
Automatically add valid values to the end of a driver properties docstring.

Often the actual valid inputs for a property are not obvious from the docstring explanation. This can be for a few reasons, such as lack of detail or complex behavior of the property. Even if the property docstring is very detailed, having a dedicated location to see valid values is useful for a quick reference.

This PR creates a standard location at the end of the docstring and format to list out **Valid Values:**.

Examples from some properties:

**Valid Values:** 6, 12, 18, 24
**Valid Values in range:**  1 - 65535
**Valid Values:** `'internal'`, `'external rear'`, `'external front'`

At the moment one datatype that isn't formatted for valid values is `np.arange` values, for example this `values=np.arange(0, 65.1, 0.1)` assignment in [agilent4156.py](https://github.com/pymeasure/pymeasure/blob/ead6fe5033872a0e9243c2f270ea95b6fe2fded4/pymeasure/instruments/agilent/agilent4156.py#L197). Should that use case be included?

Additionally,  two drivers: [ametek7270.py ](https://github.com/pymeasure/pymeasure/blob/ead6fe5033872a0e9243c2f270ea95b6fe2fded4/pymeasure/instruments/ametek/ametek7270.py#L111) and [keithley2700.py ](https://github.com/pymeasure/pymeasure/blob/ead6fe5033872a0e9243c2f270ea95b6fe2fded4/pymeasure/instruments/keithley/keithley2700.py#L108) used the `values=list(range())`. These were modified to `values=range()` which does the same function without creating a long list object.