### PR TITLE
Fix ruff error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,11 @@
 requires = ["setuptools>=45", "wheel", "setuptools_scm>=8.1.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff]
+line-length = 100
 
 [tool.ruff.lint]
 extend-select = ["E"]
-line-length = 100
 
 [project]
 name = "PyMeasure"


### PR DESCRIPTION
Fixes ruff's error. line-length should be defined in tool.ruff section. See [docs](https://docs.astral.sh/ruff/settings/#line-length)

> unknown field `line-length`, expected one of `allowed-confusables`, `dummy-variable-rgx`, `extend-ignore`, `extend-select`, `extend-fixable`, `extend-unfixable`, `external`, `fixable`, `ignore`, `extend-safe-fixes`, `extend-unsafe-fixes`, `ignore-init-module-imports`, `logger-objects`, `select`, `explicit-preview-rules`, `task-tags`, `typing-modules`, `unfixable`, `flake8-annotations`, `flake8-bandit`, `flake8-boolean-trap`, `flake8-bugbear`, `flake8-builtins`, `flake8-comprehensions`, `flake8-copyright`, `flake8-errmsg`, `flake8-quotes`, `flake8-self`, `flake8-tidy-imports`, `flake8-type-checking`, `flake8-gettext`, `flake8-implicit-str-concat`, `flake8-import-conventions`, `flake8-pytest-style`, `flake8-unused-arguments`, `isort`, `mccabe`, `pep8-naming`, `pycodestyle`, `pydocstyle`, `pyflakes`, `pylint`, `pyupgrade`, `per-file-ignores`, `extend-per-file-ignores`, `exclude`, `pydoclint`, `ruff`, `preview`