### PR TITLE
Find all instruments and channels for testing

### DIFF
--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -67,6 +67,7 @@ from . import signalrecovery
 from . import srs
 from . import tcpowerconversion
 from . import tektronix
+from . import teledyne
 from . import temptronic
 from . import texio
 from . import thermotron


### PR DESCRIPTION
Closes #904 

This PR improves the finding mechanism, such that all channels (and instrument base classes etc.) are found, even though they are not imported into the `instruments` namespace directly.

However, the module with the class definition has to be imported (i.e. `instruments.__init__.py` has to mention the manufacturer module and that module has to import the device module).

I found a few more grandfathered base classes and channels (regarding docstrings) and another instrument, which uses `Instrument` as a channel base class.
The large diff is regarding the expanded exceptions list.