### PR TITLE
Fix the encoding of datafiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Upcoming version
 
 Automation
 ----------
-- Explicitly set encoding when writing and reading data to file, allowing the use of special characters (@CasperSchippers, #1123).
+- Explicitly set encoding to utf8 when writing and reading data to file, allowing the use of special characters (@CasperSchippers, #1123).
 
 Version 0.14.0 (2024-05-22)
 ===========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Upcoming version
+================
+
+
+Automation
+----------
+- Explicitly set encoding when writing and reading data to file, allowing the use of special characters (@CasperSchippers, #1123).
 
 Version 0.14.0 (2024-05-22)
 ===========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Upcoming version
 
 Automation
 ----------
-- Explicitly set encoding to utf8 when writing and reading data to file, allowing the use of special characters (@CasperSchippers, #1123).
+- Explicitly set encoding to utf8 when writing and reading data to file, allowing the use of special characters.
+  Previously the encoding was not explicitly set, this could potentially disrupt loading old data-files; if this is required, the encoading can be changed by changing (e.g., monkey-patching) the :code:`pymeasure.experiment.Results.ENCODING` property. (@CasperSchippers, #1123)
 
 Version 0.14.0 (2024-05-22)
 ===========================

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -207,6 +207,7 @@ class Results:
     DELIMITER = ','
     LINE_BREAK = "\n"
     CHUNK_SIZE = 1000
+    ENCODING = "utf-8"
 
     def __init__(self, procedure, data_filename):
         if not isinstance(procedure, Procedure):
@@ -233,7 +234,7 @@ class Results:
             # TODO: Correctly store and retrieve status
         else:
             for filename in self.data_filenames:
-                with open(filename, 'w') as f:
+                with open(filename, 'w', encoding=Results.ENCODING) as f:
                     f.write(self.header())
                     f.write(self.labels())
             self._data = None
@@ -329,7 +330,7 @@ class Results:
             return
 
         for filename in self.data_filenames:
-            with open(filename, 'r+') as f:
+            with open(filename, 'r+', encoding=Results.ENCODING) as f:
                 contents = f.readlines()
                 contents.insert(self._header_count - 1, c_header)
 
@@ -414,7 +415,7 @@ class Results:
         header = ""
         header_read = False
         header_count = 0
-        with open(data_filename) as f:
+        with open(data_filename, "r", encoding=Results.ENCODING) as f:
             while not header_read:
                 line = f.readline()
                 if line.startswith(Results.COMMENT):

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -448,7 +448,10 @@ class Results:
                 comment=Results.COMMENT,
                 header=0,
                 names=self._data.columns,
-                chunksize=Results.CHUNK_SIZE, skiprows=skiprows, iterator=True
+                chunksize=Results.CHUNK_SIZE,
+                skiprows=skiprows,
+                iterator=True,
+                encoding=Results.ENCODING,
             )
             try:
                 tmp_frame = pd.concat(chunks, ignore_index=True)
@@ -471,7 +474,8 @@ class Results:
             self.data_filename,
             comment=Results.COMMENT,
             chunksize=Results.CHUNK_SIZE,
-            iterator=True
+            iterator=True,
+            encoding=Results.ENCODING,
         )
         try:
             self._data = pd.concat(chunks, ignore_index=True)


### PR DESCRIPTION
Explicitly set the encoding of the writen datafiles when the files is opened (either for reading and writing). This ensures the files to be written and read correclty, even with special characters (e.g., ° or Ω); this also ensures the data is correctly plotted (since it is read from file for plotting).

Resolves #1118.