### PR TITLE
Limit the Python version to >=3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+Version 0.13.0-1 (2023-10-05)
+=============================
+Post-release to fix incorrect python version restriction in the project metadata.
+
 Version 0.13.0 (2023-09-23)
 ===========================
 Main items of this new release:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = >=3.8
 install_requires =
     numpy >= 1.6.1
     pandas >= 0.14


### PR DESCRIPTION
See #973 -- we did not limit the python version appropriately.