### PR TITLE
Implemented locale compatible `ScientificInput`

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -77,4 +77,4 @@ Canyon Clark
 Connor Carr
 Jannis Kleine-Schönepauck
 Douwe den Blanken
-
+Till Zürner

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -255,9 +255,10 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
         if self._parameter.units:
             text = text[:-(len(self._parameter.units) + 1)]
         try:
-            return self.toDouble(text)
+            val = self.toDouble(text)
         except ValueError:
-            return self._parameter.default
+            val = self._parameter.default
+        return val
 
     def textFromValue(self, value):
         string = self.toString(value).replace("e+", "e")

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -240,17 +240,27 @@ class ScientificInput(Input, QtWidgets.QDoubleSpinBox):
     def fixCase(self, text):
         self.lineEdit().setText(text.toLower())
 
+    def toDouble(self, string):
+        value, success = self.validator.locale().toDouble(string)
+        if not success:
+            raise ValueError('String could not be converted to a double')
+        else:
+            return value
+
+    def toString(self, value, format='g', precision=6):
+        return self.validator.locale().toString(value, format, precision)
+
     def valueFromText(self, text):
+        text = str(text)
+        if self._parameter.units:
+            text = text[:-(len(self._parameter.units) + 1)]
         try:
-            if self._parameter.units:
-                return float(str(text)[:-(len(self._parameter.units) + 1)])
-            else:
-                return float(str(text))
+            return self.toDouble(text)
         except ValueError:
             return self._parameter.default
 
     def textFromValue(self, value):
-        string = f"{value:g}".replace("e+", "e")
+        string = self.toString(value).replace("e+", "e")
         string = re.sub(r"e(-?)0*(\d+)", r"e\1\2", string)
         return string
 


### PR DESCRIPTION
Solves #310 and #602 
- added `toDouble` and `toString` methods to `ScientificInput` for handling locale-sensitive conversion between numbers and strings through the validator's `locale()`
- have the `valueFromText` and `textFromValue` use the above methods for conversion
- move text processing in `valueFromText` outside the `try` statement