### PR TITLE
Fix Keysight E36312A confirmed SCPI functionality

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -80,3 +80,4 @@ Douwe den Blanken
 Till Zürner
 J. A. Wilcox
 Nick James Kirkby
+Konrad Gralher

--- a/pymeasure/instruments/keysight/keysightE36312A.py
+++ b/pymeasure/instruments/keysight/keysightE36312A.py
@@ -25,7 +25,7 @@
 
 import logging
 
-from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, Channel, SCPIMixin
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 log = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class VoltageChannel(Channel):
     )
 
 
-class KeysightE36312A(SCPIUnknownMixin, Instrument):
+class KeysightE36312A(SCPIMixin, Instrument):
     """ Represents the Keysight E36312A Power supply
     interface for interacting with the instrument.
 


### PR DESCRIPTION
I confirmed that the Keysight E36312A supports SCPI.