### PR TITLE
Add Keithley DAQ6510

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -82,3 +82,4 @@ Till Zürner
 J. A. Wilcox
 Nick James Kirkby
 Konrad Gralher
+David Sun

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,12 @@
 
-Version 0.14.0 (2024-05-21)
+Version 0.14.0 (2024-05-22)
 ===========================
 Main items of this new release:
 
 - Add support for numpy 2.0
 - Add support for python 3.12
 - Improve academic quotability with an up to date Zenodo DOI and with citation information.
+- Add default :code:`queue` method and a :code:`FileInputWidget`, allowing to more quickly get started with the PyMeasure user interface (:code:`ManagedWindow`).
 - Add a :code:`SCPIMixin` base class for instruments instead of defining :code:`includeSCPI=True`
 - Instrument manufacturer modules are no longer imported in the :code:`pymeasure/instruments/__init__.py` file.
   Previously, when importing a single instrument into a procedure, all instruments would be imported into memory through the manufacturer modules in :code:`pymeasure/instruments/__init__.py`.
@@ -28,7 +29,7 @@ Deprecated features
 
 Instruments mechanics
 ---------------------
-- Add a SCPI base class :code:`SCPIMixin` as replacement for :code:`includeSCPI=True` (@BenediktBurger, #905, #1007, #1019)
+- Add a SCPI base class :code:`SCPIMixin` as replacement for :code:`includeSCPI=True` (@BenediktBurger, #905, #1007, #1019, #1047)
 - Add :code:`next_error` property to SCPI instruments (@BenediktBurger, #1024)
 - Make :code:`query_delay=None` the default for :code:`wait_for` (@BenediktBurger, #1077)
 - Fix :code:`expected_protocol` using empty dictionary as default value (@BenediktBurger, #1087)

--- a/docs/api/instruments/keithley/index.rst
+++ b/docs/api/instruments/keithley/index.rst
@@ -22,3 +22,4 @@ This section contains specific documentation on the Keithley instruments that ar
    keithley2200
    keithleyDMM6500
    keithley2182
+   keithleyDAQ6510

--- a/docs/api/instruments/keithley/keithleyDAQ6510.rst
+++ b/docs/api/instruments/keithley/keithleyDAQ6510.rst
@@ -1,0 +1,8 @@
+###########################################################
+Keithley DAQ6510 Data Acquisition Logging Multimeter System
+###########################################################
+
+.. autoclass:: pymeasure.instruments.keithley.KeithleyDAQ6510
+    :members:
+    :show-inheritance:
+    :inherited-members: CommonBase

--- a/pymeasure/instruments/keithley/__init__.py
+++ b/pymeasure/instruments/keithley/__init__.py
@@ -35,3 +35,4 @@ from .keithley6517b import Keithley6517B
 from .keithley2200 import Keithley2200
 from .keithleyDMM6500 import KeithleyDMM6500
 from .keithley2182 import Keithley2182
+from .keithleyDAQ6510 import KeithleyDAQ6510

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -1,0 +1,103 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.generic_types import SCPIMixin
+from .buffer import KeithleyBuffer
+
+
+class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
+    """ Represents the Keithley DAQ6510 Data Acquisition Logging Multimeter System
+    and provides a high-level interface for interacting with the instrument.
+
+    .. code-block:: python
+
+        keithley = KeithleyDAQ6510("GPIB::1")
+        keithley = KeithleyDAQ6510("TCPIP::192.168.1.1::INSTR")
+
+    """
+
+    def __init__(self, adapter, name="Keithley DAQ6510", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )
+
+    open_channel = Instrument.setting(
+        ":ROUT:OPEN (@%d)",
+        """Set a single channel to open."""
+    )
+
+    close_channel = Instrument.setting(
+        ":ROUT:CLOS (@%d)",
+        """Set a single channel to closed."""
+    )
+
+    def no_errors(self):
+        """
+        Check to see if the instrument has any errors returned or not.
+
+        :return: ``True`` if there are no errors, ``False`` if there are errors.
+        """
+        return len(self.check_errors() == 0)
+
+    def use_mux(self):
+        """
+        Enables MUX switching. Forces open channels 134 and 135 for isolation and
+        closes channel 133 to separate MUX1 and MUX2.
+
+        :return: ``True`` if the channels were opened and closed successfully.
+        """
+        self.open_channels([134, 135])
+        self.close_channels([133])
+        return self.ask(":ROUT:CLOS?") == "(@133)\n"
+
+    def open_channels(self, channel_list):
+        """
+        Configures multiple channels to be open.
+
+        :param channel_list: List of channels to be set to open.
+        """
+        for channel in channel_list:
+            self.open_channel = channel
+
+    def close_channels(self, channel_list):
+        """
+        Configures multiple channels to be closed.
+
+        :param channel_list: List of channels to be set to closed.
+        """
+        for channel in channel_list:
+            self.close_channel = channel
+
+    def beep(self, frequency, duration):
+        """
+        Sound a system beep.
+
+        :param frequency: A frequency in Hz from 20 and 8000 Hz
+        :param duration: The amount of time to play the tone, between 0.001 s to 100 s
+        :return: None
+        """
+        self.write(f":SYST:BEEP {frequency:g}, {duration:g}")

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -64,11 +64,10 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         )
 
     sense_mode = Instrument.control(
-        ":SENS:FUNC?", ":SENS:FUNC %s",
-        """ A string property that controls the reading mode, which can
-        take the values 'current' or 'voltage'. The convenience methods
-        :meth:`~.KeithleyDAQ6510.sense_current` and :meth:`~.KeithleyDAQ6510.sense_voltage`
-        can also be used. """,
+        ":SENS:FUNC?", ":SENS:FUNC \"%s\"",
+        """ Control the reading mode, which can take the values 'current' or 'voltage'.
+        The convenience methods :meth:`~.KeithleyDAQ6510.sense_current` and
+        :meth:`~.KeithleyDAQ6510.sense_voltage` can also be used. """,
         validator=strict_discrete_set,
         values={'current': 'CURR', 'voltage': 'VOLT'},
         map_values=True
@@ -80,15 +79,14 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     current = Instrument.measurement(
         ":READ?",
-        """ Reads the current in Amps, if configured for this reading.
+        """ Measure the current in Amps, if configured for this reading.
         """
     )
 
     current_range = Instrument.control(
         ":SENS:CURR:RANG?", ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
-        """ A floating point property that controls the measurement current
-        range in Amps. If the measurement function is DC current,
-        available ranges are 10E-6 A to 3A. If the measurement function is AC current,
+        """ Control the measurement current range in Amps. If the measurement function is DC,
+        available ranges are 10E-6 A to 3A. If the measurement function is AC,
         available ranges are 100E-6 to 3A.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
@@ -97,13 +95,12 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     current_nplc = Instrument.control(
         ":SENS:CURR:NPLC?", ":SENS:CURR:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
-        (NPLC) for the DC current measurements, which sets the integration period
-        and measurement speed. Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
-        The smallest value is the shortest time, and results in the fastest reading rate,
-        but increases the reading noise and decreases the number of usable digits.
-        The largest value is the longest time, and results in the lowest reading rate,
-        but increases the number of usable digits. """
+        """ Control the number of power line cycles (NPLC) for the DC current measurements,
+        which sets the integration period and measurement speed.
+        Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz). The smallest value is the
+        shortest time, and results in the fastest reading rate, but increases the reading noise
+        and decreases the number of usable digits. The largest value is the longest time, and
+        results in the lowest reading rate, but increases the number of usable digits. """
     )
 
     ###############
@@ -112,26 +109,24 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     voltage = Instrument.measurement(
         ":READ?",
-        """ Reads the voltage in Volts, if configured for this reading.
+        """ Measure the voltage in Volts, if configured for this reading.
         """
     )
 
     voltage_range = Instrument.control(
         ":SENS:VOLT:RANG?", ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG %g",
-        """ A floating point property that controls the measurement voltage
-        range in Volts. If the measurement function is DC voltage,
-        available ranges are 100E-3 V to 1000 V. If the measurement function is AC voltage,
-        available ranges are 100E-3 to 750 V.
-        Auto-range is disabled when this property is set. """,
+        """ Control the measurement voltage range in Volts. If the measurement function is DC,
+        available ranges are 100E-3 V to 1000 V. If the measurement function is AC, available
+        ranges are 100E-3 to 750 V. Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[100E-3, 1000]
     )
 
     voltage_nplc = Instrument.control(
         ":SENS:VOLT:NPLC?", ":SENS:VOLT:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
-        (NPLC) for the DC voltage measurements, which sets the integration period
-        and measurement speed. Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
+        """ Control the number of power line cycles (NPLC) for the DC voltage measurements,
+        which sets the integration period and measurement speed.
+        Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
         The smallest value is the shortest time, and results in the fastest reading rate,
         but increases the reading noise and decreases the number of usable digits.
         The largest value is the longest time, and results in the lowest reading rate,
@@ -144,14 +139,13 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     resistance = Instrument.measurement(
         ":READ?",
-        """ Reads the resistance in Ohms, if configured for this reading.
+        """ Measure the resistance in Ohms, if configured for this reading.
         """
     )
 
     resistance_range = Instrument.control(
         ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
-        """ A floating point property that controls the resistance range
-        in Ohms. If the measurement function is 2-wire resistance,
+        """ Control the resistance range in Ohms. If the measurement function is 2-wire,
         the available ranges are 10 to 100E6 Ohms. If the measurement function is
         4-wire resistance with offset compensation off, the available ranges
         are 1 to 100E6 Ohms. If the measurement function is 4-wire resistance
@@ -163,7 +157,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     offset_compensated = Instrument.control(
         ":SENS:FRES:OCOM?", ":SENS:FRES:OCOM %s",
-        """ A string property that determines if offset compensation is used or not.
+        """ Control if offset compensation is used or not.
         Valid values are OFF, ON, and AUTO. """,
         validator=strict_discrete_set,
         values=["OFF", "ON", "AUTO"],
@@ -172,9 +166,9 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     resistance_nplc = Instrument.control(
         ":SENS:RES:NPLC?", ":SENS:RES:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
-        (NPLC) for the 2-wire resistance measurements, which sets the integration period
-        and measurement speed. Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
+        """ Control the number of power line cycles (NPLC) for the 2-wire resistance measurements,
+        which sets the integration period and measurement speed.
+        Takes values from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
         The smallest value is the shortest time, and results in the fastest reading rate,
         but increases the reading noise and decreases the number of usable digits.
         The largest value is the longest time, and results in the lowest reading rate,

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -56,6 +56,13 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     """
 
+    def __init__(self, adapter, name="Keithley DAQ6510", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )
+
     sense_mode = Instrument.control(
         ":SENS:FUNC?", ":SENS:FUNC %s",
         """ A string property that controls the reading mode, which can
@@ -174,13 +181,6 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     ####################
     # Methods        #
     ####################
-
-    def __init__(self, adapter, name="Keithley DAQ6510", **kwargs):
-        super().__init__(
-            adapter,
-            name,
-            **kwargs
-        )
 
     def measure_resistance(self, nplc=1, resistance=100e6, auto_range=True):
         """ Configures the measurement of resistance.

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -42,7 +42,17 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         keithley = KeithleyDAQ6510("GPIB::1")
         keithley = KeithleyDAQ6510("TCPIP::192.168.1.1::INSTR")
 
-        keithley.apply_current()                # Sets up to source current
+        print(keithley.current)                 # Prints the current in Amps
+        keithley.current_range = 10E-6          # Select the 10 uA range
+
+        print(keithley.voltage)                 # Prints the voltage in Volts
+        keithley.voltage_range = 100e-3         # Select the 100 mV range
+
+        print(keithley.resistance)              # Prints the resistance in Ohms
+        keithley.offset_compensated = "ON"      # Turns offset-compensated ohms on
+
+        keithley.open_channels([134, 135])      # Open channels 134 and 135 on the MUX card
+        keithley.close_channel(133)             # Close channel 133 on the MUX card
 
     """
 

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -87,8 +87,9 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     current_range = Instrument.control(
         ":SENS:CURR:RANG?", ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
         """ A floating point property that controls the measurement current
-        range in Amps. If the measurement function is DC current, available ranges are 10E-6 A to 3A.
-        If the measurement function is AC current, available ranges are 100E-6 to 3A.
+        range in Amps. If the measurement function is DC current,
+        available ranges are 10E-6 A to 3A. If the measurement function is AC current,
+        available ranges are 100E-6 to 3A.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[10E-6, 3]
@@ -118,8 +119,9 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     voltage_range = Instrument.control(
         ":SENS:VOLT:RANG?", ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG %g",
         """ A floating point property that controls the measurement voltage
-        range in Volts. If the measurement function is DC voltage, available ranges are 100E-3 V to 1000 V.
-        If the measurement function is AC voltage, available ranges are 100E-3 to 750 V.
+        range in Volts. If the measurement function is DC voltage,
+        available ranges are 100E-3 V to 1000 V. If the measurement function is AC voltage,
+        available ranges are 100E-3 to 750 V.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[100E-3, 1000]
@@ -149,9 +151,10 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     resistance_range = Instrument.control(
         ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
         """ A floating point property that controls the resistance range
-        in Ohms. If the measurement function is 2-wire resistance, the available ranges are 10 to 100E6 Ohms.
-        If the measurement function is 4-wire resistance with offset compensation off,
-        the available ranges are 1 to 100E6 Ohms. If the measurement function is 4-wire resistance
+        in Ohms. If the measurement function is 2-wire resistance,
+        the available ranges are 10 to 100E6 Ohms. If the measurement function is
+        4-wire resistance with offset compensation off, the available ranges
+        are 1 to 100E6 Ohms. If the measurement function is 4-wire resistance
         with offset compensation on, the available ranges are 1 to 10E3 Ohms.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
@@ -185,10 +188,12 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     def measure_resistance(self, nplc=1, resistance=100e6, auto_range=True):
         """ Configures the measurement of resistance.
 
-        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
+        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
+                     or 12 (50 Hz or 400 Hz).
         :param resistance: Upper limit of resistance in Ohms, from 10 to 100E6 (2-wire),
-        1 to 100E6 (4-wire with OCOM off), or 1 to 10E3 (4-wire with OCOM on).
-        :param auto_range: A boolean value to enable auto_range if ``True``, else uses the set resistance.
+                           1 to 100E6 (4-wire with OCOM off), or 1 to 10E3 (4-wire with OCOM on).
+        :param auto_range: A boolean value to enable auto_range if ``True``,
+                           else uses the set resistance.
         """
         log.info(f"{self.name} is measuring resistance.")
         self.write(f":SENS:FUNC \"RES\";:SENS:RES:NPLC {nplc};")
@@ -201,9 +206,12 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     def measure_voltage(self, nplc=1, voltage=1000, auto_range=True):
         """ Configures the measurement of voltage.
 
-        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
-        :param voltage: Upper limit of voltage in Volts, from 100E-3 to 1000 V (DC) or 100E-3 to 750 V (AC).
-        :param auto_range: A boolean value to enable auto_range if ``True``, else uses the set resistance.
+        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
+                     or 12 (50 Hz or 400 Hz).
+        :param voltage: Upper limit of voltage in Volts, from 100E-3 to 1000 V (DC)
+                        or 100E-3 to 750 V (AC).
+        :param auto_range: A boolean value to enable auto_range if ``True``,
+                           else uses the set voltage.
         """
         log.info(f"{self.name} is measuring voltage.")
         self.write(f":SENS:FUNC \"VOLT\";:SENS:VOLT:NPLC {nplc};")
@@ -214,13 +222,16 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         self.check_errors()
 
     def measure_current(self, nplc=1, current=3, auto_range=True):
-        """ Configures the measurement of voltage.
+        """ Configures the measurement of current.
 
-        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz) or 12 (50 Hz or 400 Hz).
-        :param current: Upper limit of current in Amps, from 10E-6 to 3 A (DC) or 100E-6 to 3A (AC).
-        :param auto_range: A boolean value to enable auto_range if ``True``, else uses the set resistance.
+        :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
+                     or 12 (50 Hz or 400 Hz).
+        :param current: Upper limit of current in Amps, from 10E-6 to 3 A (DC)
+                        or 100E-6 to 3A (AC).
+        :param auto_range: A boolean value to enable auto_range if ``True``,
+                           else uses the set current.
         """
-        log.info(f"{self.name} is measuring voltage.")
+        log.info(f"{self.name} is measuring current.")
         self.write(f":SENS:FUNC \"CURR\";:SENS:CURR:NPLC {nplc};")
         if auto_range:
             self.write(":SENS:CURR:RANG:AUTO ON;")

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -159,7 +159,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     )
 
     offset_compensated = Instrument.control(
-        ":SENS:RES:OCOM?", ":SENS:RES:OCOM %s",
+        ":SENS:FRES:OCOM?", ":SENS:FRES:OCOM %s",
         """ A string property that determines if offset compensation is used or not.
         Valid values are OFF, ON, and AUTO. """,
         validator=strict_discrete_set,

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -233,14 +233,6 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
             self.current_range = current
         self.check_errors()
 
-    def no_errors(self):
-        """
-        Check to see if the instrument has any errors returned or not.
-
-        :return: ``True`` if there are no errors, ``False`` if there are errors.
-        """
-        return len(self.check_errors() == 0)
-
     def open_channel(self, channel):
         """
         Set a single channel to open.

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -45,16 +45,6 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
             **kwargs
         )
 
-    open_channel = Instrument.setting(
-        ":ROUT:OPEN (@%d)",
-        """Set a single channel to open."""
-    )
-
-    close_channel = Instrument.setting(
-        ":ROUT:CLOS (@%d)",
-        """Set a single channel to closed."""
-    )
-
     def no_errors(self):
         """
         Check to see if the instrument has any errors returned or not.
@@ -73,6 +63,22 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         self.open_channels([134, 135])
         self.close_channels([133])
         return self.ask(":ROUT:CLOS?") == "(@133)\n"
+
+    def open_channel(self, channel):
+        """
+        Set a single channel to open.
+
+        :param channel: Channel to be set to open.
+        """
+        self.write(f":ROUT:OPEN (@{channel})")
+
+    def close_channel(self, channel):
+        """
+        Set a single channel to closed.
+
+        :param channel: Channel to be set to closed.
+        """
+        self.write(f":ROUT:CLOS (@{channel})")
 
     def open_channels(self, channel_list):
         """

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -180,7 +180,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
     ####################
 
     def measure_resistance(self, nplc=1, resistance=100e6, auto_range=True):
-        """ Configures the measurement of resistance.
+        """ Configure the measurement of resistance.
 
         :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
                      or 12 (50 Hz or 400 Hz).
@@ -198,7 +198,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         self.check_errors()
 
     def measure_voltage(self, nplc=1, voltage=1000, auto_range=True):
-        """ Configures the measurement of voltage.
+        """ Configure the measurement of voltage.
 
         :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
                      or 12 (50 Hz or 400 Hz).
@@ -216,7 +216,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         self.check_errors()
 
     def measure_current(self, nplc=1, current=3, auto_range=True):
-        """ Configures the measurement of current.
+        """ Configure the measurement of current.
 
         :param nplc: Number of power line cycles (NPLC) from 5E-4 to 15 (60 Hz)
                      or 12 (50 Hz or 400 Hz).
@@ -259,7 +259,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     def open_channels(self, channel_list):
         """
-        Configures multiple channels to be open.
+        Configure multiple channels to be open.
 
         :param channel_list: List of channels to be set to open.
         """
@@ -268,7 +268,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
 
     def close_channels(self, channel_list):
         """
-        Configures multiple channels to be closed.
+        Configure multiple channels to be closed.
 
         :param channel_list: List of channels to be set to closed.
         """

--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -87,7 +87,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         :param channel_list: List of channels to be set to open.
         """
         for channel in channel_list:
-            self.open_channel = channel
+            self.open_channel(channel)
 
     def close_channels(self, channel_list):
         """
@@ -96,7 +96,7 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         :param channel_list: List of channels to be set to closed.
         """
         for channel in channel_list:
-            self.close_channel = channel
+            self.close_channel(channel)
 
     def beep(self, frequency, duration):
         """

--- a/tests/instruments/keithley/test_keithleyDAQ6510.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510.py
@@ -37,8 +37,7 @@ def test_init():
 def test_current_range_set():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b':SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG 1', None)],
+            [(b':SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG 1', None)],
     ) as inst:
         inst.current_range = 1.0
 
@@ -46,8 +45,7 @@ def test_current_range_set():
 def test_current_range_get():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b':SENS:CURR:RANG?', b'1.0\n')],
+            [(b':SENS:CURR:RANG?', b'1.0\n')],
     ) as inst:
         assert inst.current_range == 1.0
 
@@ -55,8 +53,7 @@ def test_current_range_get():
 def test_current_nplc_set():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b':SENS:CURR:NPLC 2', None)],
+            [(b':SENS:CURR:NPLC 2', None)],
     ) as inst:
         inst.current_nplc = 2
 
@@ -64,8 +61,7 @@ def test_current_nplc_set():
 def test_current_nplc_get():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b':SENS:CURR:NPLC?', b'2\n')],
+            [(b':SENS:CURR:NPLC?', b'2\n')],
     ) as inst:
         assert inst.current_nplc == 2.0
 
@@ -73,8 +69,7 @@ def test_current_nplc_get():
 def test_id():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b'*IDN?', b'KEITHLEY INSTRUMENTS,MODEL DAQ6510,04591126,1.7.12b\n')],
+            [(b'*IDN?', b'KEITHLEY INSTRUMENTS,MODEL DAQ6510,04591126,1.7.12b\n')],
     ) as inst:
         assert inst.id == 'KEITHLEY INSTRUMENTS,MODEL DAQ6510,04591126,1.7.12b'
 
@@ -82,7 +77,6 @@ def test_id():
 def test_reset():
     with expected_protocol(
             KeithleyDAQ6510,
-            [(b'*LANG SCPI', None),
-             (b'*RST', None)],
+            [(b'*RST', None)],
     ) as inst:
         assert inst.reset() is None

--- a/tests/instruments/keithley/test_keithleyDAQ6510.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510.py
@@ -26,14 +26,6 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.keithley import KeithleyDAQ6510
 
 
-def test_init():
-    with expected_protocol(
-            KeithleyDAQ6510,
-            [(b'*LANG SCPI', None)],
-    ):
-        pass  # Verify the expected communication.
-
-
 def test_current_range_set():
     with expected_protocol(
             KeithleyDAQ6510,

--- a/tests/instruments/keithley/test_keithleyDAQ6510.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510.py
@@ -26,6 +26,12 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.keithley import KeithleyDAQ6510
 
 
+def test_init():
+    with expected_protocol(
+        KeithleyDAQ6510,
+    ):
+        pass
+
 def test_current_range_set():
     with expected_protocol(
             KeithleyDAQ6510,

--- a/tests/instruments/keithley/test_keithleyDAQ6510.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510.py
@@ -22,8 +22,6 @@
 # THE SOFTWARE.
 #
 
-import pytest
-import logging
 from pymeasure.test import expected_protocol
 from pymeasure.instruments.keithley import KeithleyDAQ6510
 

--- a/tests/instruments/keithley/test_keithleyDAQ6510.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510.py
@@ -1,0 +1,90 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import logging
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.keithley import KeithleyDAQ6510
+
+
+def test_init():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None)],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_current_range_set():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b':SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG 1', None)],
+    ) as inst:
+        inst.current_range = 1.0
+
+
+def test_current_range_get():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b':SENS:CURR:RANG?', b'1.0\n')],
+    ) as inst:
+        assert inst.current_range == 1.0
+
+
+def test_current_nplc_set():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b':SENS:CURR:NPLC 2', None)],
+    ) as inst:
+        inst.current_nplc = 2
+
+
+def test_current_nplc_get():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b':SENS:CURR:NPLC?', b'2\n')],
+    ) as inst:
+        assert inst.current_nplc == 2.0
+
+
+def test_id():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b'*IDN?', b'KEITHLEY INSTRUMENTS,MODEL DAQ6510,04591126,1.7.12b\n')],
+    ) as inst:
+        assert inst.id == 'KEITHLEY INSTRUMENTS,MODEL DAQ6510,04591126,1.7.12b'
+
+
+def test_reset():
+    with expected_protocol(
+            KeithleyDAQ6510,
+            [(b'*LANG SCPI', None),
+             (b'*RST', None)],
+    ) as inst:
+        assert inst.reset() is None

--- a/tests/instruments/keithley/test_keithleyDAQ6510_with_device.py
+++ b/tests/instruments/keithley/test_keithleyDAQ6510_with_device.py
@@ -1,0 +1,61 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+import logging
+from pymeasure.instruments.keithley import KeithleyDAQ6510
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+@pytest.fixture(scope="module")
+def daq6510(connected_device_address):
+    instr = KeithleyDAQ6510(connected_device_address)
+    instr.adapter.connection.timeout = 10000
+    return instr
+
+
+@pytest.fixture
+def reset_daq(daq6510):
+    daq6510.clear()
+    daq6510.reset()
+    return daq6510
+
+
+def test_correct_model_by_idn(reset_daq):
+    assert "6510" in reset_daq.id.lower()
+
+
+def test_beep(reset_daq):
+    reset_daq.beep(440, 0.1)
+    assert len(reset_daq.check_errors()) == 0
+
+
+def test_mux(reset_daq):
+    assert reset_daq.use_mux()
+
+
+def test_rear(reset_daq):
+    assert reset_daq.ask(":ROUT:TERM?") == "REAR\n"


### PR DESCRIPTION
Add support for the [Keithley DAQ6510 Data Acquisition and Logging Multimeter System](https://www.tek.com/en/products/keithley/digital-multimeter/keithley-daq6510).