### PR TITLE
Update ibeamsmart.py

### DIFF
--- a/pymeasure/instruments/toptica/ibeamsmart.py
+++ b/pymeasure/instruments/toptica/ibeamsmart.py
@@ -119,7 +119,7 @@ class IBeamSmart(Instrument):
             includeSCPI=False,
             read_termination='\r\n',
             write_termination='\r\n',
-            asrl={'baud_rate', baud_rate},
+            asrl={'baud_rate': baud_rate},
             **kwargs
         )
         # configure communication mode: no repeating and no command prompt


### PR DESCRIPTION
There is a mistake in the asrl= assignment. This should be a dict, not a set, since the `visa.py` adapter expects this. Other instruments implement this correctly.

Otherwise the visa adapter throws an exception:

```python
  File ".../envs/seschet-device-env/lib/python3.11/site-packages/pymeasure/adapters/visa.py", line 122, in __init__
    for k, v in kwargs[key].items():
                ^^^^^^^^^^^^^^^^^
AttributeError: 'set' object has no attribute 'items'
```