### PR TITLE
add output_enabled property to individual channels (Keysight E3631A)

### DIFF
--- a/pymeasure/instruments/keysight/keysightE3631A.py
+++ b/pymeasure/instruments/keysight/keysightE3631A.py
@@ -113,7 +113,7 @@ class KeysightE3631A(SCPIMixin, Instrument):
     output_enabled = Instrument.control(
         "OUTPut?",
         "OUTPut %d",
-        """Control whether the channel output is enabled (boolean).""",
+        """Control whether the output of the last used channel is enabled (boolean).""",
         validator=strict_discrete_set,
         map_values=True,
         values={True: 1, False: 0},

--- a/pymeasure/instruments/keysight/keysightE3631A.py
+++ b/pymeasure/instruments/keysight/keysightE3631A.py
@@ -53,6 +53,15 @@ class VoltageChannel(Channel):
         dynamic=True,
     )
 
+    output_enabled = Channel.control(
+        "INST:NSEL {ch};:OUTPut?",
+        "OUTPut %d, (@{ch})",
+        """Control whether the channel output is enabled (boolean).""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: 1, False: 0},
+    )
+
     voltage = Channel.measurement(
         "INST:NSEL {ch};:MEAS:VOLT?",
         """Measure actual voltage of this channel.""",


### PR DESCRIPTION
The output_enabled property only existed for the Instrument class before, where it only showed (and controlled) the output status for the channel that was last used. This PR adds the ability to read and control the output status on every channel individually, regardless if it is the last used channel or not.