### PR TITLE
For GitHub CI actions, increase pyvisa to 1.13.0

### DIFF
--- a/.github/pymeasure.yml
+++ b/.github/pymeasure.yml
@@ -9,7 +9,7 @@ dependencies:
   - pyqt=5.15.7
   - pyqtgraph=0.12.4
   - pyserial=3.4
-  - pyvisa=1.12.0
+  - pyvisa=1.13.0
   - pyzmq=24.0.1
   - qt=5.15.6
 # Development dependencies below


### PR DESCRIPTION
Runs had recently started failing for `macos-latest` github runners. I'm pretty sure the addition of Mac M1 CPUs to the `macos-latest` GitHub runners runner pool is the cause. This PR increases the PyVISA version used in GitHub CI actions to 1.13.0, which is the oldest "noarch" release of PyVISA, which work on Mac M1 CPUs.

Previously `macos-latest` worked for PyVISA 1.12.0 by installing the `osx-64/pyvisa-1.12.0-py38h50d1736_1.tar.bz2` from conda forge. This worked when the `macos-latest` runners were on x64 chips. At some point recently M1 CPUs were added to the `macos-latest` pool, as they are listed now on the github runners page:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners

PyVISA added support for `noarch` to their conda-forge feedstock late last year to support M1 cpus:
https://github.com/conda-forge/pyvisa-feedstock/pull/38

Browsing the available packages, the oldest version that supports `noarch` is 1.13.0: `noarch/pyvisa-1.13.0-pyhd8ed1ab_2.conda`. There isn't a `noarch` version for 1.12.0.

Since this version requirement is for CI runners only, I think it is fine to increase the version to run the oldest `noarch` package which will run on x64 or M1 cpus.

