### PR TITLE
Fix temptronic test timing issue

### DIFF
--- a/tests/instruments/temptronic/test_temptronic_base.py
+++ b/tests/instruments/temptronic/test_temptronic_base.py
@@ -33,4 +33,7 @@ def test_check_query_delay():
         start = perf_counter_ns()
         assert inst.maximum_test_time == 7
         delay = perf_counter_ns() - start
-        assert delay > 0.05 * 1e9
+        # HACK acceptable factor is needed, as in CI under windows (Py38, Py39) the `sleep` interval
+        # is slightly shorter than the given argument.
+        acceptable_factor = 0.95
+        assert delay > 0.05 * 1e9 * acceptable_factor


### PR DESCRIPTION
Closes #1106 

This should solve the problem: reducing the time limit.
It's brute force, but I do not see any other option.