### PR TITLE
fix MKS937B check_set_errors functions and improve tests

### DIFF
--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -155,7 +155,8 @@ class MKS937B(Instrument):
         reply = self._re_response.search(ret)
         if reply:
             if reply.group('ack') == 'ACK':
-                return
+                self._check_extra_termination()
+                return []
         # no valid acknowledgement message found
         raise ValueError(f"invalid reply '{ret}' found in check_errors")
 

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -57,8 +57,18 @@ def test_ion_gauge_status_invalid_channel():
             inst.ch_2.ion_gauge_status
 
 
-def test_unit():
-    """Verify the communication of the voltage getter."""
+def test_unit_setter():
+    """Verify the communication of the unit setter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253U!TORR", "@253ACKTORR"),
+         (None, b"FF")],
+    ) as inst:
+        inst.unit = "Torr"
+
+
+def test_unit_getter():
+    """Verify the communication of the unit getter."""
     with expected_protocol(
         MKS937B,
         [("@253U?", "@253ACKTORR"),
@@ -68,7 +78,7 @@ def test_unit():
 
 
 def test_power_enabled():
-    """Verify the communication of the voltage getter."""
+    """Verify the communication of the channel power getter."""
     with expected_protocol(
         MKS937B,
         [("@253CP1?", "@253ACKON"),


### PR DESCRIPTION
previously the test did not cover any property setter. Also the `check_set_errors` function did not read back the additional termination characters. `check_set_errors` now returns a list upon success as required.

This fixes #935 