### PR TITLE
Add typing to expected_protocol

### DIFF
--- a/pymeasure/test.py
+++ b/pymeasure/test.py
@@ -22,15 +22,25 @@
 # THE SOFTWARE.
 #
 
+from __future__ import annotations
 from contextlib import contextmanager
+
+from typing import Any, Generator, Optional, TypeVar, Union
 
 from pymeasure.adapters.protocol import ProtocolAdapter
 
 
+Inst = TypeVar("Inst")
+
+
 @contextmanager
-def expected_protocol(instrument_cls, comm_pairs,
-                      connection_attributes={}, connection_methods={},
-                      **kwargs):
+def expected_protocol(
+    instrument_cls: type[Inst],
+    comm_pairs: list[tuple[Union[str, bytes, None], Union[str, bytes, None]]],
+    connection_attributes: Optional[dict[str, Any]] = None,
+    connection_methods: Optional[dict[str, Any]] = None,
+    **kwargs,
+) -> Generator[Inst, Any, None]:
     """Context manager that checks sent/received instrument commands without a
     device connected.
 


### PR DESCRIPTION
I know, that typing is not yet used for pymeasure.
However, for `expected_protocol` I see a good use case case: With my typing changes, an IDE knows, that `with expected_protocol(Instrument) as inst` will behave like `Instrument()`. Therefore auto completion of methods/properties will work.

This PR fixes, that expected_protocol uses an empty dictionary as default value!