### PR TITLE
Regression: fix CSVFormatter.format not recording np.float types

### DIFF
--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -121,8 +121,6 @@ def unique_filename(directory, prefix='DATA', suffix='', ext='csv',
 class CSVFormatter(logging.Formatter):
     """ Formatter of data results """
 
-    numeric_types = (float, int, Decimal)
-
     def __init__(self, columns, delimiter=','):
         """Creates a csv formatter for a given list of columns (=header).
 
@@ -146,7 +144,7 @@ class CSVFormatter(logging.Formatter):
         line = []
         for x in self.columns:
             value = record.get(x, float("nan"))
-            if type(value) in self.numeric_types:
+            if isinstance(value, (float, int, Decimal)) and type(value) is not bool:
                 line.append(f"{value}")
             else:
                 units = self.units.get(x, None)

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -70,7 +70,8 @@ class Test_csv_formatter_format:
                               ('magnetic (T)', 7, "7"),
                               ('string', "abcdef", "abcdef"),
                               ('count', 9 * ureg.dimensionless, "9"),
-                              ('boolean', True, "True")
+                              ('boolean', True, "True"),
+                              ('numpy (V)', np.float64(1.1), "1.1")
                               ))
     def test_unitful(self, head, value, result):
         """Test, whether units are appended correctly"""

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -71,7 +71,8 @@ class Test_csv_formatter_format:
                               ('string', "abcdef", "abcdef"),
                               ('count', 9 * ureg.dimensionless, "9"),
                               ('boolean', True, "True"),
-                              ('numpy (V)', np.float64(1.1), "1.1")
+                              ('numpy (V)', np.float64(1.1), "1.1"),
+                              ('boolean nan (V)', True, "nan"),
                               ))
     def test_unitful(self, head, value, result):
         """Test, whether units are appended correctly"""


### PR DESCRIPTION
This is my first regression from a PR I submitted, oops. Achievement unlocked?

The https://github.com/pymeasure/pymeasure/pull/796 PR decreased the number of type comparisons before a float is written to the results file, which speeds up recording of a procedure.

If the `value` is of a numeric type, then we should write it straight away. However, this PR used `type(value) in (float, int, Decimal)` to evaluate numeric-ness because `isinstance(True, int)` would evaluate to `True`, which it shouldn't. Boolean values are evaluated later, and for instance if current value's `DATA_COLUMN` has a Pint unit in it, then booleans should not be written to the results file.

However the `type(value) in (float, int, Decimal)` check would miss other numeric types like `np.float64`, causing `np.float64` to be evaluated as `'nan'`.

This PR fixes the issue by reverting back to `isinstance` but adding a check for boolean type.
`if isinstance(value, (float, int, Decimal)) and type(value) is not bool:`

While this adds a logical comparison, the number of comparisons is still fewer then what it was beforehand.

Added a test case for `np.float64`. 