### PR TITLE
Fix VISAAdapter flush_read_buffer

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -64,3 +64,4 @@ Ashok Bruno
 Robert Roos
 Sebastien Weber
 Sebastian Neusch
+Ulrich Sauter

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -257,12 +257,13 @@ class VISAAdapter(Adapter):
     def flush_read_buffer(self):
         """ Flush and discard the input buffer
 
-        As detailed by pyvisa, discard the read buffer contents and if data was present
-        in the read buffer and no END-indicator was present, read from the device until
-        encountering an END indicator (which causes loss of data).
+        As detailed by pyvisa, discard the read and receivee buffer contents
+        and if data was present in the read buffer and no END-indicator was present,
+        read from the device until encountering an END indicator (which causes loss of data).
         """
         try:
             self.connection.flush(pyvisa.constants.BufferOperation.discard_read_buffer)
+            self.connection.flush(pyvisa.constants.BufferOperation.discard_receive_buffer)
         except NotImplementedError:
             # NotImplementedError is raised when using resource types other than `asrl`
             # in conjunction with pyvisa-py.


### PR DESCRIPTION
Added `discard_receive_buffer` after `discard_read_buffer` to make sure buffer is empty.

See discussion #965.