### PR TITLE
add MKS 974B vacuum pressure transducer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Deprecated features
 - Replaced :code:`error` property of Keithley instruments by :code:`next_error`.
 - Replaced :code:`measurement_time` property of Pendulum CNT-91 by :code:`gate_time`.
 - Replaced :code:`sample_rate` keyword-argument of :code:`buffer_frequency_time_series` of Pendulum CNT-91 by :code:`gate_time`.
+- The property :code:`unit` of MKS937B switched to using values defined in :code:`instruments/mksinst/mks937b/Unit`. Old string values are not supported anymore. (@dkriegner, @BenediktBurger #1034)
 
 GUI
 ---

--- a/docs/api/instruments/mksinst/index.rst
+++ b/docs/api/instruments/mksinst/index.rst
@@ -9,4 +9,6 @@ This section contains specific documentation on the MKS Instruments devices that
 .. toctree::
    :maxdepth: 2
 
+   mksinst
    mks937b
+   mks974b

--- a/docs/api/instruments/mksinst/mks937b.rst
+++ b/docs/api/instruments/mksinst/mks937b.rst
@@ -13,3 +13,7 @@ MKS Instruments 937B Vacuum Gauge Controller
 .. autoclass:: pymeasure.instruments.mksinst.mks937b.PressureChannel
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.mksinst.mks937b.Relay
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/mksinst/mks974b.rst
+++ b/docs/api/instruments/mksinst/mks974b.rst
@@ -6,6 +6,6 @@ MKS Instruments 974B Vacuum Pressure Transducer
     :members:
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.mksinst.mks974b.SetpointChannel
+.. autoclass:: pymeasure.instruments.mksinst.mks974b.Relay
     :members:
     :show-inheritance:

--- a/docs/api/instruments/mksinst/mks974b.rst
+++ b/docs/api/instruments/mksinst/mks974b.rst
@@ -1,0 +1,11 @@
+###############################################
+MKS Instruments 974B Vacuum Pressure Transducer
+###############################################
+
+.. autoclass:: pymeasure.instruments.mksinst.mks974b.MKS974B
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.mksinst.mks974b.SetpointChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/mksinst/mksinst.rst
+++ b/docs/api/instruments/mksinst/mksinst.rst
@@ -1,0 +1,7 @@
+###################################
+MKS Instruments abstract Instrument
+###################################
+
+.. autoclass:: pymeasure.instruments.mksinst.mksinst.MKSInstrument
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/mksinst/mksinst.rst
+++ b/docs/api/instruments/mksinst/mksinst.rst
@@ -1,5 +1,5 @@
 ###################################
-MKS Instruments abstract Instrument
+MKS Instruments Abstract Instrument
 ###################################
 
 .. autoclass:: pymeasure.instruments.mksinst.mksinst.MKSInstrument

--- a/docs/api/instruments/mksinst/mksinst.rst
+++ b/docs/api/instruments/mksinst/mksinst.rst
@@ -5,3 +5,7 @@ MKS Instruments Abstract Instrument
 .. autoclass:: pymeasure.instruments.mksinst.mksinst.MKSInstrument
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.mksinst.mksinst.RelayChannel
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/keithley/keithley2306.py
+++ b/pymeasure/instruments/keithley/keithley2306.py
@@ -659,7 +659,7 @@ class Keithley2306(Instrument):
 
         :param: relay_number:
             int: the number of the relay to be selected
-        :type: :class:`.Relay`
+        :type: :class:`~Relay`
 
         """
         if relay_number == 1:

--- a/pymeasure/instruments/mksinst/__init__.py
+++ b/pymeasure/instruments/mksinst/__init__.py
@@ -22,4 +22,6 @@
 # THE SOFTWARE.
 #
 
+from .mksinst import MKSInstrument
 from .mks937b import MKS937B
+from .mks974b import MKS974B

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -26,7 +26,7 @@ from enum import StrEnum
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
-from .mksinst import MKSInstrument
+from .mksinst import MKSInstrument, RelayChannel
 
 
 _ion_gauge_status = {"Wait": "W",
@@ -48,6 +48,24 @@ class Unit(StrEnum):
     mbar = "mBAR"
     Pa = "PASCAL"
     uHg = "MICRON"
+
+
+class Relay(RelayChannel):
+
+    enabled = Channel.control(
+        "EN{ch}?", "EN{ch}!%s",
+        """Control the relay function or disable the setpoint relay.
+
+        Possible values are True/False to enable/disable pressure based
+        activation of the relay and 'SET' to permanently energize the relay.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: "CLEAR",
+                True: "ENABLE",
+                "SET": "SET",
+                },
+        check_set_errors=True,
+    )
 
 
 class PressureChannel(Channel):
@@ -80,13 +98,13 @@ class MKS937B(MKSInstrument):
     """ MKS 937B vacuum gauge controller
 
     Connection to the device is made through an RS232/RS485 serial connection.
-    The communication protocol of this device is as follows:
 
-    Query: '@<aaa><Command>?;FF' with the response '@<aaa>ACK<Response>;FF'
-    Set command: '@<aaa><Command>!<parameter>;FF' with the response '@<aaa>ACK<Response>;FF'
-    Above <aaa> is an address from 001 to 254 which can be specified upon
-    initialization. Since ';FF' is not supported by pyvisa as terminator this
-    class overloads the device communication methods.
+    The 937B gauge controller can connect up to 6 pressure measurement channels
+    for gauges of various types which includes ionization gauges, Pirani and
+    piezo gauges. Based on the pressure values of the gauges twelve setpoint
+    relays can be energized when certain pressure values are reached. The
+    assignment of the relays to measurement channels is fixed to have two
+    relays for each pressure channel.
 
     :param adapter: pyvisa resource name of the instrument or adapter instance
     :param string name: The name of the instrument.
@@ -107,6 +125,30 @@ class MKS937B(MKSInstrument):
     ch_5 = Instrument.ChannelCreator(IonGaugeAndPressureChannel, 5)
 
     ch_6 = Instrument.ChannelCreator(PressureChannel, 6)
+
+    relay_1 = Instrument.ChannelCreator(Relay, 1)
+
+    relay_2 = Instrument.ChannelCreator(Relay, 2)
+
+    relay_3 = Instrument.ChannelCreator(Relay, 3)
+
+    relay_4 = Instrument.ChannelCreator(Relay, 4)
+
+    relay_5 = Instrument.ChannelCreator(Relay, 5)
+
+    relay_6 = Instrument.ChannelCreator(Relay, 6)
+
+    relay_7 = Instrument.ChannelCreator(Relay, 7)
+
+    relay_8 = Instrument.ChannelCreator(Relay, 8)
+
+    relay_9 = Instrument.ChannelCreator(Relay, 9)
+
+    relay_10 = Instrument.ChannelCreator(Relay, 10)
+
+    relay_11 = Instrument.ChannelCreator(Relay, 11)
+
+    relay_12 = Instrument.ChannelCreator(Relay, 12)
 
     def __init__(self, adapter, name="MKS 937B vacuum gauge controller", address=253, **kwargs):
         super().__init__(

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -192,6 +192,11 @@ class MKS937B(MKSInstrument):
         Unit.uHg/'Micron'.""",
         validator=strict_discrete_set,
         map_values=True,
-        values={u: u.value for u in Unit},
+        values={"Torr": "TORR",
+                "mBar": "mBAR",
+                "Pascal": "PASCAL",
+                "Micron": "MICRON",
+                **{u: u.value for u in Unit},
+                },
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from enum import StrEnum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
@@ -40,6 +41,13 @@ _ion_gauge_status = {"Wait": "W",
                      "NOT_IONGAUGE": "NAK152",
                      "INVALID COMMAND": "NAK160",
                      }
+
+
+class Unit(StrEnum):
+    Torr = "TORR"
+    mbar = "mBAR"
+    Pa = "PASCAL"
+    uHg = "MICRON"
 
 
 class PressureChannel(Channel):
@@ -127,13 +135,11 @@ class MKS937B(MKSInstrument):
 
     unit = Instrument.control(
         "U?", "U!%s",
-        """Control pressure unit used for all pressure readings from the instrument""",
+        """Control pressure unit used for all pressure readings from the instrument.
+
+        Allowed units are Unit.Torr, Unit.mbar, Unit.Pa, Unit.uHg""",
         validator=strict_discrete_set,
         map_values=True,
-        values={"Torr": "TORR",
-                "mBar": "mBAR",
-                "Pascal": "PASCAL",
-                "Micron": "MICRON",
-                },
+        values={u: u.value for u in Unit},
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -35,6 +35,7 @@ except ImportError:
 
     class StrEnum(str, Enum):
         """Until StrEnum is broadly available from the standard library"""
+        # Python>3.10 remove it
 
 
 _ion_gauge_status = {"Wait": "W",

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -188,15 +188,9 @@ class MKS937B(MKSInstrument):
         "U?", "U!%s",
         """Control pressure unit used for all pressure readings from the instrument.
 
-        Allowed units are Unit.Torr/'Torr', Unit.mbar/'mBar', Unit.Pa/'Pascal',
-        Unit.uHg/'Micron'.""",
+        Allowed units are Unit.Torr, Unit.mbar, Unit.Pa, Unit.uHg.""",
         validator=strict_discrete_set,
         map_values=True,
-        values={"Torr": "TORR",
-                "mBar": "mBAR",
-                "Pascal": "PASCAL",
-                "Micron": "MICRON",
-                **{u: u.value for u in Unit},
-                },
+        values={u: u.value for u in Unit},
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from enum import StrEnum
+from enum import Enum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
@@ -43,7 +43,7 @@ _ion_gauge_status = {"Wait": "W",
                      }
 
 
-class Unit(StrEnum):
+class Unit(Enum):
     Torr = "TORR"
     mbar = "mBAR"
     Pa = "PASCAL"

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -179,9 +179,15 @@ class MKS937B(MKSInstrument):
         "U?", "U!%s",
         """Control pressure unit used for all pressure readings from the instrument.
 
-        Allowed units are Unit.Torr, Unit.mbar, Unit.Pa, Unit.uHg""",
+        Allowed units are Unit.Torr/'Torr', Unit.mbar/'mBar', Unit.Pa/'Pascal',
+        Unit.uHg/'Micron'.""",
         validator=strict_discrete_set,
         map_values=True,
-        values={u: u.value for u in Unit},
+        values={**{u: u.value for u in Unit},
+                "Torr": "TORR",
+                "mBar": "mBAR",
+                "Pascal": "PASCAL",
+                "Micron": "MICRON",
+                },
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -21,12 +21,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from enum import Enum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
 from .mksinst import MKSInstrument, RelayChannel
+
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Until StrEnum is broadly available from the standard library"""
 
 
 _ion_gauge_status = {"Wait": "W",
@@ -43,7 +51,7 @@ _ion_gauge_status = {"Wait": "W",
                      }
 
 
-class Unit(Enum):
+class Unit(StrEnum):
     Torr = "TORR"
     mbar = "mBAR"
     Pa = "PASCAL"
@@ -184,10 +192,7 @@ class MKS937B(MKSInstrument):
         validator=strict_discrete_set,
         map_values=True,
         values={**{u: u.value for u in Unit},
-                "Torr": "TORR",
                 "mBar": "mBAR",
-                "Pascal": "PASCAL",
-                "Micron": "MICRON",
                 },
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -191,8 +191,6 @@ class MKS937B(MKSInstrument):
         Unit.uHg/'Micron'.""",
         validator=strict_discrete_set,
         map_values=True,
-        values={**{u: u.value for u in Unit},
-                "mBar": "mBAR",
-                },
+        values={u: u.value for u in Unit},
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from enum import StrEnum
+from enum import Enum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
@@ -29,7 +29,7 @@ from pymeasure.instruments.validators import strict_discrete_set
 from .mksinst import MKSInstrument, RelayChannel
 
 
-class Unit(StrEnum):
+class Unit(Enum):
     Torr = "TORR"
     mbar = "MBAR"
     Pa = "PASCAL"

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -35,6 +35,7 @@ except ImportError:
 
     class StrEnum(str, Enum):
         """Until StrEnum is broadly available from the standard library"""
+        # Python>3.10 remove it.
 
 
 class Unit(StrEnum):

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -167,7 +167,7 @@ class MKS974B(MKSInstrument):
 
         Allowed units are Unit.Torr, Unit.mbar, Unit.Pa.""",
         validator=strict_discrete_set,
-        map_values = True,
+        map_values=True,
         values={u: u.value for u in Unit},
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -21,7 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-from enum import Enum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
@@ -29,7 +28,16 @@ from pymeasure.instruments.validators import strict_discrete_set
 from .mksinst import MKSInstrument, RelayChannel
 
 
-class Unit(Enum):
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Until StrEnum is broadly available from the standard library"""
+
+
+class Unit(StrEnum):
     Torr = "TORR"
     mbar = "MBAR"
     Pa = "PASCAL"

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -21,11 +21,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from enum import StrEnum
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.instruments.validators import strict_discrete_set
 
 from .mksinst import MKSInstrument
+
+
+class Unit(StrEnum):
+    Torr = "TORR"
+    mbar = "MBAR"
+    Pa = "PASCAL"
 
 
 class RelayChannel(Channel):
@@ -68,7 +75,7 @@ class RelayChannel(Channel):
         check_set_errors=True,
     )
 
-    enable = Channel.control(
+    enabled = Channel.control(
         "EN{ch}?", "EN{ch}!%s",
         """Control the assigned input channel or disable the setpoint relay.""",
         validator=strict_discrete_set,
@@ -196,13 +203,12 @@ class MKS974B(MKSInstrument):
 
     unit = Instrument.control(
         "U?", "U!%s",
-        """Control pressure unit used for all pressure readings from the instrument""",
+        """Control pressure unit used for all pressure readings from the instrument.
+
+        Allowed units are Unit.Torr, Unit.mbar, Unit.Pa.""",
         validator=strict_discrete_set,
-        map_values=True,
-        values={"Torr": "TORR",
-                "mBar": "MBAR",
-                "Pascal": "PASCAL",
-                },
+        map_values = True,
+        values={u: u.value for u in Unit},
         check_set_errors=True,
     )
 

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -1,0 +1,214 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Channel, Instrument
+from pymeasure.instruments.validators import strict_discrete_set
+
+from .mksinst import MKSInstrument
+
+
+class SetpointChannel(Channel):
+    """
+    Settings of the optionally included setpoint relays.
+    
+    Note that 974B transducer has an auto hysteresis setting of 10% of the setpoint value that
+    overwrites the current reset value whenever the setpoint value or setpoint
+    direction is changed. If other hysteresis value than 10% is required, first set the
+    setpoint value and setpoint direction before setting the reset value.
+    """
+    status = Channel.measurement(
+        "SS{ch}?",
+        """Get the setpoint relay status""",
+        values={True: "SET", False: "CLEAR"},
+    )
+
+    value = Channel.control(
+        "SP{ch}?", "SP{ch}!%s",
+        """Control the relay switch value. The setpoint value is the pressure either below or above which the setpoint relay will be energized.""",
+        check_set_errors=True,
+    )
+
+    reset_value = Channel.control(
+        "SH{ch}?", "SH{ch}!%s",
+        """Control the relay switch off value. The reset value is the pressure value at which the setpoint relay will be de-energized.""",
+        check_set_errors=True,
+    )
+
+    direction = Channel.control(
+        "SD{ch}?", "SD{ch}!%s",
+        """Get the setpoint relay status""",
+        validator=strict_discrete_set,
+        values=["ABOVE", "BELOW"],
+        check_set_errors=True,
+    )
+    
+    enable = Channel.control(
+        "EN{ch}?", "EN{ch}!%s",
+        """Control the assigned input channel or disable the setpoint relay.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: "OFF",
+                "combined": "CMB",
+                "pirani": "PIR",
+                "piezo": "PZ",
+                "cold cathode": "CC",
+                },
+        check_set_errors=True,
+    )
+    
+
+class MKS974B(MKSInstrument):
+    """ MKS 974B vacuum pressure transducer
+
+    Connection to the device is made through an RS232/RS485 serial connection.
+    The communication protocol of this device is as follows:
+
+    Query: '@<aaa><Command>?;FF' with the response '@<aaa>ACK<Response>;FF'
+    Set command: '@<aaa><Command>!<parameter>;FF' with the response '@<aaa>ACK<Response>;FF'
+    Above <aaa> is an address from 001 to 254 which can be specified upon
+    initialization. Since ';FF' is not supported by pyvisa as terminator this
+    class overloads the device communication methods.
+
+    :param adapter: pyvisa resource name of the instrument or adapter instance
+    :param string name: The name of the instrument.
+    :param address: device address included in every message to the instrument
+                    (default=253)
+    :param kwargs: Any valid key-word argument for Instrument
+    """
+
+    setpoint_1 = Instrument.ChannelCreator(SetpointChannel, 1)
+
+    setpoint_2 = Instrument.ChannelCreator(SetpointChannel, 2)
+
+    setpoint_3 = Instrument.ChannelCreator(SetpointChannel, 3)
+
+    def __init__(self, adapter, name="MKS 974B vacuum pressure transducer", address=253, **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            address=address,
+            **kwargs
+        )
+
+    serial = Instrument.measurement(
+        "SN?", """Get the serial number of the instrument""",
+        cast=str,
+    )
+
+    hardware_version = Instrument.measurement(
+        "HV?", """Get the hardware version of the instrument""",
+        cast=str,
+    )
+
+    firmware_version = Instrument.measurement(
+        "FV?", """Get the firmware version of the instrument""",
+        cast=str,
+    )
+
+    device_type = Instrument.measurement(
+        "DT?", """Get the device type""",
+        cast=str,
+    )
+    
+    manufacturer = Instrument.measurement(
+        "MF?", """Get the manufacturer name""",
+        cast=str,
+    )
+
+    model = Instrument.measurement(
+        "MD?", """Get the transducer model number""",
+        cast=str,
+    )
+     
+    part_number = Instrument.measurement(
+        "MD?", """Get the transducer part number""",
+        cast=str,
+    )
+
+    operation_hours = Instrument.measurement(
+        "TIM?", """Get the operation hours of the instrument""",
+        cast=int,
+    )
+ 
+    temperature = Instrument.measurement(
+        "TEM?", """Get the MicroPirani sensor temperature""",
+    )
+      
+    status = Channel.measurement(
+        "T?",
+        """Get transducer status""",
+        map_values=True,
+        values= {"Ok": "O",
+                 "MicroPirani failure": "M",
+                 "Cold Cathode failure": "C",
+                 "Piezo sensor failure": "Z",
+                 "pressure dose setpoint exceeded": "R",
+                 "Cold Cathode On": "G",
+                 },
+    )
+    
+    pirani_pressure = Instrument.measurement(
+        "PR1?", """Get MicroPirani sensor pressure""",
+    )
+
+    piezo_pressure = Instrument.measurement(
+        "PR2?", """Get Piezo differential sensor pressure""",
+    )
+
+    pressure = Instrument.measurement(
+        "PR4?", """Get combined pressure reading""",
+    )
+
+    coldcathode_pressure = Instrument.measurement(
+        "PR5?", """ Get Cold Cathode sensor pressure""",
+    )
+
+    unit = Instrument.control(
+        "U?", "U!%s",
+        """Control pressure unit used for all pressure readings from the instrument""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={"Torr": "TORR",
+                "mBar": "mBAR",
+                "Pascal": "PASCAL",
+                "Micron": "MICRON",
+                },
+        check_set_errors=True,
+    )
+
+    user_tag = Instrument.control(
+        "UT?", "UT!%s", """Control the user programmable tag""",
+        cast=str,
+        check_set_errors=True,
+    )
+
+    switch_enabled = Instrument.control(
+        "SW?", "SW!%s", """Control the user switch to prevent accidental execution of adjustments""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: "ON",
+                False: "OFF",
+                },
+        check_set_errors=True,
+    )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -30,7 +30,7 @@ from .mksinst import MKSInstrument
 
 class SetpointChannel(Channel):
     """
-    Settings of the optionally included setpoint relays.
+    Settings of the optionally included setpoint relay.
 
     The relay is energized either below or above the setpoint 'value' depending on the
     'direction' property. The relay is de-energized when the reset value is crossed in
@@ -73,6 +73,7 @@ class SetpointChannel(Channel):
         validator=strict_discrete_set,
         map_values=True,
         values={False: "OFF",
+                True: "ON",
                 "combined": "CMB",
                 "pirani": "PIR",
                 "piezo": "PZ",
@@ -115,7 +116,11 @@ class MKS974B(MKSInstrument):
             **kwargs
         )
 
-    serial = Instrument.measurement(
+    def id(self):
+        """ Get the identification of the instrument. """
+        return f"{self.manufacturer}{self.model} {self.device_type} ({self.serial_number})"
+
+    serial_number = Instrument.measurement(
         "SN?", """Get the serial number of the instrument""",
         cast=str,
     )
@@ -194,9 +199,8 @@ class MKS974B(MKSInstrument):
         validator=strict_discrete_set,
         map_values=True,
         values={"Torr": "TORR",
-                "mBar": "mBAR",
+                "mBar": "MBAR",
                 "Pascal": "PASCAL",
-                "Micron": "MICRON",
                 },
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -28,18 +28,19 @@ from pymeasure.instruments.validators import strict_discrete_set
 from .mksinst import MKSInstrument
 
 
-class SetpointChannel(Channel):
+class RelayChannel(Channel):
     """
     Settings of the optionally included setpoint relay.
 
-    The relay is energized either below or above the setpoint 'value' depending on the
-    'direction' property. The relay is de-energized when the reset value is crossed in
-    the opposite direction.
+    The relay is energized either below or above the setpoint depending on the
+    'direction' property. The relay is de-energized when the reset value is
+    crossed in the opposite direction.
 
-    Note that 974B transducer has an auto hysteresis setting of 10% of the setpoint value that
-    overwrites the current reset value whenever the setpoint value or setpoint direction is
-    changed. If other hysteresis value than 10% is required, first set the setpoint value
-    and setpoint direction before setting the reset value.
+    Note that 974B transducer has an auto hysteresis setting of 10% of the
+    setpoint value that overwrites the current reset value whenever the setpoint
+    value or direction is changed. If other hysteresis value than 10% is
+    required, first set the setpoint value and direction before setting the
+    reset value.
     """
     status = Channel.measurement(
         "SS{ch}?",
@@ -47,13 +48,13 @@ class SetpointChannel(Channel):
         values={True: "SET", False: "CLEAR"},
     )
 
-    value = Channel.control(
+    setpoint = Channel.control(
         "SP{ch}?", "SP{ch}!%s",
-        """Control the relay switch value""",
+        """Control the relay switch setpoint""",
         check_set_errors=True,
     )
 
-    reset_value = Channel.control(
+    resetpoint = Channel.control(
         "SH{ch}?", "SH{ch}!%s",
         """Control the relay switch off value""",
         check_set_errors=True,
@@ -102,11 +103,11 @@ class MKS974B(MKSInstrument):
     :param kwargs: Any valid key-word argument for :class:`Instrument`
     """
 
-    setpoint_1 = Instrument.ChannelCreator(SetpointChannel, 1)
+    relay_1 = Instrument.ChannelCreator(RelayChannel, 1)
 
-    setpoint_2 = Instrument.ChannelCreator(SetpointChannel, 2)
+    relay_2 = Instrument.ChannelCreator(RelayChannel, 2)
 
-    setpoint_3 = Instrument.ChannelCreator(SetpointChannel, 3)
+    relay_3 = Instrument.ChannelCreator(RelayChannel, 3)
 
     def __init__(self, adapter, name="MKS 974B vacuum pressure transducer", address=253, **kwargs):
         super().__init__(

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -31,11 +31,11 @@ from .mksinst import MKSInstrument
 class SetpointChannel(Channel):
     """
     Settings of the optionally included setpoint relays.
-    
+
     The relay is energized either below or above the setpoint 'value' depending on the
     'direction' property. The relay is de-energized when the reset value is crossed in
     the opposite direction.
-    
+
     Note that 974B transducer has an auto hysteresis setting of 10% of the setpoint value that
     overwrites the current reset value whenever the setpoint value or setpoint direction is
     changed. If other hysteresis value than 10% is required, first set the setpoint value
@@ -49,7 +49,7 @@ class SetpointChannel(Channel):
 
     value = Channel.control(
         "SP{ch}?", "SP{ch}!%s",
-        """Control the relay switch value"""
+        """Control the relay switch value""",
         check_set_errors=True,
     )
 

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -32,10 +32,14 @@ class SetpointChannel(Channel):
     """
     Settings of the optionally included setpoint relays.
     
+    The relay is energized either below or above the setpoint 'value' depending on the
+    'direction' property. The relay is de-energized when the reset value is crossed in
+    the opposite direction.
+    
     Note that 974B transducer has an auto hysteresis setting of 10% of the setpoint value that
-    overwrites the current reset value whenever the setpoint value or setpoint
-    direction is changed. If other hysteresis value than 10% is required, first set the
-    setpoint value and setpoint direction before setting the reset value.
+    overwrites the current reset value whenever the setpoint value or setpoint direction is
+    changed. If other hysteresis value than 10% is required, first set the setpoint value
+    and setpoint direction before setting the reset value.
     """
     status = Channel.measurement(
         "SS{ch}?",
@@ -45,19 +49,19 @@ class SetpointChannel(Channel):
 
     value = Channel.control(
         "SP{ch}?", "SP{ch}!%s",
-        """Control the relay switch value. The setpoint value is the pressure either below or above which the setpoint relay will be energized.""",
+        """Control the relay switch value"""
         check_set_errors=True,
     )
 
     reset_value = Channel.control(
         "SH{ch}?", "SH{ch}!%s",
-        """Control the relay switch off value. The reset value is the pressure value at which the setpoint relay will be de-energized.""",
+        """Control the relay switch off value""",
         check_set_errors=True,
     )
 
     direction = Channel.control(
         "SD{ch}?", "SD{ch}!%s",
-        """Get the setpoint relay status""",
+        """Control the switching direction""",
         validator=strict_discrete_set,
         values=["ABOVE", "BELOW"],
         check_set_errors=True,
@@ -159,13 +163,13 @@ class MKS974B(MKSInstrument):
         "T?",
         """Get transducer status""",
         map_values=True,
-        values= {"Ok": "O",
-                 "MicroPirani failure": "M",
-                 "Cold Cathode failure": "C",
-                 "Piezo sensor failure": "Z",
-                 "pressure dose setpoint exceeded": "R",
-                 "Cold Cathode On": "G",
-                 },
+        values={"Ok": "O",
+                "MicroPirani failure": "M",
+                "Cold Cathode failure": "C",
+                "Piezo sensor failure": "Z",
+                "pressure dose setpoint exceeded": "R",
+                "Cold Cathode On": "G",
+                },
     )
     
     pirani_pressure = Instrument.measurement(
@@ -198,13 +202,15 @@ class MKS974B(MKSInstrument):
     )
 
     user_tag = Instrument.control(
-        "UT?", "UT!%s", """Control the user programmable tag""",
+        "UT?", "UT!%s",
+        """Control the user programmable tag""",
         cast=str,
         check_set_errors=True,
     )
 
     switch_enabled = Instrument.control(
-        "SW?", "SW!%s", """Control the user switch to prevent accidental execution of adjustments""",
+        "SW?", "SW!%s",
+        """Control the user switch to prevent accidental execution of adjustments""",
         validator=strict_discrete_set,
         map_values=True,
         values={True: "ON",

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -66,7 +66,7 @@ class SetpointChannel(Channel):
         values=["ABOVE", "BELOW"],
         check_set_errors=True,
     )
-    
+
     enable = Channel.control(
         "EN{ch}?", "EN{ch}!%s",
         """Control the assigned input channel or disable the setpoint relay.""",
@@ -80,7 +80,7 @@ class SetpointChannel(Channel):
                 },
         check_set_errors=True,
     )
-    
+
 
 class MKS974B(MKSInstrument):
     """ MKS 974B vacuum pressure transducer
@@ -134,7 +134,7 @@ class MKS974B(MKSInstrument):
         "DT?", """Get the device type""",
         cast=str,
     )
-    
+
     manufacturer = Instrument.measurement(
         "MF?", """Get the manufacturer name""",
         cast=str,
@@ -144,7 +144,7 @@ class MKS974B(MKSInstrument):
         "MD?", """Get the transducer model number""",
         cast=str,
     )
-     
+
     part_number = Instrument.measurement(
         "MD?", """Get the transducer part number""",
         cast=str,
@@ -154,11 +154,11 @@ class MKS974B(MKSInstrument):
         "TIM?", """Get the operation hours of the instrument""",
         cast=int,
     )
- 
+
     temperature = Instrument.measurement(
         "TEM?", """Get the MicroPirani sensor temperature""",
     )
-      
+
     status = Channel.measurement(
         "T?",
         """Get transducer status""",
@@ -171,7 +171,7 @@ class MKS974B(MKSInstrument):
                 "Cold Cathode On": "G",
                 },
     )
-    
+
     pirani_pressure = Instrument.measurement(
         "PR1?", """Get MicroPirani sensor pressure""",
     )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -99,7 +99,7 @@ class MKS974B(MKSInstrument):
     :param string name: The name of the instrument.
     :param address: device address included in every message to the instrument
                     (default=253)
-    :param kwargs: Any valid key-word argument for Instrument
+    :param kwargs: Any valid key-word argument for :class:`Instrument`
     """
 
     setpoint_1 = Instrument.ChannelCreator(SetpointChannel, 1)

--- a/pymeasure/instruments/mksinst/mksinst.py
+++ b/pymeasure/instruments/mksinst/mksinst.py
@@ -45,6 +45,7 @@ class MKSInstrument(Instrument):
                     (default=253)
     :param kwargs: Any valid key-word argument for Instrument
     """
+
     def __init__(self, adapter, name="MKS Instrument", address=253, **kwargs):
         super().__init__(
             adapter,

--- a/pymeasure/instruments/mksinst/mksinst.py
+++ b/pymeasure/instruments/mksinst/mksinst.py
@@ -1,0 +1,116 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import re
+
+from pymeasure.instruments import Instrument
+
+
+class MKSInstrument(Instrument):
+    """Abstract MKS Instrument
+
+    Connection to the device is made through an RS232/RS485 serial connection.
+    The communication protocol of these devices is as follows:
+
+    Query: '@<aaa><Command>?;FF' with the response '@<aaa>ACK<Response>;FF'
+    Set command: '@<aaa><Command>!<parameter>;FF' with the response '@<aaa>ACK<Response>;FF'
+    Above <aaa> is an address from 001 to 254 which can be specified upon
+    initialization. Since ';FF' is not supported by pyvisa as terminator this
+    class overloads the device communication methods.
+
+    :param adapter: pyvisa resource name of the instrument or adapter instance
+    :param string name: The name of the instrument.
+    :param address: device address included in every message to the instrument
+                    (default=253)
+    :param kwargs: Any valid key-word argument for Instrument
+    """
+    def __init__(self, adapter, name="MKS Instrument", address=253, **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            includeSCPI=False,
+            read_termination=";",  # in reality its ";FF"
+            # which is, however, invalid for pyvisa. Therefore extra bytes have to
+            # be read in the read() method and the terminators are hardcoded here.
+            write_termination=";FF",
+            **kwargs
+        )
+        self.address = address
+        # compiled regular expression for finding numerical values in reply strings
+        self._re_response = re.compile(fr"@{self.address:03d}(?P<ack>ACK)?(?P<msg>.*)")
+
+    def _extract_reply(self, reply):
+        """ preprocess_reply function which tries to extract <Response> from
+        '@<aaa>ACK<Response>;FF'. If <Response> can not be identified the orignal string
+        is returned.
+        :param reply: reply string
+        :returns: string with only the response, or the original string
+        """
+        rvalue = self._re_response.search(reply)
+        if rvalue:
+            return rvalue.group('msg')
+        return reply
+
+    def _prepend_address(self, cmd):
+        """
+        create command string by including the device address
+        """
+        return f"@{self.address:03d}{cmd}"
+
+    def _check_extra_termination(self):
+        """
+        Check the read termination to correspond to the protocol
+        """
+        t = super().read_bytes(2)  # read extra termination chars 'FF'
+        if t != b'FF':
+            raise ValueError(f"unexpected termination string received {t}")
+
+    def read(self):
+        """
+        Reads from the instrument including the correct termination characters
+        """
+        ret = super().read()
+        self._check_extra_termination()
+        return self._extract_reply(ret)
+
+    def write(self, command):
+        """
+        Write to the instrument including the device address.
+
+        :param command: command string to be sent to the instrument
+        """
+        super().write(self._prepend_address(command))
+
+    def check_set_errors(self):
+        """
+        Check reply string for acknowledgement string.
+        """
+        ret = super().read()  # use super read to get raw reply
+        reply = self._re_response.search(ret)
+        if reply:
+            if reply.group('ack') == 'ACK':
+                self._check_extra_termination()
+                return []
+        # no valid acknowledgement message found
+        raise ValueError(f"invalid reply '{ret}' found in check_errors")

--- a/pymeasure/instruments/mksinst/mksinst.py
+++ b/pymeasure/instruments/mksinst/mksinst.py
@@ -24,7 +24,49 @@
 
 from re import compile
 
-from pymeasure.instruments import Instrument
+from pymeasure.instruments import Channel, Instrument
+from pymeasure.instruments.validators import strict_discrete_set
+
+
+class RelayChannel(Channel):
+    """
+    Settings of the optionally included setpoint relay.
+
+    The relay is energized either below or above the setpoint depending on the
+    'direction' property. The relay is de-energized when the reset value is
+    crossed in the opposite direction.
+
+    Note that device by default uses an auto hysteresis setting of 10% of the
+    setpoint value that overwrites the current reset value whenever the setpoint
+    value or direction is changed. If other hysteresis value than 10% is
+    required, first set the setpoint value and direction before setting the
+    reset value.
+    """
+    status = Channel.measurement(
+        "SS{ch}?",
+        """Get the setpoint relay status""",
+        values={True: "SET", False: "CLEAR"},
+    )
+
+    setpoint = Channel.control(
+        "SP{ch}?", "SP{ch}!%s",
+        """Control the relay switch setpoint""",
+        check_set_errors=True,
+    )
+
+    resetpoint = Channel.control(
+        "SH{ch}?", "SH{ch}!%s",
+        """Control the relay switch off value""",
+        check_set_errors=True,
+    )
+
+    direction = Channel.control(
+        "SD{ch}?", "SD{ch}!%s",
+        """Control the switching direction""",
+        validator=strict_discrete_set,
+        values=["ABOVE", "BELOW"],
+        check_set_errors=True,
+    )
 
 
 class MKSInstrument(Instrument):

--- a/pymeasure/instruments/mksinst/mksinst.py
+++ b/pymeasure/instruments/mksinst/mksinst.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-import re
+from re import compile
 
 from pymeasure.instruments import Instrument
 
@@ -59,7 +59,7 @@ class MKSInstrument(Instrument):
         )
         self.address = address
         # compiled regular expression for finding numerical values in reply strings
-        self._re_response = re.compile(fr"@{self.address:03d}(?P<ack>ACK)?(?P<msg>.*)")
+        self._re_response = compile(fr"@{self.address:03d}(?P<ack>ACK)?(?P<msg>.*)")
 
     def _extract_reply(self, reply):
         """ preprocess_reply function which tries to extract <Response> from

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -114,4 +114,4 @@ def test_relay_enabled():
         [("@253EN6?", "@253ACKENABLE"),
          (None, b"FF")],
     ) as inst:
-        assert inst.relay_6.enabled == True
+        assert inst.relay_6.enabled is True

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -85,3 +85,33 @@ def test_power_enabled():
          (None, b"FF")],
     ) as inst:
         assert inst.ch_1.power_enabled is True
+
+
+def test_relay_value():
+    """Verify the communication of the relay setpoint getter."""
+    with expected_protocol(
+        MKS937B,
+        [("@253SP10?", "@253ACK2.00E+0"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.relay_10.setpoint == pytest.approx(2.00e0)
+
+
+def test_relay_direction():
+    """Verify the communication of the relay direction."""
+    with expected_protocol(
+        MKS937B,
+        [("@253SD3?", "@253ACKABOVE"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.relay_3.direction == "ABOVE"
+
+
+def test_relay_enabled():
+    """Verify the communication of the relay enabled property."""
+    with expected_protocol(
+        MKS937B,
+        [("@253EN6?", "@253ACKENABLE"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.relay_6.enabled == True

--- a/tests/instruments/mksinst/test_mks937b.py
+++ b/tests/instruments/mksinst/test_mks937b.py
@@ -24,7 +24,7 @@
 import pytest
 
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.mksinst.mks937b import MKS937B
+from pymeasure.instruments.mksinst.mks937b import MKS937B, Unit
 
 
 def test_pressure():
@@ -61,10 +61,10 @@ def test_unit_setter():
     """Verify the communication of the unit setter."""
     with expected_protocol(
         MKS937B,
-        [("@253U!TORR", "@253ACKTORR"),
+        [("@253U!MICRON", "@253ACKMICRON"),
          (None, b"FF")],
     ) as inst:
-        inst.unit = "Torr"
+        inst.unit = Unit.uHg
 
 
 def test_unit_getter():
@@ -74,7 +74,7 @@ def test_unit_getter():
         [("@253U?", "@253ACKTORR"),
          (None, b"FF")],
     ) as inst:
-        assert inst.unit == "Torr"
+        assert inst.unit == Unit.Torr
 
 
 def test_power_enabled():

--- a/tests/instruments/mksinst/test_mks974b.py
+++ b/tests/instruments/mksinst/test_mks974b.py
@@ -115,3 +115,13 @@ def test_relay_direction():
          (None, b"FF")],
     ) as inst:
         assert inst.relay_2.direction == "BELOW"
+
+
+def test_relay_enabled():
+    """Verify the communication of the relay enabled property."""
+    with expected_protocol(
+        MKS974B,
+        [("@253EN3?", "@253ACKPIR"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.relay_3.enabled == "pirani"

--- a/tests/instruments/mksinst/test_mks974b.py
+++ b/tests/instruments/mksinst/test_mks974b.py
@@ -1,0 +1,117 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2023 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.mksinst.mks974b import MKS974B
+
+
+def test_device_type():
+    """Verify the communication of the device type."""
+    with expected_protocol(
+        MKS974B,
+        [("@253DT?", "@253ACKQUADMAG"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.device_type == "QUADMAG"
+
+
+def test_status():
+    """Verify the communication of the status."""
+    with expected_protocol(
+        MKS974B,
+        [("@253T?", "@253ACKO"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.status == "Ok"
+
+
+def test_pressure():
+    """Verify the communication of the pressure getter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253PR4?", "@253ACK1.234E-3"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.pressure == pytest.approx(1.234e-3)
+
+
+def test_pirani_pressure():
+    """Verify the communication of the pirani pressure getter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253PR1?", "@253ACK1.23E-3"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.pirani_pressure == pytest.approx(1.23e-3)
+
+
+def test_unit_setter():
+    """Verify the communication of the unit setter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253U!TORR", "@253ACKTORR"),
+         (None, b"FF")],
+    ) as inst:
+        inst.unit = "Torr"
+
+
+def test_unit_getter():
+    """Verify the communication of the unit getter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253U?", "@253ACKTORR"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.unit == "Torr"
+
+
+def test_switch_enabled():
+    """Verify the communication of the user swith getter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253SW?", "@253ACKON"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.switch_enabled is True
+
+
+def test_setpoint_value():
+    """Verify the communication of the setpoint getter."""
+    with expected_protocol(
+        MKS974B,
+        [("@253SP1?", "@253ACK2.00E+1"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.setpoint_1.value == pytest.approx(2.00e1)
+
+
+def test_setpoint_direction():
+    """Verify the communication of the setpoint direction."""
+    with expected_protocol(
+        MKS974B,
+        [("@253SD2?", "@253ACKBELOW"),
+         (None, b"FF")],
+    ) as inst:
+        assert inst.setpoint_2.direction == "BELOW"

--- a/tests/instruments/mksinst/test_mks974b.py
+++ b/tests/instruments/mksinst/test_mks974b.py
@@ -24,7 +24,7 @@
 import pytest
 
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.mksinst.mks974b import MKS974B
+from pymeasure.instruments.mksinst.mks974b import MKS974B, Unit
 
 
 def test_device_type():
@@ -71,10 +71,10 @@ def test_unit_setter():
     """Verify the communication of the unit setter."""
     with expected_protocol(
         MKS974B,
-        [("@253U!TORR", "@253ACKTORR"),
+        [("@253U!PASCAL", "@253ACKPASCAL"),
          (None, b"FF")],
     ) as inst:
-        inst.unit = "Torr"
+        inst.unit = Unit.Pa
 
 
 def test_unit_getter():
@@ -84,7 +84,7 @@ def test_unit_getter():
         [("@253U?", "@253ACKTORR"),
          (None, b"FF")],
     ) as inst:
-        assert inst.unit == "Torr"
+        assert inst.unit == Unit.Torr
 
 
 def test_switch_enabled():
@@ -97,21 +97,21 @@ def test_switch_enabled():
         assert inst.switch_enabled is True
 
 
-def test_setpoint_value():
-    """Verify the communication of the setpoint getter."""
+def test_relay_value():
+    """Verify the communication of the relay setpoint getter."""
     with expected_protocol(
         MKS974B,
         [("@253SP1?", "@253ACK2.00E+1"),
          (None, b"FF")],
     ) as inst:
-        assert inst.setpoint_1.value == pytest.approx(2.00e1)
+        assert inst.relay_1.setpoint == pytest.approx(2.00e1)
 
 
-def test_setpoint_direction():
-    """Verify the communication of the setpoint direction."""
+def test_relay_direction():
+    """Verify the communication of the relay direction."""
     with expected_protocol(
         MKS974B,
         [("@253SD2?", "@253ACKBELOW"),
          (None, b"FF")],
     ) as inst:
-        assert inst.setpoint_2.direction == "BELOW"
+        assert inst.relay_2.direction == "BELOW"


### PR DESCRIPTION
I suggest to add a second device from MKS. Since the communication protocol it uses is equal to the one of the other included MKS device I created an `MKSInstrument` class which is reused by both device implementations.

The manual for this device can be found at 
https://www.idealvac.com/files/manuals/MKS-974-MAN-RH.pdf