### PR TITLE
Fix documentation relating to Kepco BOP power supplies.

### DIFF
--- a/docs/api/instruments/kepco/KepcoBOP.rst
+++ b/docs/api/instruments/kepco/KepcoBOP.rst
@@ -2,6 +2,6 @@
 BOP Bipolar Power Supply with BIT 4886 Digital Interface Card
 #############################################################
 
-.. autoclass:: pymeasure.instruments.kepco.kepcobop
+.. autoclass:: pymeasure.instruments.kepco.KepcoBOP3612
     :members:
     :show-inheritance:

--- a/docs/api/instruments/kepco/index.rst
+++ b/docs/api/instruments/kepco/index.rst
@@ -4,9 +4,9 @@
 KEPCO INC.
 ##########
 
-This section contains specific dpcumentation on the Kepco Inc. power supplies instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+This section contains specific documentation on the Kepco Inc. power supplies instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 
 .. toctree::
     :maxdepth: 2
 
-    bop
+    KepcoBOP


### PR DESCRIPTION
Fixed documentation for Kepco BOP Power supplies so that documentation is generated correctly.