### PR TITLE
Dedicated filename input and default queue method

### DIFF
--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -35,11 +35,9 @@ python gui.py
 
 import sys
 import random
-import tempfile
 from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
-from pymeasure.experiment import Results
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -91,15 +91,6 @@ class MainWindow(ManagedWindow):
         )
         self.setWindowTitle('GUI Example')
 
-    def queue(self):
-        filename = tempfile.mktemp()
-
-        procedure = self.make_procedure()
-        results = Results(procedure, filename)
-        experiment = self.new_experiment(results)
-
-        self.manager.queue(experiment)
-
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -35,13 +35,11 @@ python gui.py
 
 import sys
 import random
-import tempfile
 from time import sleep
 
 from datetime import datetime, timedelta
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
-from pymeasure.experiment import Results
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -138,17 +138,6 @@ class MainWindow(ManagedWindow):
         )
         self.setWindowTitle('GUI Example')
 
-    def queue(self, procedure=None):
-        filename = tempfile.mktemp()
-
-        if procedure is None:
-            procedure = self.make_procedure()
-
-        results = Results(procedure, filename)
-        experiment = self.new_experiment(results)
-
-        self.manager.queue(experiment)
-
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -36,11 +36,9 @@ python gui_foreign_instrument.py
 
 import sys
 import random
-import tempfile
 from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, FloatParameter
-from pymeasure.experiment import Results
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -106,15 +106,6 @@ class MainWindow(ManagedWindow):
         )
         self.setWindowTitle('GUI Example for Foreign Instrument')
 
-    def queue(self):
-        filename = tempfile.mktemp()
-
-        procedure = self.make_procedure()
-        results = Results(procedure, filename)
-        experiment = self.new_experiment(results)
-
-        self.manager.queue(experiment)
-
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -96,17 +96,6 @@ class MainWindow(ManagedWindow):
         )
         self.setWindowTitle('GUI Example')
 
-    def queue(self, *, procedure=None):
-        filename = tempfile.mktemp()
-
-        if procedure is None:
-            procedure = self.make_procedure()
-
-        results = Results(procedure, filename)
-        experiment = self.new_experiment(results)
-
-        self.manager.queue(experiment)
-
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -35,12 +35,10 @@ python gui_sequencer.py
 
 import sys
 import random
-import tempfile
 from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, \
     FloatParameter
-from pymeasure.experiment import Results
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 

--- a/examples/Basic/gui_table.py
+++ b/examples/Basic/gui_table.py
@@ -94,6 +94,8 @@ class MainWindow(ManagedWindowBase):
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],
             widget_list=widget_list,
+            filename_input=False,
+            directory_input=False,
         )
         logging.getLogger().addHandler(widget_list[1].handler)
         log.setLevel(self.log_level)

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -106,7 +106,7 @@ class TestImageGUI(ManagedImageWindow):
             z_axis='pixel_data',
             inputs=['X_start', 'X_end', 'X_step', 'Y_start', 'Y_end', 'Y_step',
                     'delay'],
-            displays=['X_start', 'X_end', 'Y_start', 'Y_end', 'delay']
+            displays=['X_start', 'X_end', 'Y_start', 'Y_end', 'delay'],
             filename_input=False,
             directory_input=False,
         )

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -107,6 +107,8 @@ class TestImageGUI(ManagedImageWindow):
             inputs=['X_start', 'X_end', 'X_step', 'Y_start', 'Y_end', 'Y_step',
                     'delay'],
             displays=['X_start', 'X_end', 'Y_start', 'Y_end', 'delay']
+            filename_input=False,
+            directory_input=False,
         )
         self.setWindowTitle('PyMeasure Image Test')
 

--- a/pymeasure/display/widgets/filename_widget.py
+++ b/pymeasure/display/widgets/filename_widget.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from ..Qt import QtCore, QtGui, QtWidgets
+from ..Qt import QtCore, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/widgets/filename_widget.py
+++ b/pymeasure/display/widgets/filename_widget.py
@@ -38,3 +38,30 @@ class FilenameLineEdit(QtWidgets.QLineEdit):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
+
+        placeholders = parent.procedure_class.placeholder_names()
+        completer = PlaceholderCompleter(placeholders)
+        self.setCompleter(completer)
+
+
+class PlaceholderCompleter(QtWidgets.QCompleter):
+
+    def __init__(self, placeholders):
+        super().__init__()
+        self.placeholders = placeholders
+
+        self.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
+        self.setModelSorting(QtWidgets.QCompleter.ModelSorting.CaseInsensitivelySortedModel)
+        self.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
+        self.setFilterMode(QtCore.Qt.MatchContains)
+
+    def splitPath(self, path):
+        if path.endswith('{'):
+            options = [path + placeholder for placeholder in self.placeholders]
+            model = QtCore.QStringListModel(options)
+            self.setModel(model)
+        elif path.count("{") == path.count("}"):
+            # Clear the autocomplete options
+            self.setModel(QtCore.QStringListModel())
+
+        return [path]

--- a/pymeasure/display/widgets/filename_widget.py
+++ b/pymeasure/display/widgets/filename_widget.py
@@ -22,17 +22,19 @@
 # THE SOFTWARE.
 #
 
-from .browser_widget import BrowserWidget
-from .directory_widget import DirectoryLineEdit
-from .filename_widget import FilenameLineEdit
-from .estimator_widget import EstimatorWidget, EstimatorThread
-from .image_frame import ImageFrame
-from .image_widget import ImageWidget
-from .inputs_widget import InputsWidget
-from .log_widget import LogWidget
-from .plot_frame import PlotFrame
-from .plot_widget import PlotWidget
-from .results_dialog import ResultsDialog
-from .sequencer_widget import SequencerWidget
-from .tab_widget import TabWidget
-from .table_widget import TableWidget
+import logging
+
+from ..Qt import QtCore, QtGui, QtWidgets
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class FilenameLineEdit(QtWidgets.QLineEdit):
+    """
+    Widget that allows to choose a filename.
+    A completer is implemented for quick completion of placeholders
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -27,6 +27,7 @@ import logging
 import os
 import platform
 import subprocess
+import tempfile
 
 import pyqtgraph as pg
 
@@ -550,12 +551,14 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         if procedure is None:
             procedure = self.make_procedure()
 
-        # TODO: use toggle for saving data
-        filename = unique_filename(
-            self.directory,
-            prefix=self.filename,
-            procedure=procedure
-        )
+        if self.store_measurement:
+            filename = unique_filename(
+                self.directory,
+                prefix=self.filename,
+                procedure=procedure
+            )
+        else:
+            filename = tempfile.mktemp(prefix='TempFile_', suffix='.csv')
 
         results = Results(procedure, filename)
 

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -161,7 +161,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
     def _setup_ui(self):
         if self.filename_input:
-            self.filename_label = QtGui.QLabel(self)
+            self.filename_label = QtWidgets.QLabel(self)
             self.filename_label.setText('Filename')
             self.filename_line = FilenameLineEdit(parent=self)
         if self.directory_input:
@@ -234,7 +234,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         hbox.addWidget(self.abort_button)
         hbox.addStretch()
 
-        vbox = QtGui.QVBoxLayout()
+        vbox = QtWidgets.QVBoxLayout()
 
         if self.filename_input:
             vbox.addWidget(self.filename_label)

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -126,7 +126,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                  sequencer_inputs=None,
                  sequence_file=None,
                  inputs_in_scrollarea=False,
-                 directory_input=False,
+                 directory_input=True,
                  filename_input=True,
                  hide_groups=True,
                  ):
@@ -161,6 +161,11 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
 
     def _setup_ui(self):
         if self.filename_input:
+            self.writefile_toggle = QtWidgets.QCheckBox('Write file', self)
+            self.writefile_toggle.setLayoutDirection(QtCore.Qt.RightToLeft)
+            self.writefile_toggle.setChecked(True)
+            self.writefile_toggle.stateChanged.connect(self.toggle_file_dir_input_active)
+
             self.filename_label = QtWidgets.QLabel(self)
             self.filename_label.setText('Filename')
             self.filename_line = FilenameLineEdit(parent=self)
@@ -237,7 +242,10 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         vbox = QtWidgets.QVBoxLayout()
 
         if self.filename_input:
-            vbox.addWidget(self.filename_label)
+            filename_box = QtWidgets.QHBoxLayout()
+            vbox.addLayout(filename_box)
+            filename_box.addWidget(self.filename_label)
+            filename_box.addWidget(self.writefile_toggle)
             vbox.addWidget(self.filename_line)
         if self.directory_input:
             vbox.addWidget(self.directory_label)
@@ -593,8 +601,32 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
     @property
     def filename(self):
         if not self.filename_input:
-            raise ValueError("No directory input in the ManagedWindow")
+            raise ValueError("No filename input in the ManagedWindow")
         return self.filename_line.text()
+
+    @filename.setter
+    def filename(self, value):
+        if not self.filename_input:
+            raise ValueError("No filename input in the ManagedWindow")
+        self.filename_line.setText(str(value))
+
+    @property
+    def store_measurement(self):
+        if not self.writefile_toggle:
+            raise ValueError("No write-file checkbox in the ManagedWindow")
+        return self.writefile_toggle.isChecked()
+
+    @store_measurement.setter
+    def store_measurement(self, value):
+        if not self.writefile_toggle:
+            raise ValueError("No write-file checkbox in the ManagedWindow")
+        self.writefile_toggle.setChecked(bool(value))
+
+    def toggle_file_dir_input_active(self, state):
+        if self.filename_input:
+            self.filename_line.setEnabled(bool(state))
+        if self.directory_input:
+            self.directory_line.setEnabled(bool(state))
 
 
 class ManagedWindow(ManagedWindowBase):

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -41,6 +41,7 @@ from ..widgets import (
     ResultsDialog,
     SequencerWidget,
     DirectoryLineEdit,
+    FilenameLineEdit,
     EstimatorWidget,
 )
 from ...experiment import Results, Procedure
@@ -107,8 +108,10 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         code:`Load sequence` button
     :param inputs_in_scrollarea: boolean that display or hide a scrollbar to the input area
     :param directory_input: specify, if present, where the experiment's result will be saved.
+    :param filename_input: specify, if present, the base of the filename where the results will be saved.
     :param hide_groups: a boolean controlling whether parameter groups are hidden (True, default)
         or disabled/grayed-out (False) when the group conditions are not met.
+
     """
 
     def __init__(self,
@@ -124,6 +127,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                  sequence_file=None,
                  inputs_in_scrollarea=False,
                  directory_input=False,
+                 filename_input=True,
                  hide_groups=True,
                  ):
 
@@ -139,6 +143,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         self.sequence_file = sequence_file
         self.inputs_in_scrollarea = inputs_in_scrollarea
         self.directory_input = directory_input
+        self.filename_input = filename_input
         self.log = logging.getLogger(log_channel)
         self.log_level = log_level
         log.setLevel(log_level)
@@ -155,6 +160,10 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         self._layout()
 
     def _setup_ui(self):
+        if self.filename_input:
+            self.filename_label = QtGui.QLabel(self)
+            self.filename_label.setText('Filename')
+            self.filename_line = FilenameLineEdit(parent=self)
         if self.directory_input:
             self.directory_label = QtWidgets.QLabel(self)
             self.directory_label.setText('Directory')
@@ -225,11 +234,16 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         hbox.addWidget(self.abort_button)
         hbox.addStretch()
 
+        vbox = QtGui.QVBoxLayout()
+
+        if self.filename_input:
+            vbox.addWidget(self.filename_label)
+            vbox.addWidget(self.filename_line)
         if self.directory_input:
-            vbox = QtWidgets.QVBoxLayout()
             vbox.addWidget(self.directory_label)
             vbox.addWidget(self.directory_line)
-            vbox.addLayout(hbox)
+
+        vbox.addLayout(hbox)
 
         if self.inputs_in_scrollarea:
             inputs_scroll = QtWidgets.QScrollArea()
@@ -244,10 +258,7 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
         else:
             inputs_vbox.addWidget(self.inputs)
 
-        if self.directory_input:
-            inputs_vbox.addLayout(vbox)
-        else:
-            inputs_vbox.addLayout(hbox)
+        inputs_vbox.addLayout(vbox)
 
         inputs_vbox.addStretch(0)
         inputs_dock.setLayout(inputs_vbox)
@@ -578,6 +589,12 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
             raise ValueError("No directory input in the ManagedWindow")
 
         self.directory_line.setText(str(value))
+
+    @property
+    def filename(self):
+        if not self.filename_input:
+            raise ValueError("No directory input in the ManagedWindow")
+        return self.filename_line.text()
 
 
 class ManagedWindow(ManagedWindowBase):

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -246,7 +246,7 @@ class Procedure:
         return self._metadata
 
     def placeholder_objects(self):
-        """ Collect all elegible placeholders (parameters & metadata) with their value into a dictionairy
+        """ Collect all eligible placeholders (parameters & metadata) with their value in a dict.
         """
         return {**self.parameter_objects(), **self.metadata_objects()}
 

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -245,6 +245,21 @@ class Procedure:
         """
         return self._metadata
 
+    def placeholder_objects(self):
+        """ Collect all elegible placeholders (parameters & metadata) with their value into a dictionairy
+        """
+        return {**self.parameter_objects(), **self.metadata_objects()}
+
+    @classmethod
+    def placeholder_names(cls):
+        """ Collect the names of all elegible placeholders (parameters & metadata)"""
+        placeholders = []
+        for name, item in inspect.getmembers(cls):
+            if isinstance(item, Metadata) or isinstance(item, Parameter):
+                placeholders.extend([name, item.name])
+
+        return list(set(placeholders))
+
     def startup(self):
         """ Executes the commands needed at the start-up of the measurement
         """

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -69,8 +69,9 @@ def replace_placeholders(string, procedure, date_format="%Y-%m-%d", time_format=
     """
     now = datetime.now()
 
-    parameters = procedure.parameter_objects()
+    parameters = procedure.placeholder_objects()
     placeholders = {param.name: param.value for param in parameters.values()}
+    placeholders.update({varname: param.value for varname, param in parameters.items()})
 
     placeholders["date"] = now.strftime(date_format)
     placeholders["time"] = now.strftime(time_format)


### PR DESCRIPTION
Something I've been wanting to add for quite a while now (initial idea based on #317 and #423).

This PR adds
- a dedicated filename input field (similar to the directory input field that has been added in #317).
- The input field also has a toggle which allows to easily switch between storing the measurement in a file, or to a temporary file.
- I propose to add a default queue method: together with the directory input we have everything we need for a default queue method, reducing the boilerplate code needed to get a working GUI. The queue method doesn't work if the filename and directory input fields are disabled (which can be done via keyword arguments in the ManagedWindows). I hence also removed the queue methods in the examples (whenever applicable).
- I propose to enable the filename and directory input-widgets by default.

I'd like to hear what you think of this?