### PR TITLE
Update numpy 2 test

### DIFF
--- a/.github/pymeasure_numpy2.yml
+++ b/.github/pymeasure_numpy2.yml
@@ -3,8 +3,9 @@ channels:
   - conda-forge
 dependencies:
   - cloudpickle=1.6.0
-#  - pandas>=2.2.2  # The version on conda-forge seems not be built with numpy==2, but the pip version has been
-#  - pint=0.18  # A pint version that has not yet been released (>0.23) is required to work with numpy2
+  - numpy=2.0.0
+  - pandas=2.2.2
+  - pint=0.24
   - pyqt=5.15.7
   - pyqtgraph=0.12.4
   - pyserial=3.4
@@ -22,8 +23,4 @@ dependencies:
   - sphinx=5.3.0
   - sphinx_rtd_theme=1.2.2
 #  pip is currently not needed, but the recommended tool when packages that are unavailable on conda are required
-  - pip  # don't pin, to gain newest conda compatibility fixes
-  - pip:
-      - numpy==2.0.0rc1
-      - pandas==2.2.2
-      - git+https://github.com/hgrecco/pint.git#egg=pint
+# - pip  # don't pin, to gain newest conda compatibility fixes


### PR DESCRIPTION
Great news: numpy 2.0.0 has been released!
This means that we can update our requirements yml file for the numpy 2 tests.