### PR TITLE
Add Kepco BOP 36-12 Bipolar Power Supply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ settings.json
 
 # Vim
 *.swp
+pymeasure.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,3 @@ settings.json
 
 # Vim
 *.swp
-pymeasure.code-workspace

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -78,3 +78,4 @@ Connor Carr
 Jannis Kleine-Schönepauck
 Douwe den Blanken
 Till Zürner
+J. A. Wilcox

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -45,6 +45,7 @@ Instruments by manufacturer:
    inficon/index
    ipgphotonics/index
    keithley/index
+   kepco/index
    keysight/index
    lakeshore/index
    lecroy/index

--- a/docs/api/instruments/kepco/bop.rst
+++ b/docs/api/instruments/kepco/bop.rst
@@ -1,0 +1,7 @@
+#######################
+BOP Bipolar Power Supply with BIT 4886 Digital Interface Card
+#######################
+
+.. autoclass:: pymeasure.instruments.kepco.kepcobop
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/kepco/bop.rst
+++ b/docs/api/instruments/kepco/bop.rst
@@ -1,6 +1,6 @@
-#######################
+#############################################################
 BOP Bipolar Power Supply with BIT 4886 Digital Interface Card
-#######################
+#############################################################
 
 .. autoclass:: pymeasure.instruments.kepco.kepcobop
     :members:

--- a/docs/api/instruments/kepco/index.rst
+++ b/docs/api/instruments/kepco/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.kepco
+
+#########################
+KEPCO INC.
+#########################
+
+This section contains specific dpcumentation on the Kepco Inc. power supplies instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+    :maxdepth: 2
+
+    bop

--- a/docs/api/instruments/kepco/index.rst
+++ b/docs/api/instruments/kepco/index.rst
@@ -1,8 +1,8 @@
 .. module:: pymeasure.instruments.kepco
 
-#########################
+##########
 KEPCO INC.
-#########################
+##########
 
 This section contains specific dpcumentation on the Kepco Inc. power supplies instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 

--- a/pymeasure/instruments/kepco/__init__.py
+++ b/pymeasure/instruments/kepco/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .kepcobop import KepcoBOP3612

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -83,7 +83,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         map_values=True,
     )
 
-    # TODO 
+    # TODO
     # Return list of errors based on return number.
 
     def beep(self):
@@ -161,7 +161,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         (see: `current`).
         If power supply in voltage mode, this sets the compliance current
         for the corresponding voltage set point.
-        Query returns programmed value, meaning of which is dependent on 
+        Query returns programmed value, meaning of which is dependent on
         power supply operating context (see: `operating_mode`).
 
         Output must be enabled separately (see: `output_enabled`)
@@ -181,7 +181,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         (see: `voltage`).
         If power supply in current mode, this sets the compliance voltage
         for the corresponding current set point.
-        Query returns programmed value, meaning of which is dependent on 
+        Query returns programmed value, meaning of which is dependent on
         power supply operating context (see: `operating_mode`).
 
         Output must be enabled separately (see: `output_enabled`)

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -79,9 +79,8 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     def __init__(self, adapter, name="Kepco BOP 36-12 Bipolar Power Supply",
                  **kwargs):
         super().__init__(
-            adapter,
-            name,
-            baud_rate=9600,
+            adapter=adapter,
+            name=name,
             read_termination="\n",
             write_termination="\n",
             **kwargs

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -62,10 +62,12 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     _Imax = 12
 
     def __init__(self, adapter, name="Kepco BOP 36-12 Bipolar Power Supply",
-                 read_termination="\n", write_termination="\n", **kwargs):
+                 baud_rate=9600, read_termination="\n", write_termination="\n",
+                 **kwargs):
         super().__init__(
             adapter,
             name,
+            baud_rate=baud_rate,
             read_termination=read_termination,
             write_termination=write_termination,
             **kwargs
@@ -114,7 +116,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         commands or queries. """
         self.write("*WAI")
 
-    voltage_measure = Instrument.measurement(
+    voltage = Instrument.measurement(
         "MEASure:VOLTage?",
         """
         Measures actual voltage that is across the output terminals.
@@ -122,7 +124,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         cast=float
     )
 
-    current_measure = Instrument.measurement(
+    current = Instrument.measurement(
         "MEASure:CURRent?",
         """
         Measures the actual current through the output terminals.
@@ -143,7 +145,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         get_process=lambda x: OPERATING_MODES[int(x)]
     )
 
-    current = Instrument.control(
+    current_setpoint = Instrument.control(
         "CURRent?", "CURRent %g",
         """
         Sets the output current setpoint, depending on the operating mode.
@@ -160,7 +162,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         values=[-1*_Imax, _Imax]
     )
 
-    voltage = Instrument.control(
+    voltage_setpoint = Instrument.control(
         "VOLTage?", "VOLTage %g",
         """
         Sets the output voltage setpoint, depending on the operating mode.

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -62,14 +62,13 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     _Imax = 12
 
     def __init__(self, adapter, name="Kepco BOP 36-12 Bipolar Power Supply",
-                 baud_rate=9600, read_termination="\n", write_termination="\n",
                  **kwargs):
         super().__init__(
             adapter,
             name,
-            baud_rate=baud_rate,
-            read_termination=read_termination,
-            write_termination=write_termination,
+            baud_rate=9600,
+            read_termination="\n",
+            write_termination="\n",
             **kwargs
         )
 

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -1,0 +1,40 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument
+
+
+class KepcoBOP3612(Instrument):
+    """ Represents the Kepco BOP 36-12 (M or D) 400 W bipolar power supply 
+    (fitted with BIT 4886 digital interface card)
+    and provides a high-level interface for interacting
+    with the instrument.
+    """
+
+    def __init__(self, adapter, name="Kepco BOP", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -45,11 +45,26 @@
 # 72-6
 # 100-4
 
+from enum import IntFlag
 from pymeasure.instruments import Instrument, SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set, \
     truncated_range
 
 OPERATING_MODES = ['VOLT', 'CURR']
+
+
+class TestErrorCode(IntFlag):
+    QUARTER_SCALE_VOLTAGE_READBACK = 512
+    QUARTER_SCALE_VOLTAGE = 256
+    MIN_VOLTAGE_OUTPUT = 128
+    MAX_VOLTAGE_OUTPUT = 64
+    LOOP_BACK_TEST = 32
+    DIGITAL_POT = 16
+    OPTICAL_BUFFER = 8
+    FLASH = 4
+    RAM = 2
+    ROM = 1
+    OK = 0
 
 
 class KepcoBOP3612(SCPIMixin, Instrument):
@@ -83,9 +98,6 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         map_values=True,
     )
 
-    # TODO
-    # Return list of errors based on return number.
-
     def beep(self):
         """Cause the unit to emit a brief audible tone."""
         self.write("SYSTem:BEEP")
@@ -98,7 +110,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         Returns 0 if all tests passed, otherwise corresponding error code
         as detailed in manual.
         """,
-        cast=int
+        get_process=lambda v: TestErrorCode(v),
     )
 
     bop_test = Instrument.measurement(
@@ -111,7 +123,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         Caution: Output will switch on and swing to maximum values.
         Disconnect any load before testing.
         """,
-        cast=int
+        get_process=lambda v: TestErrorCode(v),
     )
 
     def wait_to_continue(self):

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -83,16 +83,20 @@ class KepcoBOP3612(SCPIMixin, Instrument):
         map_values=True,
     )
 
+    # TODO 
+    # Return list of errors based on return number.
+
     def beep(self):
-        """Causes the unit to emit a brief audible tone."""
+        """Cause the unit to emit a brief audible tone."""
         self.write("SYSTem:BEEP")
 
     confidence_test = Instrument.measurement(
         "*TST?",
         """
-        Power supply interface self-test procedure.
-        Returns 0 if all tests passed,
-        otherwise corresponding error code.
+        Get error code after performing interface self-test procedure.
+
+        Returns 0 if all tests passed, otherwise corresponding error code
+        as detailed in manual.
         """,
         cast=int
     )
@@ -100,17 +104,18 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     bop_test = Instrument.measurement(
         "DIAG:TST?",
         """
-        Power supply self-test (includes interface plus BOP operation).
+        Get error code after performing full power supply self-test.
+
+        Returns 0 if all tests passed, otherwise corresponding error code
+        as detailed in manual.
         Caution: Output will switch on and swing to maximum values.
         Disconnect any load before testing.
-        Reutnrs 0 if all tests passed,
-        otherwise corresponding error code.
         """,
         cast=int
     )
 
     def wait_to_continue(self):
-        """ Causes the power supply to wait until all previously issued
+        """ Cause the power supply to wait until all previously issued
         commands and queries are complete before executing subsequent
         commands or queries. """
         self.write("*WAI")
@@ -118,7 +123,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     voltage = Instrument.measurement(
         "MEASure:VOLTage?",
         """
-        Measures actual voltage that is across the output terminals.
+        Measure voltage present across the output terminals in Volts.
         """,
         cast=float
     )
@@ -126,7 +131,7 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     current = Instrument.measurement(
         "MEASure:CURRent?",
         """
-        Measures the actual current through the output terminals.
+        Measure current through the output terminals in Amps.
         """,
         cast=float
     )
@@ -134,9 +139,10 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     operating_mode = Instrument.control(
         "FUNCtion:MODE?", "FUNCtion:MODE %s",
         """
-        A string property that controls the operating mode of the BOP.
+        Control the operating mode of the BOP.
+
         As a command, a string, VOLT or CURR, is sent.
-        As a query, a 0 or 1 is returned, corresponding to (VOLT, CURR) respectively.
+        As a query, a 0 or 1 is returned, corresponding to VOLT or CURR respectively.
         This is mapped to corresponding string.
         """,
         validator=strict_discrete_set,
@@ -147,14 +153,17 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     current_setpoint = Instrument.control(
         "CURRent?", "CURRent %g",
         """
-        Sets the output current setpoint, depending on the operating mode.
-        If power supply in current mode, this sets the output current,
-        depending on the voltage compliance and load conditions.
+        Control the output current setpoint.
+
+        Functionality depends on the operating mode.
+        If power supply in current mode, this sets the output current setpoint.
+        The current achieved depends on the voltage compliance and load conditions
+        (see: `current`).
         If power supply in voltage mode, this sets the compliance current
         for the corresponding voltage set point.
-        Query returns corresponding programmed value, meaning of which
-        is dependent on power supply operating context (see: `operating_mode`).
-        Set current not same as actual current (see: `current_measure`).
+        Query returns programmed value, meaning of which is dependent on 
+        power supply operating context (see: `operating_mode`).
+
         Output must be enabled separately (see: `output_enabled`)
         """,
         validator=truncated_range,
@@ -164,14 +173,17 @@ class KepcoBOP3612(SCPIMixin, Instrument):
     voltage_setpoint = Instrument.control(
         "VOLTage?", "VOLTage %g",
         """
-        Sets the output voltage setpoint, depending on the operating mode.
-        If power supply in voltage mode, this sets the output voltage,
-        depending on the current compliance and load conditions.
+        Control the output voltage setpoint.
+
+        Functionality depends on the operating mode.
+        If power supply in voltage mode, this sets the output voltage setpoint.
+        The voltage achieved depends on the current compliance and load conditions
+        (see: `voltage`).
         If power supply in current mode, this sets the compliance voltage
         for the corresponding current set point.
-        Query returns corresponding programmed value, meaning of which
-        is dependent on power supply operating context (see: `operating_mode`).
-        Set voltage not same as actual voltage (see: `voltage_measure`).
+        Query returns programmed value, meaning of which is dependent on 
+        power supply operating context (see: `operating_mode`).
+
         Output must be enabled separately (see: `output_enabled`)
         """,
         validator=truncated_range,

--- a/pymeasure/instruments/kepco/kepcobop.py
+++ b/pymeasure/instruments/kepco/kepcobop.py
@@ -22,19 +22,157 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument
+# List of Kepco BOP's (Vmax,Imax) [single channel output]
+# 100 W:
+# 5-20
+# 20-5
+# 50-2
+# 100-1
+
+# 200 W:
+# 5-30
+# 20-10
+# 36-6
+# 50-4
+# 72-3
+# 100-2
+# 200-1
+
+# 400 W:
+# 20-20
+# 36-12
+# 50-8
+# 72-6
+# 100-4
+
+from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, \
+    truncated_range
+
+OPERATING_MODES = ['VOLT', 'CURR']
 
 
-class KepcoBOP3612(Instrument):
-    """ Represents the Kepco BOP 36-12 (M or D) 400 W bipolar power supply 
-    (fitted with BIT 4886 digital interface card)
-    and provides a high-level interface for interacting
-    with the instrument.
+class KepcoBOP3612(SCPIMixin, Instrument):
     """
+    Represents the Kepco BOP 36-12 (M or D) 400 W bipolar power supply
+    fitted with BIT 4886 digital interface card (minimal implementation)
+    and provides a high-level interface for interacting with the instrument.
+    """
+    _Vmax = 36
+    _Imax = 12
 
-    def __init__(self, adapter, name="Kepco BOP", **kwargs):
+    def __init__(self, adapter, name="Kepco BOP 36-12 Bipolar Power Supply",
+                 read_termination="\n", write_termination="\n", **kwargs):
         super().__init__(
             adapter,
             name,
+            read_termination=read_termination,
+            write_termination=write_termination,
             **kwargs
         )
+
+    output_enabled = Instrument.control(
+        "OUTPut?",
+        "OUTPut %d",
+        """
+        Control whether the source is enabled, takes values True or False (bool)
+        """,
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    def beep(self):
+        """Causes the unit to emit a brief audible tone."""
+        self.write("SYSTem:BEEP")
+
+    confidence_test = Instrument.measurement(
+        "*TST?",
+        """
+        Power supply interface self-test procedure.
+        Returns 0 if all tests passed,
+        otherwise corresponding error code.
+        """,
+        cast=int
+    )
+
+    bop_test = Instrument.measurement(
+        "DIAG:TST?",
+        """
+        Power supply self-test (includes interface plus BOP operation).
+        Caution: Output will switch on and swing to maximum values.
+        Disconnect any load before testing.
+        Reutnrs 0 if all tests passed,
+        otherwise corresponding error code.
+        """,
+        cast=int
+    )
+
+    def wait_to_continue(self):
+        """ Causes the power supply to wait until all previously issued
+        commands and queries are complete before executing subsequent
+        commands or queries. """
+        self.write("*WAI")
+
+    voltage_measure = Instrument.measurement(
+        "MEASure:VOLTage?",
+        """
+        Measures actual voltage that is across the output terminals.
+        """,
+        cast=float
+    )
+
+    current_measure = Instrument.measurement(
+        "MEASure:CURRent?",
+        """
+        Measures the actual current through the output terminals.
+        """,
+        cast=float
+    )
+
+    operating_mode = Instrument.control(
+        "FUNCtion:MODE?", "FUNCtion:MODE %s",
+        """
+        A string property that controls the operating mode of the BOP.
+        As a command, a string, VOLT or CURR, is sent.
+        As a query, a 0 or 1 is returned, corresponding to (VOLT, CURR) respectively.
+        This is mapped to corresponding string.
+        """,
+        validator=strict_discrete_set,
+        values=OPERATING_MODES,
+        get_process=lambda x: OPERATING_MODES[int(x)]
+    )
+
+    current = Instrument.control(
+        "CURRent?", "CURRent %g",
+        """
+        Sets the output current setpoint, depending on the operating mode.
+        If power supply in current mode, this sets the output current,
+        depending on the voltage compliance and load conditions.
+        If power supply in voltage mode, this sets the compliance current
+        for the corresponding voltage set point.
+        Query returns corresponding programmed value, meaning of which
+        is dependent on power supply operating context (see: `operating_mode`).
+        Set current not same as actual current (see: `current_measure`).
+        Output must be enabled separately (see: `output_enabled`)
+        """,
+        validator=truncated_range,
+        values=[-1*_Imax, _Imax]
+    )
+
+    voltage = Instrument.control(
+        "VOLTage?", "VOLTage %g",
+        """
+        Sets the output voltage setpoint, depending on the operating mode.
+        If power supply in voltage mode, this sets the output voltage,
+        depending on the current compliance and load conditions.
+        If power supply in current mode, this sets the compliance voltage
+        for the corresponding current set point.
+        Query returns corresponding programmed value, meaning of which
+        is dependent on power supply operating context (see: `operating_mode`).
+        Set voltage not same as actual voltage (see: `voltage_measure`).
+        Output must be enabled separately (see: `output_enabled`)
+        """,
+        validator=truncated_range,
+        values=[-1*_Vmax, _Vmax]
+    )

--- a/tests/instruments/kepco/test_kepcobop.py
+++ b/tests/instruments/kepco/test_kepcobop.py
@@ -1,0 +1,123 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.kepco import KepcoBOP3612
+
+
+def test_init():
+    with expected_protocol(
+            KepcoBOP3612,
+            [],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_bop_test_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'DIAG:TST?', b'0')],
+    ) as inst:
+        assert inst.bop_test == 0
+
+
+def test_confidence_test_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'*TST?', b'0')],
+    ) as inst:
+        assert inst.confidence_test == 0
+
+
+def test_current_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'MEASure:CURRent?', b'4.99E-3')],
+    ) as inst:
+        assert inst.current == 0.00499
+
+
+def test_current_setpoint_setter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'CURRent 0.1', None)],
+    ) as inst:
+        inst.current_setpoint = 0.1
+
+
+def test_current_setpoint_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'CURRent?', b'9.989E-2')],
+    ) as inst:
+        assert inst.current_setpoint == 0.09989
+
+
+def test_id_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'*IDN?', b'KEPCO,BIT 4886 36-12  08-04-2023,H249977,4.04-1.82')],
+    ) as inst:
+        assert inst.id == 'KEPCO,BIT 4886 36-12  08-04-2023,H249977,4.04-1.82'
+
+
+def test_output_enabled_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'OUTPut?', b'0')],
+    ) as inst:
+        assert inst.output_enabled is False
+
+
+def test_voltage_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'MEASure:VOLTage?', b'8.0E-3')],
+    ) as inst:
+        assert inst.voltage == 0.008
+
+
+def test_voltage_setpoint_setter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'VOLTage 0.1', None)],
+    ) as inst:
+        inst.voltage_setpoint = 0.1
+
+
+def test_voltage_setpoint_getter():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'VOLTage?', b'1.000E-1')],
+    ) as inst:
+        assert inst.voltage_setpoint == 0.1
+
+
+def test_beep():
+    with expected_protocol(
+            KepcoBOP3612,
+            [(b'SYSTem:BEEP', None)],
+    ) as inst:
+        assert inst.beep() is None

--- a/tests/instruments/kepco/test_kepcobop.py
+++ b/tests/instruments/kepco/test_kepcobop.py
@@ -21,7 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import pytest
 
 from pymeasure.test import expected_protocol
 from pymeasure.instruments.kepco import KepcoBOP3612


### PR DESCRIPTION
I have written a minimal driver for Kepco BOP power supplies with BIT 4886 digital interface cards. I have tested with a BOP 36-12 over GPIB and all is working as expected. It is possible to carry out more sophisticated control sequences etc but I thought it was best to keep things simple for the time being. In principle it is also possible to communicate over RS-232 but I haven't checked this for myself yet (I don't have an intention to use it this way).

This is my first time contributing to an open source project, so a bit new to the whole process! I followed the guidance in the documentation and think I have done most of the requirements, though I haven't included any tests just yet. I tried to follow the Keithley 2260B as an example in terms of naming conventions etc.