### PR TITLE
Add keithley6221 delta mode

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -97,3 +97,4 @@ Emmanuel Ferdman
 Johannes Rothmayr
 Fred Gillard
 Dimitrios Simatos
+Dongkai Pan

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -95,7 +95,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     shield_connection = Instrument.control(
         ":OUTPut:ISHield?", ":OUTPut:ISHield %s",
-        """ A string property that controls 
+        """ A string property that controls
         to whom the shield is connected, default to 'output-low'.
         Valid values are 'guard' and 'output-low'. """,
         validator=strict_discrete_set,
@@ -161,7 +161,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_unit = Instrument.control(
         ":UNIT:VOLT:DC?", ":UNIT:VOLT:DC %s",
-        """ A string property that controls the reading unit. 
+        """ A string property that controls the reading unit.
         Valid values are 'V', 'Ohms', 'W' and 'Siemens' """,
         validator=strict_discrete_set,
         values={"V": "V", "Ohms": "OHMS", "W": "W", "Siemens": "SIEM"},
@@ -177,8 +177,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_low_source = Instrument.control(
         ":SOUR:DELT:LOW?", ":SOUR:DELT:LOW %g",
-        """ A floating point property that controls the delta 
-        low source value in Amps. By default, 
+        """ A floating point property that controls the delta
+        low source value in Amps. By default,
         the low source value is minus the high source value.""",
         validator=truncated_range,
         values=[-0.105, 0]
@@ -186,8 +186,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_delay = Instrument.control(
         ":SOUR:DELT:DELay?", ":SOUR:DELT:DELay %s",
-        """ A floating point property that controls the delta delay 
-        in seconds. Can be a value between 0 and 9999.999, 
+        """ A floating point property that controls the delta delay
+        in seconds. Can be a value between 0 and 9999.999,
         or "INF" for infinite delay.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([0, 9999.999], ["INF"]),
@@ -195,8 +195,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_cycles = Instrument.control(
         ":SOUR:DELT:COUN?", ":SOUR:DELT:COUN %s",
-        """ An integer property that controls the number of cycles 
-        to run for the delta measurements. Can be a value 
+        """ An integer property that controls the number of cycles
+        to run for the delta measurements. Can be a value
         between 1 and 65536, or "INF" for infinite cycles.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
@@ -204,8 +204,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_measurement_sets = Instrument.control(
         ":SOUR:SWEep:COUN?", ":SOUR:SWEep:COUN %s",
-        """ An integer property that controls the number of 
-        measurement sets to repeat for delta measurements. Can be 
+        """ An integer property that controls the number of
+        measurement sets to repeat for delta measurements. Can be
         a value between 1 and 65536, or "INF" for infinite sets.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
@@ -213,8 +213,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_compliance_abort = Instrument.control(
         ":SOUR:DELT:CAB?", ":SOUR:DELT:CAB %s",
-        """ A boolean property that controls whether the 
-        compliance abort is turned on or off. 
+        """ A boolean property that controls whether the
+        compliance abort is turned on or off.
         Valid values True (on) or False (off). """,
         values={True: "ON", False: "OFF"},
         map_values=True,
@@ -222,8 +222,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_cold_switch = Instrument.control(
         ":SOUR:DELT:CSW?", ":SOUR:DELT:CSW %s",
-        """ A boolean property that controls whether the 
-        cold switching mode is turned on or off. 
+        """ A boolean property that controls whether the
+        cold switching mode is turned on or off.
         Valid values True (on) or False (off). """,
         values={True: "ON", False: "OFF"},
         map_values=True,
@@ -231,8 +231,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_buffer_points = Instrument.control(
         "TRAC:POIN?", "TRAC:POIN %d",
-        """ A integer property that controls the size of the buffer. 
-        (Buffer size should be the same value as Delta count.) 
+        """ A integer property that controls the size of the buffer.
+        (Buffer size should be the same value as Delta count.)
         Can be a value between 1 and 1000000. """,
         validator=truncated_range,
         values=[1, 1000000]

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -93,6 +93,15 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         map_values=True
     )
 
+    shield_connection = Instrument.control(
+        ":OUTPut:ISHield?", ":OUTPut:ISHield %s",
+        """ A string property that controls to whom the shield is connected, default to 'output-low'.
+        Valid values are 'guard' and 'output-low'. """,
+        validator=strict_discrete_set,
+        values={"guard": "GUARd", "output-low": "OLOW"},
+        map_values=True
+    )
+
     source_delay = Instrument.control(
         ":SOUR:DEL?", ":SOUR:DEL %g",
         """ A floating point property that sets a manual delay for the source

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -95,7 +95,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     shield_connection = Instrument.control(
         ":OUTPut:ISHield?", ":OUTPut:ISHield %s",
-        """ A string property that controls to whom the shield is connected, default to 'output-low'.
+        """ A string property that controls 
+        to whom the shield is connected, default to 'output-low'.
         Valid values are 'guard' and 'output-low'. """,
         validator=strict_discrete_set,
         values={"guard": "GUARd", "output-low": "OLOW"},
@@ -160,7 +161,8 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_unit = Instrument.control(
         ":UNIT:VOLT:DC?", ":UNIT:VOLT:DC %s",
-        """ A string property that controls the reading unit. Valid values are 'V', 'Ohms', 'W' and 'Siemens' """,
+        """ A string property that controls the reading unit. 
+        Valid values are 'V', 'Ohms', 'W' and 'Siemens' """,
         validator=strict_discrete_set,
         values={"V": "V", "Ohms": "OHMS", "W": "W", "Siemens": "SIEM"},
         map_values=True
@@ -175,49 +177,63 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_low_source = Instrument.control(
         ":SOUR:DELT:LOW?", ":SOUR:DELT:LOW %g",
-        """ A floating point property that controls the delta low source value in Amps. By default, the low source value is minus the high source value.""",
+        """ A floating point property that controls the delta 
+        low source value in Amps. By default, 
+        the low source value is minus the high source value.""",
         validator=truncated_range,
         values=[-0.105, 0]
     )
 
     delta_delay = Instrument.control(
         ":SOUR:DELT:DELay?", ":SOUR:DELT:DELay %s",
-        """ A floating point property that controls the delta delay in seconds. Can be a value between 0 and 9999.999, or "INF" for infinite delay.""",
+        """ A floating point property that controls the delta delay 
+        in seconds. Can be a value between 0 and 9999.999, 
+        or "INF" for infinite delay.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([0, 9999.999], ["INF"]),
     )
 
-    delta_cycles = Instrument.control( 
+    delta_cycles = Instrument.control(
         ":SOUR:DELT:COUN?", ":SOUR:DELT:COUN %s",
-        """ An integer property that controls the number of cycles to run for the delta measurements. Can be a value between 1 and 65536, or "INF" for infinite cycles.""",
+        """ An integer property that controls the number of cycles 
+        to run for the delta measurements. Can be a value 
+        between 1 and 65536, or "INF" for infinite cycles.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
     )
 
-    delta_measurement_sets = Instrument.control( 
+    delta_measurement_sets = Instrument.control(
         ":SOUR:SWEep:COUN?", ":SOUR:SWEep:COUN %s",
-        """ An integer property that controls the number of measurement sets to repeat for the delta measurements. Can be a value between 1 and 65536, or "INF" for infinite sets.""",
+        """ An integer property that controls the number of 
+        measurement sets to repeat for delta measurements. Can be 
+        a value between 1 and 65536, or "INF" for infinite sets.""",
         validator=joined_validators(truncated_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
     )
 
     delta_compliance_abort = Instrument.control(
         ":SOUR:DELT:CAB?", ":SOUR:DELT:CAB %s",
-        """ A boolean property that controls whether the compliance abort is turned on or off. Valid values True (on) or False (off). """,
+        """ A boolean property that controls whether the 
+        compliance abort is turned on or off. 
+        Valid values True (on) or False (off). """,
         values={True: "ON", False: "OFF"},
         map_values=True,
     )
 
     delta_cold_switch = Instrument.control(
         ":SOUR:DELT:CSW?", ":SOUR:DELT:CSW %s",
-        """ A boolean property that controls whether the cold switching mode is turned on or off. Valid values True (on) or False (off). """,
+        """ A boolean property that controls whether the 
+        cold switching mode is turned on or off. 
+        Valid values True (on) or False (off). """,
         values={True: "ON", False: "OFF"},
         map_values=True,
     )
 
     delta_buffer_points = Instrument.control(
         "TRAC:POIN?", "TRAC:POIN %d",
-        """ A integer property that controls the size of the buffer. (Buffer size should be the same value as Delta count.) Can be a value between 1 and 1000000. """,
+        """ A integer property that controls the size of the buffer. 
+        (Buffer size should be the same value as Delta count.) 
+        Can be a value between 1 and 1000000. """,
         validator=truncated_range,
         values=[1, 1000000]
     )

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -211,14 +211,14 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         values=([1, 65536], ["INF"]),
     )
 
-    delta_compliance_abort = Instrument.control(
+    delta_compliance_abort_enabled = Instrument.control(
         ":SOUR:DELT:CAB?", ":SOUR:DELT:CAB %s",
         """Control if compliance abort is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
         map_values=True,
     )
 
-    delta_cold_switch = Instrument.control(
+    delta_cold_switch_enabled = Instrument.control(
         ":SOUR:DELT:CSW?", ":SOUR:DELT:CSW %s",
         """Control if cold switching mode is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
@@ -251,12 +251,12 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         """Get the latest delta reading results from 2182/2182A."""
     )
 
-    delta_recall = Instrument.measurement(
+    delta_values = Instrument.measurement(
         ":TRAC:DATA?",
         """Get delta sense readings stored in 6221 buffer."""
     )
 
-    delta_verify = Instrument.measurement(
+    delta_connected = Instrument.measurement(
         ":SOUR:DELT:NVPR?",
         """Get connection status to 2182A.""",
         cast=bool,

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -93,13 +93,12 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         map_values=True
     )
 
-    shield_connection = Instrument.control(
+    shield_to_guard_enabled = Instrument.control(
         ":OUTPut:ISHield?", ":OUTPut:ISHield %s",
-        """ A string property that controls
-        to whom the shield is connected, default to 'output-low'.
-        Valid values are 'guard' and 'output-low'. """,
-        validator=strict_discrete_set,
-        values={"guard": "GUARd", "output-low": "OLOW"},
+        """ Control if shield is connected to the guard(boolean).
+        
+        If not, the shield is connected to the output-low.""",
+        values={True: "GUAR", False: "OLOW"},
         map_values=True
     )
 

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -175,7 +175,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         ":SOUR:DELT:HIGH?", ":SOUR:DELT:HIGH %g",
         """Control the delta high source value in A (float strictly from 0 to 0.105).
 
-        Set high source value will automatically set the low source value 
+        Set high source value will automatically set the low source value
         to minus the high source value.""",
         validator=strict_range,
         values=[0, 0.105]
@@ -200,7 +200,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_cycles = Instrument.control(
         ":SOUR:DELT:COUN?", ":SOUR:DELT:COUN %s",
-        """Control the number of cycles to run for the delta measurements 
+        """Control the number of cycles to run for the delta measurements
         (integer strictly from 1 to 65536, or "INF").""",
         validator=joined_validators(strict_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
@@ -208,7 +208,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_measurement_sets = Instrument.control(
         ":SOUR:SWEep:COUN?", ":SOUR:SWEep:COUN %s",
-        """Control the number of measurement sets to repeat for delta measurements 
+        """Control the number of measurement sets to repeat for delta measurements
         (integer strictly from 1 to 65536, or "INF").""",
         validator=joined_validators(strict_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -216,6 +216,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         """Control if compliance abort is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
         map_values=True,
+        get_process={1:"ON", 0:"OFF"}.get
     )
 
     delta_cold_switch_enabled = Instrument.control(
@@ -223,6 +224,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         """Control if cold switching mode is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
         map_values=True,
+        get_process={1:"ON", 0:"OFF"}.get
     )
 
     delta_buffer_points = Instrument.control(

--- a/pymeasure/instruments/keithley/keithley6221.py
+++ b/pymeasure/instruments/keithley/keithley6221.py
@@ -101,7 +101,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
     shield_to_guard_enabled = Instrument.control(
         ":OUTPut:ISHield?", ":OUTPut:ISHield %s",
         """ Control if shield is connected to the guard(boolean).
-        
+
         If not, the shield is connected to the output-low.""",
         values={True: "GUAR", False: "OLOW"},
         map_values=True
@@ -174,8 +174,9 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
     delta_high_source = Instrument.control(
         ":SOUR:DELT:HIGH?", ":SOUR:DELT:HIGH %g",
         """Control the delta high source value in A (float strictly from 0 to 0.105).
-        
-        Set high source value will automatically set the low source value to minus the high source value.""",
+
+        Set high source value will automatically set the low source value 
+        to minus the high source value.""",
         validator=strict_range,
         values=[0, 0.105]
     )
@@ -199,14 +200,16 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
 
     delta_cycles = Instrument.control(
         ":SOUR:DELT:COUN?", ":SOUR:DELT:COUN %s",
-        """Control the number of cycles to run for the delta measurements (integer strictly from 1 to 65536, or "INF").""",
+        """Control the number of cycles to run for the delta measurements 
+        (integer strictly from 1 to 65536, or "INF").""",
         validator=joined_validators(strict_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
     )
 
     delta_measurement_sets = Instrument.control(
         ":SOUR:SWEep:COUN?", ":SOUR:SWEep:COUN %s",
-        """Control the number of measurement sets to repeat for delta measurements (integer strictly from 1 to 65536, or "INF").""",
+        """Control the number of measurement sets to repeat for delta measurements 
+        (integer strictly from 1 to 65536, or "INF").""",
         validator=joined_validators(strict_range, strict_discrete_set),
         values=([1, 65536], ["INF"]),
     )
@@ -216,7 +219,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         """Control if compliance abort is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
         map_values=True,
-        get_process={1:"ON", 0:"OFF"}.get
+        get_process={1: "ON", 0: "OFF"}.get
     )
 
     delta_cold_switch_enabled = Instrument.control(
@@ -224,7 +227,7 @@ class Keithley6221(KeithleyBuffer, SCPIMixin, Instrument):
         """Control if cold switching mode is enabled (boolean).""",
         values={True: "ON", False: "OFF"},
         map_values=True,
-        get_process={1:"ON", 0:"OFF"}.get
+        get_process={1: "ON", 0: "OFF"}.get
     )
 
     delta_buffer_points = Instrument.control(


### PR DESCRIPTION
Hello,
I've added the delta mode related controls and methods into Keithley 6221 driver. And I've tested them on a real-world Keithley 6221 together 2182a.
(Reference: ~ 5-31 of Model 6220/6221 Reference Manual)
While delta mode requires the combined use of both Keithley 6221 and 2182a, I think it more appropriate to include the relevant parameters within the 6221 driver for better integration.
This pull request includes significant enhancements to the `Keithley 6221` instrument control in the `pymeasure` library. The changes primarily focus on adding new functionalities and validators to support delta mode operations.

### Improvements in this PR:

* **Addition of `shield_connection` Property**:
  - new property `shield_connection` to control the shield connection settings. Valid values are 'guard' and 'output-low'.

* **Delta Mode Support**:
  - Added several new properties to support delta mode operations, including `delta_unit`, `delta_high_source`, `delta_low_source`, `delta_delay`, `delta_cycles`, `delta_measurement_sets`, `delta_compliance_abort`, `delta_cold_switch`, and `delta_buffer_points`. These properties allow for detailed configuration of delta measurements.
  - Implemented methods `delta_arm`, `delta_start`, and `delta_abort` to control the delta measurement process.
  - Added measurement properties `delta_sense`, `delta_recall`, and `delta_verify` for retrieving delta measurement results and verifying connections.

* **Validator Enhancements**:
  - Imported `joined_validators` to combine multiple validation strategies for properties like `delta_delay`, `delta_cycles`, and `delta_measurement_sets`.