### PR TITLE
Increase test_visa.py adapter timeout to 120 seconds to avoid timeout

### DIFF
--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -41,7 +41,7 @@ if not is_pyvisa_sim_installed:
 def adapter():
     adapter = VISAAdapter(SIM_RESOURCE, visa_library='@sim',
                           read_termination="\n",
-                          timeout=10,
+                          timeout=120,
                           )
     yield adapter
     # Empty the read buffer, as something might remain there after a test.

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -41,7 +41,8 @@ if not is_pyvisa_sim_installed:
 def adapter():
     adapter = VISAAdapter(SIM_RESOURCE, visa_library='@sim',
                           read_termination="\n",
-                          timeout=120,
+                          # Large timeout allows very slow GitHub action runners to complete.
+                          timeout=60,
                           )
     yield adapter
     # Empty the read buffer, as something might remain there after a test.


### PR DESCRIPTION
for the `tests/adapter/test_visa.py` test, the simulated visa adapter has a timeout of 10 seconds.
https://github.com/pymeasure/pymeasure/blob/eab361ccfef345a6ffd347868ef68cfa25d21aaf/tests/adapters/test_visa.py#L44

Many CI runners are timing out with this test. I've tested changing the timeout to 60, 1, .2
https://github.com/mcdo0486/pymeasure/commit/dbc1ab778afeefaa8c7b1466a7ca9b5457c50964
https://github.com/mcdo0486/pymeasure/commit/d3eb8666fc6e11b4b5fa4999c4192069060c2cb4
https://github.com/mcdo0486/pymeasure/commit/1294d5af873f784bfc068f90bd0026343093624e

The 60 second timeout github action worked. The 1 second and .2 second both timed out with the same test. I think there is a lot of resource contention on the github runners that can slow the execution of workflows

Increasing the timeout to 120 seconds to account for that.