### PR TITLE
Add Oxford Instruments Mercury Intelligent Temperature Controller

### DIFF
--- a/docs/api/instruments/oxfordinstruments/MercuryiTC.rst
+++ b/docs/api/instruments/oxfordinstruments/MercuryiTC.rst
@@ -1,0 +1,14 @@
+#############################################################
+Oxford Instruments Mercury Intelligent Temperature Controller
+#############################################################
+
+.. autoclass:: pymeasure.instruments.oxfordinstruments.MercuryiTC
+    :members:
+
+.. autoclass:: pymeasure.instruments.oxfordinstruments.mercuryitc.TemperatureSensor
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.oxfordinstruments.mercuryitc.Heater
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/oxfordinstruments/index.rst
+++ b/docs/api/instruments/oxfordinstruments/index.rst
@@ -12,5 +12,5 @@ This section contains specific documentation on the Oxford Instruments instrumen
    base
    ITC503
    IPS120_10
-   PS120_10
    MercuryiTC
+   PS120_10

--- a/docs/api/instruments/oxfordinstruments/index.rst
+++ b/docs/api/instruments/oxfordinstruments/index.rst
@@ -13,3 +13,4 @@ This section contains specific documentation on the Oxford Instruments instrumen
    ITC503
    IPS120_10
    PS120_10
+   MercuryiTC

--- a/pymeasure/instruments/oxfordinstruments/__init__.py
+++ b/pymeasure/instruments/oxfordinstruments/__init__.py
@@ -26,3 +26,4 @@
 from .itc503 import ITC503
 from .ips120_10 import IPS120_10
 from .ps120_10 import PS120_10
+from .mercuryitc import MercuryiTC

--- a/pymeasure/instruments/oxfordinstruments/__init__.py
+++ b/pymeasure/instruments/oxfordinstruments/__init__.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2024 PyMeasure Developers
+# Copyright (c) 2013-2025 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -69,12 +69,6 @@ class TemperatureSensor(Channel):
         get_process=lambda v: v*1e-3
     )
 
-    control_temperature = Channel.measurement(
-        "READ:DEV:{ch}:TEMP:SIG:TEMP",
-        """Get the control temperature, in Kelvin.""",
-        preprocess_reply=lambda v: v.split(":")[-1].replace("K", "")
-    )
-
     control_loop_PID_enabled = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:ENAB",
         "SET:DEV:{ch}:TEMP:LOOP:ENAB:%s",

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -147,7 +147,7 @@ class TemperatureSensor(Channel):
     loop_ramp_enabled = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:RENA",
         "SET:DEV:{ch}:TEMP:LOOP:RENA:%s",
-        """Controls whether the temperature ramping function is enabled (``True``) or
+        """Control whether the temperature ramping function is enabled (``True``) or
         disabled (``False``).""",
         check_set_errors=True,
         preprocess_reply=lambda v: v.split(":")[-1],

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -270,7 +270,7 @@ class MercuryiTC(Instrument):
         print(controller.TS['DBS.T1'].temperature)
     """
 
-    def __init__(self, adapter, name='Oxford MercuryiTC', **kwargs):
+    def __init__(self, adapter, name='Oxford MercuryiTC', includeSCPI=False, **kwargs):
         super().__init__(
             adapter=adapter,
             name=name,

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -1,0 +1,313 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from pymeasure.instruments import Instrument, Channel
+from pymeasure.instruments.validators import strict_discrete_set, strict_range, \
+                                                truncated_range
+
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class TemperatureSensor(Channel):
+    """
+    A temperature sensor channel on the Oxford Instruments Mercury iTC.
+
+    Depending on sensor type (e.g. diode, NTC/PTC resistor), some properties
+    will not be valid. Therefore, sensor configuration must be known and set
+    a priori. Only diode sensor types are currently implemented.
+
+    Control loops are accessed via temeperature sensors, rather than heaters.
+    Therefore loop control is kept with other temperature sensor properties.
+    """
+
+    def check_set_errors(self):
+        """The MercuryiTC responds to every communication (get and set).
+        This simply reads back on setting a property."""
+        try:
+            self.read()
+        except Exception as exc:
+            log.exception("Setting a property failed.", exc_info=exc)
+            raise
+        else:
+            return []
+
+    temperature = Channel.measurement(
+        "READ:DEV:{ch}:TEMP:SIG:TEMP",
+        """Get the measured temperature, in Kelvin.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("K", "")
+    )
+
+    voltage = Channel.measurement(
+        "READ:DEV:{ch}:TEMP:SIG:VOLT",
+        """Get the sensor voltage, in Volts.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("mV", ""),
+        get_process=lambda v: v*1e-3
+    )
+
+    control_temperature = Channel.measurement(
+        "READ:DEV:{ch}:TEMP:SIG:TEMP",
+        """Get the control temperature, in Kelvin.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("K", "")
+    )
+
+    loop_PID_enabled = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:ENAB",
+        "SET:DEV:{ch}:TEMP:LOOP:ENAB:%s",
+        """Control whether the control-loop heater is controlled by
+        the PID loop (``True``) or the manual heater percentage (``False``).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1],
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True
+    )
+
+    loop_P = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:P",
+        "SET:DEV:{ch}:TEMP:LOOP:P:%g",
+        """Control the proportional term, P, of the control loop.""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1]
+    )
+
+    loop_I = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:I",
+        "SET:DEV:{ch}:TEMP:LOOP:I:%g",
+        """Control the integral term, I, of the control loop.""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1]
+    )
+
+    loop_D = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:D",
+        "SET:DEV:{ch}:TEMP:LOOP:D:%g",
+        """Control the derivative term, D, of the control loop.""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1]
+    )
+
+    loop_T_setpoint = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:TSET",
+        "SET:DEV:{ch}:TEMP:LOOP:TSET:%g",
+        """Control the control loop temperature setpoint, in Kelvin (in the range
+        0 to 2000).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1].replace("K", ""),
+        validator=truncated_range,
+        values=[0, 2000]
+    )
+
+    loop_heater_pcnt = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:HSET",
+        "SET:DEV:{ch}:TEMP:LOOP:HSET:%g",
+        """Control the heater percentage when output configured to manual mode
+        (in the range 0 to 100).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1],
+        validator=truncated_range,
+        values=[0, 100]
+    )
+
+    loop_ramp_rate = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:RSET",
+        "SET:DEV:{ch}:TEMP:LOOP:RSET:%g",
+        """Control the control loop ramp rate, in K/min, if enabled (in the
+        range 0 to 100000).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1].replace("K/m", ""),
+        validator=truncated_range,
+        values=[0, 100000]
+    )
+
+    loop_ramp_enabled = Channel.control(
+        "READ:DEV:{ch}:TEMP:LOOP:RENA",
+        "SET:DEV:{ch}:TEMP:LOOP:RENA:%s",
+        """Controls whether the temperature ramping function is enabled (``True``) or
+        disabled (``False``).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1],
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True
+    )
+
+
+class Heater(Channel):
+    """
+    A heater channel on the Oxford Instruments Mercury iTC.
+
+    Various parameters of the heater output can be accessed, and some properties
+    can be configured. PID control is accessed through an associated temperature sensor.
+    It is assumed that the heater is already associated with a temperature sensor control
+    loop, or otherwise set to operate in open-loop configuration.
+    """
+
+    def check_set_errors(self):
+        """The MercuryiTC responds to every communication (get and set).
+        This simply reads back on setting a property."""
+        try:
+            self.read()
+        except Exception as exc:
+            log.exception("Setting a property failed.", exc_info=exc)
+            raise
+        else:
+            return []
+
+    voltage = Channel.measurement(
+        "READ:DEV:{ch}:HTR:SIG:VOLT",
+        """Get the heater excitation voltage, in Volts.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("V", "")
+    )
+
+    current = Channel.measurement(
+        "READ:DEV:{ch}:HTR:SIG:CURR",
+        """Get the heater excitation current, in Amps.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("A", "")
+    )
+
+    power = Channel.measurement(
+        "READ:DEV:{ch}:HTR:SIG:POWR",
+        """Get the heater power dissipation, in Watts.""",
+        preprocess_reply=lambda v: v.split(":")[-1].replace("W", "")
+    )
+
+    voltage_limit = Channel.control(
+        "READ:DEV:{ch}:HTR:VLIM",
+        "SET:DEV:{ch}:HTR:VLIM:%g",
+        """Control the voltage limit of the heater output, in Volts (float strictly
+        from 0 to 40).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1],
+        validator=strict_range,
+        values=[0, 40]
+    )
+
+    resistance = Channel.control(
+        "READ:DEV:{ch}:HTR:RES",
+        "SET:DEV:{ch}:HTR:RES:%g",
+        """Control the programmed heater resistance, in Ohms (float strictly
+        in the range of 10 to 2000).""",
+        check_set_errors=True,
+        preprocess_reply=lambda v: v.split(":")[-1],
+        validator=strict_range,
+        values=[10, 2000]
+    )
+
+    max_power = Channel.measurement(
+        "READ:DEV:{ch}:HTR:PMAX",
+        """Get the provisional maximum power of the heater, in Watts.""",
+        preprocess_reply=lambda v: v.split(":")[-1]
+    )
+
+
+class MercuryiTC(Instrument):
+    """
+    Represents the Oxford Instruments Mercury iTC (Intelligent Temperature
+    Controller) and provides a high-level interface for interacting with the instrument.
+    Note thath the GPIB implementation on this instrument is not fully
+    SCPI-compliant, with only the ``*IDN?`` command supported. The Mercury iTC
+    can be configured to respond to a so-called SCPI instruction set (that is,
+    again, not actually an SCPI implementation) or to a legacy instruction set.
+    The implementation used here is the so-called SCPI instruction set.
+
+    The iTC is expandable and supports a mixture temperature sensors,
+    heaters, pressure sensors, cryogen level sensors and auxiliary I/O
+    through the installation of additional, function-specific daughter boards.
+    Currently, only temperature sensors and heaters are implemented.
+
+    By default, there is a temperature sensor channel installed with Unique Identifier
+    (``UID``) ``'MB1.T1'`` and a heater channel with UID ``'MB0.H1'``.
+    These channels are created automatically at instantiation of the controller.
+    These can be accessed as either ``.TS_MB``  and ``.HTR_MB``, or through the collections
+    (dictionaries) ``.TS['MB1.T1']`` and ``.HTR['MB0.H1']``.
+
+    Other sensors and heaters can be installed on additional daughter boards
+    (with specific ``UID`` e.g. ``'DBX.T1'``, ``'DBX.H1'`` etc), and can be added manually
+    to an already instantiated MercuryiTC using ``.add_temperature_sensor(UID)`` and
+    ``.add_heater(UID)``. They must be given their correct UID as listed by the Mercury iTC
+    itself as this is how they are addressed during communication. Additionally, they
+    are accessed **only** through the instrument collections ``.TS[UID]`` and ``.HTR[UID]``.
+
+    .. code-block:: python
+
+        controller = MercuryiTC("GPIB::1")
+
+        # Print the current measured temperature of the motherboard temperature sensor aka 'MB1.T1'
+        print(controller.TS_MB.temperature)
+
+        # Print the motherboard temperature sensor control-loop setpoint
+        print(controller.TS['MB1.T1'].loop_T_setpoint)
+
+        # Add new temperature sensor with UID 'DB6.T1'
+        controller.add_temperature_sensor('DB6.T1')
+
+        # Print the new sensor's temperature
+        print(controller.TS['DBS.T1'].temperature)
+    """
+
+    def __init__(self, adapter, name='Oxford MercuryiTC', **kwargs):
+        super().__init__(
+            adapter=adapter,
+            name=name,
+            read_termination="\n",
+            write_termination="\n",
+            **kwargs
+        )
+
+    identity = Instrument.measurement(
+        "*IDN?",
+        """Get identity of unit."""
+    )
+
+    TS_mobo = Instrument.ChannelCreator(
+        TemperatureSensor,
+        "MB1.T1",
+        prefix="TS",
+        collection="TS"
+        )
+
+    HTR_mobo = Instrument.ChannelCreator(
+        Heater,
+        "MB0.H1",
+        prefix="HTR",
+        collection="HTR",
+        )
+
+    def add_temperature_sensor(self, id, prefix="TS", **kwargs):
+        """Add a temperature sensor with unique identifier ``id`` to collection
+        of addressable temperature sensors: ``.TS[id]``"""
+        self.add_child(TemperatureSensor,
+                       id, collection="TS",
+                       prefix=prefix, **kwargs)
+
+    def add_heater(self, id, prefix="HTR", **kwargs):
+        """Add a heater with unique identifier  ``id`` to collection of
+        addressable heaters: ``.HTR[id]``"""
+        self.add_child(Heater,
+                       id, collection="HTR",
+                       prefix=prefix, **kwargs)

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -75,7 +75,7 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1].replace("K", "")
     )
 
-    loop_PID_enabled = Channel.control(
+    control_loop_PID_enabled = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:ENAB",
         "SET:DEV:{ch}:TEMP:LOOP:ENAB:%s",
         """Control whether the control-loop heater is controlled by
@@ -87,7 +87,7 @@ class TemperatureSensor(Channel):
         map_values=True
     )
 
-    loop_P = Channel.control(
+    control_loop_P = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:P",
         "SET:DEV:{ch}:TEMP:LOOP:P:%g",
         """Control the proportional term, P, of the control loop.""",
@@ -95,7 +95,7 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1]
     )
 
-    loop_I = Channel.control(
+    control_loop_I = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:I",
         "SET:DEV:{ch}:TEMP:LOOP:I:%g",
         """Control the integral term, I, of the control loop.""",
@@ -103,7 +103,7 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1]
     )
 
-    loop_D = Channel.control(
+    control_loop_D = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:D",
         "SET:DEV:{ch}:TEMP:LOOP:D:%g",
         """Control the derivative term, D, of the control loop.""",
@@ -111,7 +111,7 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1]
     )
 
-    loop_T_setpoint = Channel.control(
+    control_loop_temperature_setpoint = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:TSET",
         "SET:DEV:{ch}:TEMP:LOOP:TSET:%g",
         """Control the control loop temperature setpoint, in Kelvin (in the range
@@ -122,7 +122,7 @@ class TemperatureSensor(Channel):
         values=[0, 2000]
     )
 
-    loop_heater_pcnt = Channel.control(
+    control_loop_heater_percent = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:HSET",
         "SET:DEV:{ch}:TEMP:LOOP:HSET:%g",
         """Control the heater percentage when output configured to manual mode
@@ -133,7 +133,7 @@ class TemperatureSensor(Channel):
         values=[0, 100]
     )
 
-    loop_ramp_rate = Channel.control(
+    control_loop_ramp_rate = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:RSET",
         "SET:DEV:{ch}:TEMP:LOOP:RSET:%g",
         """Control the control loop ramp rate, in K/min, if enabled (in the
@@ -144,7 +144,7 @@ class TemperatureSensor(Channel):
         values=[0, 100000]
     )
 
-    loop_ramp_enabled = Channel.control(
+    control_loop_ramp_enabled = Channel.control(
         "READ:DEV:{ch}:TEMP:LOOP:RENA",
         "SET:DEV:{ch}:TEMP:LOOP:RENA:%s",
         """Control whether the temperature ramping function is enabled (``True``) or
@@ -285,14 +285,14 @@ class MercuryiTC(Instrument):
         """Get identity of unit."""
     )
 
-    TS_mobo = Instrument.ChannelCreator(
+    TS_MB = Instrument.ChannelCreator(
         TemperatureSensor,
         "MB1.T1",
         prefix="TS",
         collection="TS"
         )
 
-    HTR_mobo = Instrument.ChannelCreator(
+    HTR_MB = Instrument.ChannelCreator(
         Heater,
         "MB0.H1",
         prefix="HTR",

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -270,12 +270,13 @@ class MercuryiTC(Instrument):
         print(controller.TS['DBS.T1'].temperature)
     """
 
-    def __init__(self, adapter, name='Oxford MercuryiTC', includeSCPI=False, **kwargs):
+    def __init__(self, adapter, name='Oxford MercuryiTC', **kwargs):
         super().__init__(
             adapter=adapter,
             name=name,
             read_termination="\n",
             write_termination="\n",
+            includeSCPI=False,
             **kwargs
         )
 

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2024 PyMeasure Developers
+# Copyright (c) 2013-2025 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -34,156 +34,158 @@ def test_init():
         pass  # Verify the expected communication.
 
 
-def test_HTR_MB_current_getter():
+def test_HTR_mobo_current_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:SIG:CURR', b'STAT:DEV:MB0.H1:HTR:SIG:CURR:-0.0000A')],
     ) as inst:
-        assert inst.HTR_MB.current == -0.0
+        assert inst.HTR_mobo.current == -0.0
 
 
-def test_HTR_MB_max_power_getter():
+def test_HTR_mobo_max_power_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:PMAX', b'STAT:DEV:MB0.H1:HTR:PMAX:12.5000')],
     ) as inst:
-        assert inst.HTR_MB.max_power == 12.5
+        assert inst.HTR_mobo.max_power == 12.5
 
 
-def test_HTR_MB_power_getter():
+def test_HTR_mobo_power_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:SIG:POWR', b'STAT:DEV:MB0.H1:HTR:SIG:POWR:0.0000W')],
     ) as inst:
-        assert inst.HTR_MB.power == 0.0
+        assert inst.HTR_mobo.power == 0.0
 
 
-def test_HTR_MB_resistance_getter():
+def test_HTR_mobo_resistance_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:RES', b'STAT:DEV:MB0.H1:HTR:RES:50')],
     ) as inst:
-        assert inst.HTR_MB.resistance == 50.0
+        assert inst.HTR_mobo.resistance == 50.0
 
 
-def test_HTR_MB_voltage_getter():
+def test_HTR_mobo_voltage_getter():
     with expected_protocol(
             MercuryiTC,
-            [(b'READ:DEV:MB0.H1:HTR:SIG:VOLT', b'STAT:DEV:MB0.H1:HTR:SIG:VOLT:-0.0292V')],
+            [(b'READ:DEV:MB0.H1:HTR:SIG:VOLT', b'STAT:DEV:MB0.H1:HTR:SIG:VOLT:-0.0481V')],
     ) as inst:
-        assert inst.HTR_MB.voltage == -0.0292
+        assert inst.HTR_mobo.voltage == -0.0481
 
 
-def test_HTR_MB_voltage_limit_getter():
+def test_HTR_mobo_voltage_limit_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:VLIM', b'STAT:DEV:MB0.H1:HTR:VLIM:25')],
     ) as inst:
-        assert inst.HTR_MB.voltage_limit == 25.0
+        assert inst.HTR_mobo.voltage_limit == 25.0
 
 
-def test_TS_MB_control_temperature_getter():
+def test_TS_mobo_control_temperature_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
     ) as inst:
-        assert inst.TS_MB.control_temperature == 330.0725
+        assert inst.TS_mobo.control_temperature == 330.0725
 
 
-def test_TS_MB_loop_D_getter():
+def test_TS_mobo_loop_D_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:D', b'STAT:DEV:MB1.T1:TEMP:LOOP:D:0.0')],
     ) as inst:
-        assert inst.TS_MB.loop_D == 0.0
+        assert inst.TS_mobo.loop_D == 0.0
 
 
-def test_TS_MB_loop_I_getter():
+def test_TS_mobo_loop_I_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:I', b'STAT:DEV:MB1.T1:TEMP:LOOP:I:1.8')],
     ) as inst:
-        assert inst.TS_MB.loop_I == 1.8
+        assert inst.TS_mobo.loop_I == 1.8
 
 
-def test_TS_MB_loop_P_getter():
+def test_TS_mobo_loop_P_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:P', b'STAT:DEV:MB1.T1:TEMP:LOOP:P:3.5')],
     ) as inst:
-        assert inst.TS_MB.loop_P == 3.5
+        assert inst.TS_mobo.loop_P == 3.5
 
 
-def test_TS_MB_loop_PID_enabled_setter():
+def test_TS_mobo_loop_PID_enabled_setter():
     with expected_protocol(
             MercuryiTC,
-            [(b'SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF', b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF:VALID')],
+            [(b'SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF',
+              b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF:VALID')],
     ) as inst:
-        inst.TS_MB.loop_PID_enabled = False
+        inst.TS_mobo.loop_PID_enabled = False
 
 
-def test_TS_MB_loop_PID_enabled_getter():
+def test_TS_mobo_loop_PID_enabled_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:ENAB', b'STAT:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF')],
     ) as inst:
-        assert inst.TS_MB.loop_PID_enabled is False
+        assert inst.TS_mobo.loop_PID_enabled is False
 
 
-def test_TS_MB_loop_T_setpoint_getter():
+def test_TS_mobo_loop_T_setpoint_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:TSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:TSET:61.0000K')],
     ) as inst:
-        assert inst.TS_MB.loop_T_setpoint == 61.0
+        assert inst.TS_mobo.loop_T_setpoint == 61.0
 
 
-def test_TS_MB_loop_heater_pcnt_getter():
+def test_TS_mobo_loop_heater_pcnt_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:HSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:HSET:0')],
     ) as inst:
-        assert inst.TS_MB.loop_heater_pcnt == 0.0
+        assert inst.TS_mobo.loop_heater_pcnt == 0.0
 
 
-def test_TS_MB_loop_ramp_enabled_setter():
+def test_TS_mobo_loop_ramp_enabled_setter():
     with expected_protocol(
             MercuryiTC,
-            [(b'SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF', b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF:VALID')],
+            [(b'SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF',
+              b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF:VALID')],
     ) as inst:
-        inst.TS_MB.loop_ramp_enabled = False
+        inst.TS_mobo.loop_ramp_enabled = False
 
 
-def test_TS_MB_loop_ramp_enabled_getter():
+def test_TS_mobo_loop_ramp_enabled_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:RENA', b'STAT:DEV:MB1.T1:TEMP:LOOP:RENA:OFF')],
     ) as inst:
-        assert inst.TS_MB.loop_ramp_enabled is False
+        assert inst.TS_mobo.loop_ramp_enabled is False
 
 
-def test_TS_MB_loop_ramp_rate_getter():
+def test_TS_mobo_loop_ramp_rate_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:RSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:RSET:5.0000K/m')],
     ) as inst:
-        assert inst.TS_MB.loop_ramp_rate == 5.0
+        assert inst.TS_mobo.loop_ramp_rate == 5.0
 
 
-def test_TS_MB_temperature_getter():
+def test_TS_mobo_temperature_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
     ) as inst:
-        assert inst.TS_MB.temperature == 330.0725
+        assert inst.TS_mobo.temperature == 330.0725
 
 
-def test_TS_MB_voltage_getter():
+def test_TS_mobo_voltage_getter():
     with expected_protocol(
             MercuryiTC,
-            [(b'READ:DEV:MB1.T1:TEMP:SIG:VOLT', b'STAT:DEV:MB1.T1:TEMP:SIG:VOLT:223.7550mV')],
+            [(b'READ:DEV:MB1.T1:TEMP:SIG:VOLT', b'STAT:DEV:MB1.T1:TEMP:SIG:VOLT:174.3112mV')],
     ) as inst:
-        assert inst.TS_MB.voltage == 0.223755
+        assert inst.TS_mobo.voltage == 0.17431120000000003
 
 
 def test_identity_getter():

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -136,7 +136,7 @@ def test_TS_MB_control_loop_temperature_setpoint_getter():
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:TSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:TSET:61.0000K')],
     ) as inst:
-        assert inst.TS_MB.control_loop_T_setpoint == 61.0
+        assert inst.TS_MB.control_loop_temperature_setpoint == 61.0
 
 
 def test_TS_MB_control_loop_heater_percent_getter():

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -82,14 +82,6 @@ def test_HTR_MB_voltage_limit_getter():
         assert inst.HTR_MB.voltage_limit == 25.0
 
 
-def test_TS_MB_control_temperature_getter():
-    with expected_protocol(
-            MercuryiTC,
-            [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
-    ) as inst:
-        assert inst.TS_MB.control_temperature == 330.0725
-
-
 def test_TS_MB_control_loop_D_getter():
     with expected_protocol(
             MercuryiTC,

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -34,158 +34,158 @@ def test_init():
         pass  # Verify the expected communication.
 
 
-def test_HTR_mobo_current_getter():
+def test_HTR_MB_current_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:SIG:CURR', b'STAT:DEV:MB0.H1:HTR:SIG:CURR:-0.0000A')],
     ) as inst:
-        assert inst.HTR_mobo.current == -0.0
+        assert inst.HTR_MB.current == -0.0
 
 
-def test_HTR_mobo_max_power_getter():
+def test_HTR_MB_max_power_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:PMAX', b'STAT:DEV:MB0.H1:HTR:PMAX:12.5000')],
     ) as inst:
-        assert inst.HTR_mobo.max_power == 12.5
+        assert inst.HTR_MB.max_power == 12.5
 
 
-def test_HTR_mobo_power_getter():
+def test_HTR_MB_power_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:SIG:POWR', b'STAT:DEV:MB0.H1:HTR:SIG:POWR:0.0000W')],
     ) as inst:
-        assert inst.HTR_mobo.power == 0.0
+        assert inst.HTR_MB.power == 0.0
 
 
-def test_HTR_mobo_resistance_getter():
+def test_HTR_MB_resistance_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:RES', b'STAT:DEV:MB0.H1:HTR:RES:50')],
     ) as inst:
-        assert inst.HTR_mobo.resistance == 50.0
+        assert inst.HTR_MB.resistance == 50.0
 
 
-def test_HTR_mobo_voltage_getter():
+def test_HTR_MB_voltage_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:SIG:VOLT', b'STAT:DEV:MB0.H1:HTR:SIG:VOLT:-0.0481V')],
     ) as inst:
-        assert inst.HTR_mobo.voltage == -0.0481
+        assert inst.HTR_MB.voltage == -0.0481
 
 
-def test_HTR_mobo_voltage_limit_getter():
+def test_HTR_MB_voltage_limit_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB0.H1:HTR:VLIM', b'STAT:DEV:MB0.H1:HTR:VLIM:25')],
     ) as inst:
-        assert inst.HTR_mobo.voltage_limit == 25.0
+        assert inst.HTR_MB.voltage_limit == 25.0
 
 
-def test_TS_mobo_control_temperature_getter():
+def test_TS_MB_control_temperature_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
     ) as inst:
-        assert inst.TS_mobo.control_temperature == 330.0725
+        assert inst.TS_MB.control_temperature == 330.0725
 
 
-def test_TS_mobo_loop_D_getter():
+def test_TS_MB_control_loop_D_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:D', b'STAT:DEV:MB1.T1:TEMP:LOOP:D:0.0')],
     ) as inst:
-        assert inst.TS_mobo.loop_D == 0.0
+        assert inst.TS_MB.control_loop_D == 0.0
 
 
-def test_TS_mobo_loop_I_getter():
+def test_TS_MB_control_loop_I_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:I', b'STAT:DEV:MB1.T1:TEMP:LOOP:I:1.8')],
     ) as inst:
-        assert inst.TS_mobo.loop_I == 1.8
+        assert inst.TS_MB.control_loop_I == 1.8
 
 
-def test_TS_mobo_loop_P_getter():
+def test_TS_MB_control_loop_P_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:P', b'STAT:DEV:MB1.T1:TEMP:LOOP:P:3.5')],
     ) as inst:
-        assert inst.TS_mobo.loop_P == 3.5
+        assert inst.TS_MB.control_loop_P == 3.5
 
 
-def test_TS_mobo_loop_PID_enabled_setter():
+def test_TS_MB_control_loop_PID_enabled_setter():
     with expected_protocol(
             MercuryiTC,
             [(b'SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF',
               b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF:VALID')],
     ) as inst:
-        inst.TS_mobo.loop_PID_enabled = False
+        inst.TS_MB.control_loop_PID_enabled = False
 
 
-def test_TS_mobo_loop_PID_enabled_getter():
+def test_TS_MB_control_loop_PID_enabled_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:ENAB', b'STAT:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF')],
     ) as inst:
-        assert inst.TS_mobo.loop_PID_enabled is False
+        assert inst.TS_MB.control_loop_PID_enabled is False
 
 
-def test_TS_mobo_loop_T_setpoint_getter():
+def test_TS_MB_control_loop_temperature_setpoint_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:TSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:TSET:61.0000K')],
     ) as inst:
-        assert inst.TS_mobo.loop_T_setpoint == 61.0
+        assert inst.TS_MB.control_loop_T_setpoint == 61.0
 
 
-def test_TS_mobo_loop_heater_pcnt_getter():
+def test_TS_MB_control_loop_heater_percent_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:HSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:HSET:0')],
     ) as inst:
-        assert inst.TS_mobo.loop_heater_pcnt == 0.0
+        assert inst.TS_MB.control_loop_heater_percent == 0.0
 
 
-def test_TS_mobo_loop_ramp_enabled_setter():
+def test_TS_MB_control_loop_ramp_enabled_setter():
     with expected_protocol(
             MercuryiTC,
             [(b'SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF',
               b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF:VALID')],
     ) as inst:
-        inst.TS_mobo.loop_ramp_enabled = False
+        inst.TS_MB.control_loop_ramp_enabled = False
 
 
-def test_TS_mobo_loop_ramp_enabled_getter():
+def test_TS_MB_control_loop_ramp_enabled_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:RENA', b'STAT:DEV:MB1.T1:TEMP:LOOP:RENA:OFF')],
     ) as inst:
-        assert inst.TS_mobo.loop_ramp_enabled is False
+        assert inst.TS_MB.control_loop_ramp_enabled is False
 
 
-def test_TS_mobo_loop_ramp_rate_getter():
+def test_TS_MB_control_loop_ramp_rate_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:LOOP:RSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:RSET:5.0000K/m')],
     ) as inst:
-        assert inst.TS_mobo.loop_ramp_rate == 5.0
+        assert inst.TS_MB.control_loop_ramp_rate == 5.0
 
 
-def test_TS_mobo_temperature_getter():
+def test_TS_MB_temperature_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
     ) as inst:
-        assert inst.TS_mobo.temperature == 330.0725
+        assert inst.TS_MB.temperature == 330.0725
 
 
-def test_TS_mobo_voltage_getter():
+def test_TS_MB_voltage_getter():
     with expected_protocol(
             MercuryiTC,
             [(b'READ:DEV:MB1.T1:TEMP:SIG:VOLT', b'STAT:DEV:MB1.T1:TEMP:SIG:VOLT:174.3112mV')],
     ) as inst:
-        assert inst.TS_mobo.voltage == 0.17431120000000003
+        assert inst.TS_MB.voltage == 0.17431120000000003
 
 
 def test_identity_getter():

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -1,0 +1,194 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2024 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.oxfordinstruments import MercuryiTC
+
+
+def test_init():
+    with expected_protocol(
+            MercuryiTC,
+            [],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_HTR_MB_current_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:SIG:CURR', b'STAT:DEV:MB0.H1:HTR:SIG:CURR:-0.0000A')],
+    ) as inst:
+        assert inst.HTR_MB.current == -0.0
+
+
+def test_HTR_MB_max_power_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:PMAX', b'STAT:DEV:MB0.H1:HTR:PMAX:12.5000')],
+    ) as inst:
+        assert inst.HTR_MB.max_power == 12.5
+
+
+def test_HTR_MB_power_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:SIG:POWR', b'STAT:DEV:MB0.H1:HTR:SIG:POWR:0.0000W')],
+    ) as inst:
+        assert inst.HTR_MB.power == 0.0
+
+
+def test_HTR_MB_resistance_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:RES', b'STAT:DEV:MB0.H1:HTR:RES:50')],
+    ) as inst:
+        assert inst.HTR_MB.resistance == 50.0
+
+
+def test_HTR_MB_voltage_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:SIG:VOLT', b'STAT:DEV:MB0.H1:HTR:SIG:VOLT:-0.0292V')],
+    ) as inst:
+        assert inst.HTR_MB.voltage == -0.0292
+
+
+def test_HTR_MB_voltage_limit_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB0.H1:HTR:VLIM', b'STAT:DEV:MB0.H1:HTR:VLIM:25')],
+    ) as inst:
+        assert inst.HTR_MB.voltage_limit == 25.0
+
+
+def test_TS_MB_control_temperature_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
+    ) as inst:
+        assert inst.TS_MB.control_temperature == 330.0725
+
+
+def test_TS_MB_loop_D_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:D', b'STAT:DEV:MB1.T1:TEMP:LOOP:D:0.0')],
+    ) as inst:
+        assert inst.TS_MB.loop_D == 0.0
+
+
+def test_TS_MB_loop_I_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:I', b'STAT:DEV:MB1.T1:TEMP:LOOP:I:1.8')],
+    ) as inst:
+        assert inst.TS_MB.loop_I == 1.8
+
+
+def test_TS_MB_loop_P_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:P', b'STAT:DEV:MB1.T1:TEMP:LOOP:P:3.5')],
+    ) as inst:
+        assert inst.TS_MB.loop_P == 3.5
+
+
+def test_TS_MB_loop_PID_enabled_setter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF', b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF:VALID')],
+    ) as inst:
+        inst.TS_MB.loop_PID_enabled = False
+
+
+def test_TS_MB_loop_PID_enabled_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:ENAB', b'STAT:DEV:MB1.T1:TEMP:LOOP:ENAB:OFF')],
+    ) as inst:
+        assert inst.TS_MB.loop_PID_enabled is False
+
+
+def test_TS_MB_loop_T_setpoint_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:TSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:TSET:61.0000K')],
+    ) as inst:
+        assert inst.TS_MB.loop_T_setpoint == 61.0
+
+
+def test_TS_MB_loop_heater_pcnt_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:HSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:HSET:0')],
+    ) as inst:
+        assert inst.TS_MB.loop_heater_pcnt == 0.0
+
+
+def test_TS_MB_loop_ramp_enabled_setter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF', b'STAT:SET:DEV:MB1.T1:TEMP:LOOP:RENA:OFF:VALID')],
+    ) as inst:
+        inst.TS_MB.loop_ramp_enabled = False
+
+
+def test_TS_MB_loop_ramp_enabled_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:RENA', b'STAT:DEV:MB1.T1:TEMP:LOOP:RENA:OFF')],
+    ) as inst:
+        assert inst.TS_MB.loop_ramp_enabled is False
+
+
+def test_TS_MB_loop_ramp_rate_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:LOOP:RSET', b'STAT:DEV:MB1.T1:TEMP:LOOP:RSET:5.0000K/m')],
+    ) as inst:
+        assert inst.TS_MB.loop_ramp_rate == 5.0
+
+
+def test_TS_MB_temperature_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:SIG:TEMP', b'STAT:DEV:MB1.T1:TEMP:SIG:TEMP:330.0725K')],
+    ) as inst:
+        assert inst.TS_MB.temperature == 330.0725
+
+
+def test_TS_MB_voltage_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'READ:DEV:MB1.T1:TEMP:SIG:VOLT', b'STAT:DEV:MB1.T1:TEMP:SIG:VOLT:223.7550mV')],
+    ) as inst:
+        assert inst.TS_MB.voltage == 0.223755
+
+
+def test_identity_getter():
+    with expected_protocol(
+            MercuryiTC,
+            [(b'*IDN?', b'IDN:OXFORD INSTRUMENTS:MERCURY ITC:232150255:2.6.04.000')],
+    ) as inst:
+        assert inst.identity == 'IDN:OXFORD INSTRUMENTS:MERCURY ITC:232150255:2.6.04.000'

--- a/tests/instruments/oxfordinstruments/test_mercuryitc.py
+++ b/tests/instruments/oxfordinstruments/test_mercuryitc.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2024 PyMeasure Developers
+# Copyright (c) 2013-2025 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add new instrument: Oxford Instruments Mercury Intelligent Temperature Controller (aka iTC).

This instrument is a temperature controller that can read temperature sensors of different types, e.g. silicon diodes, metallic negative thermal coefficient (NTC), positive thermal coefficient (PTC) and also thermocouples. It can also control resistive heaters. I have implemented two channel types, ``Temperature Sensor`` and ``Heater`` to support these two functionalities. There are additional daughterboards that provide further functionality, but these are not implemented (as I don't have any to test).