### PR TITLE
Add has_next method to Procedure class

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -88,3 +88,4 @@ David Sun
 Kévin Petit
 Orion Smedley
 Samuel Simpson
+Dawid Maślanka

--- a/pymeasure/display/manager.py
+++ b/pymeasure/display/manager.py
@@ -203,7 +203,7 @@ class BaseManager(QtCore.QObject):
                 self._running_experiment = experiment
 
                 self._worker = Worker(experiment.results, port=self.port, log_level=self.log_level)
-                self._worker.has_next = self.experiments.has_next
+                self._worker.is_last = lambda: not self.experiments.has_next()
 
                 self._monitor = Monitor(self._worker.monitor_queue)
                 self._monitor.worker_running.connect(self._running)

--- a/pymeasure/display/manager.py
+++ b/pymeasure/display/manager.py
@@ -203,6 +203,7 @@ class BaseManager(QtCore.QObject):
                 self._running_experiment = experiment
 
                 self._worker = Worker(experiment.results, port=self.port, log_level=self.log_level)
+                self._worker.has_next = self.experiments.has_next
 
                 self._monitor = Monitor(self._worker.monitor_queue)
                 self._monitor.worker_running.connect(self._running)

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -284,8 +284,15 @@ class Procedure:
     def should_stop(self):
         raise NotImplementedError('should be monkey patched by a worker')
 
-    def has_next(self):
-        raise NotImplementedError('should be monkey patched by a worker')
+    def is_last(self) -> bool:
+        """Check if the procedure is the last one in the queue.
+
+        This method must be monkey patched by a worker to provide functionality.
+
+        Returns:
+            bool: True if the procedure is the last one in the queue, False otherwise.
+        """
+        raise NotImplementedError("should be monkey patched by a worker")
 
     def get_estimates(self):
         """ Function that returns estimates that are to be displayed by

--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -284,6 +284,9 @@ class Procedure:
     def should_stop(self):
         raise NotImplementedError('should be monkey patched by a worker')
 
+    def has_next(self):
+        raise NotImplementedError('should be monkey patched by a worker')
+
     def get_estimates(self):
         """ Function that returns estimates that are to be displayed by
         the EstimatorWidget. Must be reimplemented by subclasses. Should

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -129,6 +129,9 @@ class Worker(StoppableThread):
         self.emit('error', traceback_str)
         self.update_status(Procedure.FAILED)
 
+    def has_next(self):
+        raise NotImplementedError('should be monkey patched by a manager')
+
     def update_status(self, status):
         self.procedure.status = status
         self.emit('status', status)
@@ -164,6 +167,7 @@ class Worker(StoppableThread):
         # route Procedure methods & log
         self.procedure.should_stop = self.should_stop
         self.procedure.emit = self.emit
+        self.procedure.has_next = self.has_next
 
         log.info("Worker started running an instance of %r", self.procedure.__class__.__name__)
         self.update_status(Procedure.RUNNING)

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -129,7 +129,7 @@ class Worker(StoppableThread):
         self.emit('error', traceback_str)
         self.update_status(Procedure.FAILED)
 
-    def has_next(self):
+    def is_last(self):
         raise NotImplementedError('should be monkey patched by a manager')
 
     def update_status(self, status):
@@ -167,7 +167,7 @@ class Worker(StoppableThread):
         # route Procedure methods & log
         self.procedure.should_stop = self.should_stop
         self.procedure.emit = self.emit
-        self.procedure.has_next = self.has_next
+        self.procedure.is_last = self.is_last
 
         log.info("Worker started running an instance of %r", self.procedure.__class__.__name__)
         self.update_status(Procedure.RUNNING)


### PR DESCRIPTION
Pass information on whether the currently executing procedure is the last in the queue. The has_next method of the ExperimentQueue class is first monkeypatched to the Worker and then to the Procedure.