### PR TITLE
Updated Keithley2450's docstring to inform that buffer handling is currently unsupported

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -95,3 +95,4 @@ Dawid Maślanka
 Felix Thouin
 Emmanuel Ferdman
 Johannes Rothmayr
+Dimitrios Simatos

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -41,9 +41,9 @@ class Keithley2450(KeithleyBuffer, SCPIMixin, Instrument):
     """ Represents the Keithley 2450 SourceMeter and provides a
     high-level interface for interacting with the instrument.
 
-    NOTE: Buffer handling for the Keithley 2450 model is currently unsupported.
-    The instrument can be used in emulation mode as a 2400 model if its
-    command set is set to "SCPI 2400" through the instrument's system settings.
+    NOTE: The default buffer handling SCPI command set of the Keithley 2450 model
+    is currently unsupported. The instrument works if made to emulate a 2400 model
+    by setting its command set to "SCPI 2400" through the instrument's system settings.
 
     .. code-block:: python
 

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -41,6 +41,10 @@ class Keithley2450(KeithleyBuffer, SCPIMixin, Instrument):
     """ Represents the Keithley 2450 SourceMeter and provides a
     high-level interface for interacting with the instrument.
 
+    NOTE: Buffer handling for the Keithley 2450 model is currently unsupported.
+    The instrument can be used in emulation mode as a 2400 model if its
+    command set is set to "SCPI 2400" through the instrument's system settings.
+
     .. code-block:: python
 
         keithley = Keithley2450("GPIB::1")


### PR DESCRIPTION
I have added a note in the docstring of class Keithley2450 that informs that buffer handling for the 2450 is currently unsupported but that the instrument can be used in emulation mode as a 2400 model.

Closes #1200