### PR TITLE
Rework Keithleys' next_error

### DIFF
--- a/pymeasure/instruments/keithley/keithley2260B.py
+++ b/pymeasure/instruments/keithley/keithley2260B.py
@@ -25,8 +25,8 @@
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
-import time
 import logging
+from warnings import warn
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -115,6 +115,12 @@ class Keithley2260B(Instrument):
     )
 
     @property
+    def error(self):
+        """Get the next error of the instrument (list of code and message)."""
+        warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
+        return self.next_error
+
+    @property
     def enabled(self):
         """Control whether the output is enabled, see :attr:`output_enabled`."""
         log.warning('Deprecated property name "enabled", use the identical "output_enabled", '
@@ -126,30 +132,6 @@ class Keithley2260B(Instrument):
         log.warning('Deprecated property name "enabled", use the identical "output_enabled", '
                     'instead.', FutureWarning)
         self.output_enabled = value
-
-    @property
-    def next_error(self):
-        """ Get a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', "")
-        return (code, message)
-
-    error = next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 2260B reported error: %d, %s" % (code, message))
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 2260B error retrieval.")
 
     def shutdown(self):
         """ Disable output, call parent function"""

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -511,31 +511,9 @@ class Keithley2400(KeithleyBuffer, Instrument):
     )
 
     @property
-    def next_error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', '')
-        return (code, message)
-
-    @property
     def error(self):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 2400 reported error: %d, %s" % (code, message))
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 2400 error retrieval.")
 
     def reset(self):
         """ Resets the instrument and clears the queue.  """

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -498,31 +498,9 @@ class Keithley2450(KeithleyBuffer, Instrument):
         self.beep(base_frequency * 6.0 / 4.0, duration)
 
     @property
-    def next_error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', '')
-        return (code, message)
-
-    @property
     def error(self):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 2450 reported error: %d, %s", code, message)
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 2450 error retrieval.")
 
     def reset(self):
         """ Resets the instrument and clears the queue.  """

--- a/pymeasure/instruments/keithley/keithley2600.py
+++ b/pymeasure/instruments/keithley/keithley2600.py
@@ -69,17 +69,6 @@ class Keithley2600(Instrument):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
 
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 2600 reported error: %d, %s" % (code, message))
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 2600 error retrieval.")
-
 
 class Channel:
 

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -281,32 +281,9 @@ class Keithley2700(KeithleyBuffer, Instrument):
         self.beep(base_frequency * 6.0 / 4.0, duration)
 
     @property
-    def next_error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', '')
-        return (code, message)
-
-    @property
     def error(self):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 2700 reported error: %d, %s" % (code, message))
-            print(code, message)
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 2700 error retrieval.")
 
     def reset(self):
         """ Resets the instrument and clears the queue.  """

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -330,31 +330,9 @@ class Keithley6221(KeithleyBuffer, Instrument):
     )
 
     @property
-    def next_error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', '')
-        return (code, message)
-
-    @property
     def error(self):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 6221 reported error: %d, %s" % (code, message))
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 6221 error retrieval.")
 
     def reset(self):
         """ Resets the instrument and clears the queue.  """

--- a/pymeasure/instruments/keithley/keithley6517b.py
+++ b/pymeasure/instruments/keithley/keithley6517b.py
@@ -282,31 +282,9 @@ class Keithley6517B(KeithleyBuffer, Instrument):
         self.check_errors()
 
     @property
-    def next_error(self):
-        """ Returns a tuple of an error code and message from a
-        single error. """
-        err = super().next_error
-        if len(err) < 2:
-            err = self.read()  # Try reading again
-        code = err[0]
-        message = err[1].replace('"', '')
-        return (code, message)
-
-    @property
     def error(self):
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
-
-    def check_errors(self):
-        """ Logs any system errors reported by the instrument.
-        """
-        code, message = self.next_error
-        while code != 0:
-            t = time.time()
-            log.info("Keithley 6517B reported error: %d, %s", code, message)
-            code, message = self.next_error
-            if (time.time() - t) > 10:
-                log.warning("Timed out for Keithley 6517B error retrieval.")
 
     def reset(self):
         """ Resets the instrument and clears the queue.  """

--- a/tests/instruments/keithley/test_keithley2400.py
+++ b/tests/instruments/keithley/test_keithley2400.py
@@ -39,7 +39,7 @@ def test_next_error():
     with expected_protocol(Keithley2400,
                            [("SYST:ERR?", '-113, "Undefined header"')],
                            ) as inst:
-        assert inst.next_error == (-113, " Undefined header")
+        assert inst.next_error == [-113, ' "Undefined header"']
 
 
 def test_enable_source():


### PR DESCRIPTION
Address #1027

I think some initial code was developed a long time ago and then copied in all subsequent drivers.

This PR removes exception for `check_errors` method, aligning error logging to the main method.
In addition to this, it removes also customisation of `next_error`, since this is standard SCPI.
The changes have been tested in Keithley2400 class using Keithley 2420 connected via GPIB.
