### PR TITLE
Fix documentation errors

### DIFF
--- a/docs/api/instruments/agilent/agilentB1500.rst
+++ b/docs/api/instruments/agilent/agilentB1500.rst
@@ -31,7 +31,7 @@ method/attribute names in this instrument driver.
 ===========     =============================================
 Command         Property/Method
 ===========     =============================================
-``AAD``         :meth:`SMU.adc_type`
+``AAD``         :attr:`SMU.adc_type`
 ``AB``          :meth:`~AgilentB1500.abort`
 ``AIT``         :meth:`~AgilentB1500.adc_setup`
 ``AV``          :meth:`~AgilentB1500.adc_averaging`
@@ -39,7 +39,7 @@ Command         Property/Method
 ``BC``          :meth:`~AgilentB1500.clear_buffer`
 ``CL``          :meth:`SMU.disable`
 ``CM``          :attr:`~AgilentB1500.auto_calibration`
-``CMM``         :meth:`SMU.meas_op_mode`
+``CMM``         :attr:`SMU.meas_op_mode`
 ``CN``          :meth:`SMU.enable`
 ``DI``          :meth:`SMU.force` mode: ``'CURRENT'``
 ``DV``          :meth:`SMU.force` mode: ``'VOLTAGE'``
@@ -47,7 +47,7 @@ Command         Property/Method
 ``ERRX?``       :meth:`~AgilentB1500.check_errors`
 ``FL``          :attr:`SMU.filter`
 ``FMT``         :meth:`~AgilentB1500.data_format`
-``*IDN?``       :meth:`~AgilentB1500.id`
+``*IDN?``       :attr:`~AgilentB1500.id`
 ``*LRN?``       :meth:`~AgilentB1500.query_learn`, |br|
                 multiple methods to read/format settings directly
 ``MI``          :meth:`SMU.sampling_source` mode: ``'CURRENT'``


### PR DESCRIPTION
Some properties were declared as methods by mistake.
(See #1130)
