### PR TITLE
fixing set command of SR860 aux output

### DIFF
--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -335,7 +335,7 @@ class SR860(Instrument):
     )
 
     aux_out_1 = Instrument.control(
-        "AUXV? 0", "AUXV 1, %f",
+        "AUXV? 0", "AUXV 0, %f",
         """ A floating point property that controls the output of Aux output 1 in
         Volts, taking values between -10.5 V and +10.5 V.
         This property can be set.""",
@@ -346,7 +346,7 @@ class SR860(Instrument):
     dac1 = aux_out_1
 
     aux_out_2 = Instrument.control(
-        "AUXV? 1", "AUXV 2, %f",
+        "AUXV? 1", "AUXV 1, %f",
         """ A floating point property that controls the output of Aux output 2 in
         Volts, taking values between -10.5 V and +10.5 V.
         This property can be set.""",
@@ -357,7 +357,7 @@ class SR860(Instrument):
     dac2 = aux_out_2
 
     aux_out_3 = Instrument.control(
-        "AUXV? 2", "AUXV 3, %f",
+        "AUXV? 2", "AUXV 2, %f",
         """ A floating point property that controls the output of Aux output 3 in
         Volts, taking values between -10.5 V and +10.5 V.
         This property can be set.""",
@@ -368,7 +368,7 @@ class SR860(Instrument):
     dac3 = aux_out_3
 
     aux_out_4 = Instrument.control(
-        "AUXV? 3", "AUXV 4, %f",
+        "AUXV? 3", "AUXV 3, %f",
         """ A floating point property that controls the output of Aux output 4 in
         Volts, taking values between -10.5 V and +10.5 V.
         This property can be set.""",


### PR DESCRIPTION
Between the SR830 and the SR860 the numbering of the aux outputs has changed from 1 to 4 towards 0 to 3. This has been accounted for the aux output read commands, but not for the set commands. This leads to a mismatch (tested on a real device), so the aux_out_1 command in facts set the voltage of channel 2. The commit fixes this issue.