### PR TITLE
Fix print statement in DSPBase.sensitivity

### DIFF
--- a/pymeasure/instruments/signalrecovery/dsp_base.py
+++ b/pymeasure/instruments/signalrecovery/dsp_base.py
@@ -290,7 +290,6 @@ class DSPBase(Instrument):
 
         # Check and map the value
         value = strict_discrete_set(value, sensitivities)
-        print(value)
         value = sensitivities.index(value)
 
         # Set sensitivity


### PR DESCRIPTION
There was an extraneous print statement here:
https://github.com/pymeasure/pymeasure/blob/1a6a9425104d6d382dab04ef0c96667afab3eca4/pymeasure/instruments/signalrecovery/dsp_base.py#L293

This PR removes it.
