### PR TITLE
Add citation file for PyMeasure repository

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,9 +4,5 @@ authors:
 - name: PyMeasure Developers
 title: "PyMeasure"
 version: 0.13.1
-identifiers:
-  - type: doi
-    value: 10.5281/zenodo.595633
+doi: 10.5281/zenodo.595633
 repository-code: https://github.com/pymeasure/pymeasure
-commit: a064eef80cb072d1c2e905e2f64f0a0455060446
-

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,4 +5,6 @@ authors:
 title: "PyMeasure"
 version: 0.13.1
 doi: 10.5281/zenodo.595633
+publisher:
+- name: Zenodo
 repository-code: https://github.com/pymeasure/pymeasure

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- name: PyMeasure Developers
+title: "PyMeasure"
+version: 0.13.1
+repository-code: https://github.com/pymeasure/pymeasure
+commit: a064eef80cb072d1c2e905e2f64f0a0455060446
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,9 @@ authors:
 - name: PyMeasure Developers
 title: "PyMeasure"
 version: 0.13.1
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.595633
 repository-code: https://github.com/pymeasure/pymeasure
 commit: a064eef80cb072d1c2e905e2f64f0a0455060446
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,19 +11,21 @@
     * Adapt the format and structure to the previous release message:
     * Divide the entries into categories and try to begin entries with "New", "Add", "Fix" or "Remove" as appropriate. (This could also be automated by the above generator with some labeling effort on our part)
     * We also remove the PR URLs as they clutter the log and condense the new contributors list.
-4. Push the changes up as a PR
-5. Verify that the builds complete
-6. Merge the PR
-7. Fetch `master`, build and check the source packages
+4. Update the version number in CITATION.cff
+    * On the line starting with `version: `, replace the current version number with the new version number 
+5. Push the changes up as a PR
+6. Verify that the builds complete
+7. Merge the PR
+8. Fetch `master`, build and check the source packages
     - `python -m pip install --upgrade build twine`
     - `python -m build`
     - Check the distributions (`twine check dist/*`, version will not yet be correct)
-8. Create a git tag in the format "vX.Y.Z"
-9. Build final packages and confirm the correct version number is being used
-    - `python -m build`
-    - Check the distributions (`twine check dist/*`)
-10. Push the Git tag
-11. Create a tagged [release on GitHub](https://github.com/pymeasure/pymeasure/releases). You'll have to paste in the changelog entry and probably edit it a bit as that form expects Markdown, not ReST (probably just removing `:code:` tags will be sufficient).
+9. Create a git tag in the format "vX.Y.Z"
+10. Build final packages and confirm the correct version number is being used
+     - `python -m build`
+     - Check the distributions (`twine check dist/*`)
+11. Push the Git tag
+12. Create a tagged [release on GitHub](https://github.com/pymeasure/pymeasure/releases). You'll have to paste in the changelog entry and probably edit it a bit as that form expects Markdown, not ReST (probably just removing `:code:` tags will be sufficient).
 
 ## PyPI release
 


### PR DESCRIPTION
Hi,

I'm collaborating on a paper that uses PyMeasure and I would like to cite this main repository in the paper. Popular open source projects often include a preference for how the project is cited and I think that can be useful for PyMeasure.

Specifically, because the PyMeasure framework is in active development with many changes to the codebase, I'd like the citation to include as much info into the version of PyMeasure that was used at time of publication. That will help make sure any shared code that builds off of PyMeasure at the time of the publication release will work.

GitHub [supports](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) using the [Citation File Format](https://github.com/citation-file-format/citation-file-format/tree/main) to integrate citation information into the GitHub repo. You can see what that looks like in the branch for this PR here: https://github.com/mcdo0486/pymeasure/tree/dev/citation (look at the "Cite this repository" on the right)

The [CITATION.cff](https://github.com/mcdo0486/pymeasure/blob/dev/citation/CITATION.cff) I'm proposing keeps things simple. It includes a generic message to encourage citing PyMeasure, credits "PyMeasure Developers" like the license, includes the current release version, and the commit of that release. This would add another step to the action list of publishing a version of PyMeasure as the release version and commit would need to be updated in CITATION.cff.

Including the CITATION.cff will encourage people to cite PyMeasure and will help capture info about the version of PyMeasure that was used at the time of publication.

Here are some examples of how PyMeasure has been cited so far, from a quick search of PyMeasure in google scholar.

https://doi.org/10.1063/5.0032116 
`8. See https://pymeasure.readthedocs.io for PyMeasure, Scientific package.`

https://doi.org/10.1016/j.cpc.2018.07.024
`11. PyMeasure scientific package, URL https://pymeasure.readthedocs.io/`

https://orbi.umons.ac.be/bitstream/20.500.12907/42331/1/R-testbench__v_1.0.pdf
`[24]. PyMeasure Developers, PyMeasure scientific package
— PyMeasure 0.8.0 documentation, 2020
(https://pymeasure.readthedocs.io/en/latest/index.html). `

https://doi.org/10.3390/software2010005
`35. Jermain, C.; Minhhai; Rowlands, G.; Girard, H.-L.; Schippers, C.; Schneider, M.; Chweiser; Buchner, C.; Spirito, D.; Feinstein, B.; et al. Ralph-Group/Pymeasure: PyMeasure 0.8; Zenodo; Organisation Europenne Pour la Recherche Nucleaire: Geneva, Switzerland, 2020.`