### PR TITLE
Bump checkout v3 to v4

### DIFF
--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install pymeasure requirements
@@ -54,7 +54,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install pymeasure requirements
@@ -98,7 +98,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install pymeasure requirements


### PR DESCRIPTION
Due to deprecation:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

https://github.com/pymeasure/pymeasure/actions/runs/7745575518/job/21121896789

Pipeline #3062