### PR TITLE
Make query_delay=None the default.

### DIFF
--- a/pymeasure/instruments/aja/dcxs.py
+++ b/pymeasure/instruments/aja/dcxs.py
@@ -31,7 +31,7 @@ class DCXS(Instrument):
 
     Connection to the device is made through an RS232 serial connection.
     The communication settings are fixed in the device at 38400, one stopbit, no parity.
-    The communication protocol of the device uses single character commands and fixed length replys,
+    The device's communication protocol uses single character commands and fixed length replies,
     both without any terminator.
 
     :param adapter: pyvisa resource name of the instrument or adapter instance
@@ -53,7 +53,7 @@ class DCXS(Instrument):
         # characters.
         self.adapter.flush_read_buffer()
 
-    def ask(self, command, query_delay=0, **kwargs):
+    def ask(self, command, query_delay=None, **kwargs):
         """Write a command to the instrument and return the read response.
 
         :param command: Command string to be sent to the instrument.

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -248,7 +248,7 @@ class Ametek7270(Instrument):
         else:
             return ['Incorrect return from previously set property']
 
-    def ask(self, command, query_delay=0):
+    def ask(self, command, query_delay=None):
         """Send a command and read the response, stripping white spaces.
 
         Usually the properties use the

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -138,7 +138,7 @@ class Axis(Channel):
     stepu = Instrument.setting(
         "stepu %d",
         """Set the steps upwards for N steps. Mode must be 'stp' and N must be
-        positive. 0 causes a continous movement until stop is called.
+        positive. 0 causes a continuous movement until stop is called.
 
         .. deprecated:: 0.13.0 Use meth:`move_raw` instead.
         """,
@@ -150,7 +150,7 @@ class Axis(Channel):
     stepd = Instrument.setting(
         "stepd %d",
         """Set the steps downwards for N steps. Mode must be 'stp' and N must be
-        positive. 0 causes a continous movement until stop is called.
+        positive. 0 causes a continuous movement until stop is called.
 
         .. deprecated:: 0.13.0 Use meth:`move_raw` instead.
         """,
@@ -217,7 +217,7 @@ class Axis(Channel):
         # perform the movement
         self.move_raw(steps)
         # wait for the move to finish
-        self.parent.wait_for(abs(steps) / self.frequency)
+        self.wait_for(abs(steps) / self.frequency)
         # ask if movement finished
         self.ask('stepw')
         if gnd:
@@ -231,7 +231,7 @@ class Axis(Channel):
         """
         self.mode = 'cap'
         # wait for the measurement to finish
-        self.parent.wait_for(1)
+        self.wait_for(1)
         # ask if really finished
         self.ask('capw')
         return self.capacity
@@ -408,9 +408,9 @@ class ANC300Controller(Instrument):
                              f"command with message {msg}")
         return self._extract_value(msg)
 
-    def wait_for(self, query_delay=0):
+    def wait_for(self, query_delay=None):
         """Wait for some time. Used by 'ask' to wait before reading.
 
-        :param query_delay: Delay between writing and reading in seconds.
+        :param query_delay: Delay between writing and reading in seconds. None is default delay.
         """
-        super().wait_for(query_delay or self.query_delay)
+        super().wait_for(self.query_delay if query_delay is None else query_delay)

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -246,7 +246,7 @@ class ANC300Controller(Instrument):
     :param axisnames: a list of axis names which will be used to create
         properties with these names
     :param passwd: password for the attocube standard console
-    :param query_delay: delay between sending and reading (default 0.05 sec)
+    :param query_delay: default delay between sending and reading in s (default 0.05)
     :param host: host address of the instrument (e.g. 169.254.0.1)
 
         .. deprecated:: 0.11.2
@@ -411,6 +411,7 @@ class ANC300Controller(Instrument):
     def wait_for(self, query_delay=None):
         """Wait for some time. Used by 'ask' to wait before reading.
 
-        :param query_delay: Delay between writing and reading in seconds. None is default delay.
+        :param query_delay: Delay between writing and reading in seconds.
+            None means :attr:`query_delay`.
         """
         super().wait_for(self.query_delay if query_delay is None else query_delay)

--- a/pymeasure/instruments/channel.py
+++ b/pymeasure/instruments/channel.py
@@ -132,9 +132,9 @@ class Channel(CommonBase):
         return self.parent.check_set_errors()
 
     # Communication functions
-    def wait_for(self, query_delay=0):
+    def wait_for(self, query_delay=None):
         """Wait for some time. Used by 'ask' to wait before reading.
 
-        :param query_delay: Delay between writing and reading in seconds.
+        :param query_delay: Delay between writing and reading in seconds. None is default delay.
         """
         self.parent.wait_for(query_delay)

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -366,16 +366,16 @@ class CommonBase:
         delattr(self, child._name)
 
     # Communication functions
-    def wait_for(self, query_delay=0):
+    def wait_for(self, query_delay=None):
         """Wait for some time. Used by 'ask' to wait before reading.
 
         Implement in subclass!
 
-        :param query_delay: Delay between writing and reading in seconds.
+        :param query_delay: Delay between writing and reading in seconds. None is default delay.
         """
         raise NotImplementedError("Implement in subclass!")
 
-    def ask(self, command, query_delay=0):
+    def ask(self, command, query_delay=None):
         """Write a command to the instrument and return the read response.
 
         :param command: Command string to be sent to the instrument.

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -421,7 +421,7 @@ class CommonBase:
                 pass  # Keep as string
         return results
 
-    def binary_values(self, command, query_delay=0, **kwargs):
+    def binary_values(self, command, query_delay=None, **kwargs):
         """ Write a command to the instrument and return a numpy array of the binary data.
 
         :param command: Command to be sent to the instrument.

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -196,10 +196,10 @@ class Instrument(CommonBase):
         return self.adapter.read_binary_values(**kwargs)
 
     # Communication functions
-    def wait_for(self, query_delay=0):
+    def wait_for(self, query_delay=None):
         """Wait for some time. Used by 'ask' to wait before reading.
 
-        :param query_delay: Delay between writing and reading in seconds.
+        :param query_delay: Delay between writing and reading in seconds. None is default delay.
         """
         if query_delay:
             time.sleep(query_delay)

--- a/pymeasure/instruments/temptronic/temptronic_base.py
+++ b/pymeasure/instruments/temptronic/temptronic_base.py
@@ -125,6 +125,12 @@ class ATSBase(Instrument):
     """The base class for Temptronic ATSXXX instruments.
     """
 
+    def __init__(self, adapter, name="ATSBase", **kwargs):
+        super().__init__(adapter, name=name, **kwargs)
+
+    def wait_for(self, query_delay=None):
+        super().wait_for(0.05 if query_delay is None else query_delay)
+
     remote_mode = Instrument.setting(
         "%s",
         """``True`` disables TS GUI but displays a “Return to local" switch.""",
@@ -375,7 +381,7 @@ class ATSBase(Instrument):
          0      None
         ======  ======
 
-        Refere to chapter 4 in the manual
+        Refer to chapter 4 in the manual
 
         """,
     )
@@ -548,9 +554,6 @@ class ATSBase(Instrument):
         map_values=True,
         dynamic=True
     )
-
-    def __init__(self, adapter, name="ATSBase", **kwargs):
-        super().__init__(adapter, name=name, query_delay=0.05, **kwargs)
 
     def reset(self):
         """Reset (force) the System to the Operator screen.

--- a/pymeasure/instruments/thyracont/smartline_v2.py
+++ b/pymeasure/instruments/thyracont/smartline_v2.py
@@ -266,7 +266,7 @@ class SmartlineV2(Instrument):
         """
         self.write(f"{accessCode}{command}{compose_data(data)}")
 
-    def ask(self, command_message, query_delay=0):
+    def ask(self, command_message, query_delay=None):
         """Ask for some value and check that the response matches the original command.
 
         :param str command_message: Access code, command, length, and content.
@@ -276,14 +276,14 @@ class SmartlineV2(Instrument):
         self.wait_for(query_delay)
         return self.read(command_message[1:3])
 
-    def ask_manually(self, accessCode, command, data="", query_delay=0):
+    def ask_manually(self, accessCode, command, data="", query_delay=None):
         """
         Send a message to the transmitter and return its answer.
 
         :param accessCode: How to access the device.
         :param command: Command to send to the device.
         :param data: Data for the command.
-        :param int query_delay: Time to wait between writing and reading.
+        :param float query_delay: Time to wait between writing and reading in seconds.
         :return str: Response from the device after error checking.
         """
         self.write(f"{accessCode}{command}{compose_data(data)}")

--- a/tests/instruments/temptronic/test_temptronic_base.py
+++ b/tests/instruments/temptronic/test_temptronic_base.py
@@ -1,0 +1,36 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from time import perf_counter
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.temptronic.temptronic_base import ATSBase
+
+
+def test_check_query_delay():
+    with expected_protocol(ATSBase, [("TTIM?", "7")]) as inst:
+        start = perf_counter()
+        assert inst.maximum_test_time == 7
+        delay = perf_counter() - start
+        assert delay > 0.05

--- a/tests/instruments/test_instrument.py
+++ b/tests/instruments/test_instrument.py
@@ -218,7 +218,7 @@ class TestWaiting:
     def test_binary_values_calls_wait(self, instr):
         instr.adapter.comm_pairs = [("abc", "abcdefgh")]
         instr.binary_values("abc")
-        assert instr.waited == 0
+        assert instr.waited is None
 
 
 @pytest.mark.parametrize("method, write, reply", (("id", "*IDN?", "xyz"),

--- a/tests/instruments/test_instrument.py
+++ b/tests/instruments/test_instrument.py
@@ -195,7 +195,7 @@ class TestWaiting:
     @pytest.fixture()
     def instr(self):
         class Faked(Instrument):
-            def wait_for(self, query_delay=0):
+            def wait_for(self, query_delay=None):
                 self.waited = query_delay
         return Faked(ProtocolAdapter(), name="faked")
 
@@ -208,7 +208,7 @@ class TestWaiting:
     def test_ask_calls_wait(self, instr):
         instr.adapter.comm_pairs = [("abc", "resp")]
         instr.ask("abc")
-        assert instr.waited == 0
+        assert instr.waited is None
 
     def test_ask_calls_wait_with_delay(self, instr):
         instr.adapter.comm_pairs = [("abc", "resp")]


### PR DESCRIPTION
Reworking the codebase (#1019 ), I noticed the warning, that ATSBase still uses `query_delay`, which is deprecated (and does not work anymore, infact).

This PR fixes it.

While writing the fix, I noticed an inconvenience for instruments with a default delay (Anc300, for example):
`wait_for` cannot distinguish between an explicit `0` by the user and the _default_ `0` by `ask`. In both cases, they would wait for `self.query_delay` seconds

Therefore, I made the default `None`, such that you can distinguish between not set (in this case it will be `self.query_delay`) and between an explicit 0.

I adjusted the ANC300 as well and some other places where it was needed.