### PR TITLE
Change logger from root to module-specific logger.

### DIFF
--- a/pymeasure/experiment/experiment.py
+++ b/pymeasure/experiment/experiment.py
@@ -34,7 +34,7 @@ from .config import get_config, set_mpl_rcparams
 from pymeasure.log import setup_logging, console_log
 from pymeasure.experiment import Results, Worker
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 try:

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -33,7 +33,7 @@ from pint import UndefinedUnitError
 from .parameters import Parameter, Measurable, Metadata
 from pymeasure.units import ureg
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -73,7 +73,7 @@ class Worker(StoppableThread):
         self.log_level = log_level
 
         global log
-        log = logging.getLogger()
+        log = logging.getLogger(__name__)
         log.setLevel(self.log_level)
         # log.handlers = []  # Remove all other handlers
         # log.addHandler(TopicQueueHandler(self.monitor_queue))


### PR DESCRIPTION
Three modules (procedure.py, experiment.py, and workers.py) configure their logger incorrectly by setting it to the root logger.

The consequence of this is that in an application that uses pymeasure, if pymeasure is imported before configuring logging, then the logging configuration is ignored.

Example where pymeasure import BEFORE logging config prevents logging in main application:
```
import logging
import pymeasure.experiment.procedure     # BEFORE
logger = logging.getLogger(__name__)
logging.basicConfig(level=logging.INFO)

logger.info("This message will NOT display on console.")
```

Example where pymeasure import AFTER logging config behaves as expected:
```
import logging
logger = logging.getLogger(__name__)
logging.basicConfig(level=logging.INFO)
import pymeasure.experiment.procedure     # AFTER

logger.info("This message will display on console.")
```

This pull request fixes this issue and pymeasure can be imported before logging configuration.

A discussion on this topic can be found [here](https://ppwwyyxx.com/blog/2022/Effective-Python-Logging/#:~:text=The%20logger%20named%20by%20an,responsibility%20of%20any%20single%20library.).