### PR TITLE
Feature proposal: Possible to not save all parameters

### DIFF
--- a/examples/Basic/gui_no_save_param.py
+++ b/examples/Basic/gui_no_save_param.py
@@ -36,8 +36,10 @@ python gui.py
 import sys
 import random
 from time import sleep
+from PyQt5.QtCore import QLocale
+from pyqtgraph.Qt import QtCore
 
-from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
+from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter, ListParameter, unique_filename, Metadata, Results
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
@@ -48,15 +50,26 @@ log.addHandler(logging.NullHandler())
 
 class TestProcedure(Procedure):
 
+    p_dutId = Parameter('DUT ID', default='NA', save=False)
     iterations = IntegerParameter('Loop Iterations', default=100)
-    delay = FloatParameter('Delay Time', units='s', default=0.2)
+    delay = FloatParameter('Delay Time', units='s', default=0.02)
     seed = Parameter('Random Seed', default='12345')
+    param_set = ListParameter('Paramters to set', choices=['None','Group 1','Group 2'], default='None', save=False)
+    # Parameter group 1
+    param_1_1 = IntegerParameter('Paramter 1.1', default=1, group_by={'param_set' : 'Group 1'})
+    # Parameter group 2
+    param_2_1 = IntegerParameter('Paramter 2.1', default=2, group_by={'param_set' : 'Group 2'})
 
+    # Metadata
+    m_dutId = Metadata('DUT_ID', default='')
+
+    # a list defining the order and appearance of columns in our data file
     DATA_COLUMNS = ['Iteration', 'Random Number']
 
     def startup(self):
         log.info("Setting up random number generator")
         random.seed(self.seed)
+        self.m_dutId = self.p_dutId
 
     def execute(self):
         log.info("Starting to generate numbers")
@@ -82,16 +95,32 @@ class MainWindow(ManagedWindow):
     def __init__(self):
         super().__init__(
             procedure_class=TestProcedure,
-            inputs=['iterations', 'delay', 'seed'],
-            displays=['iterations', 'delay', 'seed'],
+            inputs=['p_dutId', 'iterations', 'delay', 'seed',
+                    'param_set', 'param_1_1', 'param_2_1'],
+            displays=['p_dutId', 'iterations', 'delay', 'seed'],
             x_axis='Iteration',
-            y_axis='Random Number'
+            y_axis='Random Number',
+            enable_file_input=False
         )
         self.setWindowTitle('GUI Example')
 
+    def queue(self):
+        procedure = self.make_procedure()
+        filename = unique_filename('Result', prefix='rnd_{DUT ID}_{Random Seed}_',procedure=procedure)
+        procedure.data_filename = filename
+        results = Results(procedure, filename)
+        experiment = self.new_experiment(results)
+        self.manager.queue(experiment)
+
 
 if __name__ == "__main__":
+    # Fix for axis scaling (2 lines) https://github.com/pyqtgraph/pyqtgraph/issues/756
+    QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough) 
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app = QtWidgets.QApplication(sys.argv)
+    # Fix to handle numeric fields, decimal dot is used https://github.com/pymeasure/pymeasure/issues/602
+    QLocale.setDefault(QLocale(QLocale.English, QLocale.UnitedStates)) 
+
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/examples/Basic/gui_no_save_param.py
+++ b/examples/Basic/gui_no_save_param.py
@@ -36,10 +36,8 @@ python gui.py
 import sys
 import random
 from time import sleep
-from PyQt5.QtCore import QLocale
-from pyqtgraph.Qt import QtCore
 
-from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter, ListParameter, unique_filename, Metadata, Results
+from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
@@ -50,26 +48,15 @@ log.addHandler(logging.NullHandler())
 
 class TestProcedure(Procedure):
 
-    p_dutId = Parameter('DUT ID', default='NA', save=False)
     iterations = IntegerParameter('Loop Iterations', default=100)
-    delay = FloatParameter('Delay Time', units='s', default=0.02)
+    delay = FloatParameter('Delay Time', units='s', default=0.2)
     seed = Parameter('Random Seed', default='12345')
-    param_set = ListParameter('Paramters to set', choices=['None','Group 1','Group 2'], default='None', save=False)
-    # Parameter group 1
-    param_1_1 = IntegerParameter('Paramter 1.1', default=1, group_by={'param_set' : 'Group 1'})
-    # Parameter group 2
-    param_2_1 = IntegerParameter('Paramter 2.1', default=2, group_by={'param_set' : 'Group 2'})
 
-    # Metadata
-    m_dutId = Metadata('DUT_ID', default='')
-
-    # a list defining the order and appearance of columns in our data file
     DATA_COLUMNS = ['Iteration', 'Random Number']
 
     def startup(self):
         log.info("Setting up random number generator")
         random.seed(self.seed)
-        self.m_dutId = self.p_dutId
 
     def execute(self):
         log.info("Starting to generate numbers")
@@ -95,32 +82,16 @@ class MainWindow(ManagedWindow):
     def __init__(self):
         super().__init__(
             procedure_class=TestProcedure,
-            inputs=['p_dutId', 'iterations', 'delay', 'seed',
-                    'param_set', 'param_1_1', 'param_2_1'],
-            displays=['p_dutId', 'iterations', 'delay', 'seed'],
+            inputs=['iterations', 'delay', 'seed'],
+            displays=['iterations', 'delay', 'seed'],
             x_axis='Iteration',
-            y_axis='Random Number',
-            enable_file_input=False
+            y_axis='Random Number'
         )
         self.setWindowTitle('GUI Example')
 
-    def queue(self):
-        procedure = self.make_procedure()
-        filename = unique_filename('Result', prefix='rnd_{DUT ID}_{Random Seed}_',procedure=procedure)
-        procedure.data_filename = filename
-        results = Results(procedure, filename)
-        experiment = self.new_experiment(results)
-        self.manager.queue(experiment)
-
 
 if __name__ == "__main__":
-    # Fix for axis scaling (2 lines) https://github.com/pyqtgraph/pyqtgraph/issues/756
-    QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough) 
-    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app = QtWidgets.QApplication(sys.argv)
-    # Fix to handle numeric fields, decimal dot is used https://github.com/pymeasure/pymeasure/issues/602
-    QLocale.setDefault(QLocale(QLocale.English, QLocale.UnitedStates)) 
-
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/examples/Basic/gui_no_save_param.py
+++ b/examples/Basic/gui_no_save_param.py
@@ -1,0 +1,126 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""
+This example demonstrates how to make a graphical interface, and uses
+a random number generator to simulate data so that it does not require
+an instrument to use.
+
+Run the program by changing to the directory containing this file and calling:
+
+python gui.py
+
+"""
+
+import sys
+import random
+from time import sleep
+from PyQt5.QtCore import QLocale
+from pyqtgraph.Qt import QtCore
+
+from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter, ListParameter, unique_filename, Metadata, Results
+from pymeasure.display.Qt import QtWidgets
+from pymeasure.display.windows import ManagedWindow
+
+import logging
+log = logging.getLogger('')
+log.addHandler(logging.NullHandler())
+
+
+class TestProcedure(Procedure):
+
+    p_dutId = Parameter('DUT ID', default='NA', save=False)
+    iterations = IntegerParameter('Loop Iterations', default=100)
+    delay = FloatParameter('Delay Time', units='s', default=0.02)
+    seed = Parameter('Random Seed', default='12345')
+    param_set = ListParameter('Paramters to set', choices=['None','Group 1','Group 2'], default='None', save=False)
+    # Parameter group 1
+    param_1_1 = IntegerParameter('Paramter 1.1', default=1, group_by={'param_set' : 'Group 1'})
+    # Parameter group 2
+    param_2_1 = IntegerParameter('Paramter 2.1', default=2, group_by={'param_set' : 'Group 2'})
+
+    # Metadata
+    m_dutId = Metadata('DUT_ID', default='')
+
+    # a list defining the order and appearance of columns in our data file
+    DATA_COLUMNS = ['Iteration', 'Random Number']
+
+    def startup(self):
+        log.info("Setting up random number generator")
+        random.seed(self.seed)
+        self.m_dutId = self.p_dutId
+
+    def execute(self):
+        log.info("Starting to generate numbers")
+        for i in range(self.iterations):
+            data = {
+                'Iteration': i,
+                'Random Number': random.random()
+            }
+            log.debug("Produced numbers: %s" % data)
+            self.emit('results', data)
+            self.emit('progress', 100 * i / self.iterations)
+            sleep(self.delay)
+            if self.should_stop():
+                log.warning("Catch stop command in procedure")
+                break
+
+    def shutdown(self):
+        log.info("Finished")
+
+
+class MainWindow(ManagedWindow):
+
+    def __init__(self):
+        super().__init__(
+            procedure_class=TestProcedure,
+            inputs=['p_dutId', 'iterations', 'delay', 'seed',
+                    'param_set', 'param_1_1', 'param_2_1'],
+            displays=['p_dutId', 'iterations', 'delay', 'seed'],
+            x_axis='Iteration',
+            y_axis='Random Number',
+            enable_file_input=False
+        )
+        self.setWindowTitle('GUI Example')
+
+    def queue(self):
+        procedure = self.make_procedure()
+        filename = unique_filename('Result', prefix='rnd_{DUT ID}_{Random Seed}_',procedure=procedure)
+        procedure.data_filename = filename
+        results = Results(procedure, filename)
+        experiment = self.new_experiment(results)
+        self.manager.queue(experiment)
+
+
+if __name__ == "__main__":
+    # Fix for axis scaling (2 lines) https://github.com/pyqtgraph/pyqtgraph/issues/756
+    QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough) 
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+    app = QtWidgets.QApplication(sys.argv)
+    # Fix to handle numeric fields, decimal dot is used https://github.com/pymeasure/pymeasure/issues/602
+    QLocale.setDefault(QLocale(QLocale.English, QLocale.UnitedStates)) 
+
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())

--- a/pymeasure/display/widgets/inputs_widget.py
+++ b/pymeasure/display/widgets/inputs_widget.py
@@ -174,7 +174,8 @@ class InputsWidget(QtWidgets.QWidget):
     def set_parameters(self, parameter_objects):
         for name in self._inputs:
             element = getattr(self, name)
-            element.set_parameter(parameter_objects[name])
+            if parameter_objects[name].save:
+                element.set_parameter(parameter_objects[name])
 
     def get_procedure(self):
         """ Returns the current procedure """

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -44,7 +44,7 @@ class Parameter:
         this argument is ignored.
     """
 
-    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True):
+    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True, save=True):
         self.name = name
         self._value = None
         if default is not None:
@@ -52,6 +52,7 @@ class Parameter:
         self.default = default
         self.ui_class = ui_class
         self._help_fields = [('units are', 'units'), 'default']
+        self.save = save
 
         self.group_by = {}
         if isinstance(group_by, dict):

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -281,8 +281,9 @@ class Results:
         h.append("Procedure: <%s>" % procedure)
         h.append("Parameters:")
         for name, parameter in self.parameters.items():
-            h.append("\t{}: {}".format(parameter.name, str(
-                parameter).encode("unicode_escape").decode("utf-8")))
+            if parameter.save:
+                h.append("\t{}: {}".format(parameter.name, str(
+                    parameter).encode("unicode_escape").decode("utf-8")))
         h.append("Data:")
         self._header_count = len(h)
         h = [Results.COMMENT + line for line in h]  # Comment each line
@@ -383,13 +384,16 @@ class Results:
 
         # Fill the procedure with the parameters found
         for name, parameter in procedure.parameter_objects().items():
-            if parameter.name in parameters:
-                value = parameters[parameter.name]
-                setattr(procedure, name, value)
+            if parameter.save:
+                if parameter.name in parameters:
+                    value = parameters[parameter.name]
+                    setattr(procedure, name, value)
+                else:
+                    log.warning(
+                        f"Parameter \"{parameter.name}\" not found when loading " +
+                        f"'{procedure_class}', setting default value")
+                    setattr(procedure, name, parameter.default)
             else:
-                log.warning(
-                    f"Parameter \"{parameter.name}\" not found when loading " +
-                    f"'{procedure_class}', setting default value")
                 setattr(procedure, name, parameter.default)
 
         procedure.refresh_parameters()  # Enforce update of meta data


### PR DESCRIPTION
I'm new to this with GitHub, PR etc, so if I do it wrong, please advice me!
I've been using pymeasure several years with several local changes, so I will try to see if I can share some changes which I hope can be of benefit for others. 
First out is a feature that has been on my mind and when I saw the implementation of Metadata, I think it will make even more sense.

The idea is to have input parameters that are not saved as Parameters in the result files. I see at least two uses for this:
1. Some of my GUIs I've made have too many parameters to fit nicely on the screen, so I've used the 'group_by'-parameter. The parameter used to show the different groups needs not be saved.
2. An ID of the DUT that the user enters and should be saved as metadata, has I don't want the parameter to be overwritten if I load parameters from a file.

I've made a proposal in this PR to add a Boolean 'save' parameter to the Parameter class and an example. Maybe this is not the right way to go, I welcome better ideas!
