### PR TITLE
Fix Keithley 2400 docstrings.

### DIFF
--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -40,7 +40,7 @@ log.addHandler(logging.NullHandler())
 
 
 class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
-    """ Represents the Keithley 2400 SourceMeter and provides a
+    """Represent the Keithley 2400 SourceMeter and provide a
     high-level interface for interacting with the instrument.
 
     .. code-block:: python
@@ -62,30 +62,36 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
 
     """
 
+    def __init__(self, adapter, name="Keithley 2400 SourceMeter", **kwargs):
+        super().__init__(
+            adapter, name,
+            **kwargs
+        )
+
     source_mode = Instrument.control(
-        ":SOUR:FUNC?", ":SOUR:FUNC %s",
-        """ A string property that controls the source mode, which can
-        take the values 'current' or 'voltage'. The convenience methods
-        :meth:`~.Keithley2400.apply_current` and :meth:`~.Keithley2400.apply_voltage`
-        can also be used. """,
+        ":SOUR:FUNC?",
+        ":SOUR:FUNC %s",
+        """ Control the source mode (string strictly  'current' or 'voltage').""",
         validator=strict_discrete_set,
-        values={'current': 'CURR', 'voltage': 'VOLT'},
-        map_values=True
+        values={"current": "CURR", "voltage": "VOLT"},
+        map_values=True,
     )
 
     source_enabled = Instrument.control(
-        "OUTPut?", "OUTPut %d",
-        """A boolean property that controls whether the source is enabled, takes
+        "OUTPut?",
+        "OUTPut %d",
+        """Control whether the source is enabled, takes
         values True or False. The convenience methods :meth:`~.Keithley2400.enable_source` and
         :meth:`~.Keithley2400.disable_source` can also be used.""",
         validator=strict_discrete_set,
         values={True: 1, False: 0},
-        map_values=True
+        map_values=True,
     )
 
     auto_output_off = Instrument.control(
-        ":SOUR:CLE:AUTO?", ":SOUR:CLE:AUTO %d",
-        """ A boolean property that enables or disables the auto output-off.
+        ":SOUR:CLE:AUTO?",
+        ":SOUR:CLE:AUTO %d",
+        """Control whether auto output-off is activated.
         Valid values are True (output off after measurement) and False (output
         stays on after measurement). """,
         values={True: 1, False: 0},
@@ -93,53 +99,50 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
     )
 
     source_delay = Instrument.control(
-        ":SOUR:DEL?", ":SOUR:DEL %g",
-        """ A floating point property that sets a manual delay for the source
-        after the output is turned on before a measurement is taken. When this
-        property is set, the auto delay is turned off. Valid values are
-        between 0 [seconds] and 999.9999 [seconds].""",
+        ":SOUR:DEL?",
+        ":SOUR:DEL %g",
+        """ Control the source delay in seconds (float, truncated from 0 to 999.9999). """,
         validator=truncated_range,
         values=[0, 999.9999],
     )
 
     source_delay_auto = Instrument.control(
-        ":SOUR:DEL:AUTO?", ":SOUR:DEL:AUTO %d",
-        """ A boolean property that enables or disables auto delay. Valid
-        values are True and False. """,
+        ":SOUR:DEL:AUTO?",
+        ":SOUR:DEL:AUTO %d",
+        """ Control the auto delay (boolean). """,
         values={True: 1, False: 0},
         map_values=True,
     )
 
     auto_zero = Instrument.control(
-        ":SYST:AZER:STAT?", ":SYST:AZER:STAT %s",
-        """ A property that controls the auto zero option. Valid values are
-        True (enabled) and False (disabled) and 'ONCE' (force immediate). """,
+        ":SYST:AZER:STAT?",
+        ":SYST:AZER:STAT %s",
+        """ Control the auto zero option (bool). """,
         values={True: 1, False: 0, "ONCE": "ONCE"},
         map_values=True,
     )
 
     line_frequency = Instrument.control(
-        ":SYST:LFR?", ":SYST:LFR %d",
-        """ An integer property that controls the line frequency in Hertz.
-        Valid values are 50 and 60. """,
+        ":SYST:LFR?",
+        ":SYST:LFR %d",
+        """ Control the line frequency in Hertz (integer, strictly 50 or 60). """,
         validator=strict_discrete_set,
         values=[50, 60],
         cast=int,
     )
 
     line_frequency_auto = Instrument.control(
-        ":SYST:LFR:AUTO?", ":SYST:LFR:AUTO %d",
-        """ A boolean property that enables or disables auto line frequency.
-        Valid values are True and False. """,
+        ":SYST:LFR:AUTO?",
+        ":SYST:LFR:AUTO %d",
+        """ Control the auto line frequency (boolean). """,
         values={True: 1, False: 0},
         map_values=True,
     )
 
     measure_concurent_functions = Instrument.control(
-        ":SENS:FUNC:CONC?", ":SENS:FUNC:CONC %d",
-        """ A boolean property that enables or disables the ability to measure
-        more than one function simultaneously. When disabled, volts function
-        is enabled. Valid values are True and False. """,
+        ":SENS:FUNC:CONC?",
+        ":SENS:FUNC:CONC %d",
+        """ Control the ability to measure more than one function simultaneously (boolean). """,
         values={True: 1, False: 0},
         map_values=True,
     )
@@ -148,92 +151,91 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
     # Current (A) #
     ###############
 
-    current = Instrument.measurement(
-        ":READ?",
-        """ Reads the current in Amps, if configured for this reading.
-        """
-    )
+    current = Instrument.measurement(":READ?", """ Get the current in Amps (float). """)
+
     current_range = Instrument.control(
-        ":SENS:CURR:RANG?", ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
-        """ A floating point property that controls the measurement current
-        range in Amps, which can take values between -1.05 and +1.05 A.
+        ":SENS:CURR:RANG?",
+        ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
+        """ Control the measurement current range in Amps (float, truncated from -1.05 to 1.05).
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[-1.05, 1.05]
+        values=[-1.05, 1.05],
     )
+
     current_nplc = Instrument.control(
-        ":SENS:CURR:NPLC?", ":SENS:CURR:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
-        (NPLC) for the DC current measurements, which sets the integration period
-        and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
-        Fast, Medium, and Slow respectively. """
+        ":SENS:CURR:NPLC?",
+        ":SENS:CURR:NPLC %g",
+        """ Control the number of power line cycles for the DC current measurements (float). """,
     )
+
     compliance_current = Instrument.control(
-        ":SENS:CURR:PROT?", ":SENS:CURR:PROT %g",
-        """ A floating point property that controls the compliance current
-        in Amps. """,
+        ":SENS:CURR:PROT?",
+        ":SENS:CURR:PROT %g",
+        """ Control the compliance current in Amps (float, truncated from -1.05 to 1.05). """,
         validator=truncated_range,
-        values=[-1.05, 1.05]
+        values=[-1.05, 1.05],
     )
+
     source_current = Instrument.control(
-        ":SOUR:CURR?", ":SOUR:CURR:LEV %g",
-        """ A floating point property that controls the source current
-        in Amps. """,
+        ":SOUR:CURR?",
+        ":SOUR:CURR:LEV %g",
+        """ Control the source current in Amps (float, truncated from -1.05 to 1.05). """,
         validator=truncated_range,
-        values=[-1.05, 1.05]
+        values=[-1.05, 1.05],
     )
+
     source_current_range = Instrument.control(
-        ":SOUR:CURR:RANG?", ":SOUR:CURR:RANG:AUTO 0;:SOUR:CURR:RANG %g",
-        """ A floating point property that controls the source current
-        range in Amps, which can take values between -1.05 and +1.05 A.
+        ":SOUR:CURR:RANG?",
+        ":SOUR:CURR:RANG:AUTO 0;:SOUR:CURR:RANG %g",
+        """ Control the source current range in Amps (float, truncated from -1.05 to 1.05).
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[-1.05, 1.05]
+        values=[-1.05, 1.05],
     )
 
     ###############
     # Voltage (V) #
     ###############
 
-    voltage = Instrument.measurement(
-        ":READ?",
-        """ Reads the voltage in Volts, if configured for this reading.
-        """
-    )
+    voltage = Instrument.measurement(":READ?", """ Get the voltage in Volts (float). """)
+
     voltage_range = Instrument.control(
-        ":SENS:VOLT:RANG?", ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG %g",
-        """ A floating point property that controls the measurement voltage
-        range in Volts, which can take values from -210 to 210 V.
+        ":SENS:VOLT:RANG?",
+        ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG %g",
+        """ Control the measurement voltage range in Volts (float, truncated from -210 to 210).
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[-210, 210]
+        values=[-210, 210],
     )
+
     voltage_nplc = Instrument.control(
-        ":SENS:VOLT:NPLC?", ":SENS:VOLT:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
+        ":SENS:VOLT:NPLC?",
+        ":SENS:VOLT:NPLC %g",
+        """ Control the number of power line cycles
         (NPLC) for the DC voltage measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
-        Fast, Medium, and Slow respectively. """
+        Fast, Medium, and Slow respectively. """,
     )
+
     compliance_voltage = Instrument.control(
-        ":SENS:VOLT:PROT?", ":SENS:VOLT:PROT %g",
-        """ A floating point property that controls the compliance voltage
-        in Volts. """,
+        ":SENS:VOLT:PROT?",
+        ":SENS:VOLT:PROT %g",
+        """ Control the compliance voltage in Volts (float, truncated from -210 to 210). """,
         validator=truncated_range,
-        values=[-210, 210]
+        values=[-210, 210],
     )
+
     source_voltage = Instrument.control(
-        ":SOUR:VOLT?", ":SOUR:VOLT:LEV %g",
-        """ A floating point property that controls the source voltage
-        in Volts. """
+        ":SOUR:VOLT?", ":SOUR:VOLT:LEV %g", """ Control the source voltage in Volts (float). """
     )
+
     source_voltage_range = Instrument.control(
-        ":SOUR:VOLT:RANG?", ":SOUR:VOLT:RANG:AUTO 0;:SOUR:VOLT:RANG %g",
-        """ A floating point property that controls the source voltage
-        range in Volts, which can take values from -210 to 210 V.
-        Auto-range is disabled when this property is set. """,
+        ":SOUR:VOLT:RANG?",
+        ":SOUR:VOLT:RANG:AUTO 0;:SOUR:VOLT:RANG %g",
+        """ Control the source voltage range in Volts (float, truncated from -210 to 210). """
+        """Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[-210, 210]
+        values=[-210, 210],
     )
 
     ####################
@@ -242,63 +244,69 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
 
     resistance = Instrument.measurement(
         ":READ?",
-        """ Reads the resistance in Ohms, if configured for this reading.
-        """
+        """ Get the resistance in Ohms (float). """,
     )
+
     resistance_range = Instrument.control(
-        ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
-        """ A floating point property that controls the resistance range
-        in Ohms, which can take values from 0 to 210 MOhms.
-        Auto-range is disabled when this property is set. """,
+        ":SENS:RES:RANG?",
+        ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
+        """ Control the resistance range in Ohms (float, truncated from 0 to 210e6). """
+        """Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[0, 210e6]
+        values=[0, 210e6],
     )
+
     resistance_nplc = Instrument.control(
-        ":SENS:RES:NPLC?", ":SENS:RES:NPLC %g",
-        """ A floating point property that controls the number of power line cycles
+        ":SENS:RES:NPLC?",
+        ":SENS:RES:NPLC %g",
+        """ Control the number of power line cycles
         (NPLC) for the 2-wire resistance measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
-        Fast, Medium, and Slow respectively. """
+        Fast, Medium, and Slow respectively. """,
     )
+
     wires = Instrument.control(
-        ":SYSTEM:RSENSE?", ":SYSTEM:RSENSE %d",
-        """ An integer property that controls the number of wires in
-        use for resistance measurements, which can take the value of
-        2 or 4.
-        """,
+        ":SYSTEM:RSENSE?",
+        ":SYSTEM:RSENSE %d",
+        """ Control the number of wires in use for resistance measurements
+        (integer, strictly 2 or 4). """,
         validator=strict_discrete_set,
         values={4: 1, 2: 0},
-        map_values=True
+        map_values=True,
     )
 
     buffer_points = Instrument.control(
-        ":TRAC:POIN?", ":TRAC:POIN %d",
-        """ An integer property that controls the number of buffer points. This
-        does not represent actual points in the buffer, but the configuration
-        value instead. """,
+        ":TRAC:POIN?",
+        ":TRAC:POIN %d",
+        """ Control the number of buffer points, the configuration value
+        (integer, truncated from 1 to 2500). """,
         validator=truncated_range,
         values=[1, 2500],
-        cast=int
+        cast=int,
     )
+
     means = Instrument.measurement(
         ":CALC3:FORM MEAN;:CALC3:DATA?;",
-        """ Reads the calculated means (averages) for voltage,
-        current, and resistance from the buffer data  as a list. """
+        """ Get the calculated means for voltage, current, and resistance from the buffer data
+        as a list (list of floats). """,
     )
+
     maximums = Instrument.measurement(
         ":CALC3:FORM MAX;:CALC3:DATA?;",
-        """ Returns the calculated maximums for voltage, current, and
-        resistance from the buffer data as a list. """
+        """ Get the calculated maximums for voltage, current, and resistance from the buffer data
+        as a list (list of floats). """,
     )
+
     minimums = Instrument.measurement(
         ":CALC3:FORM MIN;:CALC3:DATA?;",
-        """ Returns the calculated minimums for voltage, current, and
-        resistance from the buffer data as a list. """
+        """ Get the calculated minimums for voltage, current, and resistance from the buffer data
+        as a list (list of floats). """,
     )
+
     standard_devs = Instrument.measurement(
         ":CALC3:FORM SDEV;:CALC3:DATA?;",
-        """ Returns the calculated standard deviations for voltage,
-        current, and resistance from the buffer data as a list. """
+        """ Get the calculated standard deviations for voltage, current, and resistance from the
+        buffer data as a list (list of floats). """,
     )
 
     ###########
@@ -306,19 +314,20 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
     ###########
 
     trigger_count = Instrument.control(
-        ":TRIG:COUN?", ":TRIG:COUN %d",
-        """ An integer property that controls the trigger count,
-        which can take values from 1 to 9,999. """,
+        ":TRIG:COUN?",
+        ":TRIG:COUN %d",
+        """ Control the trigger count (integer, truncated from 1 to 2500). """,
         validator=truncated_range,
         values=[1, 2500],
-        cast=int
+        cast=int,
     )
+
     trigger_delay = Instrument.control(
-        ":TRIG:SEQ:DEL?", ":TRIG:SEQ:DEL %g",
-        """ A floating point property that controls the trigger delay
-        in seconds, which can take values from 0 to 999.9999 s. """,
+        ":TRIG:SEQ:DEL?",
+        ":TRIG:SEQ:DEL %g",
+        """ Control the trigger delay in seconds (float, truncated from 0 to 999.9999). """,
         validator=truncated_range,
-        values=[0, 999.9999]
+        values=[0, 999.9999],
     )
 
     ###########
@@ -326,36 +335,41 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
     ###########
 
     filter_type = Instrument.control(
-        ":SENS:AVER:TCON?", ":SENS:AVER:TCON %s",
-        """ A String property that controls the filter's type.
-        REP : Repeating filter
-        MOV : Moving filter""",
+        ":SENS:AVER:TCON?",
+        ":SENS:AVER:TCON %s",
+        """ Control the filter's type (string, strictly 'REP' or 'MOV'). """,
         validator=strict_discrete_set,
-        values=['REP', 'MOV'],
-        map_values=False)
+        values=["REP", "MOV"],
+        map_values=False,
+    )
 
     filter_count = Instrument.control(
-        ":SENS:AVER:COUNT?", ":SENS:AVER:COUNT %d",
-        """ A integer property that controls the number of readings that are
-        acquired and stored in the filter buffer for the averaging""",
+        ":SENS:AVER:COUNT?",
+        ":SENS:AVER:COUNT %d",
+        """ Control the number of readings that are acquired and stored in the filter buffer
+        (integer, truncated from 1 to 100). """,
         validator=truncated_range,
         values=[1, 100],
-        cast=int)
+        cast=int,
+    )
 
     filter_state = Instrument.control(
-        ":SENS:AVER?", ":SENS:AVER %s",
-        """ A string property that controls if the filter is active.""",
+        ":SENS:AVER?",
+        ":SENS:AVER %s",
+        """ Control if the filter is active (string, strictly 'ON' or 'OFF'). """,
         validator=strict_discrete_set,
-        values=['ON', 'OFF'],
-        map_values=False)
+        values=["ON", "OFF"],
+        map_values=False,
+    )
 
     #####################
     # Output subsystem #
     #####################
 
     output_off_state = Instrument.control(
-        ":OUTP:SMOD?", ":OUTP:SMOD %s",
-        """ Select the output-off state of the SourceMeter.
+        ":OUTP:SMOD?",
+        ":OUTP:SMOD %s",
+        """ Control the output-off state of the SourceMeter.
         HIMP : output relay is open, disconnects external circuitry.
         NORM : V-Source is selected and set to 0V, Compliance is set to 0.5%
         full scale of the present current range.
@@ -364,18 +378,13 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         range, whichever is greater.
         GUAR : I-Source is selected and set to 0A""",
         validator=strict_discrete_set,
-        values=['HIMP', 'NORM', 'ZERO', 'GUAR'],
-        map_values=False)
+        values=["HIMP", "NORM", "ZERO", "GUAR"],
+        map_values=False,
+    )
 
     ####################
     # Methods        #
     ####################
-
-    def __init__(self, adapter, name="Keithley 2400 SourceMeter", **kwargs):
-        super().__init__(
-            adapter, name,
-            **kwargs
-        )
 
     def enable_source(self):
         """ Enables the source of current or voltage depending on the
@@ -503,8 +512,9 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         self.beep(base_frequency * 6.0 / 4.0, duration)
 
     display_enabled = Instrument.control(
-        ":DISP:ENAB?", ":DISP:ENAB %d",
-        """ A boolean property that controls whether or not the display of the
+        ":DISP:ENAB?",
+        ":DISP:ENAB %d",
+        """ Control whether or not the display of the
         sourcemeter is enabled. Valid values are True and False. """,
         values={True: 1, False: 0},
         map_values=True,
@@ -512,15 +522,16 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
 
     @property
     def error(self):
+        """Get the last error message."""
         warn("Deprecated to use `error`, use `next_error` instead.", FutureWarning)
         return self.next_error
 
     def reset(self):
-        """ Resets the instrument and clears the queue.  """
+        """Reset the instrument and clear the queue."""
         self.write("status:queue:clear;*RST;:stat:pres;:*CLS;")
 
     def ramp_to_current(self, target_current, steps=30, pause=20e-3):
-        """ Ramps to a target current from the set current value over
+        """Ramp to a target current from the set current value over
         a certain number of linear steps, each separated by a pause duration.
 
         :param target_current: A current in Amps
@@ -537,7 +548,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             time.sleep(pause)
 
     def ramp_to_voltage(self, target_voltage, steps=30, pause=20e-3):
-        """ Ramps to a target voltage from the set voltage value over
+        """Ramp to a target voltage from the set voltage value over
         a certain number of linear steps, each separated by a pause duration.
 
         :param target_voltage: A voltage in Amps
@@ -554,38 +565,37 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             time.sleep(pause)
 
     def trigger(self):
-        """ Executes a bus trigger, which can be used when
+        """Execute a bus trigger, which can be used when
         :meth:`~.trigger_on_bus` is configured.
         """
         return self.write("*TRG")
 
     def trigger_immediately(self):
-        """ Configures measurements to be taken with the internal
+        """Configure measurements to be taken with the internal
         trigger at the maximum sampling rate.
         """
         self.write(":ARM:SOUR IMM;:TRIG:SOUR IMM;")
 
     def trigger_on_bus(self):
-        """ Configures the trigger to detect events based on the bus
+        """Configure the trigger to detect events based on the bus
         trigger, which can be activated by :meth:`~.trigger`.
         """
         self.write(":ARM:COUN 1;:ARM:SOUR BUS;:TRIG:SOUR BUS;")
 
     def set_trigger_counts(self, arm, trigger):
-        """ Sets the number of counts for both the sweeps (arm) and the
+        """Set the number of counts for both the sweeps (arm) and the
         points in those sweeps (trigger), where the total number of
         points can not exceed 2500
         """
         if arm * trigger > 2500 or arm * trigger < 0:
-            raise RangeException("Keithley 2400 has a combined maximum "
-                                 "of 2500 counts")
+            raise RangeException("Keithley 2400 has a combined maximum of 2500 counts")
         if arm < trigger:
             self.write(":ARM:COUN %d;:TRIG:COUN %d" % (arm, trigger))
         else:
             self.write(":TRIG:COUN %d;:ARM:COUN %d" % (trigger, arm))
 
     def sample_continuously(self):
-        """ Causes the instrument to continuously read samples
+        """Cause the instrument to continuously read samples
         and turns off any buffer or output triggering
         """
         self.disable_buffer()
@@ -593,17 +603,16 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         self.trigger_immediately()
 
     def set_timed_arm(self, interval):
-        """ Sets up the measurement to be taken with the internal
+        """Set up the measurement to be taken with the internal
         trigger at a variable sampling rate defined by the interval
         in seconds between sampling points
         """
         if interval > 99999.99 or interval < 0.001:
-            raise RangeException("Keithley 2400 can only be time"
-                                 " triggered between 1 mS and 1 Ms")
+            raise RangeException("Keithley 2400 can only be time triggered between 1 mS and 1 Ms")
         self.write(":ARM:SOUR TIM;:ARM:TIM %.3f" % interval)
 
     def trigger_on_external(self, line=1):
-        """ Configures the measurement trigger to be taken from a
+        """Configure the measurement trigger to be taken from a
         specific line of an external trigger
 
         :param line: A trigger line from 1 to 4
@@ -612,8 +621,8 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         cmd += ":ARM:ILIN %d;:TRIG:ILIN %d;" % (line, line)
         self.write(cmd)
 
-    def output_trigger_on_external(self, line=1, after='DEL'):
-        """ Configures the output trigger on the specified trigger link
+    def output_trigger_on_external(self, line=1, after="DEL"):
+        """Configure the output trigger on the specified trigger link
         line number, with the option of supplying the part of the
         measurement after which the trigger should be generated
         (default to delay, which is right before the measurement)
@@ -624,68 +633,67 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         self.write(":TRIG:OUTP %s;:TRIG:OLIN %d;" % (after, line))
 
     def disable_output_trigger(self):
-        """ Disables the output trigger for the Trigger layer
-        """
+        """Disable the output trigger for the Trigger layer"""
         self.write(":TRIG:OUTP NONE")
 
     @property
     def mean_voltage(self):
-        """ Returns the mean voltage from the buffer """
+        """Get the mean voltage from the buffer"""
         return self.means[0]
 
     @property
     def max_voltage(self):
-        """ Returns the maximum voltage from the buffer """
+        """Get the maximum voltage from the buffer"""
         return self.maximums[0]
 
     @property
     def min_voltage(self):
-        """ Returns the minimum voltage from the buffer """
+        """Get the minimum voltage from the buffer"""
         return self.minimums[0]
 
     @property
     def std_voltage(self):
-        """ Returns the voltage standard deviation from the buffer """
+        """Get the voltage standard deviation from the buffer"""
         return self.standard_devs[0]
 
     @property
     def mean_current(self):
-        """ Returns the mean current from the buffer """
+        """Get the mean current from the buffer"""
         return self.means[1]
 
     @property
     def max_current(self):
-        """ Returns the maximum current from the buffer """
+        """Get the maximum current from the buffer"""
         return self.maximums[1]
 
     @property
     def min_current(self):
-        """ Returns the minimum current from the buffer """
+        """Get the minimum current from the buffer"""
         return self.minimums[1]
 
     @property
     def std_current(self):
-        """ Returns the current standard deviation from the buffer """
+        """Get the current standard deviation from the buffer"""
         return self.standard_devs[1]
 
     @property
     def mean_resistance(self):
-        """ Returns the mean resistance from the buffer """
+        """Get the mean resistance from the buffer"""
         return self.means[2]
 
     @property
     def max_resistance(self):
-        """ Returns the maximum resistance from the buffer """
+        """Get the maximum resistance from the buffer"""
         return self.maximums[2]
 
     @property
     def min_resistance(self):
-        """ Returns the minimum resistance from the buffer """
+        """Get the minimum resistance from the buffer"""
         return self.minimums[2]
 
     @property
     def std_resistance(self):
-        """ Returns the resistance standard deviation from the buffer """
+        """Get the resistance standard deviation from the buffer"""
         return self.standard_devs[2]
 
     def status(self):

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -164,7 +164,6 @@ grandfathered_docstring_instruments = [
     "BatteryChannel",  # Keithley2306
     "Step",  # Keithley2306
     "Relay",  # Keithley2306
-    "Keithley2400",
     "Keithley2450",
     "Keithley2600",
     "Keithley2700",


### PR DESCRIPTION
I changed the docstrings with AI to our new format, it works well. This was a test to change all the docstrings.

Here is my prompt (for future usage):
~~~
Reformat the docstring, that it is in the format "Control the voltage in Volts (float strictly from -1 to 1)."

where the parenthesis indicate the type, the validator type (strict or truncated etc.) and the values.

Use "Control" for an Instrument.control, use "Set" for Instrument.setting, and "Get" for Instrument.measurement
~~~

An addition of "add additional comments before the parenthesis might help, as I had to add additional comments manually again.