### PR TITLE
Add find_serial_port to find a serial port by providing USB information

### DIFF
--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -28,6 +28,11 @@ Then construct an object by passing the VISA address. For this example we connec
         from pymeasure.instruments import list_resources
         list_resources()
 
+    If you know the USB properties (vendor id, product id, serial numer) of the serial device, you can query for the VISA resource string::
+
+        from pymeasure.instruments.resources import find_serial_port
+        resource_name = find_serial_port(vendor_id=15, product_id=0x12e5, serial_number="sn56X")
+
 For instruments with standard SCPI commands, an :code:`id` property will return the results of a :code:`*IDN?` SCPI command, identifying the instrument. ::
 
     sourcemeter.id

--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -30,7 +30,7 @@ Then construct an object by passing the VISA address. For this example we connec
 
     If you know the USB properties (vendor id, product id, serial numer) of the serial device, you can query for the VISA resource string::
 
-        from pymeasure.instruments.resources import find_serial_port
+        from pymeasure.instruments import find_serial_port
         resource_name = find_serial_port(vendor_id=15, product_id=0x12e5, serial_number="sn56X")
 
 For instruments with standard SCPI commands, an :code:`id` property will return the results of a :code:`*IDN?` SCPI command, identifying the instrument. ::

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -25,7 +25,7 @@
 from ..errors import RangeError, RangeException
 from .channel import Channel
 from .instrument import Instrument
-from .resources import list_resources
+from .resources import find_serial_port, list_resources
 from .validators import discreteTruncate
 
 from . import activetechnologies

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -69,10 +69,15 @@ def find_serial_port(vendor_id: Optional[int] = None, product_id: Optional[int] 
 
     Use `None` if you do not want to check for that property.
 
+    .. code-block:: python
+
+        resource_name = find_serial_port(vendor_id=1256, serial_number="SN12345")
+        dmm = Agilent34410(resource_name)
+
     :param int vid: Vendor ID.
     :param int pid: Product ID.
     :param str sn: Serial number.
-    :return: Port as a VISA string for a serial device (e.g. "ASRL5" or "ASRL/dev/ACMO5").
+    :return: Port as a VISA string for a serial device (e.g. "ASRL5" or "ASRL/dev/ttyACM5").
     """
     for port in sorted(list_ports.comports()):
         if ((vendor_id is None or port.vid == vendor_id)

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -22,8 +22,11 @@
 # THE SOFTWARE.
 #
 
+from typing import Optional
+
 import pyvisa
 from serial.tools import list_ports
+
 
 def list_resources():
     """
@@ -60,8 +63,8 @@ def list_resources():
     return instrs
 
 
-def find_serial_port(vendor_id: int | None = None, product_id: int | None = None,
-                     serial_number: str | None = None) -> str:
+def find_serial_port(vendor_id: Optional[int] = None, product_id: Optional[int] = None,
+                     serial_number: Optional[str] = None) -> str:
     """Find the VISA port name of the first serial device with the given USB information.
 
     Use `None` if you do not want to check for that property.
@@ -73,8 +76,8 @@ def find_serial_port(vendor_id: int | None = None, product_id: int | None = None
     """
     for port in sorted(list_ports.comports()):
         if ((vendor_id is None or port.vid == vendor_id)
-            and (product_id is None or port.pid == product_id)
-            and (serial_number is None or port.serial_number == str(serial_number))):
+                and (product_id is None or port.pid == product_id)
+                and (serial_number is None or port.serial_number == str(serial_number))):
             # remove "COM" from windows serial port names.
             port_name = port.device.replace("COM", "")
             return "ASRL" + port_name

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -23,7 +23,7 @@
 #
 
 import pyvisa
-
+from serial.tools import list_ports
 
 def list_resources():
     """
@@ -58,3 +58,24 @@ def list_resources():
             print(e)
     rm.close()
     return instrs
+
+
+def find_serial_port(vendor_id: int | None = None, product_id: int | None = None,
+                     serial_number: str | None = None) -> str:
+    """Find the VISA port name of the first serial device with the given USB information.
+
+    Use `None` if you do not want to check for that property.
+
+    :param int vid: Vendor ID.
+    :param int pid: Product ID.
+    :param str sn: Serial number.
+    :return: Port as a VISA string for a serial device (e.g. "ASRL5" or "ASRL/dev/ACMO5").
+    """
+    for port in sorted(list_ports.comports()):
+        if ((vendor_id is None or port.vid == vendor_id)
+            and (product_id is None or port.pid == product_id)
+            and (serial_number is None or port.serial_number == str(serial_number))):
+            # remove "COM" from windows serial port names.
+            port_name = port.device.replace("COM", "")
+            return "ASRL" + port_name
+    raise AttributeError("No device found for the given data.")

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -22,8 +22,6 @@
 # THE SOFTWARE.
 #
 
-from typing import Optional
-
 import pyvisa
 from serial.tools import list_ports
 
@@ -63,11 +61,10 @@ def list_resources():
     return instrs
 
 
-def find_serial_port(vendor_id: Optional[int] = None, product_id: Optional[int] = None,
-                     serial_number: Optional[str] = None) -> str:
+def find_serial_port(vendor_id=None, product_id=None, serial_number=None):
     """Find the VISA port name of the first serial device with the given USB information.
 
-    Use `None` if you do not want to check for that property.
+    Use `None` as a value if you do not want to check for that parameter.
 
     .. code-block:: python
 
@@ -77,7 +74,7 @@ def find_serial_port(vendor_id: Optional[int] = None, product_id: Optional[int] 
     :param int vid: Vendor ID.
     :param int pid: Product ID.
     :param str sn: Serial number.
-    :return: Port as a VISA string for a serial device (e.g. "ASRL5" or "ASRL/dev/ttyACM5").
+    :return str: Port as a VISA string for a serial device (e.g. "ASRL5" or "ASRL/dev/ttyACM5").
     """
     for port in sorted(list_ports.comports()):
         if ((vendor_id is None or port.vid == vendor_id)


### PR DESCRIPTION
Closes #950 

I did not add "::INSTR" at the end of the resource string, which is optional.

Reasoning for adding it to instruments.__init__: There is potential to use it often, therefore import should be shorter.
Additionally, the module `resources` is already imported and the additional dependency `serial` was already loaded by pyvisa (if pyvisa-py is used), therefore, it should not increase import time.