### PR TITLE
Bugfix: Append amplitude units

### DIFF
--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -2562,7 +2562,7 @@ class HP856Xx(Instrument):
             When a trace is in max-hold mode, if the threshold is raised above any of the
             trace data, the data below the threshold will be permanently lost.
         """,
-        validator=strict_range,
+        validator=strict_discrete_set,
         values=arange(-200, 30),
     )
 

--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -1011,9 +1011,7 @@ class HP856Xx(Instrument):
             if instr.display_line == 0:
                 pass
 
-        """,
-        validator=strict_range,
-        values=[float("-inf"), float("inf")]
+        """
     )
 
     display_line_enabled = Instrument.setting(
@@ -3191,7 +3189,7 @@ class HP8561B(HP856Xx):
         selected harmonic.
         """,
         validator=strict_range,
-        values=[int(1), int(54)],
+        values=[1, 54],
         cast=int
     )
 

--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -748,6 +748,11 @@ class HP856Xx(Instrument):
         set_process=lambda v: str(v).upper()
     )
 
+    def write(self, command, **kwargs):
+        if "{amplitude_unit}" in command:
+            command = command.format(amplitude_unit=self.amplitude_unit)
+        super(HP856Xx, self).write(command, **kwargs)
+
     def set_auto_couple(self):
         """Set the video bandwidth, resolution bandwidth, input attenuation,
         sweep time, and center frequency step-size to coupled mode.
@@ -804,7 +809,7 @@ class HP856Xx(Instrument):
         self.write("BML")
 
     center_frequency = Instrument.control(
-        "CF?", "CF %.11E",
+        "CF?", "CF %.11E Hz",
         """
         Control the center frequency in hertz and sets the spectrum analyzer to center
         frequency / span mode.
@@ -1010,7 +1015,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
         values=[[float("-inf"), float("inf")], ["ON", "OFF"]],
-        set_process=lambda v: v if isinstance(v, str) else '%.11E' % v
+        set_process=lambda v: v if isinstance(v, str) else '%.11E {amplitude_unit}' % v
     )
 
     done = Instrument.measurement(
@@ -1109,7 +1114,7 @@ class HP856Xx(Instrument):
     )
 
     start_frequency = Instrument.control(
-        "FA?", "FA %.11E",
+        "FA?", "FA %.11E Hz",
         """
         Control the start frequency and set the spectrum analyzer to start-frequency/
         stop-frequency mode. If the start frequency exceeds the stop frequency, the stop frequency
@@ -1131,7 +1136,7 @@ class HP856Xx(Instrument):
     )
 
     stop_frequency = Instrument.control(
-        "FB?", "FB %.11E",
+        "FB?", "FB %.11E Hz",
         """
         Control the stop frequency and set the spectrum analyzer to start-frequency/
         stop-frequency mode. If the stop frequency is less than the start frequency, the start
@@ -1307,7 +1312,7 @@ class HP856Xx(Instrument):
         self.write("FFT %s,%s,%s" % (source, destination, window))
 
     frequency_offset = Instrument.control(
-        "FOFFSET?", "FOFFSET %.11E",
+        "FOFFSET?", "FOFFSET %.11E Hz",
         """
         Control an offset added to the displayed absolute-frequency values,
         including marker-frequency values.
@@ -1422,7 +1427,7 @@ class HP856Xx(Instrument):
         self.write("IP")
 
     logarithmic_scale = Instrument.control(
-        "LG?", "LG %d",
+        "LG?", "LG %d DB",
         """
         Control the logarithmic amplitude scale. When in linear
         mode, querying 'logarithmic_scale' returns a “0”.
@@ -1502,7 +1507,7 @@ class HP856Xx(Instrument):
         self.write("MKCF")
 
     marker_delta = Instrument.control(
-        "MKD?", "MKD %.11E",
+        "MKD?", "MKD %.11E Hz",
         """
         Control a second marker on the trace. The parameter value specifies the distance
         in frequency or time (when in zero span) between the two markers.
@@ -1533,7 +1538,7 @@ class HP856Xx(Instrument):
     # )
 
     marker_frequency = Instrument.control(
-        "MKF?", "MKF %.11E",
+        "MKF?", "MKF %.11E Hz",
         """
         Control the frequency of the active marker.
         Default units are in Hertz.
@@ -1602,7 +1607,7 @@ class HP856Xx(Instrument):
         self.write("MKFC %s" % parameter)
 
     frequency_counter_resolution = Instrument.control(
-        "MKFCR?", "MKFCR %d",
+        "MKFCR?", "MKFCR %d Hz",
         """
         Control the resolution of the frequency counter. Refer to the 'frequency_counter_mode'
         command. The default value is 10 kHz.
@@ -1716,7 +1721,7 @@ class HP856Xx(Instrument):
         self.write("MKPK %s" % mode)
 
     marker_threshold = Instrument.control(
-        "MKPT?", "MKPT %g",
+        "MKPT?", "MKPT %g {amplitude_unit}",
         """
         Control the minimum amplitude level from which a peak on the trace can
         be detected. The default value is -130 dBm. See also the :attr:`peak_excursion` command.
@@ -1739,7 +1744,7 @@ class HP856Xx(Instrument):
     )
 
     peak_excursion = Instrument.control(
-        "MKPX?", "MKPX %g",
+        "MKPX?", "MKPX %g DB",
         """
         Control what constitutes a peak on a trace. The chosen value specifies
         the amount that a trace must increase monotonically, then decrease monotonically, in order
@@ -1827,7 +1832,7 @@ class HP856Xx(Instrument):
     )
 
     mixer_level = Instrument.control(
-        "ML?", "ML %d",
+        "ML?", "ML %d DB",
         """
         Control the maximum signal level that is at the input mixer. The
         attenuator automatically adjusts to ensure that this level is not exceeded for signals less
@@ -1897,7 +1902,7 @@ class HP856Xx(Instrument):
     )
 
     normalized_reference_level = Instrument.control(
-        "NRL?", "NRL %d",
+        "NRL?", "NRL %d {amplitude_unit}",
         """
         Control the normalized reference level. It is intended to be used with the
         :attr:`normalize_trace_data` command. When using 'normalized_reference_level', the input
@@ -1931,7 +1936,7 @@ class HP856Xx(Instrument):
     )
 
     normalized_reference_position = Instrument.control(
-        "NRPOS?", "NRPOS %f",
+        "NRPOS?", "NRPOS %f DB",
         """
         Control the normalized reference-position that corresponds to the
         position on the graticule where the difference between the measured and calibrated traces
@@ -2076,7 +2081,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
         values=[["AUTO", "MAN"], arange(10, 2e6)],
-        set_process=lambda v: v if isinstance(v, str) else int(v),
+        set_process=lambda v: v if isinstance(v, str) else str(int(v)) + " Hz",
         get_process=lambda v: v if isinstance(v, str) else int(v)
     )
 
@@ -2219,7 +2224,7 @@ class HP856Xx(Instrument):
     )
 
     reference_level = Instrument.control(
-        "RL?", "RL %g",
+        "RL?", "RL %g {amplitude_unit}",
         """
         Control the reference level, or range level when in normalized mode. (Range level
         functions the same as reference level.) The reference level is the top horizontal line on
@@ -2266,7 +2271,7 @@ class HP856Xx(Instrument):
     )
 
     reference_offset = Instrument.control(
-        "ROFFSET?", "ROFFSET %d",
+        "ROFFSET?", "ROFFSET %d DB",
         """
         Control an offset applied to all amplitude readouts (for example, the
         reference level and marker amplitude). The offset is in dB, regardless of the selected scale
@@ -2387,7 +2392,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["FULL", "ZERO"], [float("-inf"), float("inf")]],
-        set_process=lambda v: v if isinstance(v, str) else "%.11E" % v,
+        set_process=lambda v: v if isinstance(v, str) else "%.11E Hz" % v,
         get_process=lambda v: v if isinstance(v, str) else v
     )
 
@@ -2415,7 +2420,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["ON", "OFF"], range(-220, 30)],
-        set_process=lambda v: v if isinstance(v, str) else v
+        set_process=lambda v: v if isinstance(v, str) else str(v) + " {amplitude_unit}"
     )
 
     def request_service(self, input):
@@ -2452,7 +2457,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["AUTO", "MAN"], arange(50E-6, 100)],
-        set_process=lambda v: v if isinstance(v, str) else ("%.3E" % v)
+        set_process=lambda v: v if isinstance(v, str) else ("%.3E S" % v)
     )
 
     status = Instrument.measurement(
@@ -2565,7 +2570,7 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["ON", "OFF"], arange(-200, 30)],
-        set_process=lambda v: v if isinstance(v, str) else ("%.2E" % v)
+        set_process=lambda v: v if isinstance(v, str) else ("%.2E {amplitude_unit}" % v)
     )
 
     def set_title(self, string):
@@ -2763,7 +2768,8 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["AUTO", "MAN"], arange(1, 3e6)],
-        cast=int
+        cast=int,
+        set_process=lambda v: v if isinstance(v, str) else str(v) + " Hz"
     )
 
     video_bandwidth_to_resolution_bandwidth = Instrument.control(
@@ -2799,7 +2805,7 @@ class HP856Xx(Instrument):
         self.write("VIEW " + trace)
 
     video_trigger_level = Instrument.control(
-        "VTL?", "VTL %.3f",
+        "VTL?", "VTL %.3f {amplitude_unit}",
         """
         Control the video trigger level when the trigger mode is set to VIDEO (refer
         to the :attr:`trigger_mode` command). A dashed line appears on the display to indicate the
@@ -2915,7 +2921,7 @@ class HP8560A(HP856Xx):
     )
 
     source_power_offset = Instrument.control(
-        "SRCPOFS?", "SRCPOFS %g",
+        "SRCPOFS?", "SRCPOFS %g {amplitude_unit}",
         """
         Control the offset of the displayed power of the built-in tracking generator so that
         it is equal to the measured power at the input of the spectrum analyzer. This function may
@@ -2933,7 +2939,7 @@ class HP8560A(HP856Xx):
     )
 
     source_power_step = Instrument.control(
-        "SRCPSTP?", "SRCPSTP %.2f",
+        "SRCPSTP?", "SRCPSTP %.2f DB",
         """
         Control the step size of the source power level, source power offset, and
         power-sweep range functions. Range: 0.1 ... 12.75 DB with 0.05 steps.
@@ -2962,7 +2968,7 @@ class HP8560A(HP856Xx):
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
         values=[["OFF", "ON"], arange(0.1, 12.75, 0.05)],
-        set_process=lambda v: v if isinstance(v, str) else ("%.2f" % v)
+        set_process=lambda v: v if isinstance(v, str) else ("%.2f DB" % v)
     )
 
     source_power = Instrument.control(
@@ -2978,7 +2984,7 @@ class HP8560A(HP856Xx):
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
         values=[["OFF", "ON"], arange(-10, 2.8, 0.05)],
-        set_process=lambda v: v if isinstance(v, str) else ("%.2f" % v)
+        set_process=lambda v: v if isinstance(v, str) else ("%.2f {amplitude_unit}" % v)
     )
 
     def activate_source_peak_tracking(self):
@@ -3031,7 +3037,7 @@ class HP8561B(HP856Xx):
         self.span_values = [["FULL", "ZERO"], [0, self.MAX_FREQUENCY]]
 
     conversion_loss = Instrument.control(
-        "CNVLOSS?", "CNVLOSS %s",
+        "CNVLOSS?", "CNVLOSS %s DB",
         """
         Control the compensation for losses outside the instrument when in external
         mixer mode (such as losses within connector cables, external mixers, etc.).

--- a/tests/instruments/hp/test_hp856Xx.py
+++ b/tests/instruments/hp/test_hp856Xx.py
@@ -147,7 +147,7 @@ class TestHP856Xx:
     def test_frequencies(self, function, command, hp_derivat, max_freq):
         with expected_protocol(
                 hp_derivat,
-                [("%s %.11E" % (command, max_freq), None),
+                [("%s %.11E Hz" % (command, max_freq), None),
                  ("%s?" % command, '%.11E' % max_freq)]
         ) as instr:
             setattr(instr, function, max_freq)
@@ -226,7 +226,8 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("DL 1.00000000000E+01", None),
+                    ("AUNITS?", "DBM"),
+                    ("DL 1.00000000000E+01 DBM", None),
                     ("DL " + string_params, None),
                     ("DL?", "1.00000000000E+01")
                 ]
@@ -352,7 +353,7 @@ class TestHP856Xx:
     def test_logarithmic_scale(self):
         with expected_protocol(
                 HP856Xx,
-                [("LG 1", None),
+                [("LG 1 DB", None),
                  ("LG?", "10")]
         ) as instr:
             instr.logarithmic_scale = 1
@@ -396,7 +397,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("MKD %.11E" % 28, None),
+                    ("MKD %.11E Hz" % 28, None),
                     ("MKD?", 2.8e7)
                 ]
         ) as instr:
@@ -407,7 +408,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("MKF %.11E" % 1, None),
+                    ("MKF %.11E Hz" % 1, None),
                     ("MKF?", 0.5)
                 ]
         ) as instr:
@@ -429,7 +430,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("MKFCR %d" % 1e3, None),
+                    ("MKFCR %d Hz" % 1e3, None),
                     ("MKFCR?", 1e4)
                 ]
         ) as instr:
@@ -458,7 +459,8 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("MKPT %d" % -30, None),
+                    ("AUNITS?", "DBM"),
+                    ("MKPT %d DBM" % -30, None),
                     ("MKPT?", -70)
                 ]
         ) as instr:
@@ -469,7 +471,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("MKPX %g" % 10.3, None),
+                    ("MKPX %g DB" % 10.3, None),
                     ("MKPX?", 10.3)
                 ]
         ) as instr:
@@ -491,7 +493,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("ML -30", None),
+                    ("ML -30 DB", None),
                     ("ML?", "-30")
                 ]
         ) as instr:
@@ -502,7 +504,8 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("NRL -30", None),
+                    ("AUNITS?", "DBM"),
+                    ("NRL -30 DBM", None),
                     ("NRL?", "-30")
                 ]
         ) as instr:
@@ -513,7 +516,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("NRPOS 8.000000", None),
+                    ("NRPOS 8.000000 DB", None),
                     ("NRPOS?", "8")
                 ]
         ) as instr:
@@ -551,7 +554,7 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("RB 30", None),
+                    ("RB 30 Hz", None),
                     ("RB AUTO", None),
                     ("RB?", "30")
                 ]
@@ -604,7 +607,8 @@ class TestHP856Xx:
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("RL 10", None),
+                    ("AUNITS?", "DBM"),
+                    ("RL 10 DBM", None),
                     ("RL?", "10")
                 ]
         ) as instr:
@@ -667,7 +671,8 @@ class TestHP856Xx:
     def test_squelch(self, string_params):
         with expected_protocol(
                 HP856Xx,
-                [("SQUELCH 10", None),
+                [("AUNITS?", "DBM"),
+                 ("SQUELCH 10 DBM", None),
                  ("SQUELCH %s" % string_params, None),
                  ("SQUELCH?", "10")]
         ) as instr:
@@ -687,7 +692,7 @@ class TestHP856Xx:
     def test_sweep_time(self):
         with expected_protocol(
                 HP856Xx,
-                [("ST 1.000E+01", None),
+                [("ST 1.000E+01 S", None),
                  ("ST AUTO", None),
                  ("ST?", "10.00")]
         ) as instr:
@@ -728,7 +733,8 @@ class TestHP856Xx:
     def test_threshold(self):
         with expected_protocol(
                 HP856Xx,
-                [("TH 1.00E+01", None),
+                [("AUNITS?", "DBM"),
+                 ("TH 1.00E+01 DBM", None),
                  ("TH ON", None),
                  ("TH?", "10.00")]
         ) as instr:
@@ -888,7 +894,7 @@ class TestHP856Xx:
     def test_video_bandwidth(self):
         with expected_protocol(
                 HP856Xx,
-                [("VB 70", None),
+                [("VB 70 Hz", None),
                  ("VB?", "70")],
         ) as instr:
             instr.video_bandwidth = 70
@@ -923,7 +929,8 @@ class TestHP856Xx:
     def test_video_trigger_level(self):
         with expected_protocol(
                 HP856Xx,
-                [("VTL -200.780", None),
+                [("AUNITS?", "DBM"),
+                 ("VTL -200.780 DBM", None),
                  ("VTL?", "0.005")],
         ) as instr:
             instr.video_trigger_level = -200.78
@@ -963,7 +970,8 @@ class TestHP8560A:
     def test_source_power_offset(self):
         with expected_protocol(
                 HP8560A,
-                [("SRCPOFS 10", None),
+                [("AUNITS?", "DBM"),
+                 ("SRCPOFS 10 DBM", None),
                  ("SRCPOFS?", "10")]
         ) as instr:
             instr.source_power_offset = 10
@@ -972,7 +980,7 @@ class TestHP8560A:
     def test_source_power_step(self):
         with expected_protocol(
                 HP8560A,
-                [("SRCPSTP 10.10", None),
+                [("SRCPSTP 10.10 DB", None),
                  ("SRCPSTP?", "10.10")]
         ) as instr:
             instr.source_power_step = 10.1
@@ -981,7 +989,7 @@ class TestHP8560A:
     def test_source_power_sweep(self):
         with expected_protocol(
                 HP8560A,
-                [("SRCPSWP 10.00", None),
+                [("SRCPSWP 10.00 DB", None),
                  ("SRCPSWP OFF", None),
                  ("SRCPSWP?", "10.00")]
         ) as instr:
@@ -992,7 +1000,8 @@ class TestHP8560A:
     def test_source_power(self):
         with expected_protocol(
                 HP8560A,
-                [("SRCPWR 2.00", None),
+                [("AUNITS?", "DBM"),
+                 ("SRCPWR 2.00 DBM", None),
                  ("SRCPWR ON", None),
                  ("SRCPWR?", "2.00")]
         ) as instr:
@@ -1023,7 +1032,7 @@ class TestHP8561B:
     def test_conversion_loss(self):
         with expected_protocol(
                 HP8561B,
-                [("CNVLOSS 10.2", None),
+                [("CNVLOSS 10.2 DB", None),
                  ("CNVLOSS?", "10.3")]
         ) as instr:
             instr.conversion_loss = 10.2

--- a/tests/instruments/hp/test_hp856Xx.py
+++ b/tests/instruments/hp/test_hp856Xx.py
@@ -222,19 +222,14 @@ class TestHP856Xx:
             assert instr.detector_mode == detector_mode
 
     @pytest.mark.parametrize("string_params", ["ON", "OFF"])
-    def test_display_line_strings(self, string_params):
+    def test_display_line_enabled(self, string_params):
         with expected_protocol(
                 HP856Xx,
                 [
-                    ("AUNITS?", "DBM"),
-                    ("DL 1.00000000000E+01 DBM", None),
-                    ("DL " + string_params, None),
-                    ("DL?", "1.00000000000E+01")
+                    ("DL " + string_params, None)
                 ]
         ) as instr:
-            instr.display_line = 1.0e01
-            instr.display_line = string_params
-            assert instr.display_line == 10
+            instr.display_line_enabled = True if string_params == "ON" else False
 
     def test_check_done(self):
         with expected_protocol(
@@ -692,7 +687,7 @@ class TestHP856Xx:
     def test_sweep_time(self):
         with expected_protocol(
                 HP856Xx,
-                [("ST 1.000E+01 S", None),
+                [("ST 10.000 S", None),
                  ("ST AUTO", None),
                  ("ST?", "10.00")]
         ) as instr:
@@ -735,12 +730,17 @@ class TestHP856Xx:
                 HP856Xx,
                 [("AUNITS?", "DBM"),
                  ("TH 1.00E+01 DBM", None),
-                 ("TH ON", None),
                  ("TH?", "10.00")]
         ) as instr:
             instr.threshold = 10
-            instr.threshold = "ON"
             assert instr.threshold == 10
+
+    def test_threshold_enabled(self):
+        with expected_protocol(
+                HP856Xx,
+                [("TH ON", None)]
+        ) as instr:
+            instr.threshold_enabled = True
 
     def test_title(self):
         with expected_protocol(
@@ -879,17 +879,14 @@ class TestHP856Xx:
         ) as instr:
             instr.create_fft_trace_window(Trace.A, WindowType.Flattop)
 
-    @pytest.mark.parametrize("str_param", ["ON", "OFF"])
-    def test_video_average(self, str_param):
+    @pytest.mark.parametrize("param", [("ON", True), ("OFF", False)])
+    def test_video_average_enabled(self, param):
+        str_param, boolean = param
         with expected_protocol(
                 HP856Xx,
-                [("VAVG 89", None),
-                 ("VAVG " + str_param, None),
-                 ("VAVG?", "89")]
+                [("VAVG " + str_param, None)]
         ) as instr:
-            instr.video_average = 89
-            instr.video_average = str_param
-            assert instr.video_average == 89
+            instr.video_average_enabled = boolean
 
     def test_video_bandwidth(self):
         with expected_protocol(
@@ -912,7 +909,7 @@ class TestHP856Xx:
     def test_video_bandwidth_to_resolution_bandwidth(self):
         with expected_protocol(
                 HP856Xx,
-                [("VBR 5.000E-03", None),
+                [("VBR 0.005", None),
                  ("VBR?", "0.005")],
         ) as instr:
             instr.video_bandwidth_to_resolution_bandwidth = 0.005
@@ -990,12 +987,17 @@ class TestHP8560A:
         with expected_protocol(
                 HP8560A,
                 [("SRCPSWP 10.00 DB", None),
-                 ("SRCPSWP OFF", None),
                  ("SRCPSWP?", "10.00")]
         ) as instr:
             instr.source_power_sweep = 10
-            instr.source_power_sweep = "OFF"
             assert instr.source_power_sweep == 10
+
+    def test_source_power_sweep_enabled(self):
+        with expected_protocol(
+                HP8560A,
+                [("SRCPSWP OFF", None)]
+        ) as instr:
+            instr.source_power_sweep_enabled = False
 
     def test_source_power(self):
         with expected_protocol(
@@ -1056,17 +1058,23 @@ class TestHP8561B:
             with pytest.raises(ValueError):
                 instr.set_fullband("Z")
 
-    @pytest.mark.parametrize("string_params", ["ON", "OFF"])
-    def test_harmonic_number_lock(self, string_params):
+    def test_harmonic_number_lock(self):
         with expected_protocol(
                 HP8561B,
                 [("HNLOCK 10", None),
-                 ("HNLOCK %s" % string_params, None),
                  ("HNLOCK?", "10")]
         ) as instr:
             instr.harmonic_number_lock = 10
-            instr.harmonic_number_lock = string_params
             assert instr.harmonic_number_lock == 10
+
+    @pytest.mark.parametrize("params", [("ON", True), ("OFF", False)])
+    def test_harmonic_number_lock_enabled(self, params):
+        str_param, boolean = params
+        with expected_protocol(
+                HP8561B,
+                [("HNLOCK %s" % str_param, None)]
+        ) as instr:
+            instr.harmonic_number_lock_enabled = boolean
 
     @pytest.mark.parametrize(
         "function, command",
@@ -1093,17 +1101,23 @@ class TestHP8561B:
         ) as instr:
             assert instr.signal_identification_frequency == 2.7897e9
 
-    @pytest.mark.parametrize("string_params", ["ON", "OFF"])
-    def test_mixer_bias(self, string_params):
+    def test_mixer_bias(self):
         with expected_protocol(
                 HP8561B,
-                [("MBIAS -9.9", None),
-                 ("MBIAS %s" % string_params, None),
+                [("MBIAS -9.900 MA", None),
                  ("MBIAS?", "5.5")]
         ) as instr:
             instr.mixer_bias = -9.9
-            instr.mixer_bias = string_params
             assert instr.mixer_bias == 5.5
+
+    @pytest.mark.parametrize("params", [("ON", True), ("OFF", False)])
+    def test_mixer_bias_enabled(self, params):
+        str_param, boolean = params
+        with expected_protocol(
+                HP8561B,
+                [("MBIAS %s" % str_param, None)]
+        ) as instr:
+            instr.mixer_bias_enabled = boolean
 
     def test_preselector_dac_number(self):
         with expected_protocol(


### PR DESCRIPTION
Fixed an issue where the spectrum analyzer reports errors for every set value which has no unit appended.
