### PR TITLE
Change 2182 read_termination to "\n"

### DIFF
--- a/pymeasure/instruments/keithley/keithley2182.py
+++ b/pymeasure/instruments/keithley/keithley2182.py
@@ -179,7 +179,7 @@ class Keithley2182(SCPIMixin, KeithleyBuffer, Instrument):
     """
 
     def __init__(self, adapter, name="Keithley 2182 Nanovoltmeter",
-                 read_termination='\r', **kwargs):
+                 read_termination='\n', **kwargs):
         super().__init__(adapter, name, read_termination=read_termination, **kwargs)
 
     ch_1 = Instrument.ChannelCreator(Keithley2182Channel, 1)


### PR DESCRIPTION
The read_termination of 2182a turns out to be "\n". 
Error messages can be avoided by changing the termination.