### PR TITLE
Modify find_devices_in_module to search by folder

### DIFF
--- a/pymeasure/instruments/fakes.py
+++ b/pymeasure/instruments/fakes.py
@@ -172,8 +172,8 @@ class SwissArmyFake(FakeInstrument):
     def frame_format(self):
         """Control the format for image data returned from the get_frame() method.
         Allowed values are:
-            mono_8: single channel 8-bit image.
-            mono_16: single channel 16-bit image.
+        mono_8: single channel 8-bit image.
+        mono_16: single channel 16-bit image.
         """
         time.sleep(self._wait)
         return self._frame_format

--- a/pymeasure/instruments/fakes.py
+++ b/pymeasure/instruments/fakes.py
@@ -36,10 +36,10 @@ class FakeInstrument(Instrument):
     for testing purposes.
     """
 
-    def __init__(self, adapter=None, name=None, includeSCPI=False, **kwargs):
+    def __init__(self, adapter=None, name="Fake Instrument", includeSCPI=False, **kwargs):
         super().__init__(
             FakeAdapter(**kwargs),
-            name or "Fake Instrument",
+            name,
             includeSCPI=includeSCPI,
             **kwargs
         )
@@ -88,10 +88,9 @@ class SwissArmyFake(FakeInstrument):
     include 'voltages', sinusoidal 'waveforms', and mono channel 'image data'.
     """
 
-    def __init__(self, wait=.1, **kwargs):
+    def __init__(self, name="Mock instrument", wait=.1, **kwargs):
         super().__init__(
-            FakeAdapter,
-            "Mock instrument",
+            name=name,
             includeSCPI=False,
             **kwargs
         )
@@ -112,7 +111,7 @@ class SwissArmyFake(FakeInstrument):
 
     @property
     def time(self):
-        """ Float property for elapsed time. """
+        """Control the elapsed time."""
         if self._tstart == 0:
             self._tstart = time.time()
         self._time = time.time() - self._tstart
@@ -128,28 +127,28 @@ class SwissArmyFake(FakeInstrument):
 
     @property
     def wave(self):
-        """ Return a waveform.  """
+        """Measure a waveform."""
         return float(np.sin(self.time))
 
     @property
     def voltage(self):
-        """ Get the voltage. """
+        """Measure the voltage."""
         time.sleep(self._wait)
         return self._voltage
 
     @property
     def output_voltage(self):
+        """Control the voltage."""
         return self._output_voltage
 
     @output_voltage.setter
     def output_voltage(self, value):
-        """Set the voltage."""
         time.sleep(self._wait)
         self._output_voltage = value
 
     @property
     def frame_width(self):
-        """ Image frame width in pixels."""
+        """Control frame width in pixels."""
         time.sleep(self._wait)
         return self._w
 
@@ -160,7 +159,7 @@ class SwissArmyFake(FakeInstrument):
 
     @property
     def frame_height(self):
-        """ Image frame height in pixels."""
+        """Control frame height in pixels."""
         time.sleep(self._wait)
         return self._h
 
@@ -171,9 +170,10 @@ class SwissArmyFake(FakeInstrument):
 
     @property
     def frame_format(self):
-        """ Format for image data returned from the get_frame() method. Allowed values are:
-                mono_8: single channel 8-bit image.
-                mono_16: single channel 16-bit image.
+        """Control the format for image data returned from the get_frame() method.
+        Allowed values are:
+            mono_8: single channel 8-bit image.
+            mono_16: single channel 16-bit image.
         """
         time.sleep(self._wait)
         return self._frame_format
@@ -186,7 +186,7 @@ class SwissArmyFake(FakeInstrument):
 
     @property
     def frame(self):
-        """ Get a new image frame."""
+        """Get a new image frame."""
         im_format_maxval_dict = {"8": 255, "16": 65535}
         im_format_type_dict = {"8": np.uint8, "16": np.uint16}
         bit_depth = self.frame_format.split("_")[1]

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -72,7 +72,7 @@ def find_devices_in_module(module):
     return devices, channels
 
 
-devices, channels = find_devices_in_module(instruments)  # loop through the instruments module
+devices, channels = find_devices_in_module(instruments)
 
 # Collect all properties
 properties = []

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -63,6 +63,10 @@ def find_devices_in_module(module, devices, channels):
         except ModuleNotFoundError:
             # Some dependencies may not be installed on test computer, like pyvirtualbench
             pass
+        except OSError:
+            # On Windows instruments.ni.daqmx can raise an OSError
+            # if non-required dependency NI-DAQmx is tested
+            pass
 
 
 find_devices_in_module(instruments, devices, channels)  # the instruments module itself

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -86,6 +86,8 @@ for device in devices.union(channels):
 proper_adapters = []
 # Instruments with communication in their __init__, which consequently fails.
 need_init_communication = [
+    "SwissArmyFake",
+    "FakeInstrument",
     "ThorlabsPM100USB",
     "Keithley2700",
     "TC038",

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -56,16 +56,17 @@ def find_devices_in_module(module, devices, channels):
                         # d is no class
                         continue
                     else:
-                        if i and d not in devices:
+                        if i:
                             devices.add(d)
-                        elif c and d not in channels:
+                        elif c:
                             channels.add(d)
         except ModuleNotFoundError:
-            # Some dependencies may not be installed on test computer, like pyvirtualbench
+            # Some non-required driver dependencies may not be installed on test computer,
+            # for example ni.VirtualBench
             pass
         except OSError:
-            # On Windows instruments.ni.daqmx can raise an OSError
-            # if non-required dependency NI-DAQmx is tested
+            # On Windows instruments.ni.daqmx can raise an OSError before ModuleNotFoundError
+            # when checking installed driver files
             pass
 
 


### PR DESCRIPTION
This discussion https://github.com/pymeasure/pymeasure/discussions/801 talked about moving away from adding instruments from `pymeasure.instruments.__init__.py`, because as more and more drivers get included, which may have their own dependencies, auto importing every instrument when your code touches `pymeasure.instruments` will create an unnecessarily large memory footprint.

This modifies `tests/instruments/test_all_instruments.py` to find all instruments and channels by looping through manufacturer module, finding instruments not included in `pymeasure.instruments.__init__py`.