### PR TITLE
Add missing channels to docs, and fix some docstrings

### DIFF
--- a/docs/api/instruments/activetechnologies/AWG401x.rst
+++ b/docs/api/instruments/activetechnologies/AWG401x.rst
@@ -9,3 +9,7 @@ Active Technologies AWG-401x 1.2GS/s Arbitrary Waveform Generator
 .. autoclass:: pymeasure.instruments.activetechnologies.AWG401x_AWG
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.activetechnologies.AWG401x.ChannelAFG
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/agilent/agilent33521A.rst
+++ b/docs/api/instruments/agilent/agilent33521A.rst
@@ -5,3 +5,7 @@ Agilent 33521A Function/Arbitrary Waveform Generator
 .. autoclass:: pymeasure.instruments.agilent.Agilent33521A
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.agilent.agilent33500.Agilent33500Channel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/edwards/nxds.rst
+++ b/docs/api/instruments/edwards/nxds.rst
@@ -2,6 +2,6 @@
 Edwards nxds vacuum pump
 ########################
 
-.. autoclass:: pymeasure.instruments.edwards.nxds
+.. autoclass:: pymeasure.instruments.edwards.Nxds
     :members:
     :show-inheritance:

--- a/docs/api/instruments/heidenhain/nd287.rst
+++ b/docs/api/instruments/heidenhain/nd287.rst
@@ -2,7 +2,7 @@
 Heidenhain ND287 Position Display Unit
 ###########################################
 
-.. autoclass:: pymeasure.instruments.heidenhain.nd287
+.. autoclass:: pymeasure.instruments.heidenhain.ND287
     :members:
     :show-inheritance:
     

--- a/docs/api/instruments/keithley/keithley2200.rst
+++ b/docs/api/instruments/keithley/keithley2200.rst
@@ -7,3 +7,7 @@ Keithley 2200 Series Power Supplies
     :show-inheritance:
     :inherited-members:
     :exclude-members: ask, control, clear, measurement, read, setting, values, write
+
+.. autoclass:: pymeasure.instruments.keithley.keithley2200.PSChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/keysight/keysightE36312A.rst
+++ b/docs/api/instruments/keysight/keysightE36312A.rst
@@ -2,7 +2,11 @@
 Keysight E36312A Triple Output Power Supply
 ##############################################
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE36312A
+.. autoclass:: pymeasure.instruments.keysight.KeysightE36312A
     :members:
     :show-inheritance:
     :inherited-members:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE36312A.VoltageChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/lakeshore/index.rst
+++ b/docs/api/instruments/lakeshore/index.rst
@@ -5,21 +5,6 @@ Lake Shore Cryogenics
 #####################
 
 This section contains specific documentation on the Lake Shore Cryogenics instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
-Several Lakeshore instruments are channel based and make use of the :ref:`Channel Interface <channels>`. For temperature monitoring and controller instruments the
-following common :class:`Channel Classes <pymeasure.instruments.Channel>` are utilized:
-
-.. _LakeShoreChannels:
-
-LakeShore Channel Classes
---------------------------
-
-.. autoclass:: pymeasure.instruments.lakeshore.lakeshore_base.LakeShoreTemperatureChannel
-    :members:
-    :show-inheritance:
-
-.. autoclass:: pymeasure.instruments.lakeshore.lakeshore_base.LakeShoreHeaterChannel
-    :members:
-    :show-inheritance:
 
 .. toctree::
    :maxdepth: 2
@@ -29,3 +14,19 @@ LakeShore Channel Classes
    lakeshore331
    lakeshore421
    lakeshore425
+
+.. _LakeShoreChannels:
+
+LakeShore Channel Classes
+--------------------------
+
+Several Lakeshore instruments are channel based and make use of the :ref:`Channel Interface <channels>`. For temperature monitoring and controller instruments the
+following common :class:`Channel Classes <pymeasure.instruments.Channel>` are utilized:
+
+.. autoclass:: pymeasure.instruments.lakeshore.lakeshore_base.LakeShoreTemperatureChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.lakeshore.lakeshore_base.LakeShoreHeaterChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/lecroy/lecroyT3DSO1204.rst
+++ b/docs/api/instruments/lecroy/lecroyT3DSO1204.rst
@@ -7,3 +7,7 @@ LeCroy T3DSO1204 Oscilloscope
     :show-inheritance:
     :inherited-members:
     :exclude-members:
+
+.. autoclass:: pymeasure.instruments.lecroy.lecroyT3DSO1204.ScopeChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/novanta/fpu60.rst
+++ b/docs/api/instruments/novanta/fpu60.rst
@@ -2,6 +2,6 @@
 Novanta FPU60 laser power supply unit
 #####################################
 
-.. autoclass:: pymeasure.instruments.novanta.fpu60
+.. autoclass:: pymeasure.instruments.novanta.Fpu60
     :members:
     :show-inheritance:

--- a/docs/api/instruments/tcpowerconversion/tccxn.rst
+++ b/docs/api/instruments/tcpowerconversion/tccxn.rst
@@ -5,3 +5,7 @@ T&C Power Conversion AG Series Plasma Generator CXN
 .. autoclass:: pymeasure.instruments.tcpowerconversion.CXN
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.tcpowerconversion.tccxn.PresetChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/teledyne/teledyneT3AFG.rst
+++ b/docs/api/instruments/teledyne/teledyneT3AFG.rst
@@ -2,7 +2,11 @@
 Teledyne T3AFG Arbitrary Waveform Generator
 ##############################################
 
-.. autoclass:: pymeasure.instruments.teledyne.teledyneT3AFG
+.. autoclass:: pymeasure.instruments.teledyne.TeledyneT3AFG
     :members:
     :show-inheritance:
     :inherited-members:
+
+.. autoclass:: pymeasure.instruments.teledyne.teledyneT3AFG.SignalChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/thermotron/thermotron3800.rst
+++ b/docs/api/instruments/thermotron/thermotron3800.rst
@@ -2,6 +2,6 @@
 Thermotron 3800 Oven
 ####################
 
-.. autoclass:: pymeasure.instruments.thermotron.thermotron3800
+.. autoclass:: pymeasure.instruments.thermotron.Thermotron3800
     :members:
     :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -288,7 +288,7 @@ def gen_channel_docs(app, what, name, obj, options, lines):
     """
     Generate channel documentation for instruments with channels
     """
-    if hasattr(obj, '__bases__') and Instrument in obj.__bases__:
+    if hasattr(obj, '__bases__') and issubclass(obj, Instrument):
         for attr, channel_class in obj.get_channels(obj):
             if isinstance(channel_class, CommonBase.ChannelCreator):
                 channel_name = get_class_name(channel_class.pairs[0][0])

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -303,7 +303,7 @@ class Agilent33500Channel(Channel):
 
         This should be done if the same name is used continuously to load
         different arbitrary signals into the memory, since an error will occur
-         if a trace is loaded which already exists in memory.
+        if a trace is loaded which already exists in memory.
         """
         self.write("SOUR{ch}:DATA:VOL:CLE")
 

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -370,22 +370,22 @@ class Agilent33500(Instrument):
         generator = Agilent33500("GPIB::1")
 
         generator.shape = 'SIN'                 # Sets default channel output signal shape to sine
-        generator.ch[1].shape = 'SIN'           # Sets channel 1 output signal shape to sine
+        generator.ch_1.shape = 'SIN'           # Sets channel 1 output signal shape to sine
         generator.frequency = 1e3               # Sets default channel output frequency to 1 kHz
-        generator.ch[1].frequency = 1e3         # Sets channel 1 output frequency to 1 kHz
-        generator.ch[2].amplitude = 5           # Sets channel 2 output amplitude to 5 Vpp
-        generator.ch[2].output = 'on'           # Enables channel 2 output
+        generator.ch_1.frequency = 1e3         # Sets channel 1 output frequency to 1 kHz
+        generator.ch_2.amplitude = 5           # Sets channel 2 output amplitude to 5 Vpp
+        generator.ch_2.output = 'on'           # Enables channel 2 output
 
-        generator.ch[1].shape = 'ARB'           # Set channel 1 shape to arbitrary
-        generator.ch[1].arb_srate = 1e6         # Set channel 1 sample rate to 1MSa/s
+        generator.ch_1.shape = 'ARB'           # Set channel 1 shape to arbitrary
+        generator.ch_1.arb_srate = 1e6         # Set channel 1 sample rate to 1MSa/s
 
-        generator.ch[1].data_volatile_clear()   # Clear channel 1 volatile internal memory
-        generator.ch[1].data_arb(               # Send data of arbitrary waveform to channel 1
+        generator.ch_1.data_volatile_clear()   # Clear channel 1 volatile internal memory
+        generator.ch_1.data_arb(               # Send data of arbitrary waveform to channel 1
             'test',
             range(-10000, 10000, +20),          # In this case a simple ramp
             data_format='DAC'                   # Data format is set to 'DAC'
          )
-        generator.ch[1].arb_file = 'test'       # Select the transmitted waveform 'test'
+        generator.ch_1.arb_file = 'test'       # Select the transmitted waveform 'test'
 
     """
 

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -61,18 +61,18 @@ Select quantities to be measured:
     * CPG: Parallel capacitance [F] and parallel conductance [S]
     * CPRP: Parallel capacitance [F] and parallel resistance [Ohm]
 
-    * CSD: Series capacitance [F] and dissipation factor [number]
-    * CSQ: Series capacitance [F] and quality factor [number]
-    * CSRS: Series capacitance [F] and series resistance [Ohm]
+    - CSD: Series capacitance [F] and dissipation factor [number]
+    - CSQ: Series capacitance [F] and quality factor [number]
+    - CSRS: Series capacitance [F] and series resistance [Ohm]
 
-   * LPD: Parallel inductance [H] and dissipation factor [number]
-   * LPQ: Parallel inductance [H] and quality factor [number]
-   * LPG: Parallel inductance [H] and parallel conductance [S]
-   * LPRP: Parallel inductance [H] and parallel resistance [Ohm]
+    * LPD: Parallel inductance [H] and dissipation factor [number]
+    * LPQ: Parallel inductance [H] and quality factor [number]
+    * LPG: Parallel inductance [H] and parallel conductance [S]
+    * LPRP: Parallel inductance [H] and parallel resistance [Ohm]
 
-    * LSD: Series inductance [H] and dissipation factor [number]
-    * LSQ: Seriesinductance [H] and quality factor [number]
-    * LSRS: Series inductance [H] and series resistance [Ohm]
+    - LSD: Series inductance [H] and dissipation factor [number]
+    - LSQ: Seriesinductance [H] and quality factor [number]
+    - LSRS: Series inductance [H] and series resistance [Ohm]
 
     * RX: Resitance [Ohm] and reactance [Ohm]
     * ZTD: Impedance, magnitude [Ohm] and phase [deg]

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -251,8 +251,10 @@ class Ametek7270(Instrument):
     def ask(self, command, query_delay=0):
         """Send a command and read the response, stripping white spaces.
 
-        Usually the properties use the ``values()`` method that adds a strip call,
-        however several methods use directly the result from ask to be casted into some other types.
+        Usually the properties use the
+        :meth:`values() <pymeasure.instruments.common_base.CommonBase.values>`
+        method that adds a strip call,
+        however several methods use directly the result from ask to be cast into some other types.
         It should therefore also add the strip here, as all responses end with a newline character.
         """
         return super().ask(command, query_delay).strip()

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -252,10 +252,10 @@ class Ametek7270(Instrument):
         """Send a command and read the response, stripping white spaces.
 
         Usually the properties use the
-        :meth:`values() <pymeasure.instruments.common_base.CommonBase.values>`
-        method that adds a strip call,
-        however several methods use directly the result from ask to be cast into some other types.
-        It should therefore also add the strip here, as all responses end with a newline character.
+        :meth:`~pymeasure.instruments.common_base.CommonBase.values`
+        method that adds a strip call, however several methods use directly the result from ask to
+        be cast into some other types. It should therefore also add the strip here, as all responses
+        end with a newline character.
         """
         return super().ask(command, query_delay).strip()
 

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -45,7 +45,7 @@ class Ametek7270(Instrument):
     """This is the class for the Ametek DSP 7270 lockin amplifier
 
     In this instrument, some measurements are defined only for specific modes,
-    called Reference modes, see :meth`set_reference_mode` and will raise errors
+    called Reference modes, see :meth:`set_reference_mode` and will raise errors
     if called incorrectly
     """
 
@@ -251,7 +251,7 @@ class Ametek7270(Instrument):
     def ask(self, command, query_delay=0):
         """Send a command and read the response, stripping white spaces.
 
-        Usually the properties use the `values` method that adds a strip call,
+        Usually the properties use the ``values()`` method that adds a strip call,
         however several methods use directly the result from ask to be casted into some other types.
         It should therefore also add the strip here, as all responses end with a newline character.
         """

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -212,7 +212,7 @@ class DPSeriesMotorController(Instrument):
     @property
     def encoder_enabled(self):
         """ A boolean property to represent whether an external encoder is connected and should be
-        used to set the ``step_position`` property.
+        used to set the :attr:`step_position` property.
         """
         return self._encoder_enabled
 
@@ -223,11 +223,11 @@ class DPSeriesMotorController(Instrument):
     @property
     def step_position(self):
         """ Integer property representing the value of the motor position measured in steps counted
-        by the motor controller or, if encoder_enabled is set, the steps counted by an
+        by the motor controller or, if :attr:`encoder_enabled` is set, the steps counted by an
         externally connected encoder. Note that in the DP series motor controller instrument
         manuals, this property would be referred to as the 'absolute position' while this
-        driver implements a conversion between steps and absolute units for the ``absolute_
-        position`` property. This property can be set.
+        driver implements a conversion between steps and absolute units for the
+        :attr:`absolute_position` property. This property can be set.
         """
         if self._encoder_enabled:
             pos = self.ask("VEP")
@@ -245,11 +245,12 @@ class DPSeriesMotorController(Instrument):
     def absolute_position(self):
         """ Float property representing the value of the motor position measured in absolute units.
         Note that in DP series motor controller instrument manuals, 'absolute position' refers to
-        the ``step_position`` property rather than this property. Also note that use of this
-        property relies on ``steps_to_absolute()`` and ``absolute_to_steps()`` being implemented in
-        a subclass. In this way, the user can define the conversion from a motor step position into
-        any desired absolute unit. Absolute units could be the position in meters of a linear stage
-        or the angular position of a gimbal mount, etc. This property can be set.
+        the :attr:`step_position` property rather than this property. Also note that use of this
+        property relies on :meth:`steps_to_absolute()` and :meth:`absolute_to_steps()`
+        being implemented in a subclass. In this way, the user can define the conversion from a
+        motor step position into any desired absolute unit. Absolute units could be the position in
+        meters of a linear stage or the angular position of a gimbal mount, etc. This property can
+        be set.
         """
         step_pos = self.step_position
         return self.steps_to_absolute(step_pos)
@@ -264,7 +265,7 @@ class DPSeriesMotorController(Instrument):
         subclasses.
 
         :param pos: Absolute position in the units determined by the subclassed
-               ``absolute_to_steps()`` method.
+               :meth:`absolute_to_steps()` method.
         """
         raise NotImplementedError("absolute_to_steps() must be implemented in subclasses!")
 

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -212,7 +212,7 @@ class DPSeriesMotorController(Instrument):
     @property
     def encoder_enabled(self):
         """ A boolean property to represent whether an external encoder is connected and should be
-        used to set the step_position property.
+        used to set the ``step_position`` property.
         """
         return self._encoder_enabled
 
@@ -226,8 +226,8 @@ class DPSeriesMotorController(Instrument):
         by the motor controller or, if encoder_enabled is set, the steps counted by an
         externally connected encoder. Note that in the DP series motor controller instrument
         manuals, this property would be referred to as the 'absolute position' while this
-        driver implements a conversion between steps and absolute units for the `absolute
-        position` property. This property can be set.
+        driver implements a conversion between steps and absolute units for the ``absolute
+        position`` property. This property can be set.
         """
         if self._encoder_enabled:
             pos = self.ask("VEP")
@@ -244,12 +244,12 @@ class DPSeriesMotorController(Instrument):
     @property
     def absolute_position(self):
         """ Float property representing the value of the motor position measured in absolute units.
-        Note that in DP series motor controller instrument manuals, `absolute position` refers to
-        the 'step_position' property rather than this property. Also note that use of this property
-        relies on steps_to_absolute() and absolute_to_steps() being implemented in a subclass. In
-        this way, the user can define the conversion from a motor step position into any desired
-        absolute unit. Absolute units could be the position in meters of a linear stage or the
-        angular position of a gimbal mount, etc. This property can be set.
+        Note that in DP series motor controller instrument manuals, 'absolute position' refers to
+        the ``step_position`` property rather than this property. Also note that use of this
+        property relies on ``steps_to_absolute()`` and ``absolute_to_steps()`` being implemented in
+        a subclass. In this way, the user can define the conversion from a motor step position into
+        any desired absolute unit. Absolute units could be the position in meters of a linear stage
+        or the angular position of a gimbal mount, etc. This property can be set.
         """
         step_pos = self.step_position
         return self.steps_to_absolute(step_pos)
@@ -263,8 +263,8 @@ class DPSeriesMotorController(Instrument):
         """ Convert an absolute position to a number of steps to move. This must be implemented in
         subclasses.
 
-        :param pos: Absolute position in the units determined by the subclassed absolute_to_steps()
-            method.
+        :param pos: Absolute position in the units determined by the subclassed
+               ``absolute_to_steps()`` method.
         """
         raise NotImplementedError("absolute_to_steps() must be implemented in subclasses!")
 
@@ -301,7 +301,7 @@ class DPSeriesMotorController(Instrument):
     def home(self, home_mode):
         """ Send command to the motor controller to 'home' the motor.
 
-        :param home_mode: 0 or 1 specifying which homing mode to run.
+        :param home_mode: ``0`` or ``1`` specifying which homing mode to run.
 
             0 will perform a homing operation where the controller moves the motor until a soft
             limit is reached, then will ramp down to base speed and continue motion until a home

--- a/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
+++ b/pymeasure/instruments/anaheimautomation/dpseriesmotorcontroller.py
@@ -226,7 +226,7 @@ class DPSeriesMotorController(Instrument):
         by the motor controller or, if encoder_enabled is set, the steps counted by an
         externally connected encoder. Note that in the DP series motor controller instrument
         manuals, this property would be referred to as the 'absolute position' while this
-        driver implements a conversion between steps and absolute units for the ``absolute
+        driver implements a conversion between steps and absolute units for the ``absolute_
         position`` property. This property can be set.
         """
         if self._encoder_enabled:

--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -516,10 +516,10 @@ class HP3478A(HPLegacyInstrument):
     def write_calibration_data(self, cal_data, verify_calibration_data=True):
         """Method to write calibration data.
 
-        The cal_data parameter format is the same as the 'calibration_data' property.
+        The cal_data parameter format is the same as the ``calibration_data`` property.
 
         Verification of the cal_data array can be bypassed by setting
-        'verify_calibration_data' to False.
+        ``verify_calibration_data`` to ``False``.
 
         """
         if verify_calibration_data and not self.verify_calibration_data(cal_data):

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -58,10 +58,10 @@ class Keithley2000(Instrument, KeithleyBuffer):
     mode = Instrument.control(
         ":CONF?", ":CONF:%s",
         """ A string property that controls the configuration mode for measurements,
-        which can take the values: :code:'current' (DC), :code:'current ac',
-        :code:'voltage' (DC),  :code:'voltage ac', :code:'resistance' (2-wire),
-        :code:'resistance 4W' (4-wire), :code:'period', :code:'frequency',
-        :code:'temperature', :code:'diode', and :code:'frequency'. """,
+        which can take the values: ``current`` (DC), ``current ac``,
+        ``voltage`` (DC),  ``voltage ac``, ``resistance`` (2-wire),
+        ``resistance 4W`` (4-wire), ``period``,
+        ``temperature``, ``diode``, and ``frequency``.""",
         validator=strict_discrete_set,
         values=MODES,
         map_values=True,
@@ -72,7 +72,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         ":SYST:BEEP:STAT?",
         ":SYST:BEEP:STAT %g",
         """ A string property that enables or disables the system status beeper,
-        which can take the values: :code:'enabled' and :code:'disabled'. """,
+        which can take the values: ``enabled`` and ``disabled``. """,
         validator=strict_discrete_set,
         values={'enabled': 1, 'disabled': 0},
         map_values=True

--- a/pymeasure/instruments/keysight/keysightE36312A.py
+++ b/pymeasure/instruments/keysight/keysightE36312A.py
@@ -76,11 +76,12 @@ class KeysightE36312A(Instrument):
     interface for interacting with the instrument.
 
     .. code-block:: python
-    supply = KeysightE36312A(resource)
-    supply.ch_1.voltage_setpoint=10
-    supply.ch_1.current_setpoint=0.1
-    supply.ch_1.output_enabled=True
-    print(supply.ch_1.voltage)
+
+        supply = KeysightE36312A(resource)
+        supply.ch_1.voltage_setpoint=10
+        supply.ch_1.current_setpoint=0.1
+        supply.ch_1.output_enabled=True
+        print(supply.ch_1.voltage)
     """
 
     ch_1 = Instrument.ChannelCreator(VoltageChannel, 1)

--- a/pymeasure/instruments/keysight/keysightN5767A.py
+++ b/pymeasure/instruments/keysight/keysightN5767A.py
@@ -37,9 +37,6 @@ log.addHandler(logging.NullHandler())
 class KeysightN5767A(Instrument):
     """ Represents the Keysight N5767A Power supply
     interface for interacting with the instrument.
-
-    .. code-block:: python
-
     """
     ###############
     # Current (A) #

--- a/pymeasure/instruments/lakeshore/lakeshore421.py
+++ b/pymeasure/instruments/lakeshore/lakeshore421.py
@@ -34,6 +34,7 @@ class LakeShore421(Instrument):
     """
     Represents the Lake Shore 421 Gaussmeter and provides a high-level interface for interacting
     with the instrument.
+
     .. code-block:: python
 
         gaussmeter = LakeShore421("COM1")

--- a/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
+++ b/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
@@ -293,12 +293,13 @@ class ScopeChannel(Channel):
     trigger_coupling = Instrument.control(
         "TRCP?", "TRCP %s",
         """ A string parameter that specifies the input coupling for the selected trigger sources.
-        • ac    — AC coupling block DC component in the trigger path, removing dc offset voltage
-                  from the trigger waveform. Use AC coupling to get a stable edge trigger when
-                  your waveform has a large dc offset.
-        • dc    — DC coupling allows dc and ac signals into the trigger path.
-        • lowpass  — HFREJ coupling places a lowpass filter in the trigger path.
-        • highpass — LFREJ coupling places a highpass filter in the trigger path.
+
+        - ac: AC coupling block DC component in the trigger path, removing dc offset voltage
+          from the trigger waveform. Use AC coupling to get a stable edge trigger when
+          your waveform has a large dc offset.
+        - dc: DC coupling allows dc and ac signals into the trigger path.
+        - lowpass: HFREJ coupling places a lowpass filter in the trigger path.
+        - highpass: LFREJ coupling places a highpass filter in the trigger path.
         """,
         validator=strict_discrete_set,
         values={"ac": "AC", "dc": "DC", "lowpass": "HFREJ", "highpass": "LFREJ"},
@@ -332,6 +333,16 @@ class ScopeChannel(Channel):
         """ A string parameter that sets the trigger slope of the specified trigger source.
         <trig_slope>:={NEG,POS,WINDOW} for edge trigger.
         <trig_slope>:={NEG,POS} for other trigger
+
+        +------------+--------------------------------------------------+
+        | parameter  | trigger slope                                    |
+        +------------+--------------------------------------------------+
+        | negative   | Negative slope for edge trigger or other trigger |
+        +------------+--------------------------------------------------+
+        | positive   | Positive slope for edge trigger or other trigger |
+        +------------+--------------------------------------------------+
+        | window     | Window slope for edge trigger                    |
+        +------------+--------------------------------------------------+
         """,
         validator=strict_discrete_set,
         values={"negative": "NEG", "positive": "POS", "window": "WINDOW"},
@@ -346,31 +357,59 @@ class ScopeChannel(Channel):
         "PACU %s",
         """Set the waveform processing of this channel with the specified algorithm and the result
         is displayed on the front panel. The command accepts the following parameters:
-        Parameter   Description
-        PKPK        vertical peak-to-peak
-        MAX         maximum vertical value
-        MIN         minimum vertical value
-        AMPL        vertical amplitude
-        TOP         waveform top value
-        BASE        waveform base value
-        CMEAN       average value in the first cycle
-        MEAN        average value
-        RMS         RMS value
-        CRMS        RMS value in the first cycle
-        OVSN        overshoot of a falling edge
-        FPRE        preshoot of a falling edge
-        OVSP        overshoot of a rising edge
-        RPRE        preshoot of a rising edge
-        PER         period
-        FREQ        frequency
-        PWID        positive pulse width
-        NWID        negative pulse width
-        RISE        rise-time
-        FALL        fall-time
-        WID         Burst width
-        DUTY        positive duty cycle
-        NDUTY       negative duty cycle
-        ALL         All measurement """,
+
+        +------------+----------------------------------+
+        | Parameter  | Description                      |
+        +============+==================================+
+        | PKPK       | vertical peak-to-peak            |
+        +------------+----------------------------------+
+        | MAX        | maximum vertical value           |
+        +------------+----------------------------------+
+        | MIN        | minimum vertical value           |
+        +------------+----------------------------------+
+        | AMPL       | vertical amplitude               |
+        +------------+----------------------------------+
+        | TOP        | waveform top value               |
+        +------------+----------------------------------+
+        | BASE       | waveform base value              |
+        +------------+----------------------------------+
+        | CMEAN      | average value in the first cycle |
+        +------------+----------------------------------+
+        | MEAN       |  average value                   |
+        +------------+----------------------------------+
+        | RMS        | RMS value                        |
+        +------------+----------------------------------+
+        | CRMS       | RMS value in the first cycle     |
+        +------------+----------------------------------+
+        | OVSN       | overshoot of a falling edge      |
+        +------------+----------------------------------+
+        | FPRE       | preshoot of a falling edge       |
+        +------------+----------------------------------+
+        | OVSP       | overshoot of a rising edge       |
+        +------------+----------------------------------+
+        | RPRE       | preshoot of a rising edge        |
+        +------------+----------------------------------+
+        | PER        | period                           |
+        +------------+----------------------------------+
+        | FREQ       | frequency                        |
+        +------------+----------------------------------+
+        | PWID       | positive pulse width             |
+        +------------+----------------------------------+
+        | NWID       | negative pulse width             |
+        +------------+----------------------------------+
+        | RISE       | rise-time                        |
+        +------------+----------------------------------+
+        | FALL       | fall-time                        |
+        +------------+----------------------------------+
+        | WID        | Burst width                      |
+        +------------+----------------------------------+
+        | DUTY       | positive duty cycle              |
+        +------------+----------------------------------+
+        | NDUTY      | negative duty cycle              |
+        +------------+----------------------------------+
+        | ALL        | all measurement                  |
+        +------------+----------------------------------+
+        """,
         validator=strict_discrete_set,
         values=_measurable_parameters
     )
@@ -427,20 +466,21 @@ class ScopeChannel(Channel):
     @property
     def current_configuration(self):
         """ Read channel configuration as a dict containing the following keys:
-            - "channel": channel number (int)
-            - "attenuation": probe attenuation (float)
-            - "bandwidth_limit": bandwidth limiting enabled (bool)
-            - "coupling": "ac 1M", "dc 1M", "ground" coupling (str)
-            - "offset": vertical offset (float)
-            - "skew_factor": channel-tochannel skew factor (float)
-            - "display": currently displayed (bool)
-            - "unit": "A" or "V" units (str)
-            - "volts_div": vertical divisions (float)
-            - "inverted": inverted (bool)
-            - "trigger_coupling": trigger coupling can be "dc" "ac" "highpass" "lowpass" (str)
-            - "trigger_level": trigger level (float)
-            - "trigger_level2": trigger lower level for SLEW or RUNT trigger (float)
-            - "trigger_slope": trigger slope can be "negative" "positive" "window" (str)
+
+        - "channel": channel number (int)
+        - "attenuation": probe attenuation (float)
+        - "bandwidth_limit": bandwidth limiting enabled (bool)
+        - "coupling": "ac 1M", "dc 1M", "ground" coupling (str)
+        - "offset": vertical offset (float)
+        - "skew_factor": channel-tochannel skew factor (float)
+        - "display": currently displayed (bool)
+        - "unit": "A" or "V" units (str)
+        - "volts_div": vertical divisions (float)
+        - "inverted": inverted (bool)
+        - "trigger_coupling": trigger coupling can be "dc" "ac" "highpass" "lowpass" (str)
+        - "trigger_level": trigger level (float)
+        - "trigger_level2": trigger lower level for SLEW or RUNT trigger (float)
+        - "trigger_slope": trigger slope can be "negative" "positive" "window" (str)
         """
 
         ch_setup = {
@@ -469,10 +509,11 @@ class LeCroyT3DSO1204(Instrument):
     using the lower-level methods to interact directly with the scope.
 
     Attributes:
+
         WRITE_INTERVAL_S: minimum time between two commands. If a command is received less than
         WRITE_INTERVAL_S after the previous one, the code blocks until at least WRITE_INTERVAL_S
         seconds have passed.
-        Because the oscilloscope takes a non neglibile time to perform some operations, it might
+        Because the oscilloscope takes a non-negligible time to perform some operations, it might
         be needed for the user to tweak the sleep time between commands.
         The WRITE_INTERVAL_S is set to 10ms as default however its optimal value heavily depends
         on the actual commands and on the connection type, so it is impossible to give a unique
@@ -612,12 +653,13 @@ class LeCroyT3DSO1204(Instrument):
     @property
     def timebase(self):
         """ Read timebase setup as a dict containing the following keys:
+
             - "timebase_scale": horizontal scale in seconds/div (float)
             - "timebase_offset": interval in seconds between the trigger and the reference
-            position (float)
+              position (float)
             - "timebase_hor_magnify": horizontal scale in the zoomed window in seconds/div (float)
             - "timebase_hor_position": horizontal position in the zoomed window in seconds
-            (float)"""
+              (float)"""
         tb_setup = {
             "timebase_scale": self.timebase_scale,
             "timebase_offset": self.timebase_offset,
@@ -785,10 +827,13 @@ class LeCroyT3DSO1204(Instrument):
     memory_size = Instrument.control(
         "MSIZ?", "MSIZ %s",
         """ A float parameter that selects the maximum depth of memory.
+
         <size>:={7K,70K,700K,7M} for non-interleaved mode. Non-interleaved means a single channel is
         active per A/D converter. Most oscilloscopes feature two channels per A/D converter.
+
         <size>:={14K,140K,1.4M,14M} for interleave mode. Interleave mode means multiple active
-        channels per A/D converter. """,
+        channels per A/D converter.
+        """,
         validator=strict_discrete_set,
         values={7e3: "7K", 7e4: "70K", 7e5: "700K", 7e6: "7M",
                 14e3: "14K", 14e4: "140K", 14e5: "1.4M", 14e6: "14M"},
@@ -799,6 +844,7 @@ class LeCroyT3DSO1204(Instrument):
     def waveform_preamble(self):
         """ Get preamble information for the selected waveform source as a dict with the
         following keys:
+
         - "type": normal, peak detect, average, high resolution (str)
         - "requested_points": number of data points requested by the user (int)
         - "sampled_points": number of data points sampled by the oscilloscope (int)
@@ -813,7 +859,7 @@ class LeCroyT3DSO1204(Instrument):
         - "sampling_rate": sampling rate (it is a read-only property)
         - "grid_number": number of horizontal grids (it is a read-only property)
         - "status": acquisition status of the scope. Can be "stopped", "triggered", "ready",
-        "auto", "armed"
+          "auto", "armed"
         - "xdiv": horizontal scale (units per division) in seconds
         - "xoffset": time interval in seconds between the trigger event and the reference position
         - "ydiv": vertical scale (units per division) in Volts
@@ -992,16 +1038,18 @@ class LeCroyT3DSO1204(Instrument):
         """ Get data points from the specified source of the oscilloscope. The returned objects are
         two np.ndarray of data and time points and a dict with the waveform preamble, that contains
         metadata about the waveform.
-        Note.
+
         :param source: measurement source. It can be "C1", "C2", "C3", "C4", "MATH".
         :param requested_points: number of points to acquire. If None the number of points
-        requested in the previous call will be assumed, i.e. the value of the number of points
-        stored in the oscilloscope memory. If 0 the maximum number of points will be returned.
+               requested in the previous call will be assumed, i.e. the value of the number of
+               points stored in the oscilloscope memory. If 0 the maximum number of points will be
+               returned.
         :param sparsing: interval between data points. For example if sparsing = 4, only one
-        point every 4 points is read. If 0 or None the sparsing of the previous call is assumed,
-        i.e. the value of the sparsing stored in the oscilloscope memory.
+               point every 4 points is read. If 0 or None the sparsing of the previous call is
+               assumed, i.e. the value of the sparsing stored in the oscilloscope memory.
         :return: data_ndarray, time_ndarray, waveform_preamble_dict: see waveform_preamble
-        property for dict format. """
+                 property for dict format.
+        """
         # Sanitize the input arguments
         if not sparsing:
             sparsing = self.waveform_sparsing
@@ -1026,29 +1074,31 @@ class LeCroyT3DSO1204(Instrument):
         "TRMD?", "TRMD %s",
         """ A string parameter that selects the trigger sweep mode.
         <mode>:= {AUTO,NORM,SINGLE,STOP}
-        • auto : When AUTO sweep mode is selected, the oscilloscope begins to search for the
-        trigger signal that meets the conditions.
-        If the trigger signal is satisfied, the running state on the top left corner of
-        the user interface shows Trig'd, and the interface shows stable waveform.
-        Otherwise, the running state always shows Auto, and the interface shows unstable
-        waveform.
-        • normal : When NORMAL sweep mode is selected, the oscilloscope enters the wait trigger
-        state and begins to search for trigger signals that meet the conditions.
-        If the trigger signal is satisfied, the running state shows Trig'd, and the interface
-        shows stable waveform.
-        Otherwise, the running state shows Ready, and the interface displays the last
-        triggered waveform (previous trigger) or does not display the waveform (no
-        previous trigger).
-        • single : When SINGLE sweep mode is selected, the backlight of SINGLE key lights up,
-        the oscilloscope enters the waiting trigger state and begins to search for the
-        trigger signal that meets the conditions.
-        If the trigger signal is satisfied, the running state shows Trig'd, and the interface
-        shows stable waveform.
-        Then, the oscilloscope stops scanning, the RUN/STOP key is red light,
-        and the running status shows Stop.
-        Otherwise, the running state shows Ready, and the interface does not display the waveform.
-        • stopped : STOP is a part of the option of this command, but not a trigger mode of the
-        oscilloscope.""",
+
+        - auto : When AUTO sweep mode is selected, the oscilloscope begins to search for the
+          trigger signal that meets the conditions.
+          If the trigger signal is satisfied, the running state on the top left corner of
+          the user interface shows Trig'd, and the interface shows stable waveform.
+          Otherwise, the running state always shows Auto, and the interface shows unstable
+          waveform.
+        - normal : When NORMAL sweep mode is selected, the oscilloscope enters the wait trigger
+          state and begins to search for trigger signals that meet the conditions.
+          If the trigger signal is satisfied, the running state shows Trig'd, and the interface
+          shows stable waveform.
+          Otherwise, the running state shows Ready, and the interface displays the last
+          triggered waveform (previous trigger) or does not display the waveform (no
+          previous trigger).
+        - single : When SINGLE sweep mode is selected, the backlight of SINGLE key lights up,
+          the oscilloscope enters the waiting trigger state and begins to search for the
+          trigger signal that meets the conditions.
+          If the trigger signal is satisfied, the running state shows Trig'd, and the interface
+          shows stable waveform.
+          Then, the oscilloscope stops scanning, the RUN/STOP key is red light,
+          and the running status shows Stop.
+          Otherwise, the running state shows Ready, and the interface does not display the waveform.
+        - stopped : STOP is a part of the option of this command, but not a trigger mode of the
+          oscilloscope.
+        """,
         validator=strict_discrete_set,
         values={"stopped": "STOP", "normal": "NORM", "single": "SINGLE", "auto": "AUTO"},
         map_values=True
@@ -1091,22 +1141,26 @@ class LeCroyT3DSO1204(Instrument):
         restricted to those variables to be changed.
         There are five parameters that can be specified. Parameters 1. 2. 3. are always mandatory.
         Parameters 4. 5. are required only for certain combinations of the previous parameters.
+
         1. <trig_type>:={edge, slew, glit, intv, runt, drop}
         2. <source>:={c1, c2, c3, c4, line}
         3. - <hold_type>:={ti, off} for edge trigger.
-        - <hold_type>:={ti} for drop trigger.
-        - <hold_type>:={ps, pl, p2, p1} for glit/runt trigger.
-        - <hold_type>:={is, il, i2, i1} for slew/intv trigger.
+           - <hold_type>:={ti} for drop trigger.
+           - <hold_type>:={ps, pl, p2, p1} for glit/runt trigger.
+           - <hold_type>:={is, il, i2, i1} for slew/intv trigger.
         4. <hold_value1>:= a time value with unit.
         5. <hold_value2>:= a time value with unit.
+
         Note:
-        • "line" can only be selected when the trigger type is "edge".
-        • All time arguments should be given in multiples of seconds. Use the scientific notation
-        if necessary.
-        • The range of hold_values varies from trigger types. [80nS, 1.5S] for "edge" trigger,
-        and [2nS, 4.2S] for others.
-        • The trigger_select command is switched automatically between the short, normal and
-        extended version depending on the number of expected parameters. """
+
+        - "line" can only be selected when the trigger type is "edge".
+        - All time arguments should be given in multiples of seconds. Use the scientific notation
+          if necessary.
+        - The range of hold_values varies from trigger types. [80nS, 1.5S] for "edge" trigger,
+          and [2nS, 4.2S] for others.
+        - The trigger_select command is switched automatically between the short, normal and
+          extended version depending on the number of expected parameters.
+        """
         return self._trigger_select
 
     # noinspection PyAttributeOutsideInit
@@ -1127,18 +1181,20 @@ class LeCroyT3DSO1204(Instrument):
         """ Set up trigger. Unspecified parameters are not modified. Modifying a single parameter
         might impact other parameters. Refer to oscilloscope documentation and make multiple
         consecutive calls to trigger_setup and channel_setup if needed.
+
         :param mode: trigger sweep mode [auto, normal, single, stop]
         :param source: trigger source [c1, c2, c3, c4, line]
         :param trigger_type: condition that will trigger the acquisition of waveforms
-        [edge,slew,glit,intv,runt,drop]
+               [edge,slew,glit,intv,runt,drop]
         :param hold_type: hold type (refer to page 172 of programing guide)
         :param hold_value1: hold value1 (refer to page 172 of programing guide)
         :param hold_value2: hold value2 (refer to page 172 of programing guide)
         :param coupling: input coupling for the selected trigger sources
         :param level: trigger level voltage for the active trigger source
         :param level2: trigger lower level voltage for the active trigger source (only slew/runt
-        trigger)
-        :param slope: trigger slope of the specified trigger source"""
+               trigger)
+        :param slope: trigger slope of the specified trigger source
+        """
         if mode is not None:
             self.trigger_mode = mode
         if all(i is not None for i in [source, trigger_type, hold_type]):
@@ -1166,18 +1222,19 @@ class LeCroyT3DSO1204(Instrument):
     @property
     def trigger(self):
         """ Read trigger setup as a dict containing the following keys:
-            - "mode": trigger sweep mode [auto, normal, single, stop]
-            - "trigger_type": condition that will trigger the acquisition of waveforms [edge,
-            slew,glit,intv,runt,drop]
-            - "source": trigger source [c1,c2,c3,c4]
-            - "hold_type": hold type (refer to page 172 of programing guide)
-            - "hold_value1": hold value1 (refer to page 172 of programing guide)
-            - "hold_value2": hold value2 (refer to page 172 of programing guide)
-            - "coupling": input coupling for the selected trigger sources
-            - "level": trigger level voltage for the active trigger source
-            - "level2": trigger lower level voltage for the active trigger source (only slew/runt
-            trigger)
-            - "slope": trigger slope of the specified trigger source
+
+        - "mode": trigger sweep mode [auto, normal, single, stop]
+        - "trigger_type": condition that will trigger the acquisition of waveforms [edge,
+          slew,glit,intv,runt,drop]
+        - "source": trigger source [c1,c2,c3,c4]
+        - "hold_type": hold type (refer to page 172 of programing guide)
+        - "hold_value1": hold value1 (refer to page 172 of programing guide)
+        - "hold_value2": hold value2 (refer to page 172 of programing guide)
+        - "coupling": input coupling for the selected trigger sources
+        - "level": trigger level voltage for the active trigger source
+        - "level2": trigger lower level voltage for the active trigger source (only slew/runt
+          trigger)
+        - "slope": trigger slope of the specified trigger source
         """
         trigger_select = self.trigger_select
         ch = self.ch(trigger_select[1])
@@ -1242,20 +1299,37 @@ class LeCroyT3DSO1204(Instrument):
         starts a type of delay measurement.
         The MEASURE_DELY? query returns the measured value of delay type.
         The command accepts three arguments with the following syntax:
-        measure_delay = (<type>,<sourceA>,<sourceB>)
-        <type> := {PHA,FRR,FRF,FFR,FFF,LRR,LRF,LFR,LFF,SKEW}
-        <sourceA>,<sourceB> := {C1,C2,C3,C4} where if sourceA=CX and sourceB=CY, then X < Y
-        Type      Description
-        PHA       The phase difference between two channels. (rising edge - rising edge)
-        FRR       Delay between two channels. (first rising edge - first rising edge)
-        FRF       Delay between two channels. (first rising edge - first falling edge)
-        FFR       Delay between two channels. (first falling edge - first rising edge)
-        FFF       Delay between two channels. (first falling edge - first falling edge)
-        LRR       Delay between two channels. (first rising edge - last rising edge)
-        LRF       Delay between two channels. (first rising edge - last falling edge)
-        LFR       Delay between two channels. (first falling edge - last rising edge)
-        LFF       Delay between two channels. (first falling edge - last falling edge)
-        Skew      Delay between two channels. (edge – edge of the same type) """,
+
+            measure_delay = (<type>,<sourceA>,<sourceB>)
+
+            <type> := {PHA,FRR,FRF,FFR,FFF,LRR,LRF,LFR,LFF,SKEW}
+
+            <sourceA>,<sourceB> := {C1,C2,C3,C4} where if sourceA=CX and sourceB=CY, then X < Y
+
+        +------------+-----------------------------------------------------------------------+
+        | Type       | Description                                                           |
+        +============+=======================================================================+
+        | PHA        | The phase difference between two channels. (rising edge - rising edge)|
+        +------------+-----------------------------------------------------------------------+
+        | FRR        |Delay between two channels. (first rising edge - first rising edge)    |
+        +------------+-----------------------------------------------------------------------+
+        | FRF        | Delay between two channels. (first rising edge - first falling edge)  |
+        +------------+-----------------------------------------------------------------------+
+        | FFR        | Delay between two channels. (first falling edge - first rising edge)  |
+        +------------+-----------------------------------------------------------------------+
+        | FFF        | Delay between two channels. (first falling edge - first falling edge) |
+        +------------+-----------------------------------------------------------------------+
+        | LRR        | Delay between two channels. (first rising edge - last rising edge)    |
+        +------------+-----------------------------------------------------------------------+
+        | LRF        | Delay between two channels. (first rising edge - last falling edge)   |
+        +------------+-----------------------------------------------------------------------+
+        | LFR        |  Delay between two channels. (first falling edge - last rising edge)  |
+        +------------+-----------------------------------------------------------------------+
+        | LFF        | Delay between two channels. (first falling edge - last falling edge)  |
+        +------------+-----------------------------------------------------------------------+
+        | Skew       | Delay between two channels. (edge – edge of the same type)            |
+        +------------+-----------------------------------------------------------------------+
+        """,
         validator=_measure_delay_validator,
         values=[["PHA", "FRR", "FRF", "FFR", "FFF", "LRR", "LRF", "LFR", "LFF", "Skey"],
                 ["C1", "C2", "C3", "C4"], ["C1", "C2", "C3", "C4"]]

--- a/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
+++ b/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
@@ -1311,7 +1311,7 @@ class LeCroyT3DSO1204(Instrument):
         +============+=======================================================================+
         | PHA        | The phase difference between two channels. (rising edge - rising edge)|
         +------------+-----------------------------------------------------------------------+
-        | FRR        |Delay between two channels. (first rising edge - first rising edge)    |
+        | FRR        | Delay between two channels. (first rising edge - first rising edge)   |
         +------------+-----------------------------------------------------------------------+
         | FRF        | Delay between two channels. (first rising edge - first falling edge)  |
         +------------+-----------------------------------------------------------------------+
@@ -1323,7 +1323,7 @@ class LeCroyT3DSO1204(Instrument):
         +------------+-----------------------------------------------------------------------+
         | LRF        | Delay between two channels. (first rising edge - last falling edge)   |
         +------------+-----------------------------------------------------------------------+
-        | LFR        |  Delay between two channels. (first falling edge - last rising edge)  |
+        | LFR        | Delay between two channels. (first falling edge - last rising edge)   |
         +------------+-----------------------------------------------------------------------+
         | LFF        | Delay between two channels. (first falling edge - last falling edge)  |
         +------------+-----------------------------------------------------------------------+

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -121,14 +121,26 @@ class SR830(Instrument):
         "LIAS?",
         """ Reads the value of the lockin amplifier (LIA) status byte. Returns a binary string with
             positions within the string corresponding to different status flags:
-            bit 0: Input/Amplifier overload
-            bit 1: Time constant filter overload
-            bit 2: Output overload
-            bit 3: Reference unlock
-            bit 4: Detection frequency range switched
-            bit 5: Time constant changed indirectly
-            bit 6: Data storage triggered
-            bit 7: unused
+
+            +----+--------------------------------------+
+            |Bit | Status                               |
+            +====+======================================+
+            | 0  | Input/Amplifier overload             |
+            +----+--------------------------------------+
+            | 1  | Time constant filter overload        |
+            +----+--------------------------------------+
+            | 2  | Output overload                      |
+            +----+--------------------------------------+
+            | 3  | Reference unlock                     |
+            +----+--------------------------------------+
+            | 4  | Detection frequency range switched   |
+            +----+--------------------------------------+
+            | 5  | Time constant changed indirectly     |
+            +----+--------------------------------------+
+            | 6  | Data storage triggered               |
+            +----+--------------------------------------+
+            | 7  | unused                               |
+            +----+--------------------------------------+
             """,
         get_process=lambda s: LIAStatus(int(s)),
     )
@@ -136,16 +148,28 @@ class SR830(Instrument):
     err_status = Instrument.measurement(
         "ERRS?",
         """Reads the value of the lockin error (ERR) status byte. Returns an IntFlag type with
-           positions within the string corresponding to different error flags:
-           bit 0: unused
-           bit 1: backup error
-           bit 2: RAM error
-           bit 3: unused
-           bit 4: ROM error
-           bit 5: GPIB error
-           bit 6: DSP error
-           bit 7: Math error
-           """,
+        positions within the string corresponding to different error flags:
+
+        +----+--------------------------------------+
+        |Bit | Status                               |
+        +====+======================================+
+        | 0  | unused                               |
+        +----+--------------------------------------+
+        | 1  | backup error                         |
+        +----+--------------------------------------+
+        | 2  | RAM error                            |
+        +----+--------------------------------------+
+        | 3  | unused                               |
+        +----+--------------------------------------+
+        | 4  | ROM error                            |
+        +----+--------------------------------------+
+        | 5  | GPIB error                           |
+        +----+--------------------------------------+
+        | 6  | DSP error                            |
+        +----+--------------------------------------+
+        | 7  | DSP error                            |
+        +----+--------------------------------------+
+        """,
         get_process=lambda s: ERRStatus(int(s)),
     )
 

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -410,17 +410,43 @@ class SR860(Instrument):
         """retrieve 2 or 3 parameters at once
         parameters can be chosen by index, or enumeration as follows:
 
-        j enumeration parameter     j enumeration parameter
-
-        0 X           X output      9 YNOise      Ynoise
-        1 Y           Youtput      10 OUT1        Aux Out1
-        2 R           R output     11 OUT2        Aux Out2
-        3 THeta       θ output     12 PHAse       Reference Phase
-        4 IN1         Aux In1      13 SAMp        Sine Out Amplitude
-        5 IN2         Aux In2      14 LEVel       DC Level
-        6 IN3         Aux In3      15 FInt        Int. Ref. Frequency
-        7 IN4         Aux In4      16 FExt        Ext. Ref. Frequency
-        8 XNOise      Xnoise
+        +--------+-------------+------------------------+
+        | index  | enumeration | parameter              |
+        +========+=============+========================+
+        | 0      | X           | X output               |
+        +--------+-------------+------------------------+
+        | 1      | Y           | Y output               |
+        +--------+-------------+------------------------+
+        | 2      | R           | R output               |
+        +--------+-------------+------------------------+
+        | 3      | THeta       | θ output               |
+        +--------+-------------+------------------------+
+        | 4      | IN1         | Aux In1                |
+        +--------+-------------+------------------------+
+        | 5      | IN2         | Aux In2                |
+        +--------+-------------+------------------------+
+        | 6      | IN3         | Aux In3                |
+        +--------+-------------+------------------------+
+        | 7      | IN4         | Aux In4                |
+        +--------+-------------+------------------------+
+        | 8      | XNOise      | Xnoise                 |
+        +--------+-------------+------------------------+
+        | 9      | YNOise      | Ynoise                 |
+        +--------+-------------+------------------------+
+        | 10     | OUT1        | Aux Out1               |
+        +--------+-------------+------------------------+
+        | 11     | OUT2        | Aux Out2               |
+        +--------+-------------+------------------------+
+        | 12     | PHAse       | Reference Phase        |
+        +--------+-------------+------------------------+
+        | 13     | SAMp        | Sine Out Amplitude     |
+        +--------+-------------+------------------------+
+        | 14     | LEVel       | DC Level               |
+        +--------+-------------+------------------------+
+        | 15     | FInt        | Int. Ref. Frequency    |
+        +--------+-------------+------------------------+
+        | 16     | FExt        | Ext. Ref. Frequency    |
+        +--------+-------------+------------------------+
 
         :param val1: parameter enumeration/index
         :param val2: parameter enumeration/index

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -188,6 +188,8 @@ class AFG3152C(Instrument):
     arbitrary function generator and provides a high-level for
     interacting with the instrument.
 
+    .. code-block:: python
+
         afg=AFG3152C("GPIB::1")        # AFG on GPIB 1
         afg.reset()                    # Reset to default
         afg.ch1.shape='sinusoidal'     # Sinusoidal shape

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -137,12 +137,13 @@ class TeledyneT3AFG(Instrument):
     - Add channel coupling control
 
     .. code-block: python
-    # Example assumes Ethernet (TCPIP) interface
-    generator=TeledyneT3AFG('TCPIP0::xxx.xxx.xxx.xxx::pppp::SOCKET')
-    generator.reset()
-    generator.ch_1.wavetype='SINE'
-    generator.ch_1.amplitude=2
-    generator.ch_1.output_enabled=True
+
+        # Example assumes Ethernet (TCPIP) interface
+        generator=TeledyneT3AFG('TCPIP0::xxx.xxx.xxx.xxx::pppp::SOCKET')
+        generator.reset()
+        generator.ch_1.wavetype='SINE'
+        generator.ch_1.amplitude=2
+        generator.ch_1.output_enabled=True
     """
 
     ch_1 = Instrument.ChannelCreator(SignalChannel, 1)

--- a/pymeasure/instruments/thermotron/thermotron3800.py
+++ b/pymeasure/instruments/thermotron/thermotron3800.py
@@ -88,6 +88,7 @@ class Thermotron3800(Instrument):
     def run(self):
         '''
         Starts temperature forcing. The oven will ramp to the setpoint.
+
         :return: None
         '''
         self.write("RUNM")
@@ -95,6 +96,7 @@ class Thermotron3800(Instrument):
     def stop(self):
         '''
         Stops temperature forcing on the oven.
+
         :return: None
         '''
         self.write("STOP")
@@ -104,8 +106,8 @@ class Thermotron3800(Instrument):
         The manufacturer recommends a 3 second wait time after after initializing the oven.
         The optional "wait" variable should remain true, unless the 3 second wait time is
         taken care of on the user end. The wait time is split up in the following way:
-            1 second (built into the write function) +
-            2 seconds (optional wait time from this function (initialize_oven)).
+        1 second (built into the write function) +
+        2 seconds (optional wait time from this function (initialize_oven)).
 
         :return: None
         '''
@@ -114,16 +116,27 @@ class Thermotron3800(Instrument):
             sleep(2)
 
     class Thermotron3800Mode(IntFlag):
-        '''
-        Bit 0 = Program mode
-        Bit 1 = Edit mode (controller in stop mode)
-        Bit 2 = View program mode
-        Bit 3 = Edit mode (controller in hold mode)
-        Bit 4 = Manual mode
-        Bit 5 = Delayed start mode
-        Bit 6 = Unused
-        Bit 7 = Calibration mode
-        '''
+        """
+        +--------+--------------------------------------+
+        | Bit    | Mode                                 |
+        +========+======================================+
+        | 0      | Program mode                         |
+        +--------+--------------------------------------+
+        | 1      | Edit mode (controller in stop mode)  |
+        +--------+--------------------------------------+
+        | 2      | View program mode                    |
+        +--------+--------------------------------------+
+        | 3      | Edit mode (controller in hold mode)  |
+        +--------+--------------------------------------+
+        | 4      | Manual mode                          |
+        +--------+--------------------------------------+
+        | 5      | Delayed start mode                   |
+        +--------+--------------------------------------+
+        | 6      | Unused                               |
+        +--------+--------------------------------------+
+        | 7      | Calibration mode                     |
+        +--------+--------------------------------------+
+        """
         PROGRAM_MODE = 1
         EDIT_MODE_STOP = 2
         VIEW_PROGRAM_MODE = 4


### PR DESCRIPTION
Some channels are not in the docs, added those channels so they're properties can be viewed.

Fix docstring formatting in some instrument driver files.

Modified docs/conf.py to pickup channels in base Instrument classes.