### PR TITLE
Continue #1153: Add `description` to `Parameters`

### DIFF
--- a/pymeasure/display/console.py
+++ b/pymeasure/display/console.py
@@ -162,12 +162,15 @@ class ManagedConsole(QtCore.QCoreApplication):
             (see :class:`~pymeasure.experiment.procedure.Procedure`)
     :param log_channel: :code:`logging.Logger` instance to use for logging output
     :param log_level: logging level
+    :param kwargs: additional keyword arguments to be passed to the
+            :class:`~pymeasure.display.console.ConsoleArgumentParser` constructor
     """
 
     def __init__(self,
                  procedure_class,
                  log_channel='',
                  log_level=logging.INFO,
+                 **kwargs,
                  ):
 
         super().__init__([])
@@ -187,7 +190,7 @@ class ManagedConsole(QtCore.QCoreApplication):
         signal.signal(signal.SIGINT, lambda sig, _: self.abort())
 
         # Parse command line arguments
-        parser = ConsoleArgumentParser(procedure_class)
+        parser = ConsoleArgumentParser(procedure_class, **kwargs)
         args = vars(parser.parse_args())
 
         self.directory = args['result_directory']

--- a/pymeasure/display/console.py
+++ b/pymeasure/display/console.py
@@ -116,8 +116,8 @@ class ConsoleArgumentParser(argparse.ArgumentParser):
                                 "is already defined as common options")
             kwargs = {}
             parameter = parameter_objects[name]
-            default, help_fields, _type = parameter.cli_args
-            kwargs['help'] = self._cli_help_fields(parameter.name, parameter, help_fields)
+            default, _, _type = parameter.cli_args
+            kwargs['help'] = parameter._cli_help_fields()
             kwargs['default'] = default
             if _type is not None:
                 kwargs['type'] = _type

--- a/pymeasure/display/console.py
+++ b/pymeasure/display/console.py
@@ -117,7 +117,7 @@ class ConsoleArgumentParser(argparse.ArgumentParser):
             kwargs = {}
             parameter = parameter_objects[name]
             default, _, _type = parameter.cli_args
-            kwargs['help'] = parameter._cli_help_fields()
+            kwargs['help'] = parameter._cli_help_fields().replace("%", "%%")
             kwargs['default'] = default
             if _type is not None:
                 kwargs['type'] = _type

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -61,10 +61,7 @@ class Input:
         if hasattr(parameter, 'units') and parameter.units:
             self.setSuffix(" %s" % parameter.units)
 
-        if hasattr(parameter, 'description'):
-            if not (description := parameter.description):
-                description = parameter._cli_help_fields()
-            self.setToolTip(description)
+        self.setToolTip(parameter._cli_help_fields())
 
     def update_parameter(self):
         """

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -61,6 +61,9 @@ class Input:
         if hasattr(parameter, 'units') and parameter.units:
             self.setSuffix(" %s" % parameter.units)
 
+        if hasattr(parameter, '_description') and parameter._description:
+            self.setToolTip(parameter._description)
+
     def update_parameter(self):
         """
         Update the parameter value with the Input GUI element's current value.

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -61,8 +61,10 @@ class Input:
         if hasattr(parameter, 'units') and parameter.units:
             self.setSuffix(" %s" % parameter.units)
 
-        if hasattr(parameter, 'description') and parameter.description:
-            self.setToolTip(parameter.description)
+        if hasattr(parameter, 'description'):
+            if not (description := parameter.description):
+                description = parameter._cli_help_fields()
+            self.setToolTip(description)
 
     def update_parameter(self):
         """

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -61,8 +61,8 @@ class Input:
         if hasattr(parameter, 'units') and parameter.units:
             self.setSuffix(" %s" % parameter.units)
 
-        if hasattr(parameter, '_description') and parameter._description:
-            self.setToolTip(parameter._description)
+        if hasattr(parameter, 'description') and parameter.description:
+            self.setToolTip(parameter.description)
 
     def update_parameter(self):
         """

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -42,8 +42,8 @@ class Parameter:
         list of strings, this argument can be either a single condition or
         a list of conditions. If the group_by argument is provided as a dict
         this argument is ignored.
-    :description: A string providing a human-friendly description for the 
-		parameter.
+    :description: A string providing a human-friendly description for the
+        parameter.
     """
 
     def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True, description=None):
@@ -73,7 +73,7 @@ class Parameter:
         elif group_by is not None:
             raise TypeError("The provided group_by argument is not valid, should be either a "
                             "string, a list of strings, or a dict with {string: condition} pairs.")
-		
+
         if description is not None and not isinstance(description, str):
             raise TypeError("The provided description argument is not a string.")
         self._description = description

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -133,7 +133,6 @@ class Parameter:
                 value = getattr(self, field[1])
                 message += ", {} {}".format(prefix, value)
 
-        message = message.replace("%", "%%")
         return message
 
     def __str__(self):

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -59,7 +59,7 @@ class Parameter:
             self.value = default
         self.default = default
         self.ui_class = ui_class
-        self._help_fields = [('units are', 'units'), 'default']
+        self._help_fields = ['description', ('units are', 'units'), 'default']
 
         self.group_by = {}
         if isinstance(group_by, dict):
@@ -121,6 +121,20 @@ class Parameter:
         """
 
         return value
+
+    def _cli_help_fields(self):
+        message = self.name
+        for field in self._help_fields:
+            if isinstance(field, str):
+                field = ["{} is".format(field), field]
+
+            if hasattr(self, field[1]) and getattr(self, field[1]) is not None:
+                prefix = field[0]
+                value = getattr(self, field[1])
+                message += ", {} {}".format(prefix, value)
+
+        message = message.replace("%", "%%")
+        return message
 
     def __str__(self):
         return str(self._value) if self.is_set() else ''
@@ -239,7 +253,7 @@ class FloatParameter(Parameter):
         super().__init__(name, **kwargs)
         self.decimals = decimals
         self.step = step
-        self._help_fields.append('decimals')
+        self._help_fields.append(('decimals are', 'decimals'))
 
     def convert(self, value):
         if isinstance(value, str):

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -77,7 +77,7 @@ class Parameter:
 
         if description is not None and not isinstance(description, str):
             raise TypeError("The provided description argument is not a string.")
-        self._description = description
+        self.description = description
 
     @property
     def value(self):

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -46,7 +46,8 @@ class Parameter:
         parameter.
     """
 
-    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True, description=None):
+    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True,
+                 description=None):
         self.name = name
         separator = ": "
         if separator in name:

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -59,7 +59,7 @@ class Parameter:
             self.value = default
         self.default = default
         self.ui_class = ui_class
-        self._help_fields = ['description', ('units are', 'units'), 'default']
+        self._help_fields = [('units are', 'units'), 'default']
 
         self.group_by = {}
         if isinstance(group_by, dict):
@@ -123,15 +123,19 @@ class Parameter:
         return value
 
     def _cli_help_fields(self):
-        message = self.name
+        message = f"{self.name}:\n"
+        if (description := self.description) is not None:
+            if not description.endswith("."):
+                description += "."
+            message += f"{description}\n"
+
         for field in self._help_fields:
             if isinstance(field, str):
-                field = ["{} is".format(field), field]
+                field = (f"{field} is", field)
 
-            if hasattr(self, field[1]) and getattr(self, field[1]) is not None:
-                prefix = field[0]
-                value = getattr(self, field[1])
-                message += ", {} {}".format(prefix, value)
+            if (value := getattr(self, field[1], None)) is not None:
+                prefix = field[0].capitalize()
+                message += f"\n{prefix} {value}."
 
         return message
 

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -42,9 +42,11 @@ class Parameter:
         list of strings, this argument can be either a single condition or
         a list of conditions. If the group_by argument is provided as a dict
         this argument is ignored.
+    :description: A string providing a human-friendly description for the 
+		parameter.
     """
 
-    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True):
+    def __init__(self, name, default=None, ui_class=None, group_by=None, group_condition=True, description=None):
         self.name = name
         separator = ": "
         if separator in name:
@@ -71,6 +73,10 @@ class Parameter:
         elif group_by is not None:
             raise TypeError("The provided group_by argument is not valid, should be either a "
                             "string, a list of strings, or a dict with {string: condition} pairs.")
+		
+        if description is not None and not isinstance(description, str):
+            raise TypeError("The provided description argument is not a string.")
+        self._description = description
 
     @property
     def value(self):

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -135,6 +135,9 @@ class Parameter:
 
             if (value := getattr(self, field[1], None)) is not None:
                 prefix = field[0].capitalize()
+                if isinstance(value, str):
+                    value = f'"{value}"'
+
                 message += f"\n{prefix} {value}."
 
         return message

--- a/tests/display/test_console.py
+++ b/tests/display/test_console.py
@@ -89,5 +89,5 @@ class TestArgHelpString:
             if desc in help_line:
                 break
         assert desc in help_line
-        assert 'default' in help_line
+        assert 'default' in help_line.lower()
         assert str(default_value) in help_line

--- a/tests/experiment/test_parameters.py
+++ b/tests/experiment/test_parameters.py
@@ -36,14 +36,14 @@ def test_parameter_default():
     p = Parameter('Test', default=5)
     assert p.value == 5
     assert p.cli_args[0] == 5
-    assert p.cli_args[1] == [('units are', 'units'), 'default']
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default']
 
 
 def test_integer_units():
     p = IntegerParameter('Test', units='V')
     assert p.units == 'V'
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', 'minimum', 'maximum']
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', 'minimum', 'maximum']
 
 
 def test_integer_value():
@@ -100,7 +100,7 @@ def test_boolean_value():
     p.value = True
     assert p.value is True
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default']
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default']
 
 
 def test_float_value():
@@ -121,7 +121,7 @@ def test_float_value():
     with pytest.raises(ValueError):
         p.value = '31.3 incorrect units'  # not the correct units
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', 'decimals']
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('decimals are', 'decimals')]
 
 
 def test_float_bounds():
@@ -157,7 +157,7 @@ def test_list_value():
     with pytest.raises(ValueError):
         p.value = 5
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
 
 
 def test_list_value_with_units():
@@ -173,7 +173,7 @@ def test_list_value_with_units():
     p.value = 'and four tests'
     assert p.value == 'and four'
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
 
 
 def test_list_order():
@@ -181,7 +181,7 @@ def test_list_order():
     # check if order is preserved, choices are internally stored as dict
     assert p.choices == (1, 2.2, 'three', 'and four')
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
 
 
 def test_vector():
@@ -202,6 +202,6 @@ def test_vector():
         p.value = '0, 1, 2'
 
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == [('units are', 'units'), 'default', '_length']
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', '_length']
 
 # TODO: Add tests for Measurable

--- a/tests/experiment/test_parameters.py
+++ b/tests/experiment/test_parameters.py
@@ -121,7 +121,8 @@ def test_float_value():
     with pytest.raises(ValueError):
         p.value = '31.3 incorrect units'  # not the correct units
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('decimals are', 'decimals')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+                             ('decimals are', 'decimals')]
 
 
 def test_float_bounds():
@@ -157,7 +158,8 @@ def test_list_value():
     with pytest.raises(ValueError):
         p.value = 5
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+                             ('choices are', 'choices')]
 
 
 def test_list_value_with_units():
@@ -173,7 +175,8 @@ def test_list_value_with_units():
     p.value = 'and four tests'
     assert p.value == 'and four'
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+                             ('choices are', 'choices')]
 
 
 def test_list_order():
@@ -181,7 +184,8 @@ def test_list_order():
     # check if order is preserved, choices are internally stored as dict
     assert p.choices == (1, 2.2, 'three', 'and four')
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', ('choices are', 'choices')]
+    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+                             ('choices are', 'choices')]
 
 
 def test_vector():

--- a/tests/experiment/test_parameters.py
+++ b/tests/experiment/test_parameters.py
@@ -36,14 +36,15 @@ def test_parameter_default():
     p = Parameter('Test', default=5)
     assert p.value == 5
     assert p.cli_args[0] == 5
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default']
+    assert p.cli_args[1] == [('units are', 'units'), 'default']
+    assert p._cli_help_fields() == 'Test:\n\nDefault is 5.'
 
 
 def test_integer_units():
     p = IntegerParameter('Test', units='V')
     assert p.units == 'V'
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', 'minimum', 'maximum']
+    assert p.cli_args[1] == [('units are', 'units'), 'default', 'minimum', 'maximum']
 
 
 def test_integer_value():
@@ -100,7 +101,7 @@ def test_boolean_value():
     p.value = True
     assert p.value is True
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default']
+    assert p.cli_args[1] == [('units are', 'units'), 'default']
 
 
 def test_float_value():
@@ -121,7 +122,7 @@ def test_float_value():
     with pytest.raises(ValueError):
         p.value = '31.3 incorrect units'  # not the correct units
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+    assert p.cli_args[1] == [('units are', 'units'), 'default',
                              ('decimals are', 'decimals')]
 
 
@@ -158,7 +159,7 @@ def test_list_value():
     with pytest.raises(ValueError):
         p.value = 5
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+    assert p.cli_args[1] == [('units are', 'units'), 'default',
                              ('choices are', 'choices')]
 
 
@@ -175,7 +176,7 @@ def test_list_value_with_units():
     p.value = 'and four tests'
     assert p.value == 'and four'
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+    assert p.cli_args[1] == [('units are', 'units'), 'default',
                              ('choices are', 'choices')]
 
 
@@ -184,7 +185,7 @@ def test_list_order():
     # check if order is preserved, choices are internally stored as dict
     assert p.choices == (1, 2.2, 'three', 'and four')
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default',
+    assert p.cli_args[1] == [('units are', 'units'), 'default',
                              ('choices are', 'choices')]
 
 
@@ -206,6 +207,6 @@ def test_vector():
         p.value = '0, 1, 2'
 
     assert p.cli_args[0] is None
-    assert p.cli_args[1] == ['description', ('units are', 'units'), 'default', '_length']
+    assert p.cli_args[1] == [('units are', 'units'), 'default', '_length']
 
 # TODO: Add tests for Measurable


### PR DESCRIPTION
This PR continues the work from #1153 (as suggested by SengerM), introducing a new `description` argument to the `Parameter` class. The string is stored in the `_description` attribute. I’m unsure whether to keep it hidden or rename it as `description`, giving it more importance. If the latter is preferred, it should also be added to the `_help_fields` list attribute and the `__repr__` method in subclasses.

Additionally, tooltip support has been implemented. While keeping the PR simple, adding a default description that shows input limits could be considered.

![image](https://github.com/user-attachments/assets/a524aeee-f635-4b27-acb6-e2d07dcf4b64)

Let me know if this should be rewritten, expanded upon, or entirely thrown away :)