### PR TITLE
Agilent E5062A: docs + rename `active_traces` to `visible_traces`

### DIFF
--- a/pymeasure/instruments/agilent/agilentE5062A.py
+++ b/pymeasure/instruments/agilent/agilentE5062A.py
@@ -544,13 +544,15 @@ class AgilentE5062A(SCPIMixin, Instrument):
         "TRIGger:SOURce?", "TRIGger:SOURce %s",
         """Control the trigger source (str). From the documentation:
 
-         - INT: Uses the internal trigger to generate continuous triggers
-        automatically (default).
-         - EXT: Generates a trigger when the trigger signal is inputted
-        externally via the Ext Trig connector or the handler interface.
-         - MAN: Generates a trigger when the key operation of [Trigger] -
-        Trigger is executed from the front panel.
-         - BUS: Generates a trigger when the ``*TRG`` command is executed.""",
+        - INT: Uses the internal trigger to generate continuous triggers
+          automatically (default).
+        - EXT: Generates a trigger when the trigger signal is inputted
+          externally via the Ext Trig connector or the handler interface.
+        - MAN: Generates a trigger when the key operation of [Trigger] -
+          Trigger is executed from the front panel.
+        - BUS: Generates a trigger when the ``*TRG`` command is executed.
+
+        """,
         validator=strict_discrete_set,
         values=[
             'INT',

--- a/pymeasure/instruments/agilent/agilentE5062A.py
+++ b/pymeasure/instruments/agilent/agilentE5062A.py
@@ -380,6 +380,7 @@ class VNAChannel(Channel):
                 re, im = ch.data
                 s_matrix[:, i] = re + 1j * im
             s_matrix = s_matrix.reshape(-1, 2, 2)  # ready for use with e.g. skrf
+
         """
         self.write(f'CALC{self.id}:DATA:FDAT?')
         numeric_data = self._read_binary_data()
@@ -466,6 +467,7 @@ class AgilentE5062A(SCPIMixin, Instrument):
             vna.wait_for_complete()     # wait until the sweep is complete
 
         # see `agilentE5062A.data` for an example of saving the measurement
+
     """
 
     ch_1 = Instrument.ChannelCreator(VNAChannel, 1)

--- a/pymeasure/instruments/agilent/agilentE5062A.py
+++ b/pymeasure/instruments/agilent/agilentE5062A.py
@@ -26,6 +26,7 @@ from pymeasure.instruments import Instrument, SCPIMixin, Channel
 from pymeasure.instruments.validators import strict_range, strict_discrete_range, \
     strict_discrete_set
 
+from pyvisa.errors import VisaIOError
 import numpy as np
 
 import functools
@@ -73,22 +74,22 @@ class VNAChannel(Channel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._add_trace(override_id=1)                # add just a single trace to init it all
-        self._update_trace_count(self.active_traces)  # add remaining traces if necessary
-        self._update_power_values(self.attenuation)   # update dynamic limits of power
+        self._add_trace(override_id=1)                 # add just a single trace to init it all
+        self._update_trace_count(self.visible_traces)  # add remaining traces if necessary
+        self._update_power_values(self.attenuation)    # update dynamic limits of power
 
     def _add_trace(self, override_id=None):
         """Internal method that adds a trace to the traces list"""
         tr_id = len(self.traces) + 1 if override_id is None else override_id
         self.add_child(VNATrace, tr_id, 'traces', 'tr_')
 
-    def _update_trace_count(self, active_traces):
+    def _update_trace_count(self, visible_traces):
         """Internal method that updates the trace list based on the number
-        of active traces.
+        of visible traces.
         """
-        while len(self.traces) > active_traces:
+        while len(self.traces) > visible_traces:
             self.remove_child(self.traces[max(self.traces.keys())])
-        while len(self.traces) < active_traces:
+        while len(self.traces) < visible_traces:
             self._add_trace()
 
     def _update_power_values(self, attenuation):
@@ -200,12 +201,12 @@ class VNAChannel(Channel):
         self.write("DISP:WIND{ch}:ACT")
 
     @property
-    def active_traces(self):
-        """Control the number of traces active (visible) in the channel (int)."""
+    def visible_traces(self):
+        """Control the number of traces visible in the channel (int)."""
         return int(self.ask("CALC{ch}:PARameter:COUNt?"))
 
-    @active_traces.setter
-    def active_traces(self, value):
+    @visible_traces.setter
+    def visible_traces(self, value):
         value = int(float(value))
         value = strict_range(value, [1, 4])
         self.write("CALC{ch}:PARameter:COUNt %d" % value)
@@ -367,6 +368,18 @@ class VNAChannel(Channel):
 
         Frequency data is accessed via the ``frequencies`` property.
 
+        .. code-block:: python
+
+            # build an s-parameter matrix by measuring the trace data,
+            # where s_matrix[i] = [[S11, S12], [S21, S22]] @ freqs[i]
+            freqs = ch.frequencies
+            s_matrix = np.empty((freqs.size, 4), dtype=np.complex64)
+            for i, tr in enumerate(ch.traces.values()):
+                tr.activate()
+                ch.trace_format = 'POL'
+                re, im = ch.data
+                s_matrix[:, i] = re + 1j * im
+            s_matrix = s_matrix.reshape(-1, 2, 2)  # ready for use with e.g. skrf
         """
         self.write(f'CALC{self.id}:DATA:FDAT?')
         numeric_data = self._read_binary_data()
@@ -407,12 +420,15 @@ class AgilentE5062A(SCPIMixin, Instrument):
 
     This VNA has 4 separate channels, each of which has its own sweep. The
     channels are stored in the ``channels`` dictionary. Channels can be enabled
-    even if not displayed. Reading out data happens at the channel level.
+    even if not displayed. Many trace-specific operations, including reading
+    out data, happen at the channel level, but pertain to only the *active
+    trace*.
 
-    Each channel can display up to 4 traces (controlled via the ``active_traces``
-    parameter). Note that each channel also has a ``display_layout`` property
-    that controls the layout of the traces in the channel. The traces are
-    accessed via the ``traces`` dictionary (i.e. ``vna.channels[1].traces[1]``).
+    Each channel can display up to 4 traces (controlled via the
+    ``visible_traces`` parameter). Each channel also has a ``display_layout``
+    property that controls the layout of the traces in the channel. The traces
+    are accessed via the ``traces`` dictionary
+    (i.e. ``vna.channels[1].traces[1]``).
 
     The VNA supports multiple transfer formats. This API only supports the IEEE
     64-bit floating point format. The VNA is configured for this format during
@@ -422,10 +438,34 @@ class AgilentE5062A(SCPIMixin, Instrument):
     This class implements only a subset of the total E5062A functionality. The
     more significant missing functionality includes (TODO):
 
-    - editing the scale of the graphs
+    - editing the scale of the display
     - markers
     - calibration
     - power sweeps
+
+    .. code-block:: python
+
+        # connect to the VNA and make a measurement consisting of 10 averages
+        vna = AgilentE5062A("TCPIP::192.168.2.233::INSTR")
+        ch = vna.channels[1]            # use channel 1
+        ch.visible_traces = 4            # use all 4 traces
+        for i, (tr, parameter) in enumerate(zip(
+                ch.traces.values(),
+                ['S11', 'S12', 'S21', 'S22'])):
+            tr.parameter = parameter
+
+        ch.averages = 10                # use 10x averaging
+        ch.averaging_enabled = True     # turn averaging on
+        ch.trigger_continuous = False   # turn off continuous triggering
+        vna.trigger_source = 'BUS'      # require remote trigger
+        vna.abort()                     # stop the current sweep
+        ch.restart_averaging()          # clear current averaging
+        for _ in range(ch.averages):
+            ch.trigger_initiate()       # arm channel 1 for single sweep
+            vna.trigger_single()        # send a trigger
+            vna.wait_for_complete()     # wait until the sweep is complete
+
+        # see `agilentE5062A.data` for an example of saving the measurement
 
     """
 
@@ -476,7 +516,7 @@ class AgilentE5062A(SCPIMixin, Instrument):
         Note that this splits windows for multiple *channels*, not
         traces. Basic S-param measurements most likely want to use only a
         single channel, but with multuple *traces* instead. See
-        e.g. ``AgilentE5062A.channels[1].active_traces``
+        e.g. ``AgilentE5062A.channels[1].visible_traces``
         """,
         validator=strict_discrete_set,
         values=DISPLAY_LAYOUT_OPTIONS
@@ -503,16 +543,13 @@ class AgilentE5062A(SCPIMixin, Instrument):
         "TRIGger:SOURce?", "TRIGger:SOURce %s",
         """Control the trigger source (str). From the documentation:
 
-        INT: Uses the internal trigger to generate continuous triggers
+         - INT: Uses the internal trigger to generate continuous triggers
         automatically (default).
-
-        EXT: Generates a trigger when the trigger signal is inputted
+         - EXT: Generates a trigger when the trigger signal is inputted
         externally via the Ext Trig connector or the handler interface.
-
-        MAN: Generates a trigger when the key operation of [Trigger] -
+         - MAN: Generates a trigger when the key operation of [Trigger] -
         Trigger is executed from the front panel.
-
-        BUS: Generates a trigger when the ``*TRG`` command is executed.""",
+         - BUS: Generates a trigger when the ``*TRG`` command is executed.""",
         validator=strict_discrete_set,
         values=[
             'INT',
@@ -521,28 +558,49 @@ class AgilentE5062A(SCPIMixin, Instrument):
             'BUS'])
 
     def trigger_bus(self):
-        """If the trigger source if BUS and the VNA is waiting for a trigger,
-        generates a trigger"""
+        """If the trigger source is BUS and the VNA is waiting for a trigger
+        (the trigger has been initialized), generate a trigger.
+
+        """
         self.write('*TRG')
 
     def trigger(self):
-        """Regardless of the trigger setting, generates a trigger (if the
-        trigger is in the trigger wait state)"""
+        """Regardless of the trigger setting, generate a trigger (if the
+        trigger has been initialized, i.e. is in the trigger wait state)
+
+        """
         self.write('TRIGger')
 
     def trigger_single(self):
         """like trigger(), but the `complete` SCPI property (synchronization
-        bit) waits for the sweep to be complete, which is useful to wait for a
-        sweep to be complete.
+        bit) waits for the sweep to be complete (see
+        `agilentE5062A.wait_for_complete()`).
+
         """
         self.write('TRIGger:SINGle')
+
+    def wait_for_complete(self, attempt=1, max_attempts=20):
+        """Wait a potentially long time for the synchronization bit.  This is
+        useful in conjunction with `agilentE5062A.trigger_single()` to wait for
+        a single sweep to complete.
+
+        """
+        try:
+            self.complete
+        except VisaIOError:
+            if attempt == max_attempts:
+                raise
+            else:
+                self.wait_for_complete(
+                    attempt=attempt+1,
+                    max_attempts=max_attempts)
 
     def pop_err(self):
 
         """Pop an error off the error queue. Returns a tuple containing the
         code and error description. An error code 0 indicates success.
 
-        The Error queue can be deleted using the standard SCPI
+        The Error queue can be cleared using the standard SCPI
         ``agilentE5062A.clear()`` method.
 
         """

--- a/pymeasure/instruments/agilent/agilentE5062A.py
+++ b/pymeasure/instruments/agilent/agilentE5062A.py
@@ -466,7 +466,6 @@ class AgilentE5062A(SCPIMixin, Instrument):
             vna.wait_for_complete()     # wait until the sweep is complete
 
         # see `agilentE5062A.data` for an example of saving the measurement
-
     """
 
     ch_1 = Instrument.ChannelCreator(VNAChannel, 1)

--- a/tests/instruments/agilent/test_agilentE5062A.py
+++ b/tests/instruments/agilent/test_agilentE5062A.py
@@ -67,7 +67,7 @@ def initial_comm_pairs():
     return comms
 
 
-def test_ch_active_traces():
+def test_ch_visible_traces():
     with expected_protocol(
             AgilentE5062A,
             [
@@ -81,12 +81,12 @@ def test_ch_active_traces():
                 ("CALC1:PARameter:COUNt 4", None),
                 ("CALC1:PARameter:COUNt?", "4")
             ]) as inst:
-        # test ch active_traces
+        # test ch visible_traces
         ot4 = np.arange(4) + 1
         ch = inst.channels[1]
         for opt in ot4:
-            ch.active_traces = opt
-            assert ch.active_traces == opt
+            ch.visible_traces = opt
+            assert ch.visible_traces == opt
 
 
 def test_ch_traces():

--- a/tests/instruments/agilent/test_agilentE5062A.py
+++ b/tests/instruments/agilent/test_agilentE5062A.py
@@ -472,3 +472,15 @@ def test_trigger_single():
                 ("TRIGger:SINGle", None)
             ]) as inst:
         inst.trigger_single()
+
+
+def test_wait_for_complete():
+    with expected_protocol(
+            AgilentE5062A,
+            [
+                *initial_comm_pairs(),
+                ("TRIGger:SINGle", None),
+                ("*OPC?", "1")
+            ]) as inst:
+        inst.trigger_single()
+        inst.wait_for_complete()

--- a/tests/instruments/agilent/test_agilentE5062A_with_device.py
+++ b/tests/instruments/agilent/test_agilentE5062A_with_device.py
@@ -29,7 +29,6 @@
 # port connection can be anything that is safe for that power level.
 
 import pytest
-from pyvisa.errors import VisaIOError
 from pymeasure.instruments.agilent.agilentE5062A import AgilentE5062A
 
 import numpy as np

--- a/tests/instruments/agilent/test_agilentE5062A_with_device.py
+++ b/tests/instruments/agilent/test_agilentE5062A_with_device.py
@@ -317,16 +317,6 @@ def test_trigger_single(agilentE5062A):
         complete.
 
     """
-
-    def wait_for_complete(vna, attempt=1):
-        try:
-            vna.complete
-        except VisaIOError:     # IO timeout
-            if attempt > 10:
-                raise
-            else:
-                wait_for_complete(vna, attempt=attempt+1)
-
     agilentE5062A.clear()
     agilentE5062A.reset()
     agilentE5062A.trigger_source = 'BUS'
@@ -335,7 +325,7 @@ def test_trigger_single(agilentE5062A):
         agilentE5062A.abort()
         ch.trigger_initiate()
         agilentE5062A.trigger_single()
-        wait_for_complete(agilentE5062A)
+        agilentE5062A.wait_for_complete()
     agilentE5062A.trigger_source = 'INT'
     agilentE5062A.trigger_continuous = True
     assert not agilentE5062A.pop_err()[0]

--- a/tests/instruments/agilent/test_agilentE5062A_with_device.py
+++ b/tests/instruments/agilent/test_agilentE5062A_with_device.py
@@ -59,21 +59,21 @@ def agilentE5062A(connected_device_address):
     return instr
 
 
-def test_ch_active_traces(agilentE5062A):
+def test_ch_visible_traces(agilentE5062A):
     agilentE5062A.clear()
-    # test ch active_traces
+    # test ch visible_traces
     ot4 = np.arange(4) + 1
     for ch in agilentE5062A.channels.values():
         for opt in ot4:
-            ch.active_traces = opt
-            assert ch.active_traces == opt
+            ch.visible_traces = opt
+            assert ch.visible_traces == opt
     assert not agilentE5062A.pop_err()[0]
 
 
 def test_ch_traces(agilentE5062A):
     agilentE5062A.clear()
     for ch in agilentE5062A.channels.values():
-        ch.active_traces = 4
+        ch.visible_traces = 4
         for tr in ch.traces.values():
             for p in ['S11', 'S12', 'S21', 'S22']:
                 tr.parameter = p
@@ -207,7 +207,7 @@ def test_tr_format(agilentE5062A):
     agilentE5062A.clear()
     ch = agilentE5062A.channels[1]
     ch.activate()
-    ch.active_traces = 4
+    ch.visible_traces = 4
     for tr in ch.traces.values():
         tr.activate()
         for opt in ch.TRACE_FORMAT:
@@ -220,7 +220,7 @@ def test_data(agilentE5062A):
     agilentE5062A.clear()
     agilentE5062A.display_layout = 'D12_34'
     for ch in agilentE5062A.channels.values():
-        ch.active_traces = 1
+        ch.visible_traces = 1
         tr = ch.traces[1]
         tr.activate()
         tr.trace_format = 'SCOM'


### PR DESCRIPTION
Sorry for not including this in the recently merged PR, but I was hoping to improve the docs and make a minor change to the API before a release containing this instrument goes out.

There might be some confusion between the concept of the "active trace" (the currently selected trace) and the `active_traces` parameter, which controls how many traces are visible. There is only ever one "active trace", so I renamed `active_traces` to `visible_traces`. I also cleaned up the docs a bit and added some example code, with a `wait_for_complete` helper method.