### PR TITLE
Support for numpy 2.0

### DIFF
--- a/.github/pymeasure_np2.yml
+++ b/.github/pymeasure_np2.yml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - cloudpickle=1.6.0
-  - pandas>=2.2.2
-#  - pint=0.18 a pint version that has not yet been released (>0.23) is required to work with numpy2
+#  - pandas>=2.2.2  # The version on conda-forge seems not be built with numpy==2, but the pip version has been
+#  - pint=0.18  # A pint version that has not yet been released (>0.23) is required to work with numpy2
   - pyqt=5.15.7
   - pyqtgraph=0.12.4
   - pyserial=3.4
@@ -25,4 +25,5 @@ dependencies:
   - pip  # don't pin, to gain newest conda compatibility fixes
   - pip:
       - numpy==2.0.0rc1
+      - pandas==2.2.2
       - -e git+https://github.com/hgrecco/pint.git#egg=pint

--- a/.github/pymeasure_np2.yml
+++ b/.github/pymeasure_np2.yml
@@ -1,0 +1,28 @@
+name: pymeasure_np2
+channels:
+  - conda-forge
+dependencies:
+  - cloudpickle=1.6.0
+  - pandas>=2.2.2
+#  - pint=0.18 a pint version that has not yet been released (>0.23) is required to work with numpy2
+  - pyqt=5.15.7
+  - pyqtgraph=0.12.4
+  - pyserial=3.4
+  - pyvisa=1.12.0
+  - pyzmq=24.0.1
+  - qt=5.15.6
+# Development dependencies below
+  - pytest-qt=4.2.0
+  - pytest-runner=5.2
+  - pytest=7.2.0
+  - pytest-cov=4.1.0
+  - pyvisa-sim==0.5.1
+  - flake8=6.0.0
+  - setuptools_scm # don't pin, to get newest features
+  - sphinx=5.3.0
+  - sphinx_rtd_theme=1.2.2
+#  pip is currently not needed, but the recommended tool when packages that are unavailable on conda are required
+  - pip  # don't pin, to gain newest conda compatibility fixes
+  - pip:
+      - numpy==2.0.0rc1
+      - -e git+https://github.com/hgrecco/pint.git#egg=pint

--- a/.github/pymeasure_numpy2.yml
+++ b/.github/pymeasure_numpy2.yml
@@ -1,4 +1,4 @@
-name: pymeasure_np2
+name: pymeasure_numpy2
 channels:
   - conda-forge
 dependencies:
@@ -26,4 +26,4 @@ dependencies:
   - pip:
       - numpy==2.0.0rc1
       - pandas==2.2.2
-      - -e git+https://github.com/hgrecco/pint.git#egg=pint
+      - git+https://github.com/hgrecco/pint.git#egg=pint

--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -127,7 +127,7 @@ jobs:
 
 
   test_numpy2:
-    name: Python ${{ matrix.python-version }} with numpy>=2
+    name: Python 3.11, ubuntu-latest, numpy>=2
     runs-on: "ubuntu-latest"
     defaults:
       run:
@@ -139,7 +139,7 @@ jobs:
       - name: Install pymeasure requirements
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: .github/pymeasure_np2.yml
+          environment-file: .github/pymeasure_numpy2.yml
           create-args: python=3.11
           cache-environment-key: py3.11-ubuntu-latest-mamba-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
           cache-downloads: false

--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -124,3 +124,33 @@ jobs:
         run: |
           echo "::add-matcher::.github/pytest.json"
           pytest
+
+
+  test_numpy2:
+    name: Python ${{ matrix.python-version }} with numpy>=2
+    runs-on: "ubuntu-latest"
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install pymeasure requirements
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: .github/pymeasure_np2.yml
+          create-args: python=3.11
+          cache-environment-key: py3.11-ubuntu-latest-mamba-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+          cache-downloads: false
+      - name: Python version
+        run: python --version
+      - name: Install Pymeasure
+        # If the pytest problem matcher stops working because of bad paths, do an editable install
+        run: pip install .[tests]
+      - name: Pymeasure version
+        run: python -c "import pymeasure;print(pymeasure.__version__)"
+      - name: Run pytest with xvfb
+        run: |
+          echo "::add-matcher::.github/pytest.json"
+          xvfb-run -a pytest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Upcoming version
 ================
 Main items of this new release:
-- Added support for numpy 2.0; limited the allowed numpy version to <3.
+- Added support for numpy 2.0.
 
 Added features
 - SCPI instruments have :code:`next_error` property giving the next error.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 Upcoming version
 ================
+Main items of this new release:
+- Added support for numpy 2.0; limited the allowed numpy version to <3.
 
 Added features
 - SCPI instruments have :code:`next_error` property giving the next error.
@@ -24,6 +26,7 @@ GUI
 Dropped Support
 ---------------
 - Instrument manufacturer modules are no longer imported in the :code:`pymeasure/instruments/__init__.py` file. Previously, when importing a single instrument into a procedure, all instruments would be imported into memory through the manufacturer modules in :code:`pymeasure/instruments/__init__.py`. Removing manufacturer modules from that file lowers the memory footprint of pymeasure when importing an instrument. Instrument classes will need to be imported from the manufacturer module or explicitly from the instrument driver file. For example, :code:`from pymeasure.instruments import Extreme5000` will need to change to :code:`from pymeasure.instruments.extreme import Extreme5000` or :code:`from pymeasure.instruments.extreme.extreme5000 import Extreme5000`.
+
 
 Version 0.13.1 (2023-10-05)
 ===========================

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -62,9 +62,3 @@ Execute the following Python code.
     pymeasure.__version__
 
 You should see the version of PyMeasure printed out. At this point you have PyMeasure installed, and you are ready to start using it! Are you ready to :doc:`connect to an instrument <./tutorial/connecting>`?
-
-.. warning::
-    The release of numpy version 2 caused some compatibility issues.
-    PyMeasure is compatible with version 2 as of PyMeasure version 0.14.
-    To use PyMeasure with numpy>=2, you also ensure the dependencies are compatible.
-    This means installing pandas>=2.2.2 and pint>0.23 (at the time of writing, pint needs to be installed directly from the github repository, as no numpy-2 compatible version has been released).

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -49,6 +49,7 @@ However, this needs a VISA implementation installed to handle device communicati
 If you do not already know what this means, install the pure-Python :code:`pyvisa-py` package (using the same installation you used above).
 If you want to know more, consult `the PyVISA documentation <https://pyvisa.readthedocs.io/en/latest/introduction/configuring.html>`__. 
 
+
 Checking the version
 --------------------
 
@@ -61,3 +62,9 @@ Execute the following Python code.
     pymeasure.__version__
 
 You should see the version of PyMeasure printed out. At this point you have PyMeasure installed, and you are ready to start using it! Are you ready to :doc:`connect to an instrument <./tutorial/connecting>`?
+
+.. warning::
+    The release of numpy version 2 caused some compatibility issues.
+    PyMeasure is compatible with version 2 as of PyMeasure version 0.14.
+    To use PyMeasure with numpy>=2, you also ensure the dependencies are compatible.
+    This means installing pandas>=2.2.2 and pint>0.23 (at the time of writing, pint needs to be installed directly from the github repository, as no numpy-2 compatible version has been released).

--- a/pymeasure/display/widgets/table_widget.py
+++ b/pymeasure/display/widgets/table_widget.py
@@ -23,7 +23,7 @@
 #
 
 import logging
-from numpy import float64, NaN
+from numpy import float64, nan
 from functools import partial
 import pyqtgraph as pg
 import pandas as pd
@@ -178,7 +178,7 @@ class PandasModelBase(QtCore.QAbstractTableModel):
                 # Cast to column type
                 value_render = column_type.type(value)
             except (IndexError, ValueError, TypeError):
-                value = NaN
+                value = nan
                 value_render = ""
             if isinstance(value_render, float64):
                 # limit maximum number of decimal digits displayed
@@ -297,7 +297,7 @@ class PandasModelBase(QtCore.QAbstractTableModel):
             df = None
         else:
             # Concatenate pandas data frames
-            df = pd.concat(df_list, axis=self.concat_axis).replace(to_replace=NaN, value="")
+            df = pd.concat(df_list, axis=self.concat_axis).replace(to_replace=nan, value="")
         return df
 
     def set_index(self, index):

--- a/pymeasure/display/widgets/table_widget.py
+++ b/pymeasure/display/widgets/table_widget.py
@@ -23,8 +23,9 @@
 #
 
 import logging
-from numpy import float64, nan
 from functools import partial
+
+import numpy as np
 import pyqtgraph as pg
 import pandas as pd
 
@@ -178,9 +179,9 @@ class PandasModelBase(QtCore.QAbstractTableModel):
                 # Cast to column type
                 value_render = column_type.type(value)
             except (IndexError, ValueError, TypeError):
-                value = nan
+                value = np.nan
                 value_render = ""
-            if isinstance(value_render, float64):
+            if isinstance(value_render, np.float64):
                 # limit maximum number of decimal digits displayed
                 value_render = f"{value_render:.{self.float_digits:d}g}"
 
@@ -297,7 +298,7 @@ class PandasModelBase(QtCore.QAbstractTableModel):
             df = None
         else:
             # Concatenate pandas data frames
-            df = pd.concat(df_list, axis=self.concat_axis).replace(to_replace=nan, value="")
+            df = pd.concat(df_list, axis=self.concat_axis).replace(to_replace=np.nan, value="")
         return df
 
     def set_index(self, index):

--- a/pymeasure/experiment/sequencer.py
+++ b/pymeasure/experiment/sequencer.py
@@ -24,8 +24,9 @@
 
 import logging
 import re
-import numpy
 from itertools import product
+
+import numpy as np
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -101,35 +102,35 @@ class SequenceHandler:
         'range': range,
         'sorted': sorted,
         'list': list,
-        'arange': numpy.arange,
-        'linspace': numpy.linspace,
-        'arccos': numpy.arccos,
-        'arcsin': numpy.arcsin,
-        'arctan': numpy.arctan,
-        'arctan2': numpy.arctan2,
-        'ceil': numpy.ceil,
-        'cos': numpy.cos,
-        'cosh': numpy.cosh,
-        'degrees': numpy.degrees,
-        'e': numpy.e,
-        'exp': numpy.exp,
-        'fabs': numpy.fabs,
-        'floor': numpy.floor,
-        'fmod': numpy.fmod,
-        'frexp': numpy.frexp,
-        'hypot': numpy.hypot,
-        'ldexp': numpy.ldexp,
-        'log': numpy.log,
-        'log10': numpy.log10,
-        'modf': numpy.modf,
-        'pi': numpy.pi,
-        'power': numpy.power,
-        'radians': numpy.radians,
-        'sin': numpy.sin,
-        'sinh': numpy.sinh,
-        'sqrt': numpy.sqrt,
-        'tan': numpy.tan,
-        'tanh': numpy.tanh,
+        'arange': np.arange,
+        'linspace': np.linspace,
+        'arccos': np.arccos,
+        'arcsin': np.arcsin,
+        'arctan': np.arctan,
+        'arctan2': np.arctan2,
+        'ceil': np.ceil,
+        'cos': np.cos,
+        'cosh': np.cosh,
+        'degrees': np.degrees,
+        'e': np.e,
+        'exp': np.exp,
+        'fabs': np.fabs,
+        'floor': np.floor,
+        'fmod': np.fmod,
+        'frexp': np.frexp,
+        'hypot': np.hypot,
+        'ldexp': np.ldexp,
+        'log': np.log,
+        'log10': np.log10,
+        'modf': np.modf,
+        'pi': np.pi,
+        'power': np.power,
+        'radians': np.radians,
+        'sin': np.sin,
+        'sinh': np.sinh,
+        'sqrt': np.sqrt,
+        'tan': np.tan,
+        'tanh': np.tanh,
     }
 
     def __init__(self, valid_inputs=(), file_obj=None):
@@ -185,7 +186,7 @@ class SequenceHandler:
                           "for parameter '{}', depth {}".format(name, depth))
             raise SequenceEvaluationError("No sequence entered")
 
-        evaluated_string = numpy.array(evaluated_string)
+        evaluated_string = np.array(evaluated_string)
         return evaluated_string
 
     def _get_idx(self, seq_item):

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -26,7 +26,8 @@ from pymeasure.instruments import Instrument, SCPIUnknownMixin
 from pymeasure.instruments.validators import strict_range
 
 from time import sleep
-from numpy import linspace
+
+import numpy as np
 
 
 class SM7045D(SCPIUnknownMixin, Instrument):
@@ -124,7 +125,7 @@ class SM7045D(SCPIUnknownMixin, Instrument):
 
         curr = self.current
         n = round(abs(curr - target_current) / current_step) + 1
-        for i in linspace(curr, target_current, n):
+        for i in np.linspace(curr, target_current, n):
             self.current = i
             sleep(0.1)
 

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -24,8 +24,9 @@
 
 from pymeasure.instruments import Instrument, SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set
-from numpy import array, float64
 from time import sleep
+
+import numpy as np
 
 
 class FWBell5080(SCPIMixin, Instrument):
@@ -127,7 +128,7 @@ class FWBell5080(SCPIMixin, Instrument):
             raise Exception("F.W. Bell 5080 does not support samples less than 1.")
         else:
             data = [self.field for i in range(int(samples))]
-            return array(data, dtype=float64)
+            return np.array(data, dtype=np.float64)
 
     def auto_range(self):
         """ Enables the auto range functionality. """

--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -25,8 +25,9 @@
 import logging
 from math import log10
 from enum import Enum, IntFlag
-from numpy import arange
 from datetime import datetime
+
+import numpy as np
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set, truncated_discrete_set, \
@@ -725,7 +726,7 @@ class HP856Xx(Instrument):
 
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
-        values=[["AUTO", "MAN"], arange(10, 80, 10)],
+        values=[["AUTO", "MAN"], np.arange(10, 80, 10)],
         cast=int,
     )
 
@@ -2035,7 +2036,7 @@ class HP856Xx(Instrument):
                 pbw = instr.power_bandwidth(Trace.A, 99.0)
                 print("The power bandwidth at 99 percent is %f kHz" % (pbw / 1e3))
         """
-        ran = arange(0, 100, 0.1)
+        ran = np.arange(0, 100, 0.1)
 
         if not isinstance(trace, str):
             raise TypeError("Should be of type string but is '%s'" % type(trace))
@@ -2064,7 +2065,7 @@ class HP856Xx(Instrument):
         Type: :code:`str, dec`
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
-        values=[["AUTO", "MAN"], arange(10, 2e6)],
+        values=[["AUTO", "MAN"], np.arange(10, 2e6)],
         set_process=lambda v: v if isinstance(v, str) else f"{int(v)} Hz",
         get_process=lambda v: v if isinstance(v, str) else int(v)
     )
@@ -2078,7 +2079,7 @@ class HP856Xx(Instrument):
         parameters adjust the ratio in a 1, 2, 5 sequence. The default ratio is 0.011.
         """,
         validator=strict_range,
-        values=arange(0.002, 0.10, 0.001)
+        values=np.arange(0.002, 0.10, 0.001)
     )
 
     def recall_open_short_average(self):
@@ -2450,7 +2451,7 @@ class HP856Xx(Instrument):
         cannot be adjusted.
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[["AUTO", "MAN"], arange(50E-6, 100)],
+        values=[["AUTO", "MAN"], np.arange(50E-6, 100)],
         set_process=lambda v: v if isinstance(v, str) else ("%.3f S" % v)
     )
 
@@ -2563,7 +2564,7 @@ class HP856Xx(Instrument):
             trace data, the data below the threshold will be permanently lost.
         """,
         validator=strict_discrete_set,
-        values=arange(-200, 30),
+        values=np.arange(-200, 30),
     )
 
     threshold_enabled = Instrument.setting(
@@ -2745,7 +2746,7 @@ class HP856Xx(Instrument):
         Type: :code:`str, int`
         """,
         validator=strict_range,
-        values=arange(1, 999),
+        values=np.arange(1, 999),
         cast=int
     )
 
@@ -2779,7 +2780,7 @@ class HP856Xx(Instrument):
         Type: :code:`int`
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[["AUTO", "MAN"], arange(1, 3e6)],
+        values=[["AUTO", "MAN"], np.arange(1, 3e6)],
         cast=int,
         set_process=lambda v: v if isinstance(v, str) else f"{v} Hz"
     )
@@ -2794,7 +2795,7 @@ class HP856Xx(Instrument):
         new ratio—the resolution bandwidth does not change value.
         """,
         validator=strict_range,
-        values=arange(0.002, 0.10, 0.001)
+        values=np.arange(0.002, 0.10, 0.001)
     )
 
     def view_trace(self, trace):
@@ -2962,7 +2963,7 @@ class HP8560A(HP856Xx):
             Only available with an HP 8560A Option 002.
         """,
         validator=strict_range,
-        values=arange(0.1, 12.75, 0.05)
+        values=np.arange(0.1, 12.75, 0.05)
     )
 
     source_power_sweep = Instrument.control(
@@ -2979,7 +2980,7 @@ class HP8560A(HP856Xx):
             Only available with an HP 8560A Option 002.
         """,
         validator=truncated_discrete_set,
-        values=arange(0.1, 12.75, 0.05),
+        values=np.arange(0.1, 12.75, 0.05),
     )
 
     source_power_sweep_enabled = Instrument.setting(
@@ -3003,7 +3004,7 @@ class HP8560A(HP856Xx):
             Only available with an HP 8560A Option 002.
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
-        values=[["OFF", "ON"], arange(-10, 2.8, 0.05)],
+        values=[["OFF", "ON"], np.arange(-10, 2.8, 0.05)],
         set_process=lambda v: v if isinstance(v, str) else ("%.2f {amplitude_unit}" % v)
     )
 

--- a/pymeasure/instruments/oxfordinstruments/itc503.py
+++ b/pymeasure/instruments/oxfordinstruments/itc503.py
@@ -25,8 +25,9 @@
 
 import logging
 from time import sleep, time
-import numpy
 from enum import IntFlag
+
+import numpy as np
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set, \
@@ -514,34 +515,34 @@ class ITC503(OxfordInstrumentsBase):
         self.sweep_status = 0
 
         # Convert input np.ndarrays
-        temperatures = numpy.array(temperatures, ndmin=1)
-        sweep_time = numpy.array(sweep_time, ndmin=1)
-        hold_time = numpy.array(hold_time, ndmin=1)
+        temperatures = np.array(temperatures, ndmin=1)
+        sweep_time = np.array(sweep_time, ndmin=1)
+        hold_time = np.array(hold_time, ndmin=1)
 
         # Make steps array
         if steps is None:
             steps = temperatures.size
-        steps = numpy.linspace(1, steps, steps)
+        steps = np.linspace(1, steps, steps)
 
         # Create interpolated arrays
-        interpolator = numpy.round(
-            numpy.linspace(1, steps.size, temperatures.size))
-        temperatures = numpy.interp(steps, interpolator, temperatures)
+        interpolator = np.round(
+            np.linspace(1, steps.size, temperatures.size))
+        temperatures = np.interp(steps, interpolator, temperatures)
 
-        interpolator = numpy.round(
-            numpy.linspace(1, steps.size, sweep_time.size))
-        sweep_time = numpy.interp(steps, interpolator, sweep_time)
+        interpolator = np.round(
+            np.linspace(1, steps.size, sweep_time.size))
+        sweep_time = np.interp(steps, interpolator, sweep_time)
 
-        interpolator = numpy.round(
-            numpy.linspace(1, steps.size, hold_time.size))
-        hold_time = numpy.interp(steps, interpolator, hold_time)
+        interpolator = np.round(
+            np.linspace(1, steps.size, hold_time.size))
+        hold_time = np.interp(steps, interpolator, hold_time)
 
         # Pad with zeros to wipe unused steps (total 16) of the sweep program
         padding = 16 - temperatures.size
-        temperatures = numpy.pad(temperatures, (0, padding), 'constant',
+        temperatures = np.pad(temperatures, (0, padding), 'constant',
                                  constant_values=temperatures[-1])
-        sweep_time = numpy.pad(sweep_time, (0, padding), 'constant')
-        hold_time = numpy.pad(hold_time, (0, padding), 'constant')
+        sweep_time = np.pad(sweep_time, (0, padding), 'constant')
+        hold_time = np.pad(hold_time, (0, padding), 'constant')
 
         # Setting the arrays to the controller
         for line, (setpoint, sweep, hold) in \

--- a/pymeasure/instruments/oxfordinstruments/itc503.py
+++ b/pymeasure/instruments/oxfordinstruments/itc503.py
@@ -35,7 +35,6 @@ from pymeasure.instruments.validators import strict_discrete_set, \
 
 from .base import OxfordInstrumentsBase
 
-
 # Setup logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -540,7 +539,7 @@ class ITC503(OxfordInstrumentsBase):
         # Pad with zeros to wipe unused steps (total 16) of the sweep program
         padding = 16 - temperatures.size
         temperatures = np.pad(temperatures, (0, padding), 'constant',
-                                 constant_values=temperatures[-1])
+                              constant_values=temperatures[-1])
         sweep_time = np.pad(sweep_time, (0, padding), 'constant')
         hold_time = np.pad(hold_time, (0, padding), 'constant')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     numpy >= 1.6.1, < 3
     pandas >= 0.14, < 3
     pint
-    pyvisa >= 1.8
+    pyvisa >= 1.9
     pyserial >= 2.7
     pyqtgraph >= 0.12
     importlib-metadata; python_version<"3.8"
@@ -42,7 +42,7 @@ tcp =
     cloudpickle>=0.3.1
 python-vxi11 = python-vxi11>=0.9
 tests =
-    pytest >= 2.9.1
+    pytest >= 3.3.0
     pytest-cov >= 4.1.0
     pytest-qt >= 2.4.0  # install pyqt or pyside manually as desired
     pyvisa-sim >= 0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     numpy >= 1.6.1, < 3
-    pandas >= 0.14
+    pandas >= 0.25.3, < 3
     pint
     pyvisa >= 1.8
     pyserial >= 2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    numpy >= 1.6.1
+    numpy >= 1.6.1, < 3
     pandas >= 0.14
     pint
     pyvisa >= 1.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     numpy >= 1.6.1, < 3
-    pandas >= 0.25.3, < 3
+    pandas >= 0.14, < 3
     pint
     pyvisa >= 1.8
     pyserial >= 2.7


### PR DESCRIPTION
Numpy 2.0 will soon (few months) be released with some (minor) breaking changes.

This PR fixes the things that break between numpy 1.x and 2.x (while keeping it compatible with both, assuming this is possible).

Also, I've tried standardizing the numpy imports a bit, such that all numpy imports in the repo read `import numpy as np`.