### PR TITLE
Extract init communication

### DIFF
--- a/pymeasure/instruments/activetechnologies/AWG401x.py
+++ b/pymeasure/instruments/activetechnologies/AWG401x.py
@@ -445,6 +445,9 @@ class AWG401x_AFG(AWG401x_base):
     def __init__(self, adapter, **kwargs):
         super().__init__(adapter, **kwargs)
 
+        self._init_communication()
+
+    def _init_communication(self):
         model = self.id.split(",")[1]
         if model == "AWG4012":
             num_ch = 2
@@ -494,16 +497,20 @@ class AWG401x_AWG(AWG401x_base):
     def __init__(self, adapter, **kwargs):
         super().__init__(adapter, **kwargs)
 
-        for i in range(1, self.num_ch + 1):
-            self.add_child(ChannelAWG, i, collection="setting_ch")
+        self._init_communication()
 
-        self.entries = self.DummyEntriesElements(self, self.num_ch)
         self.burst_count_values = [self.burst_count_min, self.burst_count_max]
 
         self.sampling_rate_values = [self.sampling_rate_min,
                                      self.sampling_rate_max]
 
         self._waveforms = self.WaveformsLazyDict(self)
+
+    def _init_communication(self):
+        for i in range(1, self.num_ch + 1):
+            self.add_child(ChannelAWG, i, collection="setting_ch")
+
+        self.entries = self.DummyEntriesElements(self, self.num_ch)
 
     num_ch = Instrument.measurement(
         "AWGControl:CONFigure:CNUMber?",

--- a/pymeasure/instruments/activetechnologies/AWG401x.py
+++ b/pymeasure/instruments/activetechnologies/AWG401x.py
@@ -445,9 +445,6 @@ class AWG401x_AFG(AWG401x_base):
     def __init__(self, adapter, **kwargs):
         super().__init__(adapter, **kwargs)
 
-        self._init_communication()
-
-    def _init_communication(self):
         model = self.id.split(",")[1]
         if model == "AWG4012":
             num_ch = 2
@@ -462,6 +459,43 @@ class AWG401x_AFG(AWG401x_base):
         for i in range(3, num_ch + 1):
             child = self.add_child(ChannelAFG, i)
             child._protected = True
+
+    _init_comm_pairs = [
+        # ("*IDN?", "x,AWG4012"),
+        ("SOURce1:INITDELay? MINimum", "1"),
+        ("SOURce1:INITDELay? MAXimum", "2"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:LOW? MINimum", "1"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:LOW? MAXimum", "2"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:HIGH? MINimum", "1"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:HIGH? MAXimum", "2"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:AMPLitude? MINimum", "VPP1"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:AMPLitude? MAXimum", "VPP2"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:OFFSet? MINimum", "1"),
+        ("SOURce1:VOLTage:LEVel:IMMediate:OFFSet? MAXimum", "2"),
+        ("SOURce1:VOLTage:BASELINE:OFFSET? MINimum", "1"),
+        ("SOURce1:VOLTage:BASELINE:OFFSET? MAXimum", "2"),
+        ("SOURce1:FREQuency? MINimum", "1"),
+        ("SOURce1:FREQuency? MAXimum", "2"),
+        ("SOURce1:PHASe:ADJust? MINimum", "1"),
+        ("SOURce1:PHASe:ADJust? MAXimum", "2"),
+        ("SOURce2:INITDELay? MINimum", "1"),
+        ("SOURce2:INITDELay? MAXimum", "2"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:LOW? MINimum", "1"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:LOW? MAXimum", "2"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:HIGH? MINimum", "1"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:HIGH? MAXimum", "2"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:AMPLitude? MINimum", "VPP1"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:AMPLitude? MAXimum", "VPP2"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:OFFSet? MINimum", "1"),
+        ("SOURce2:VOLTage:LEVel:IMMediate:OFFSet? MAXimum", "2"),
+        ("SOURce2:VOLTage:BASELINE:OFFSET? MINimum", "1"),
+        ("SOURce2:VOLTage:BASELINE:OFFSET? MAXimum", "2"),
+        ("SOURce2:FREQuency? MINimum", "1"),
+        ("SOURce2:FREQuency? MAXimum", "2"),
+        ("SOURce2:PHASe:ADJust? MINimum", "1"),
+        ("SOURce2:PHASe:ADJust? MAXimum", "2"),
+        ("*IDN?", "x,AWG4012"),
+    ]
 
 
 class AWG401x_AWG(AWG401x_base):
@@ -497,7 +531,10 @@ class AWG401x_AWG(AWG401x_base):
     def __init__(self, adapter, **kwargs):
         super().__init__(adapter, **kwargs)
 
-        self._init_communication()
+        for i in range(1, self.num_ch + 1):
+            self.add_child(ChannelAWG, i, collection="setting_ch")
+
+        self.entries = self.DummyEntriesElements(self, self.num_ch)
 
         self.burst_count_values = [self.burst_count_min, self.burst_count_max]
 
@@ -506,11 +543,19 @@ class AWG401x_AWG(AWG401x_base):
 
         self._waveforms = self.WaveformsLazyDict(self)
 
-    def _init_communication(self):
-        for i in range(1, self.num_ch + 1):
-            self.add_child(ChannelAWG, i, collection="setting_ch")
-
-        self.entries = self.DummyEntriesElements(self, self.num_ch)
+    _init_comm_pairs = [
+        ("*IDN?", "x,AWG4012"),
+        ("SOURce1:INITDELay? MINimum", "1"),
+        ("SOURce1:INITDELay? MAXimum", "2"),
+        ("SOURce2:INITDELay? MINimum", "1"),
+        ("SOURce2:INITDELay? MAXimum", "2"),
+        ("AWGControl:BURST? MINimum", "1"),
+        ("AWGControl:BURST? MAXimum", "2"),
+        ("AWGControl:SRATe? MINimum", "1"),
+        ("AWGControl:SRATe? MAXimum", "1"),
+        ("WLISt:LIST?", ""),
+        # ("*IDN?", "x,AWG4012"),
+    ]
 
     num_ch = Instrument.measurement(
         "AWGControl:CONFigure:CNUMber?",

--- a/pymeasure/instruments/activetechnologies/AWG401x.py
+++ b/pymeasure/instruments/activetechnologies/AWG401x.py
@@ -544,11 +544,12 @@ class AWG401x_AWG(AWG401x_base):
         self._waveforms = self.WaveformsLazyDict(self)
 
     _init_comm_pairs = [
-        ("*IDN?", "x,AWG4012"),
-        ("SOURce1:INITDELay? MINimum", "1"),
-        ("SOURce1:INITDELay? MAXimum", "2"),
-        ("SOURce2:INITDELay? MINimum", "1"),
-        ("SOURce2:INITDELay? MAXimum", "2"),
+        ("AWGControl:CONFigure:CNUMber?", "2"),
+        ("OUTPut1:DELay? MINimum", "1"),
+        ("OUTPut1:DELay? MAXimum", "2"),
+        ("OUTPut2:DELay? MINimum", "1"),
+        ("OUTPut2:DELay? MAXimum", "2"),
+        ("AWGControl:CONFigure:CNUMber?", "2"),
         ("AWGControl:BURST? MINimum", "1"),
         ("AWGControl:BURST? MAXimum", "2"),
         ("AWGControl:SRATe? MINimum", "1"),

--- a/pymeasure/instruments/advantest/advantestR3767CG.py
+++ b/pymeasure/instruments/advantest/advantestR3767CG.py
@@ -37,11 +37,10 @@ class AdvantestR3767CG(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         # Tell unit to operate in IEEE488.2-1987 command mode.
         self.write("OLDC OFF")
+
+    _init_comm_pairs = [("OLDC OFF", None)]
 
     id = Instrument.measurement(
         "*IDN?", """Get the instrument identification."""

--- a/pymeasure/instruments/advantest/advantestR3767CG.py
+++ b/pymeasure/instruments/advantest/advantestR3767CG.py
@@ -37,7 +37,9 @@ class AdvantestR3767CG(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
+        self._init_communication()
 
+    def _init_communication(self):
         # Tell unit to operate in IEEE488.2-1987 command mode.
         self.write("OLDC OFF")
 

--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -375,10 +375,9 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
             adapter, name, timeout=10000, **kwargs
         )
         # Configuration changes can necessitate up to 8.8 secs (per datasheet)
-        self._init_communication()
-
-    def _init_communication(self):
         self.check_errors()
+
+    _init_comm_pairs = [("SYST:ERR?", "0,None")]
 
     def configure_voltage(self, voltage_range="AUTO", ac=False, resolution="DEF"):
         """ Configures the instrument to measure voltage.

--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -375,6 +375,9 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
             adapter, name, timeout=10000, **kwargs
         )
         # Configuration changes can necessitate up to 8.8 secs (per datasheet)
+        self._init_communication()
+
+    def _init_communication(self):
         self.check_errors()
 
     def configure_voltage(self, voltage_range="AUTO", ac=False, resolution="DEF"):

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -104,6 +104,9 @@ Select trigger source; accept the values:
         )
         self.timeout = 30000
         # format: output ascii
+        self._init_communication()
+
+    def _init_communication(self):
         self.write("FORM ASC")
 
     def freq_sweep(self, freq_list, return_freq=False):

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -104,10 +104,9 @@ Select trigger source; accept the values:
         )
         self.timeout = 30000
         # format: output ascii
-        self._init_communication()
-
-    def _init_communication(self):
         self.write("FORM ASC")
+
+    _init_comm_pairs = [("FORM ASC", None)]
 
     def freq_sweep(self, freq_list, return_freq=False):
         """

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -65,11 +65,10 @@ class AMI430(SCPIMixin, Instrument):
             **kwargs
         )
         # Read twice in order to remove welcome/connect message
-        self._init_communication()
+        self.read()
+        self.read()
 
-    def _init_communication(self):
-        self.read()
-        self.read()
+    _init_comm_pairs = [(None, "welcome"), (None, "connect")]
 
     maximumfield = 1.00
     maximumcurrent = 50.63

--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -65,6 +65,9 @@ class AMI430(SCPIMixin, Instrument):
             **kwargs
         )
         # Read twice in order to remove welcome/connect message
+        self._init_communication()
+
+    def _init_communication(self):
         self.read()
         self.read()
 

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -300,9 +300,6 @@ class ANC300Controller(Instrument):
         for i, axis in enumerate(axisnames):
             setattr(self, axis, self.add_child(Axis, id=str(i + 1)))
 
-        self._init_communication(passwd)
-
-    def _init_communication(self, passwd):
         self.wait_for()
         # clear messages sent upon opening the connection,
         # this contains some non-ascii characters!
@@ -316,6 +313,13 @@ class ANC300Controller(Instrument):
             raise Exception(f"Attocube authorization failed '{auth_msg}'")
         # switch console echo off
         self.ask('echo off')
+
+    _init_comm_pairs = [
+        ("", "*" * len("")),
+        (None, "Authorization success"),
+        ("echo off", "> echo off"),
+        (None, "OK"),
+    ]
 
     def check_set_errors(self):
         """Check for errors after having set a property and log them.

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -300,6 +300,9 @@ class ANC300Controller(Instrument):
         for i, axis in enumerate(axisnames):
             setattr(self, axis, self.add_child(Axis, id=str(i + 1)))
 
+        self._init_communication(passwd)
+
+    def _init_communication(self, passwd):
         self.wait_for()
         # clear messages sent upon opening the connection,
         # this contains some non-ascii characters!

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -67,6 +67,9 @@ class Danfysik8500(Instrument):
             timeout=500,
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         # TODO verify serial connection.
         self.write("ERRT")  # Use text error messages
         self.write("UNLOCK")  # Unlock from remote or local mode

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -67,12 +67,11 @@ class Danfysik8500(Instrument):
             timeout=500,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         # TODO verify serial connection.
         self.write("ERRT")  # Use text error messages
         self.write("UNLOCK")  # Unlock from remote or local mode
+
+    _init_comm_pairs = [(b"ERRT", None), (b"UNLOCK", None)]
 
     def read(self):
         """ Read the device and raise exceptions if errors are reported by the instrument.

--- a/pymeasure/instruments/fakes.py
+++ b/pymeasure/instruments/fakes.py
@@ -26,7 +26,7 @@ import re
 import time
 import numpy as np
 
-from pymeasure.adapters import FakeAdapter
+from pymeasure.adapters import Adapter, FakeAdapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
@@ -37,7 +37,7 @@ class FakeInstrument(Instrument):
     """
 
     def __init__(self, adapter=None, name="Fake Instrument", includeSCPI=False, **kwargs):
-        if adapter is None:
+        if not isinstance(adapter, Adapter):
             adapter = FakeAdapter()
         super().__init__(
             adapter=adapter,
@@ -90,8 +90,9 @@ class SwissArmyFake(FakeInstrument):
     include 'voltages', sinusoidal 'waveforms', and mono channel 'image data'.
     """
 
-    def __init__(self, name="Mock instrument", wait=.1, **kwargs):
+    def __init__(self, name="Mock instrument", wait=.1, adapter=None, **kwargs):
         super().__init__(
+            adapter=adapter,
             name=name,
             includeSCPI=False,
             **kwargs

--- a/pymeasure/instruments/fakes.py
+++ b/pymeasure/instruments/fakes.py
@@ -37,9 +37,11 @@ class FakeInstrument(Instrument):
     """
 
     def __init__(self, adapter=None, name="Fake Instrument", includeSCPI=False, **kwargs):
+        if adapter is None:
+            adapter = FakeAdapter()
         super().__init__(
-            FakeAdapter(**kwargs),
-            name,
+            adapter=adapter,
+            name=name,
             includeSCPI=includeSCPI,
             **kwargs
         )

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -95,7 +95,9 @@ class TC038(Instrument):
             **kwargs,
         )
         self.address = address
+        self._init_communication()
 
+    def _init_communication(self):
         self.set_monitored_quantity()  # start to monitor the temperature
 
     def write(self, command):

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -95,10 +95,9 @@ class TC038(Instrument):
             **kwargs,
         )
         self.address = address
-        self._init_communication()
-
-    def _init_communication(self):
         self.set_monitored_quantity()  # start to monitor the temperature
+
+    _init_comm_pairs = [(b"\x0201010WRS01D0002\x03", b"\x020101OK\x03")]
 
     def write(self, command):
         """Send a `command` in its own protocol."""

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -42,10 +42,9 @@ class HP33120A(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self.amplitude_units = 'Vpp'
+
+    _init_comm_pairs = [(b'SOUR:VOLT:UNIT VPP', None)]
 
     SHAPES = {
         'sinusoid': 'SIN', 'square': 'SQU', 'triangle': 'TRI',

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -42,6 +42,9 @@ class HP33120A(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         self.amplitude_units = 'Vpp'
 
     SHAPES = {

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -91,10 +91,9 @@ class HP8116A(Instrument):
             includeSCPI=False,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self.has_option_001 = self._check_has_option_001()
+
+    _init_comm_pairs = [(b"CST", b"x" * 87 + b' ,\r\n')]
 
     class Digit(Enum):
         """ Enum of the digits used with the autovernier

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -91,6 +91,9 @@ class HP8116A(Instrument):
             includeSCPI=False,
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         self.has_option_001 = self._check_has_option_001()
 
     class Digit(Enum):

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -103,14 +103,7 @@ class Instrument(CommonBase):
 
         log.info("Initializing %s." % self.name)
 
-    def _init_communication(self):
-        """Do any :meth:`__init__` configuration requiring communicating with the device.
-
-        In order to test the main code of the instrument without required knowledge of the
-        communication during initialization.
-        Override in your subclass with the communication you need and call it in your `__init__`.
-        """
-        pass
+    _init_comm_pairs = []
 
     def __enter__(self):
         return self

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -103,6 +103,15 @@ class Instrument(CommonBase):
 
         log.info("Initializing %s." % self.name)
 
+    def _init_communication(self):
+        """Do any :meth:`__init__` configuration requiring communicating with the device.
+
+        In order to test the main code of the instrument without required knowledge of the
+        communication during initialization.
+        Override in your subclass with the communication you need and call it in your `__init__`.
+        """
+        pass
+
     def __enter__(self):
         return self
 

--- a/pymeasure/instruments/ipgphotonics/yar.py
+++ b/pymeasure/instruments/ipgphotonics/yar.py
@@ -82,7 +82,9 @@ class YAR(Instrument):
         # by space is option. Commands are case-insensitive.
         # Response is command echoed back, followed by ': ' and the return
         # value.
+        self._init_communication()
 
+    def _init_communication(self):
         # get valid range of power setpoint:
         self.power_setpoint_values = self.power_range
         self.power_get_process = power_get_process_generator(self.minimum_display_power)

--- a/pymeasure/instruments/ipgphotonics/yar.py
+++ b/pymeasure/instruments/ipgphotonics/yar.py
@@ -82,12 +82,12 @@ class YAR(Instrument):
         # by space is option. Commands are case-insensitive.
         # Response is command echoed back, followed by ': ' and the return
         # value.
-        self._init_communication()
 
-    def _init_communication(self):
         # get valid range of power setpoint:
         self.power_setpoint_values = self.power_range
         self.power_get_process = power_get_process_generator(self.minimum_display_power)
+
+    _init_comm_pairs = [("RNP", "RNP: 0.200"), ("RMP", "RMP: 10.5"), ("RDPT", "RDPT: 0.100")]
 
     class Status(IntFlag):
         EMISSION = 0x1  # emission is fully on

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -105,7 +105,9 @@ class Keithley2700(KeithleyBuffer, SCPIMixin, Instrument):
             name,
             **kwargs
         )
+        self._init_communication()
 
+    def _init_communication(self):
         self.check_errors()
         self.determine_valid_channels()
 

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -105,11 +105,10 @@ class Keithley2700(KeithleyBuffer, SCPIMixin, Instrument):
             name,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self.check_errors()
         self.determine_valid_channels()
+
+    _init_comm_pairs = [("SYST:ERR?", "0,None"), ("*OPT?", "")]  # TODO verify
 
     # Routing commands
     closed_channels = Instrument.control(

--- a/pymeasure/instruments/keithley/keithleyDMM6500.py
+++ b/pymeasure/instruments/keithley/keithleyDMM6500.py
@@ -217,6 +217,8 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
 
     channels = Instrument.MultiChannelCreator(ScannerCard2000Channel, list(range(1, 11)))
 
+    _init_comm_pairs = [(b'*LANG SCPI', None)]
+
     def __init__(
         self, adapter, name="Keithley DMM6500 6½-Digit Multimeter", read_termination="\n", **kwargs
     ):
@@ -225,10 +227,6 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
             name,
             read_termination=read_termination,
             **kwargs)
-
-        self._init_communication()
-
-    def _init_communication(self):
         self.command_set = "SCPI"
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/pymeasure/instruments/keithley/keithleyDMM6500.py
+++ b/pymeasure/instruments/keithley/keithleyDMM6500.py
@@ -225,6 +225,10 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
             name,
             read_termination=read_termination,
             **kwargs)
+
+        self._init_communication()
+
+    def _init_communication(self):
         self.command_set = "SCPI"
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/pymeasure/instruments/parker/parkerGV6.py
+++ b/pymeasure/instruments/parker/parkerGV6.py
@@ -45,6 +45,9 @@ class ParkerGV6(SCPIUnknownMixin, Instrument):
             write_termination="\r",
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         self.set_defaults()
 
     def read(self):

--- a/pymeasure/instruments/parker/parkerGV6.py
+++ b/pymeasure/instruments/parker/parkerGV6.py
@@ -45,10 +45,17 @@ class ParkerGV6(SCPIUnknownMixin, Instrument):
             write_termination="\r",
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self.set_defaults()
+
+    _init_comm_pairs = [
+        (b"ECHO0", None),
+        (b"LH0", None),
+        (b"MA1", None),
+        (b"MC0", None),
+        (b"AA1.0", None),
+        (b"A1.0", None),
+        (b"V3.0", None),
+    ]
 
     def read(self):
         """ Overwrites the Instrument.read command to provide the correct

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -67,6 +67,9 @@ class TDK_Lambda_Base(Instrument):
             asrl={'read_termination': "\r", 'write_termination': "\r"},
             **kwargs
         )
+        self._init_communication(address)
+
+    def _init_communication(self, address):
         self.address = address
 
     def check_set_errors(self):

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -67,10 +67,9 @@ class TDK_Lambda_Base(Instrument):
             asrl={'read_termination': "\r", 'write_termination': "\r"},
             **kwargs
         )
-        self._init_communication(address)
-
-    def _init_communication(self, address):
         self.address = address
+
+    _init_comm_pairs = [(b"ADR 6", b"OK")]
 
     def check_set_errors(self):
         """

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -497,6 +497,9 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         self._header_size = 16  # bytes
         self._footer_size = 2  # bytes
         self.waveform_source = "C1"
+        self._init_communication()
+
+    def _init_communication(self):
         self.default_setup()
 
     ################

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -497,10 +497,9 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         self._header_size = 16  # bytes
         self._footer_size = 2  # bytes
         self.waveform_source = "C1"
-        self._init_communication()
-
-    def _init_communication(self):
         self.default_setup()
+
+    _init_comm_pairs = [("CHDR OFF", None)]
 
     ################
     # System Setup #

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -38,10 +38,9 @@ class ThorlabsPM100USB(SCPIUnknownMixin, Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self._set_flags()
+
+    _init_comm_pairs = [("SYST:SENSOR:IDN?", "0, 1, 2, 3, 4, 5")]
 
     wavelength_min = Instrument.measurement(
         "SENS:CORR:WAV? MIN", "Measure minimum wavelength, in nm"

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -38,6 +38,9 @@ class ThorlabsPM100USB(SCPIUnknownMixin, Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         self._set_flags()
 
     wavelength_min = Instrument.measurement(

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -38,6 +38,9 @@ class ThorlabsPro8000(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         self.write(':SYST:ANSW VALUE')
 
     # Code for general purpose commands (mother board related)

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -38,10 +38,9 @@ class ThorlabsPro8000(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         self.write(':SYST:ANSW VALUE')
+
+    _init_comm_pairs = [(':SYST:ANSW VALUE', None)]
 
     # Code for general purpose commands (mother board related)
     slot = Instrument.control(":SLOT?", ":SLOT %d",

--- a/pymeasure/instruments/toptica/ibeamsmart.py
+++ b/pymeasure/instruments/toptica/ibeamsmart.py
@@ -122,6 +122,9 @@ class IBeamSmart(Instrument):
             asrl={'baud_rate': baud_rate},
             **kwargs
         )
+        self._init_communication()
+
+    def _init_communication(self):
         # configure communication mode: no repeating and no command prompt
         self.write('echo off')
         self.write('prom off')

--- a/pymeasure/instruments/toptica/ibeamsmart.py
+++ b/pymeasure/instruments/toptica/ibeamsmart.py
@@ -122,9 +122,6 @@ class IBeamSmart(Instrument):
             asrl={'baud_rate': baud_rate},
             **kwargs
         )
-        self._init_communication()
-
-    def _init_communication(self):
         # configure communication mode: no repeating and no command prompt
         self.write('echo off')
         self.write('prom off')
@@ -135,6 +132,8 @@ class IBeamSmart(Instrument):
         except AttributeError:
             log.warning("Adapter does not have 'flush_read_buffer' method.")
         self.ask('talk usual')
+
+    _init_comm_pairs = [("echo off", None), ("prom off", None), ("talk usual", ""), (None, "[OK]")]
 
     def read(self):
         """Read a reply of the instrument and extract the values, if possible.

--- a/pymeasure/instruments/yokogawa/yokogawa7651.py
+++ b/pymeasure/instruments/yokogawa/yokogawa7651.py
@@ -130,7 +130,9 @@ class Yokogawa7651(SCPIUnknownMixin, Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
+        self._init_communication()
 
+    def _init_communication(self):
         self.write("H0;E")  # Set no header in output data
 
     @property

--- a/pymeasure/instruments/yokogawa/yokogawa7651.py
+++ b/pymeasure/instruments/yokogawa/yokogawa7651.py
@@ -130,10 +130,10 @@ class Yokogawa7651(SCPIUnknownMixin, Instrument):
         super().__init__(
             adapter, name, **kwargs
         )
-        self._init_communication()
 
-    def _init_communication(self):
         self.write("H0;E")  # Set no header in output data
+
+    _init_comm_pairs = [("H0;E", None)]
 
     @property
     def id(self):

--- a/tests/instruments/activetechnologies/test_AWG401x.py
+++ b/tests/instruments/activetechnologies/test_AWG401x.py
@@ -25,7 +25,7 @@
 from pymeasure.test import expected_protocol
 from pymeasure.instruments import Instrument
 
-from pymeasure.instruments.activetechnologies import AWG401x_AFG
+from pymeasure.instruments.activetechnologies import AWG401x_AFG, AWG401x_AWG
 from pymeasure.instruments.activetechnologies.AWG401x import ChannelAFG, SequenceEntry
 
 
@@ -69,6 +69,13 @@ def test_AFG_frequency_getter():
              ],
     ) as inst:
         assert inst.ch_2.frequency == 1.5
+
+
+# AWG tests
+
+def test_AWG_init():
+    with expected_protocol(AWG401x_AWG, AWG401x_AWG._init_comm_pairs):
+        pass  # verify init communication
 
 
 # SequenceEntry Tests

--- a/tests/instruments/activetechnologies/test_AWG401x.py
+++ b/tests/instruments/activetechnologies/test_AWG401x.py
@@ -39,42 +39,7 @@ class SequencerInstrument(Instrument):
 
 
 # AFG Tests
-AFG_init_comm = [
-    # ("*IDN?", "x,AWG4012"),
-    ("SOURce1:INITDELay? MINimum", "1"),
-    ("SOURce1:INITDELay? MAXimum", "2"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:LOW? MINimum", "1"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:LOW? MAXimum", "2"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:HIGH? MINimum", "1"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:HIGH? MAXimum", "2"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:AMPLitude? MINimum", "VPP1"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:AMPLitude? MAXimum", "VPP2"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:OFFSet? MINimum", "1"),
-    ("SOURce1:VOLTage:LEVel:IMMediate:OFFSet? MAXimum", "2"),
-    ("SOURce1:VOLTage:BASELINE:OFFSET? MINimum", "1"),
-    ("SOURce1:VOLTage:BASELINE:OFFSET? MAXimum", "2"),
-    ("SOURce1:FREQuency? MINimum", "1"),
-    ("SOURce1:FREQuency? MAXimum", "2"),
-    ("SOURce1:PHASe:ADJust? MINimum", "1"),
-    ("SOURce1:PHASe:ADJust? MAXimum", "2"),
-    ("SOURce2:INITDELay? MINimum", "1"),
-    ("SOURce2:INITDELay? MAXimum", "2"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:LOW? MINimum", "1"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:LOW? MAXimum", "2"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:HIGH? MINimum", "1"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:HIGH? MAXimum", "2"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:AMPLitude? MINimum", "VPP1"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:AMPLitude? MAXimum", "VPP2"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:OFFSet? MINimum", "1"),
-    ("SOURce2:VOLTage:LEVel:IMMediate:OFFSet? MAXimum", "2"),
-    ("SOURce2:VOLTage:BASELINE:OFFSET? MINimum", "1"),
-    ("SOURce2:VOLTage:BASELINE:OFFSET? MAXimum", "2"),
-    ("SOURce2:FREQuency? MINimum", "1"),
-    ("SOURce2:FREQuency? MAXimum", "2"),
-    ("SOURce2:PHASe:ADJust? MINimum", "1"),
-    ("SOURce2:PHASe:ADJust? MAXimum", "2"),
-    ("*IDN?", "x,AWG4012"),
-]
+AFG_init_comm = AWG401x_AFG._init_comm_pairs
 
 
 def test_AFG_init():

--- a/tests/instruments/attocube/test_anc300.py
+++ b/tests/instruments/attocube/test_anc300.py
@@ -30,13 +30,8 @@ from pymeasure.instruments.attocube import ANC300Controller
 
 # Note: This communication does not contain the first several device
 # responses, as they are ignored due to `adapter.flush_read_buffer()`.
-passwd = "passwd"
-init_comm = [
-    (passwd, "*" * len(passwd)),
-    (None, "Authorization success"),
-    ("echo off", "> echo off"),
-    (None, "OK"),
-]
+passwd = ""
+init_comm = ANC300Controller._init_comm_pairs
 
 
 def test_stepu():

--- a/tests/instruments/ipgphotonics/test_yar.py
+++ b/tests/instruments/ipgphotonics/test_yar.py
@@ -29,7 +29,7 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.ipgphotonics.yar import YAR
 
 
-init_comm = [("RNP", "RNP: 0.200"), ("RMP", "RMP: 10.5"), ("RDPT", "RDPT: 0.100")]
+init_comm = YAR._init_comm_pairs
 
 ################################
 # Values according to the manual

--- a/tests/instruments/keithley/test_keithley2700.py
+++ b/tests/instruments/keithley/test_keithley2700.py
@@ -22,48 +22,11 @@
 # THE SOFTWARE.
 #
 
-
 from pymeasure.test import expected_protocol
 
-from pymeasure.instruments.hp import HP8116A
-from pymeasure.instruments.hp.hp8116a import Status
-
-HP8116A.status = property(fget=lambda self: Status(5))
-
-
-init_comm = HP8116A._init_comm_pairs  # communication during init
+from pymeasure.instruments.keithley import Keithley2700
 
 
 def test_init():
-    with expected_protocol(
-            HP8116A,
-            init_comm,
-    ):
-        pass  # Verify the expected communication.
-
-
-def test_duty_cycle():
-    with expected_protocol(
-            HP8116A,
-            init_comm + [(b"IDTY", b"00000035")],
-    ) as instr:
-        assert instr.duty_cycle == 35
-
-
-def test_duty_cycle_setter():
-    with expected_protocol(
-            HP8116A,
-            init_comm + [(b"DTY 34.5 %", None)],
-    ) as instr:
-        instr.duty_cycle = 34.5
-
-
-def test_sweep_time():
-    with expected_protocol(HP8116A, init_comm + [("SWT 5 S", None)]) as inst:
-        # This test tests also the generate_1_2_5_sequence method and truncation.
-        inst.sweep_time = 3
-
-
-def test_limit_enabled():
-    with expected_protocol(HP8116A, init_comm + [("L1", None)]) as inst:
-        inst.limit_enabled = True
+    with expected_protocol(Keithley2700, Keithley2700._init_comm_pairs):
+        pass  # verify init communication

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -190,13 +190,6 @@ grandfathered_docstring_instruments = [
 ]
 
 
-def create_init_communication_less_instrument(cls):
-    class ModifiedCls(cls):
-        def _init_communication(self, *args, **kwargs):
-            pass
-    return ModifiedCls
-
-
 @pytest.mark.parametrize("cls", devices)
 def test_adapter_arg(cls):
     "Test that every instrument has adapter as their input argument."
@@ -209,8 +202,7 @@ def test_adapter_arg(cls):
     elif cls.__name__ == "Instrument":
         pytest.skip("`Instrument` requires a `name` parameter.")
 
-    cls = create_init_communication_less_instrument(cls)
-    cls(adapter=ProtocolAdapter())
+    cls(adapter=ProtocolAdapter(cls._init_comm_pairs))
 
 
 @pytest.mark.parametrize("cls", devices)
@@ -221,8 +213,7 @@ def test_name_argument(cls):
     elif cls.__name__ in channel_as_instrument_subclass:
         pytest.skip(f"{cls.__name__} is a channel, not an instrument.")
 
-    cls = create_init_communication_less_instrument(cls)
-    inst = cls(adapter=ProtocolAdapter(), name="Name_Test")
+    inst = cls(adapter=ProtocolAdapter(cls._init_comm_pairs), name="Name_Test")
     assert inst.name == "Name_Test"
 
 
@@ -246,7 +237,6 @@ def test_kwargs_to_adapter(cls):
     elif cls.__name__ in ("FakeInstrument", "SwissArmyFake"):
         pytest.skip("Fake instruments replace the adapter.")
 
-    cls = create_init_communication_less_instrument(cls)
     with pytest.raises(ValueError,
                        match="'kwarg_test' is not a valid attribute for type SerialInstrument"):
         cls(adapter=SIM_RESOURCE, visa_library='@sim', kwarg_test=True)
@@ -263,8 +253,7 @@ def test_includeSCPI_explicitly_set(cls):
     elif cls.__name__ == "Instrument":
         pytest.skip("`Instrument` requires a `name` parameter.")
 
-    cls = create_init_communication_less_instrument(cls)
-    cls(adapter=ProtocolAdapter())
+    cls(adapter=ProtocolAdapter(cls._init_comm_pairs))
     # assert that no error is raised
 
 
@@ -279,8 +268,7 @@ def test_includeSCPI_not_set_to_True(cls):
     elif cls.__name__ == "Instrument":
         pytest.skip("`Instrument` requires a `name` parameter.")
 
-    cls = create_init_communication_less_instrument(cls)
-    cls(adapter=ProtocolAdapter())
+    cls(adapter=ProtocolAdapter(cls._init_comm_pairs))
     # assert that no error is raised
 
 

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -98,8 +98,7 @@ for mixin in dir(generic_types):
 proper_adapters = []
 # Instruments with communication in their __init__, which consequently fails.
 need_init_communication = [
-    "AWG401x_AWG",
-    "AWG401x_AFG",
+    "HP8116A",  # it depends on `adapter.connection.read_stb`
 ]
 # Channels which are still an Instrument subclass
 channel_as_instrument_subclass = [

--- a/tests/instruments/toptica/test_ibeamsmart.py
+++ b/tests/instruments/toptica/test_ibeamsmart.py
@@ -32,7 +32,7 @@ from pymeasure.instruments.toptica import IBeamSmart
 # Note: This communication does not contain the first two device responses, as they are
 # ignored due to `adapter.flush_read_buffer()`.
 # The device communication depends on previous commands and whether the device power cycled.
-init_comm = [("echo off", None), ("prom off", None), ("talk usual", ""), (None, "[OK]")]
+init_comm = IBeamSmart._init_comm_pairs
 
 
 def test_init():


### PR DESCRIPTION
In order to expand _all instrument tests_, I moved all the communication in the `__init__` methods into their own `_init_communication` method.
That allows to replace that method for certain tests.

The name of that method could be different, if required.