### PR TITLE
[instruments] HP34401A adding remote control command.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -70,3 +70,4 @@ Armindo Pinto
 Frank Wu
 Heinz-Alexander Fütterer
 Per-Olof Svensson
+Karl Komierowski

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -25,7 +25,6 @@
 from warnings import warn
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set
-from pymeasure.adapters import SerialAdapter
 
 
 deprecated_text = """
@@ -75,11 +74,9 @@ class HP34401A(Instrument):
         super().__init__(
             adapter,
             name,
-            asrl={'baud_rate': 9600, 'data_bits': 7, 'parity': 2},
+            asrl={'baud_rate': 9600, 'data_bits': 8, 'parity': 0},
             **kwargs
         )
-        if type(adapter) == SerialAdapter:
-            self.init_serial()
 
     # Log a deprecated warning for the old function property
     voltage_ac = Instrument.measurement("MEAS:VOLT:AC? DEF,DEF",
@@ -312,15 +309,6 @@ class HP34401A(Instrument):
         values=["LOC", "LOCAL", "REM", "REMOTE", "RWL", "RWLOCK"],
         map_values=False,
     )
-
-    def init_serial(self):
-        self.adapter.write_termination = "\n"
-        self.adapter.read_termination = "\n"
-        self.remote_local_state = "REM"
-
-        serial_settings = self.adapter.connection.get_settings()
-        if serial_settings["stopbits"] != 2:
-            print(f"Serial connection should use 2 stopbits: {serial_settings}")
 
     def beep(self):
         """This command causes the multimeter to beep once."""

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -304,7 +304,7 @@ class HP34401A(Instrument):
     # System related commands
     remote_control_enabled = Instrument.control(
         "SYST: ", "SYST:%s",
-        """Control whether remote is enabled.""",
+        """Control whether remote control is enabled.""",
         validator=strict_discrete_set,
         values={True: "REM", False: "LOC"},
         map_values=True,

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -70,11 +70,13 @@ class HP34401A(Instrument):
 
     BOOL_MAPPINGS = {True: 1, False: 0}
 
+    # Below: stop_bits: 20 comes from
+    # https://pyvisa.readthedocs.io/en/latest/api/constants.html#pyvisa.constants.StopBits
     def __init__(self, adapter, name="HP 34401A", **kwargs):
         super().__init__(
             adapter,
             name,
-            asrl={'baud_rate': 9600, 'data_bits': 8, 'parity': 0},
+            asrl={'baud_rate': 9600, 'data_bits': 8, 'parity': 0, 'stop_bits': 20},
             **kwargs
         )
 
@@ -300,14 +302,20 @@ class HP34401A(Instrument):
     )
 
     # System related commands
-    remote_local_state = Instrument.setting(
-        "SYST:%s",
-        """ A string property that controls the remote/local state of the
-        function generator. Valid values are: LOC<AL>, REM<OTE>, RWL<OCK>.
-        This setting can only be set. """,
+    remote_control_enabled = Instrument.control(
+        "SYST: ", "SYST:%s",
+        """Control whether remote is enabled.""",
         validator=strict_discrete_set,
-        values=["LOC", "LOCAL", "REM", "REMOTE", "RWL", "RWLOCK"],
-        map_values=False,
+        values={True: "REM", False: "LOC"},
+        map_values=True,
+    )
+
+    remote_lock_enabled = Instrument.control(
+        "SYST: ", "SYST:%s",
+        """Control whether the beeper is enabled.""",
+        validator=strict_discrete_set,
+        values={True: "RWL", False: "LOC"},
+        map_values=True,
     )
 
     def beep(self):


### PR DESCRIPTION
    * Checking stop bit configuration, should be two according to spec.
    * Added parameter: remote_local_state, it is set to "REM" during init
      by the driver.
      Should be set to "LOC" to return to local front display control.
