### PR TITLE
Fix/pandas futurewarning

### DIFF
--- a/examples/Basic/gui_table.py
+++ b/examples/Basic/gui_table.py
@@ -94,8 +94,7 @@ class MainWindow(ManagedWindowBase):
             inputs=['iterations', 'delay', 'seed'],
             displays=['iterations', 'delay', 'seed'],
             widget_list=widget_list,
-            filename_input=False,
-            directory_input=False,
+            enable_file_input=False,
         )
         logging.getLogger().addHandler(widget_list[1].handler)
         log.setLevel(self.log_level)

--- a/pymeasure/display/widgets/table_widget.py
+++ b/pymeasure/display/widgets/table_widget.py
@@ -173,8 +173,8 @@ class PandasModelBase(QtCore.QAbstractTableModel):
         if index.isValid() and role in (QtCore.Qt.ItemDataRole.DisplayRole, SORT_ROLE):
             try:
                 results, row, col = self.translate_to_local(index.row(), index.column())
-                value = results.data.iloc[row][col]
-                column_type = results.data.dtypes[col]
+                value = results.data.iat[row, col]
+                column_type = results.data.dtypes.iat[col]
                 # Cast to column type
                 value_render = column_type.type(value)
             except (IndexError, ValueError, TypeError):


### PR DESCRIPTION
Fixes #1061


Proposes to use `iat` to replace `__getitem__` indexing for indexing by position. Since we're indexing for a single scalar value, I thinkt the recommended method is `iat`, rather than `iloc` (https://pandas.pydata.org/docs/user_guide/indexing.html#fast-scalar-value-getting-and-setting)