### PR TITLE
Replace union operator with unpacking

### DIFF
--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -70,7 +70,7 @@ class PlotFrame(QtWidgets.QFrame):
 
         self.plot = self.plot_widget.getPlotItem()
 
-        style = dict(self.LABEL_STYLE | {'justify': 'right'})
+        style = dict({'justify': 'right'}, **self.LABEL_STYLE)
         if "font-size" in style:  # LabelItem wants the size as 'size' rather than 'font-size'
             style["size"] = style.pop("font-size")
         self.coordinates = pg.LabelItem("", parent=self.plot, **style)

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -70,7 +70,7 @@ class PlotFrame(QtWidgets.QFrame):
 
         self.plot = self.plot_widget.getPlotItem()
 
-        style = dict({'justify': 'right'}, **self.LABEL_STYLE)
+        style = dict(self.LABEL_STYLE, justify='right')
         if "font-size" in style:  # LabelItem wants the size as 'size' rather than 'font-size'
             style["size"] = style.pop("font-size")
         self.coordinates = pg.LabelItem("", parent=self.plot, **style)


### PR DESCRIPTION
Fixes https://github.com/pymeasure/pymeasure/issues/910

Dict union operator was added in 3.9. Replacing the operator by unpacking `self.LABEL_STYLE` makes the statement compatible with python 3.8 and python 3.7.