### PR TITLE
Fix SR830 missing get_buffer method

### DIFF
--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -503,7 +503,8 @@ class SR830(Instrument):
         return ch1, ch2
 
     def buffer_measure(self, count, stopRequest=None, delay=1e-3):
-        """ Start a fast measurement mode and transfers data from buffer to extract mean and std measurements
+        """ Start a fast measurement mode and transfers data from buffer to extract mean
+        and std measurements
 
         Return the mean and std from both channels
         """
@@ -589,7 +590,8 @@ class SR830(Instrument):
         return self.values(command)
 
     def save_setup(self, setup_number: int):
-        """Save the current instrument configuration (all parameters) in a memory referred to by an integer
+        """Save the current instrument configuration (all parameters) in a memory
+        referred to by an integer
 
         The integer must be comprised between 1 and 9 (included)
 
@@ -599,7 +601,8 @@ class SR830(Instrument):
             self.write(f'SSET{setup_number:d};')
 
     def load_setup(self, setup_number: int):
-        """ Load a previously saved instrument configuration from the memory referred to by an integer
+        """ Load a previously saved instrument configuration from the memory referred
+        to by an integer
 
         The integer must be comprised between 1 and 9 (included)
 

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -489,48 +489,52 @@ class SR830(Instrument):
         index = 0
         while currentCount < count:
             if currentCount > index:
-                ch1[index:currentCount] = self.buffer_data(1, index, currentCount)
-                ch2[index:currentCount] = self.buffer_data(2, index, currentCount)
+                ch1[index:currentCount] = self.get_buffer(1, index, currentCount)
+                ch2[index:currentCount] = self.get_buffer(2, index, currentCount)
                 index = currentCount
                 time.sleep(delay)
             currentCount = self.buffer_count
             if has_aborted():
                 self.pause_buffer()
                 return ch1, ch2
-        self.pauseBuffer()
-        ch1[index : count + 1] = self.buffer_data(1, index, count)  # noqa: E203
-        ch2[index : count + 1] = self.buffer_data(2, index, count)  # noqa: E203
+        self.pause_buffer()
+        ch1[index : count + 1] = self.get_buffer(1, index, count)  # noqa: E203
+        ch2[index : count + 1] = self.get_buffer(2, index, count)  # noqa: E203
         return ch1, ch2
 
     def buffer_measure(self, count, stopRequest=None, delay=1e-3):
-        self.write("FAST0;STRD")
+        """ Start a fast measurement mode and transfers data from buffer to extract mean and std measurements
+
+        Return the mean and std from both channels
+        """
+        self.write("FAST2;STRD")
         ch1 = np.empty(count, np.float64)
         ch2 = np.empty(count, np.float64)
         currentCount = self.buffer_count
         index = 0
         while currentCount < count:
             if currentCount > index:
-                ch1[index:currentCount] = self.buffer_data(1, index, currentCount)
-                ch2[index:currentCount] = self.buffer_data(2, index, currentCount)
+                ch1[index:currentCount] = self.get_buffer(1, index, currentCount)
+                ch2[index:currentCount] = self.get_buffer(2, index, currentCount)
                 index = currentCount
                 time.sleep(delay)
             currentCount = self.buffer_count
             if stopRequest is not None and stopRequest.isSet():
-                self.pauseBuffer()
+                self.pause_buffer()
                 return (0, 0, 0, 0)
-        self.pauseBuffer()
-        ch1[index:count] = self.buffer_data(1, index, count)
-        ch2[index:count] = self.buffer_data(2, index, count)
+        self.pause_buffer()
+        ch1[index:count] = self.get_buffer(1, index, count)
+        ch2[index:count] = self.get_buffer(2, index, count)
         return (ch1.mean(), ch1.std(), ch2.mean(), ch2.std())
 
     def pause_buffer(self):
         self.write("PAUS")
 
-    def start_buffer(self, fast=False):
+    def start_buffer(self, fast=True):
         if fast:
             self.write("FAST2;STRD")
         else:
-            self.write("FAST0;STRD")
+            self.write("FAST0")
 
     def wait_for_buffer(self, count, has_aborted=lambda: False,
                         timeout=60, timestep=0.01):
@@ -542,10 +546,10 @@ class SR830(Instrument):
             i += 1
             if has_aborted():
                 return False
-        self.pauseBuffer()
+        self.pause_buffer()
 
     def get_buffer(self, channel=1, start=0, end=None):
-        """ Aquires the 32 bit floating point data through binary transfer
+        """ Acquires the 32 bit floating point data through binary transfer
         """
         if end is None:
             end = self.buffer_count
@@ -583,3 +587,37 @@ class SR830(Instrument):
 
         command = "SNAP? " + ",".join(vals_idx)
         return self.values(command)
+
+    def save_setup(self, setup_number: int):
+        """Save the current instrument configuration (all parameters) in a memory referred to by an integer
+
+        The integer must be comprised between 1 and 9 (included)
+
+        :param setup_number: the integer referring to the memory (between 1 and 9 (included))
+        """
+        if 1 <= setup_number <= 9:
+            self.write(f'SSET{setup_number:d};')
+
+    def load_setup(self, setup_number: int):
+        """ Load a previously saved instrument configuration from the memory referred to by an integer
+
+        The integer must be comprised between 1 and 9 (included)
+
+        :param setup_number: the integer referring to the memory (between 1 and 9 (included))
+        """
+        if 1 <= setup_number <= 9:
+            self.write(f'RSET{setup_number:d};')
+
+    def start_scan(self):
+        """
+
+        :return:
+        """
+        self.write('STRT')
+
+    def pause_scan(self):
+        """
+
+        :return:
+        """
+        self.write('PAUS')

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -482,7 +482,11 @@ class SR830(Instrument):
         else:
             return int(query)
 
-    def fill_buffer(self, count, has_aborted=lambda: False, delay=0.001):
+    def fill_buffer(self, count: int, has_aborted=lambda: False, delay=0.001):
+        """ Fill two numpy arrays with the content of the instrument buffer
+
+        Eventually waiting until the specified number of recording is done
+        """
         ch1 = np.empty(count, np.float32)
         ch2 = np.empty(count, np.float32)
         currentCount = self.buffer_count
@@ -593,8 +597,6 @@ class SR830(Instrument):
         """Save the current instrument configuration (all parameters) in a memory
         referred to by an integer
 
-        The integer must be comprised between 1 and 9 (included)
-
         :param setup_number: the integer referring to the memory (between 1 and 9 (included))
         """
         if 1 <= setup_number <= 9:
@@ -604,23 +606,17 @@ class SR830(Instrument):
         """ Load a previously saved instrument configuration from the memory referred
         to by an integer
 
-        The integer must be comprised between 1 and 9 (included)
-
         :param setup_number: the integer referring to the memory (between 1 and 9 (included))
         """
         if 1 <= setup_number <= 9:
             self.write(f'RSET{setup_number:d};')
 
     def start_scan(self):
-        """
-
-        :return:
+        """ Start the data recording into the buffer
         """
         self.write('STRT')
 
     def pause_scan(self):
-        """
-
-        :return:
+        """ Pause the data recording
         """
         self.write('PAUS')


### PR DESCRIPTION
and change the misspelled pauseBuffer method
start_buffer was with the wrong boolean
start buffer with false should not add the STRD call

Overall, I wanted to try for fast acquisition and reading from the instrument but somehow the transfer is very slow. I will go for an external analog reading of the outputs. The function to start a scan and read data back are nonetheless working doing something like:

```
srs = SR830('GPIB0::8::INSTR')
srs.reset_buffer()
srs.start_scan()
ch1, ch2 = srs.fill_buffer(100)
```

but it takes about 3s to 20s to get the reading out even with the sample_rate set to 512 S/s ... 
