### PR TITLE
Add a `description` to `Parameter`s

### DIFF
--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -42,9 +42,11 @@ class Parameter:
         list of strings, this argument can be either a single condition or
         a list of conditions. If the group_by argument is provided as a dict
         this argument is ignored.
+    :description: A string providing a human-friendly description for the 
+		parameter.
     """
 
-    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True):
+    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True, description=None):
         self.name = name
         separator = ": "
         if separator in name:
@@ -71,6 +73,10 @@ class Parameter:
         elif group_by is not None:
             raise TypeError("The provided group_by argument is not valid, should be either a "
                             "string, a list of strings, or a dict with {string: condition} pairs.")
+		
+        if description is not None and not isinstance(description, str):
+            raise TypeError("The provided description argument is not a string.")
+        self._description = description
 
     @property
     def value(self):


### PR DESCRIPTION
I am new to pymeasure, but reading the documentation and source code I could not find a way to provide a description for each `Parameter` I add to my `Procedure`. I think it would be really nice to have an official `description` field in the constructor of `Parameter`s, so that the user can provide a human-friendly description with information that is not captured by the other fields or not obvious.

In this pull request I am simply suggesting that this would be a good idea and providing a trivial implementation. What exactly is done with the `description` afterwards I still don't know, as I am not experienced with pymeasure. However, I would guess it could probably be integrated with the graphical interface machinery and other things, instead as being mere documentation strings in the code.

Example:
```python
class ProcedureWithManyParameters(Procedure):
	repetition_rate = FloatParameter('repetition rate', units='s^-1', minimum=1e3, maximum=200e6, description='The inverse of the period between two write pulses.')
	read_fraction_start = FloatParameter('read fraction start', default=0.8, minimum=0, maximum=1, description='Fraction within each pulse at which to start the reading.')
	read_fraction_end = FloatParameter('read fraction end', default=1, minimum=0, maximum=1, description='Fraction within each pulse at which to stop the reading.')
```
as opposed to
```python
class ProcedureWithManyParameters(Procedure):
	"""A procedure with many parameters.
	
	Parameters
	----------
	repetition_rate: float
		The inverse of the period between two write pulses. units='s^-1', minimum=1e3, maximum=200e6.
	read_fraction_start: float
		Fraction within each pulse at which to start the reading. default=0.8, minimum=0, maximum=1.
	read_fraction_end: float
		Fraction within each pulse at which to stop the reading. default=1, minimum=0, maximum=1.
	"""
	
	repetition_rate = FloatParameter('repetition rate', units='s^-1', minimum=1e3, maximum=200e6)
	read_fraction_start = FloatParameter('read fraction start', default=0.8, minimum=0, maximum=1)
	read_fraction_end = FloatParameter('read fraction end', default=1, minimum=0, maximum=1)
```
which involves duplication between the code and the docstring.

Please let me know if this is already implemented somehow in Pymeasure, in that case I apologize for this.