### PR TITLE
Add Python 3.12 to pymeasure

### DIFF
--- a/.github/pymeasure_python312.yml
+++ b/.github/pymeasure_python312.yml
@@ -1,0 +1,26 @@
+name: pymeasure_python312
+channels:
+  - conda-forge
+dependencies:
+  - cloudpickle=1.6.0
+  - numpy=1.26.4
+  - pandas=2.2.0
+  - pint=0.18
+  - pyqt=5.15.9
+  - pyqtgraph=0.12.4
+  - pyserial=3.4
+  - pyvisa=1.14.1
+  - pyzmq=25.1.2
+  - qt=5.15.8
+# Development dependencies below
+  - pytest-qt=4.2.0
+  - pytest-runner=5.2
+  - pytest=7.2.0
+  - pytest-cov=4.1.0
+  - pyvisa-sim==0.5.1
+  - flake8=6.0.0
+  - setuptools_scm # don't pin, to get newest features
+  - sphinx=5.3.0
+  - sphinx_rtd_theme=1.2.2
+#  pip is currently not needed, but the recommended tool when packages that are unavailable on conda are required
+#  - pip  # don't pin, to gain newest conda compatibility fixes

--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -103,7 +103,8 @@ jobs:
       - name: Install pymeasure requirements
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: .github/pymeasure.yml
+          # ternary operator: if python-version == 3.12 use pymeasure_python312.yml else use pymeasure.yml
+          environment-file: ${{ matrix.python-version == '3.12' && '.github/pymeasure_python312.yml' || '.github/pymeasure.yml'}}
           create-args: python=${{ matrix.python-version }}
           cache-environment-key: py${{ matrix.python-version }}-${{ matrix.os }}-mamba-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
           cache-downloads: false
@@ -154,43 +155,3 @@ jobs:
         run: |
           echo "::add-matcher::.github/pytest.json"
           xvfb-run -a pytest
-
-  test_python312:
-    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -l {0}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.12"]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install pymeasure requirements
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: .github/pymeasure_python312.yml
-          create-args: python=${{ matrix.python-version }}
-          cache-environment-key: py${{ matrix.python-version }}-${{ matrix.os }}-mamba-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
-          cache-downloads: false
-      - name: Python version
-        run: python --version
-      - name: Install Pymeasure
-        # If the pytest problem matcher stops working because of bad paths, do an editable install
-        run: pip install .[tests]
-      - name: Pymeasure version
-        run: python -c "import pymeasure;print(pymeasure.__version__)"
-      - name: Run pytest with xvfb
-        if: runner.os == 'Linux'
-        run: |
-          echo "::add-matcher::.github/pytest.json"
-          xvfb-run -a pytest
-      - name: Run pytest
-        if: runner.os != 'Linux'
-        run: |
-          echo "::add-matcher::.github/pytest.json"
-          pytest

--- a/.github/workflows/pymeasure_CI.yml
+++ b/.github/workflows/pymeasure_CI.yml
@@ -154,3 +154,43 @@ jobs:
         run: |
           echo "::add-matcher::.github/pytest.json"
           xvfb-run -a pytest
+
+  test_python312:
+    name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install pymeasure requirements
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: .github/pymeasure_python312.yml
+          create-args: python=${{ matrix.python-version }}
+          cache-environment-key: py${{ matrix.python-version }}-${{ matrix.os }}-mamba-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
+          cache-downloads: false
+      - name: Python version
+        run: python --version
+      - name: Install Pymeasure
+        # If the pytest problem matcher stops working because of bad paths, do an editable install
+        run: pip install .[tests]
+      - name: Pymeasure version
+        run: python -c "import pymeasure;print(pymeasure.__version__)"
+      - name: Run pytest with xvfb
+        if: runner.os == 'Linux'
+        run: |
+          echo "::add-matcher::.github/pytest.json"
+          xvfb-run -a pytest
+      - name: Run pytest
+        if: runner.os != 'Linux'
+        run: |
+          echo "::add-matcher::.github/pytest.json"
+          pytest

--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,14 @@
 PyMeasure scientific package
 ############################
 
-PyMeasure makes scientific measurements easy to set up and run. The package contains a repository of instrument classes and a system for running experiment procedures, which provides graphical interfaces for graphing live data and managing queues of experiments. Both parts of the package are independent, and when combined provide all the necessary requirements for advanced measurements with only limited coding.
+PyMeasure makes scientific measurements easy to set up and run. The package contains a repository of instrument classes and a system for running experiment procedures, which provides graphical interfaces for graphing live data and managing queues of experiments.
+Both parts of the package are independent, and when combined provide all the necessary requirements for advanced measurements with only limited coding.
 
 PyMeasure is currently under active development, so please report any issues you experience to our `Issues page`_.
 
 .. _Issues page: https://github.com/pymeasure/pymeasure/issues
 
-PyMeasure runs on Python 3.8-3.11, and is tested with continuous-integration on Linux, macOS, and Windows.
+PyMeasure runs on Python 3.8-3.12, and is tested with continuous-integration on Linux, macOS, and Windows.
 
 .. image:: https://github.com/pymeasure/pymeasure/actions/workflows/pymeasure_CI.yml/badge.svg
     :target: https://github.com/pymeasure/pymeasure/actions/workflows/pymeasure_CI.yml

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,8 @@
 PyMeasure scientific package
 ############################
 
-PyMeasure makes scientific measurements easy to set up and run. The package contains a repository of instrument classes and a system for running experiment procedures, which provides graphical interfaces for graphing live data and managing queues of experiments.
+PyMeasure makes scientific measurements easy to set up and run.
+The package contains a repository of instrument classes and a system for running experiment procedures, which provides graphical interfaces for graphing live data and managing queues of experiments.
 Both parts of the package are independent, and when combined provide all the necessary requirements for advanced measurements with only limited coding.
 
 PyMeasure is currently under active development, so please report any issues you experience to our `Issues page`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering
 
 [options]

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -66,9 +66,10 @@ def find_devices_in_module(module):
             # Some non-required driver dependencies may not be installed on test computer,
             # for example ni.VirtualBench
             pass
-        except OSError:
+        except (OSError, AttributeError):
             # On Windows instruments.ni.daqmx can raise an OSError before ModuleNotFoundError
             # when checking installed driver files
+            # it raises an AttributeError under Python 312
             pass
     return devices, channels
 


### PR DESCRIPTION
Make pymeasure fit for python 3.12.

This PR updates first the CI to start checking for problems.

Issues, which arose:
- The environment has to be updated, as several packages are not compatible with Python 3.12
   - Pandas has to be larger than 1.5.3 (which is the last 1.* release) to be compatible with Python 3.12, but pandas>2.1 requires Python 3.9
- #1008 
- #1050 
