### PR TITLE
Santec tsl570

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -64,6 +64,7 @@ Instruments by manufacturer:
    redpitaya/index
    rigol/index
    rohdeschwarz/index
+   santec/index
    siglenttechnologies/index
    signalrecovery/index
    srs/index

--- a/docs/api/instruments/santec/index.rst
+++ b/docs/api/instruments/santec/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.santec
+
+######
+Santec
+######
+
+This section contains specific documentation on the Santec instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   tsl570

--- a/docs/api/instruments/santec/tsl570.rst
+++ b/docs/api/instruments/santec/tsl570.rst
@@ -1,0 +1,8 @@
+############################
+Santec TSL-570 Tunable Laser
+############################
+
+.. autoclass:: pymeasure.instruments.santec.tsl570
+    :members:
+    :show-inheritance:
+    :inherited-members: CommonBase

--- a/pymeasure/instruments/santec/__init__.py
+++ b/pymeasure/instruments/santec/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .tsl570 import TSL570

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -24,7 +24,48 @@
 
 from pymeasure.instruments import Instrument, SCPIMixin
 
+from pymeasure.instruments.validators import strict_discrete_set
+
 
 class TSL570(SCPIMixin, Instrument):
     """Represents the Santec TSL-570 Tunable Laser and provides a high-level interface for
     interacting with the instrument."""
+
+    def __init__(self):
+        """Set the device to use SCPI commands."""
+        Instrument.write(self, ":SYSTem:COMMunicate:CODe 1")
+
+    shutter_closed = Instrument.control(
+        ":POWer:SHUTter?",
+        ":POWer:SHUTter %d",
+        """A boolean property that controls whether shutter is closed.""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    wavelength = Instrument.control(
+        ":WAVelength?", ":WAVelength %e", """Set the output wavelength, in m."""
+    )
+
+    frequency = Instrument.control(
+        ":FREQuency?", "FREQuency %e", """Set the output wavelength in optical frequency, in Hz."""
+    )
+
+    # TODO
+    # power_setpoint
+    # power_reading
+    # power_unit
+    # wavelength_start
+    # wavelength_stop
+    # wavelength_step
+    # frequency_start
+    # frequency_stop
+    # frequency_step
+    # sweep_mode
+    # sweep_speed
+    # sweep_dwell
+    # sweep_delay
+    # single_sweep
+    # repeat_sweep
+    # sweep_status

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -37,15 +37,24 @@ class TSL570(SCPIMixin, Instrument):
 
     def __init__(self, adapter, name="Santec TSL-570", **kwargs):
         super().__init__(adapter, name, **kwargs)
-        self.write(":SYSTem:COMMunicate:CODe 1")  # Set the device to use SCPI commands
         self.check_errors()  # Clear the error queue
 
     def check_instr_errors(self):
-        """Checks the instrument for errors, and raises an exeption if any are present."""
+        """Check the instrument for errors, and raise an exception if any are present."""
         errors = self.check_errors()
         if errors:
             raise Error(errors)
 
+    command_set = Instrument.control(
+        ":SYSTem:COMMunicate:CODe?",
+        ":SYSTem:COMMunicate:CODe %d",
+        """Control the command set (str Legacy of SCPI).
+        Legacy commands use units of nm and THz for wavelength and optical frequency respectively.
+        SCPI commands use units of m and Hz for wavelength and optical frequency respectively.""",
+        validator=strict_discrete_set,
+        values={"Legacy": 0, "SCPI": 1},
+        map_values=True,
+    )
     # --- Optical power control ---
 
     output_enabled = Instrument.control(

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -28,10 +28,7 @@ from pymeasure.instruments.validators import (
     strict_discrete_range,
     strict_discrete_set,
 )
-
-
-class InstrumentError(Exception):
-    """Exception raised for errors reported by the instrument."""
+from pymeasure.errors import Error
 
 
 class TSL570(SCPIMixin, Instrument):
@@ -47,7 +44,7 @@ class TSL570(SCPIMixin, Instrument):
         """Checks the instrument for errors, and raises an exeption if any are present."""
         errors = self.check_errors()
         if errors:
-            raise InstrumentError(errors)
+            raise Error(errors)
 
     # --- Optical power control ---
 

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -24,12 +24,16 @@
 
 from pymeasure.instruments import Instrument, SCPIMixin
 
-from pymeasure.instruments.validators import strict_discrete_set
+from pymeasure.instruments.validators import truncated_range, strict_discrete_set
 
 
 class TSL570(SCPIMixin, Instrument):
     """Represents the Santec TSL-570 Tunable Laser and provides a high-level interface for
     interacting with the instrument."""
+
+    # TODO: I am unsure of the implementation of the validators. I have implemented them according
+    #       to my interpretation of the documentation, but this will need to be tested with the
+    #       instrument to validate this.
 
     def __init__(self):
         """Set the device to use SCPI commands."""
@@ -44,12 +48,91 @@ class TSL570(SCPIMixin, Instrument):
         map_values=True,
     )
 
+    # --- Wavelength control ---
+
+    wavelength_min = Instrument.measurement(
+        ":WAVelength:SWEep:RANGe:MINimum?",
+        """Get the minimum wavelength in the configurable sweep range
+        at the current sweep speed.""",
+    )
+
+    wavelength_max = Instrument.measurement(
+        ":WAVelength:SWEep:RANGe:MAXimum?",
+        """Get the maximum wavelength in the configurable sweep range
+        at the current sweep speed.""",
+    )
+
+    wavelength_start = Instrument.control(
+        ":WAVelength:SWEep:STARt?",
+        ":WAVelength:SWEep:STARt %e",
+        """Control the sweep start wavelength, in m.""",
+        validator=truncated_range,
+        values=[wavelength_min, wavelength_max],
+    )
+
+    wavelength_stop = Instrument.control(
+        ":WAVelength:SWEep:STOP?",
+        ":WAVelength:SWEep:STOP %e",
+        """Control the sweep stop wavelength, in m.""",
+        validator=truncated_range,
+        values=[wavelength_min, wavelength_max],
+    )
+
     wavelength = Instrument.control(
-        ":WAVelength?", ":WAVelength %e", """Set the output wavelength, in m."""
+        ":WAVelength?",
+        ":WAVelength %e",
+        """Control the output wavelength, in m.""",
+        validator=truncated_range,
+        values=[wavelength_start, wavelength_stop],
+    )
+
+    # --- Optical frequency control ---
+
+    frequency_min = Instrument.measurement(
+        ":FREQency:SWEep:RANGe:MINimum?",
+        """Get the minimum frequency in the configurable sweep range
+        at the current sweep speed.""",
+    )
+
+    frequency_max = Instrument.measurement(
+        ":FREQency:SWEep:RANGe:MAXimum?",
+        """Get the maximum frequency in the configurable sweep range
+        at the current sweep speed.""",
+    )
+
+    frequency_start = Instrument.control(
+        ":FREQency:SWEep:STARt?",
+        ":FREQency:SWEep:STARt %e",
+        """Control the sweep start frequency, in m.""",
+        validator=truncated_range,
+        values=[frequency_min, frequency_max],
+    )
+
+    frequency_stop = Instrument.control(
+        ":FREQency:SWEep:STOP?",
+        ":FREQency:SWEep:STOP %e",
+        """Control the sweep stop frequency, in m.""",
+        validator=truncated_range,
+        values=[frequency_min, frequency_max],
     )
 
     frequency = Instrument.control(
-        ":FREQuency?", "FREQuency %e", """Set the output wavelength in optical frequency, in Hz."""
+        ":FREQency?",
+        ":FREQency %e",
+        """Control the output frequency, in m.""",
+        validator=truncated_range,
+        values=[frequency_start, frequency_stop],
+    )
+
+    # --- Optical power control ---
+
+    power_unit = Instrument.control(
+        ":POWer:UNIT?",
+        ":POWer:UNIT %d",
+        """Control the unit of power, dBm or mW.""",
+        validator=strict_discrete_set,
+        values={"dBm": 0, "mW": 1},
+        map_values=True,
     )
 
     # TODO

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -73,7 +73,7 @@ class TSL570(SCPIMixin, Instrument):
         ":POWer?",
         ":Power %e",
         """Control the output optical power, units defined by power_unit.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     power_reading = Instrument.measurement(
@@ -99,28 +99,28 @@ class TSL570(SCPIMixin, Instrument):
         ":WAVelength?",
         ":WAVelength %e",
         """Control the output wavelength, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     wavelength_start = Instrument.control(
         ":WAVelength:SWEep:STARt?",
         ":WAVelength:SWEep:STARt %e",
         """Control the sweep start wavelength, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     wavelength_stop = Instrument.control(
         ":WAVelength:SWEep:STOP?",
         ":WAVelength:SWEep:STOP %e",
         """Control the sweep stop wavelength, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     wavelength_step = Instrument.control(
         ":WAVelength:SWEep:STEP?",
         ":WAVelength:SWEep:STEP %e",
         """Control the sweep step wavelength when in step sweep mode, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     # --- Optical frequency control ---
@@ -141,28 +141,28 @@ class TSL570(SCPIMixin, Instrument):
         ":FREQuency?",
         ":FREQuency %e",
         """Control the output frequency, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     frequency_start = Instrument.control(
         ":FREQuency:SWEep:STARt?",
         ":FREQuency:SWEep:STARt %e",
         """Control the sweep start frequency, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     frequency_stop = Instrument.control(
         ":FREQuency:SWEep:STOP?",
         ":FREQuency:SWEep:STOP %e",
         """Control the sweep stop frequency, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     frequency_step = Instrument.control(
         ":FREQuency:SWEep:STEP?",
         ":FREQuency:SWEep:STEP %e",
         """Control the sweep step frequency when in step sweep mode, in m.""",
-        check_instr_errors=True,
+        values_kwargs={"check_instr_errors": True},
     )
 
     # --- Sweep settings ---
@@ -199,7 +199,7 @@ class TSL570(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={
             "Stepped One-way": 0,
-            "Continuous One-way:": 1,
+            "Continuous One-way": 1,
             "Stepped Two-way": 2,
             "Continuous Two-way": 3,
         },

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -57,24 +57,18 @@ class TSL570(SCPIMixin, Instrument):
         ":WAVelength:SWEep:STARt?",
         ":WAVelength:SWEep:STARt %e",
         """Control the sweep start wavelength, in m.""",
-        validator=strict_range,
-        values=[wavelength_min, wavelength_max],
     )
 
     wavelength_stop = Instrument.control(
         ":WAVelength:SWEep:STOP?",
         ":WAVelength:SWEep:STOP %e",
         """Control the sweep stop wavelength, in m.""",
-        validator=strict_range,
-        values=[wavelength_min, wavelength_max],
     )
 
     wavelength = Instrument.control(
         ":WAVelength?",
         ":WAVelength %e",
         """Control the output wavelength, in m.""",
-        validator=strict_range,
-        values=[wavelength_start, wavelength_stop],
     )
 
     # --- Optical frequency control ---
@@ -95,24 +89,18 @@ class TSL570(SCPIMixin, Instrument):
         ":FREQency:SWEep:STARt?",
         ":FREQency:SWEep:STARt %e",
         """Control the sweep start frequency, in m.""",
-        validator=strict_range,
-        values=[frequency_min, frequency_max],
     )
 
     frequency_stop = Instrument.control(
         ":FREQency:SWEep:STOP?",
         ":FREQency:SWEep:STOP %e",
         """Control the sweep stop frequency, in m.""",
-        validator=strict_range,
-        values=[frequency_min, frequency_max],
     )
 
     frequency = Instrument.control(
         ":FREQency?",
         ":FREQency %e",
         """Control the output frequency, in m.""",
-        validator=strict_range,
-        values=[frequency_start, frequency_stop],
     )
 
     # --- Optical power control ---
@@ -135,20 +123,10 @@ class TSL570(SCPIMixin, Instrument):
         map_values=True,
     )
 
-    @property
-    def power_range(self):
-        if self.power_unit == "dBm":
-            return [-15, 13]
-        elif self.power_unit == "mW":
-            return [10 ** (-1.5), 10 ** (1.3)]
-
     power_setpoint = Instrument.control(
         ":POWer?",
         ":Power %e",
         """Control the output optical power, units defined by power_unit.""",
-        validator=strict_range,
-        values=power_range,
-        dynamic=True,
     )
 
     power_reading = Instrument.measurement(

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -1,0 +1,30 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument, SCPIMixin
+
+
+class TSL570(SCPIMixin, Instrument):
+    """Represents the Santec TSL-570 Tunable Laser and provides a high-level interface for
+    interacting with the instrument."""

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -55,17 +55,17 @@ class SweepPattern(IntEnum):
     CONTINUOUS = 1
 
 
-def mode_to_pattern(mode: SweepMode) -> SweepPattern:
+def mode_to_pattern(mode):
     # For mode values 0 and 2, the pattern is STEPPED; for 1 and 3, it's CONTINUOUS.
     return SweepPattern(mode % 2)
 
 
-def mode_to_routing(mode: SweepMode) -> SweepRouting:
+def mode_to_routing(mode):
     # For mode values 0 and 1, the routing is ONE_WAY; for 2 and 3, it's TWO_WAY.
     return SweepRouting(mode // 2)
 
 
-def combine_pattern_routing(pattern: SweepPattern, routing: SweepRouting) -> SweepMode:
+def combine_pattern_routing(pattern, routing):
     # The composite mode is determined by the routing times 2 plus the pattern.
     return SweepMode(routing.value * 2 + pattern.value)
 
@@ -220,18 +220,13 @@ class TSL570(SCPIMixin, Instrument):
     sweep_staus = Instrument.measurement(
         "WAVelength:SWEep?",
         """Get the current sweep status as an enum.""",
-        validator=strict_discrete_set,
-        values={0, 1, 3, 4},
-        get_process=lambda v: SweepStatus(v),  # Convert raw value to enum
-        set_process=lambda v: v.value,  # Convert enum to its integer value
+        get_process=lambda v: SweepStatus(v),
     )
 
     sweep_mode = Instrument.control(
         ":WAVelength:SWEep:MODe?",
         ":WAVelength:SWEep:MODe %d",
         """Control the sweep mode.""",
-        validator=strict_discrete_set,
-        values={0, 1, 2, 3},
         get_process=lambda v: SweepMode(v),
         set_process=lambda v: v.value,
     )

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -40,7 +40,7 @@ class TSL570(SCPIMixin, Instrument):
     command_set = Instrument.control(
         ":SYSTem:COMMunicate:CODe?",
         ":SYSTem:COMMunicate:CODe %d",
-        """Control the command set (str Legacy of SCPI).
+        """Control the command set, "Legacy" or "SCPI".
         Legacy commands use units of nm and THz for wavelength and optical frequency respectively.
         SCPI commands use units of m and Hz for wavelength and optical frequency respectively.""",
         validator=strict_discrete_set,
@@ -74,7 +74,7 @@ class TSL570(SCPIMixin, Instrument):
         check_set_errors=True,
     )
 
-    power_reading = Instrument.measurement(
+    power = Instrument.measurement(
         ":POWer:ACTual?",
         """Measure the monitored optical power, units defined by power_unit.""",
     )
@@ -93,7 +93,7 @@ class TSL570(SCPIMixin, Instrument):
         at the current sweep speed.""",
     )
 
-    wavelength = Instrument.control(
+    wavelength_setpoint = Instrument.control(
         ":WAVelength?",
         ":WAVelength %e",
         """Control the output wavelength, in m.""",
@@ -135,7 +135,7 @@ class TSL570(SCPIMixin, Instrument):
         at the current sweep speed.""",
     )
 
-    frequency = Instrument.control(
+    frequency_setpoint = Instrument.control(
         ":FREQuency?",
         ":FREQuency %e",
         """Control the output frequency, in m.""",
@@ -193,7 +193,8 @@ class TSL570(SCPIMixin, Instrument):
     sweep_mode = Instrument.control(
         ":WAVelength:SWEep:MODe?",
         ":WAVelength:SWEep:MODe %d",
-        """Control the sweep mode.""",
+        """Control the sweep mode, "Stepped One-Way", "Continuous One-Way", "Stepped Two-Way",
+        or "Continuous Two-way".""",
         validator=strict_discrete_set,
         values={
             "Stepped One-way": 0,

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -28,7 +28,6 @@ from pymeasure.instruments.validators import (
     strict_discrete_range,
     strict_discrete_set,
 )
-from pymeasure.errors import Error
 
 
 class TSL570(SCPIMixin, Instrument):
@@ -37,13 +36,6 @@ class TSL570(SCPIMixin, Instrument):
 
     def __init__(self, adapter, name="Santec TSL-570", **kwargs):
         super().__init__(adapter, name, **kwargs)
-        self.check_errors()  # Clear the error queue
-
-    def check_instr_errors(self):
-        """Check the instrument for errors, and raise an exception if any are present."""
-        errors = self.check_errors()
-        if errors:
-            raise Error(errors)
 
     command_set = Instrument.control(
         ":SYSTem:COMMunicate:CODe?",
@@ -79,7 +71,7 @@ class TSL570(SCPIMixin, Instrument):
         ":POWer?",
         ":Power %e",
         """Control the output optical power, units defined by power_unit.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     power_reading = Instrument.measurement(
@@ -105,28 +97,28 @@ class TSL570(SCPIMixin, Instrument):
         ":WAVelength?",
         ":WAVelength %e",
         """Control the output wavelength, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     wavelength_start = Instrument.control(
         ":WAVelength:SWEep:STARt?",
         ":WAVelength:SWEep:STARt %e",
         """Control the sweep start wavelength, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     wavelength_stop = Instrument.control(
         ":WAVelength:SWEep:STOP?",
         ":WAVelength:SWEep:STOP %e",
         """Control the sweep stop wavelength, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     wavelength_step = Instrument.control(
         ":WAVelength:SWEep:STEP?",
         ":WAVelength:SWEep:STEP %e",
         """Control the sweep step wavelength when in step sweep mode, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     # --- Optical frequency control ---
@@ -147,28 +139,28 @@ class TSL570(SCPIMixin, Instrument):
         ":FREQuency?",
         ":FREQuency %e",
         """Control the output frequency, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     frequency_start = Instrument.control(
         ":FREQuency:SWEep:STARt?",
         ":FREQuency:SWEep:STARt %e",
         """Control the sweep start frequency, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     frequency_stop = Instrument.control(
         ":FREQuency:SWEep:STOP?",
         ":FREQuency:SWEep:STOP %e",
         """Control the sweep stop frequency, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     frequency_step = Instrument.control(
         ":FREQuency:SWEep:STEP?",
         ":FREQuency:SWEep:STEP %e",
         """Control the sweep step frequency when in step sweep mode, in m.""",
-        values_kwargs={"check_instr_errors": True},
+        check_set_errors=True,
     )
 
     # --- Sweep settings ---

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -35,9 +35,9 @@ class TSL570(SCPIMixin, Instrument):
     #       to my interpretation of the documentation, but this will need to be tested with the
     #       instrument to validate this.
 
-    def __init__(self):
-        """Set the device to use SCPI commands."""
-        Instrument.write(self, ":SYSTem:COMMunicate:CODe 1")
+    def __init__(self, adapter, name="Yokogawa AQ3670D OSA", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+        Instrument.write(self, ":SYSTem:COMMunicate:CODe 1")  # Set the device to use SCPI commands
 
     # --- Wavelength control ---
 
@@ -151,21 +151,12 @@ class TSL570(SCPIMixin, Instrument):
         dynamic=True,
     )
 
-    power = Instrument.measurement(
+    power_reading = Instrument.measurement(
         ":POWer:ACTual?",
         """Measure the monitored optical power, units defined by power_unit.""",
     )
 
     # TODO
-    # power_setpoint
-    # power_reading
-    # power_unit
-    # wavelength_start
-    # wavelength_stop
-    # wavelength_step
-    # frequency_start
-    # frequency_stop
-    # frequency_step
     # sweep_mode
     # sweep_speed
     # sweep_dwell
@@ -173,3 +164,9 @@ class TSL570(SCPIMixin, Instrument):
     # single_sweep
     # repeat_sweep
     # sweep_status
+
+
+if __name__ == "__main__":
+    laser = TSL570("GPIB1::8::INSTR")
+
+    laser.wavelength = 1500e-9

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -219,14 +219,14 @@ class TSL570(SCPIMixin, Instrument):
 
     sweep_staus = Instrument.measurement(
         "WAVelength:SWEep?",
-        """Get the current sweep status as an enum.""",
+        """Get the current sweep status as a SweepStatus enum.""",
         get_process=lambda v: SweepStatus(v),
     )
 
     sweep_mode = Instrument.control(
         ":WAVelength:SWEep:MODe?",
         ":WAVelength:SWEep:MODe %d",
-        """Control the sweep mode.""",
+        """Control the sweep mode as a SweepMode enum.""",
         get_process=lambda v: SweepMode(v),
         set_process=lambda v: v.value,
     )
@@ -236,7 +236,7 @@ class TSL570(SCPIMixin, Instrument):
 
     @property
     def sweep_pattern(self) -> SweepPattern:
-        """Return the current sweep pattern as a SweepPattern enum."""
+        """Control the sweep pattern as a SweepPattern enum."""
         return mode_to_pattern(self.sweep_mode)
 
     @sweep_pattern.setter
@@ -246,7 +246,7 @@ class TSL570(SCPIMixin, Instrument):
 
     @property
     def sweep_routing(self) -> SweepRouting:
-        """Return the current sweep routing as a SweepRouting enum."""
+        """Control the sweep routing as a SweepRouting enum."""
         return mode_to_routing(self.sweep_mode)
 
     @sweep_routing.setter

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -34,13 +34,6 @@ class InstrumentError(Exception):
     """Exception raised for errors reported by the instrument."""
 
 
-def evaluated_strict_range(value, values):
-    print(values)
-    print(values())
-    print(dir(values))
-    return strict_range(value, values)
-
-
 class TSL570(SCPIMixin, Instrument):
     """Represents the Santec TSL-570 Tunable Laser and provides a high-level interface for
     interacting with the instrument."""
@@ -48,32 +41,13 @@ class TSL570(SCPIMixin, Instrument):
     def __init__(self, adapter, name="Santec TSL-570", **kwargs):
         super().__init__(adapter, name, **kwargs)
         self.write(":SYSTem:COMMunicate:CODe 1")  # Set the device to use SCPI commands
+        self.check_errors()  # Clear the error queue
 
-    def clear_error_queue(self):
-        """Clears the device error queue by reading until no errors remain."""
-        while True:
-            err = self.ask(":SYSTem:ERRor?")
-            try:
-                err_code, err_msg = err.split(",", 1)
-            except ValueError:
-                # If the response doesn't split as expected, break out
-                break
-            # if err_code is 0 no errors remain, break out
-            if int(err_code) == 0:
-                break
-
-    def check_set_errors(self):
-        """Checks the device for error."""
-        err = self.ask(":SYSTem:ERRor?")
-        try:
-            err_code, err_msg = err.split(",", 1)
-        except Exception:
-            # if splitting fails, just return an empty list.
-            return []
-        # err_code is 0 only if there is no error
-        if int(err_code) != 0:
-            raise InstrumentError(f"{err_code}: {err_msg}")
-        return []
+    def check_instr_errors(self):
+        """Checks the instrument for errors, and raises an exeption if any are present."""
+        errors = self.check_errors()
+        if errors:
+            raise InstrumentError(errors)
 
     # --- Optical power control ---
 
@@ -99,7 +73,7 @@ class TSL570(SCPIMixin, Instrument):
         ":POWer?",
         ":Power %e",
         """Control the output optical power, units defined by power_unit.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     power_reading = Instrument.measurement(
@@ -125,28 +99,28 @@ class TSL570(SCPIMixin, Instrument):
         ":WAVelength?",
         ":WAVelength %e",
         """Control the output wavelength, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     wavelength_start = Instrument.control(
         ":WAVelength:SWEep:STARt?",
         ":WAVelength:SWEep:STARt %e",
         """Control the sweep start wavelength, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     wavelength_stop = Instrument.control(
         ":WAVelength:SWEep:STOP?",
         ":WAVelength:SWEep:STOP %e",
         """Control the sweep stop wavelength, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     wavelength_step = Instrument.control(
         ":WAVelength:SWEep:STEP?",
         ":WAVelength:SWEep:STEP %e",
         """Control the sweep step wavelength when in step sweep mode, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     # --- Optical frequency control ---
@@ -167,28 +141,28 @@ class TSL570(SCPIMixin, Instrument):
         ":FREQuency?",
         ":FREQuency %e",
         """Control the output frequency, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     frequency_start = Instrument.control(
         ":FREQuency:SWEep:STARt?",
         ":FREQuency:SWEep:STARt %e",
         """Control the sweep start frequency, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     frequency_stop = Instrument.control(
         ":FREQuency:SWEep:STOP?",
         ":FREQuency:SWEep:STOP %e",
         """Control the sweep stop frequency, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     frequency_step = Instrument.control(
         ":FREQuency:SWEep:STEP?",
         ":FREQuency:SWEep:STEP %e",
         """Control the sweep step frequency when in step sweep mode, in m.""",
-        check_set_errors=True,
+        check_instr_errors=True,
     )
 
     # --- Sweep settings ---

--- a/pymeasure/instruments/santec/tsl570.py
+++ b/pymeasure/instruments/santec/tsl570.py
@@ -264,13 +264,3 @@ class TSL570(SCPIMixin, Instrument):
     sweep_count = Instrument.measurement(
         ":WAVelength:SWEep:COUNt?", """Get the current number of completed sweeps."""
     )
-
-
-if __name__ == "__main__":
-    laser = TSL570("GPIB0::8::INSTR")
-    laser.wavelength = 1550e-9
-    print(laser.wavelength)
-    laser.wavelength = 1500e-9
-    print(laser.wavelength)
-    laser.wavelength = 1450e-9
-    print(laser.wavelength)

--- a/tests/instruments/santec/test_tsl570.py
+++ b/tests/instruments/santec/test_tsl570.py
@@ -9,7 +9,7 @@ class TSL570Test(TSL570):
         pass
 
 
-# Patch the TSL570Test class methods to ignore the 'check_instr_errors' keyword.
+# Patch the TSL570Test class methods to ignore only the 'check_instr_errors' keyword.
 def _patched_write(self, command, **kwargs):
     kwargs.pop("check_instr_errors", None)
     return super(TSL570Test, self).write(command, **kwargs)
@@ -28,14 +28,70 @@ init_sequence = [
     (b":SYSTem:COMMunicate:CODe 1", None),
 ]
 
-
-def test_init():
-    # This test simply verifies that instantiation sends the init command.
-    with expected_protocol(TSL570Test, init_sequence):
-        pass
+# ========================= Optical Power Control Tests =========================
 
 
-# --- Wavelength Tests ---
+def test_output_enabled_setter():
+    protocol = init_sequence + [(b":POWer:STATe 1", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.output_enabled = True
+
+
+def test_output_enabled_getter():
+    protocol = init_sequence + [(b":POWer:STATe?", b"1\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.output_enabled
+        assert value is True
+
+
+def test_power_unit_setter():
+    protocol = init_sequence + [(b":POWer:UNIT 1", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.power_unit = "mW"
+
+
+def test_power_unit_getter():
+    protocol = init_sequence + [(b":POWer:UNIT?", b"0\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.power_unit
+        assert value == "dBm"
+
+
+def test_power_setpoint_setter():
+    protocol = init_sequence + [(b":Power 5.000000e+00", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.power_setpoint = 5.0
+
+
+def test_power_setpoint_getter():
+    protocol = init_sequence + [(b":POWer?", b"5.000000e+00\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.power_setpoint
+        assert abs(value - 5.0) < 1e-12
+
+
+def test_power_reading():
+    protocol = init_sequence + [(b":POWer:ACTual?", b"3.500000e+00\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.power_reading
+        assert abs(value - 3.5) < 1e-12
+
+
+# ========================= Wavelength Control Tests =========================
+
+
+def test_wavelength_min():
+    protocol = init_sequence + [(b":WAVelength:SWEep:RANGe:MINimum?", b"1.000000e-06\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength_min
+        assert abs(value - 1e-06) < 1e-12
+
+
+def test_wavelength_max():
+    protocol = init_sequence + [(b":WAVelength:SWEep:RANGe:MAXimum?", b"2.000000e-06\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength_max
+        assert abs(value - 2e-06) < 1e-12
 
 
 def test_wavelength_setter():
@@ -49,3 +105,249 @@ def test_wavelength_getter():
     with expected_protocol(TSL570Test, protocol) as inst:
         value = inst.wavelength
         assert abs(value - 1.55e-06) < 1e-12
+
+
+def test_wavelength_start_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STARt 1.500000e-06", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.wavelength_start = 1.5e-06
+
+
+def test_wavelength_start_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STARt?", b"1.500000e-06\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength_start
+        assert abs(value - 1.5e-06) < 1e-12
+
+
+def test_wavelength_stop_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STOP 1.600000e-06", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.wavelength_stop = 1.6e-06
+
+
+def test_wavelength_stop_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STOP?", b"1.600000e-06\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength_stop
+        assert abs(value - 1.6e-06) < 1e-12
+
+
+def test_wavelength_step_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STEP 1.000000e-09", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.wavelength_step = 1e-09
+
+
+def test_wavelength_step_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:STEP?", b"1.000000e-09\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength_step
+        assert abs(value - 1e-09) < 1e-12
+
+
+# ========================= Frequency Control Tests =========================
+
+
+def test_frequency_min():
+    protocol = init_sequence + [(b":FREQuency:SWEep:RANGe:MINimum?", b"1.000000e+14\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency_min
+        assert abs(value - 1e14) < 1e-6
+
+
+def test_frequency_max():
+    protocol = init_sequence + [(b":FREQuency:SWEep:RANGe:MAXimum?", b"2.000000e+14\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency_max
+        assert abs(value - 2e14) < 1e-6
+
+
+def test_frequency_setter():
+    protocol = init_sequence + [(b":FREQuency 2.000000e+14", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.frequency = 2e14
+
+
+def test_frequency_getter():
+    protocol = init_sequence + [(b":FREQuency?", b"2.000000e+14\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency
+        assert abs(value - 2e14) < 1e-6
+
+
+def test_frequency_start_setter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STARt 1.900000e+14", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.frequency_start = 1.9e14
+
+
+def test_frequency_start_getter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STARt?", b"1.900000e+14\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency_start
+        assert abs(value - 1.9e14) < 1e-6
+
+
+def test_frequency_stop_setter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STOP 2.100000e+14", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.frequency_stop = 2.1e14
+
+
+def test_frequency_stop_getter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STOP?", b"2.100000e+14\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency_stop
+        assert abs(value - 2.1e14) < 1e-6
+
+
+def test_frequency_step_setter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STEP 1.000000e+12", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.frequency_step = 1e12
+
+
+def test_frequency_step_getter():
+    protocol = init_sequence + [(b":FREQuency:SWEep:STEP?", b"1.000000e+12\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.frequency_step
+        assert abs(value - 1e12) < 1e-6
+
+
+# ========================= Sweep Settings Tests =========================
+
+
+def test_start_sweep():
+    protocol = init_sequence + [(b":WAVelength:SWEep 1", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        assert inst.start_sweep() is None
+
+
+def test_start_repeat():
+    protocol = init_sequence + [(b":WAVelength:SWEep:REPeat", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        assert inst.start_repeat() is None
+
+
+def test_stop_sweep():
+    protocol = init_sequence + [(b":WAVelength:SWEep 0", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        assert inst.stop_sweep() is None
+
+
+def test_sweep_staus():
+    protocol = init_sequence + [(b"WAVelength:SWEep?", b"0\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_staus
+        assert value == "Stopped"
+
+
+def test_sweep_mode_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:MODe 1", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_mode = "Continuous One-way"
+
+
+def test_sweep_mode_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_mode
+        assert value == "Continuous One-way"
+
+
+def test_sweep_pattern_setter():
+    # Assume the initial sweep_mode is "Stepped Two-way" (mapped from 2).
+    # Expect command to change sweep_mode to "Continuous Two-way" (mapped from 3).
+    protocol = init_sequence + [
+        (b":WAVelength:SWEep:MODe?", b"2\n"),
+        (b":WAVelength:SWEep:MODe 3", None),
+    ]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_pattern = "Continuous"
+
+
+def test_sweep_pattern_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        # Assuming the sweep_mode getter returns "Continuous One-way" (mapped from 1),
+        # then sweep_pattern should be "Continuous".
+        assert inst.sweep_pattern == "Continuous"
+
+
+def test_sweep_routing_setter():
+    # Assume the initial sweep_mode is "Stepped Two-way" (mapped from 2).
+    # Expect command to change sweep_mode to "Stepped One-way" (mapped from 0).
+    protocol = init_sequence + [
+        (b":WAVelength:SWEep:MODe?", b"2\n"),
+        (b":WAVelength:SWEep:MODe 0", None),
+    ]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_routing = "One-way"
+
+
+def test_sweep_routing_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        # Assuming the sweep_mode getter returns "Continuous One-way" (mapped from 1),
+        # then sweep_routing should be "Continuous".
+        assert inst.sweep_routing == "One-way"
+
+
+def test_sweep_speed_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:SPEed 10", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_speed = 10
+
+
+def test_sweep_speed_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:SPEed?", b"10\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_speed
+        assert value == 10
+
+
+def test_sweep_dwell_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:DWELl 0.5", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_dwell = 0.5
+
+
+def test_sweep_dwell_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:DWELl?", b"0.5\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_dwell
+        assert abs(value - 0.5) < 1e-12
+
+
+def test_sweep_delay_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:DELay 5", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_delay = 5
+
+
+def test_sweep_delay_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:DELay?", b"1.0\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_delay
+        assert abs(value - 1.0) < 1e-12
+
+
+def test_sweep_cycles_setter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:CYCLes 5", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.sweep_cycles = 5
+
+
+def test_sweep_cycles_getter():
+    protocol = init_sequence + [(b":WAVelength:SWEep:CYCLes?", b"5\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_cycles
+        assert value == 5
+
+
+def test_sweep_count():
+    protocol = init_sequence + [(b":WAVelength:SWEep:COUNt?", b"3\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.sweep_count
+        assert value == 3

--- a/tests/instruments/santec/test_tsl570.py
+++ b/tests/instruments/santec/test_tsl570.py
@@ -1,79 +1,59 @@
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.santec.tsl570 import TSL570
+from pymeasure.instruments.santec.tsl570 import (
+    TSL570,
+    SweepStatus,
+    SweepMode,
+    SweepPattern,
+    SweepRouting,
+)
 
-
-# Subclass TSL570 to override check_errors and avoid sending error queries.
-class TSL570Test(TSL570):
-    def check_errors(self):
-        # Bypass error checking during tests.
-        pass
-
-
-# Patch the TSL570Test class methods to ignore only the 'check_instr_errors' keyword.
-def _patched_write(self, command, **kwargs):
-    kwargs.pop("check_instr_errors", None)
-    return super(TSL570Test, self).write(command, **kwargs)
-
-
-def _patched_ask(self, command, **kwargs):
-    kwargs.pop("check_instr_errors", None)
-    return super(TSL570Test, self).ask(command, **kwargs)
-
-
-TSL570Test.write = _patched_write
-TSL570Test.ask = _patched_ask
-
-# With check_errors overridden, only the initialization command is expected.
-init_sequence = [
-    (b":SYSTem:COMMunicate:CODe 1", None),
-]
 
 # ========================= Optical Power Control Tests =========================
 
 
 def test_output_enabled_setter():
-    protocol = init_sequence + [(b":POWer:STATe 1", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":POWer:STATe 1", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.output_enabled = True
 
 
 def test_output_enabled_getter():
-    protocol = init_sequence + [(b":POWer:STATe?", b"1\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":POWer:STATe?", b"1\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.output_enabled
         assert value is True
 
 
 def test_power_unit_setter():
-    protocol = init_sequence + [(b":POWer:UNIT 1", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":POWer:UNIT 1", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.power_unit = "mW"
 
 
 def test_power_unit_getter():
-    protocol = init_sequence + [(b":POWer:UNIT?", b"0\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":POWer:UNIT?", b"0\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.power_unit
         assert value == "dBm"
 
 
 def test_power_setpoint_setter():
-    protocol = init_sequence + [(b":Power 5.000000e+00", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":Power 5.000000e+00", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.power_setpoint = 5.0
 
 
 def test_power_setpoint_getter():
-    protocol = init_sequence + [(b":POWer?", b"5.000000e+00\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":POWer?", b"5.000000e+00\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.power_setpoint
         assert abs(value - 5.0) < 1e-12
 
 
-def test_power_reading():
-    protocol = init_sequence + [(b":POWer:ACTual?", b"3.500000e+00\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        value = inst.power_reading
+def test_power():
+    protocol = [(b":POWer:ACTual?", b"3.500000e+00\n")]
+    with expected_protocol(TSL570, protocol) as inst:
+        value = inst.power
         assert abs(value - 3.5) < 1e-12
 
 
@@ -81,67 +61,67 @@ def test_power_reading():
 
 
 def test_wavelength_min():
-    protocol = init_sequence + [(b":WAVelength:SWEep:RANGe:MINimum?", b"1.000000e-06\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:RANGe:MINimum?", b"1.000000e-06\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.wavelength_min
         assert abs(value - 1e-06) < 1e-12
 
 
 def test_wavelength_max():
-    protocol = init_sequence + [(b":WAVelength:SWEep:RANGe:MAXimum?", b"2.000000e-06\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:RANGe:MAXimum?", b"2.000000e-06\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.wavelength_max
         assert abs(value - 2e-06) < 1e-12
 
 
-def test_wavelength_setter():
-    protocol = init_sequence + [(b":WAVelength 1.550000e-06", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        inst.wavelength = 1.55e-06
+def test_wavelength_setpoint_setter():
+    protocol = [(b":WAVelength 1.550000e-06", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
+        inst.wavelength_setpoint = 1.55e-06
 
 
-def test_wavelength_getter():
-    protocol = init_sequence + [(b":WAVelength?", b"1.550000e-06\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        value = inst.wavelength
+def test_wavelength_setpoint_getter():
+    protocol = [(b":WAVelength?", b"1.550000e-06\n")]
+    with expected_protocol(TSL570, protocol) as inst:
+        value = inst.wavelength_setpoint
         assert abs(value - 1.55e-06) < 1e-12
 
 
 def test_wavelength_start_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STARt 1.500000e-06", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STARt 1.500000e-06", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.wavelength_start = 1.5e-06
 
 
 def test_wavelength_start_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STARt?", b"1.500000e-06\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STARt?", b"1.500000e-06\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.wavelength_start
         assert abs(value - 1.5e-06) < 1e-12
 
 
 def test_wavelength_stop_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STOP 1.600000e-06", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STOP 1.600000e-06", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.wavelength_stop = 1.6e-06
 
 
 def test_wavelength_stop_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STOP?", b"1.600000e-06\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STOP?", b"1.600000e-06\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.wavelength_stop
         assert abs(value - 1.6e-06) < 1e-12
 
 
 def test_wavelength_step_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STEP 1.000000e-09", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STEP 1.000000e-09", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.wavelength_step = 1e-09
 
 
 def test_wavelength_step_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:STEP?", b"1.000000e-09\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:STEP?", b"1.000000e-09\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.wavelength_step
         assert abs(value - 1e-09) < 1e-12
 
@@ -150,67 +130,67 @@ def test_wavelength_step_getter():
 
 
 def test_frequency_min():
-    protocol = init_sequence + [(b":FREQuency:SWEep:RANGe:MINimum?", b"1.000000e+14\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:RANGe:MINimum?", b"1.000000e+14\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.frequency_min
         assert abs(value - 1e14) < 1e-6
 
 
 def test_frequency_max():
-    protocol = init_sequence + [(b":FREQuency:SWEep:RANGe:MAXimum?", b"2.000000e+14\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:RANGe:MAXimum?", b"2.000000e+14\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.frequency_max
         assert abs(value - 2e14) < 1e-6
 
 
-def test_frequency_setter():
-    protocol = init_sequence + [(b":FREQuency 2.000000e+14", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        inst.frequency = 2e14
+def test_frequency_setpoint_setter():
+    protocol = [(b":FREQuency 2.000000e+14", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
+        inst.frequency_setpoint = 2e14
 
 
-def test_frequency_getter():
-    protocol = init_sequence + [(b":FREQuency?", b"2.000000e+14\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        value = inst.frequency
+def test_frequency_setpoint_getter():
+    protocol = [(b":FREQuency?", b"2.000000e+14\n")]
+    with expected_protocol(TSL570, protocol) as inst:
+        value = inst.frequency_setpoint
         assert abs(value - 2e14) < 1e-6
 
 
 def test_frequency_start_setter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STARt 1.900000e+14", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STARt 1.900000e+14", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.frequency_start = 1.9e14
 
 
 def test_frequency_start_getter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STARt?", b"1.900000e+14\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STARt?", b"1.900000e+14\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.frequency_start
         assert abs(value - 1.9e14) < 1e-6
 
 
 def test_frequency_stop_setter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STOP 2.100000e+14", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STOP 2.100000e+14", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.frequency_stop = 2.1e14
 
 
 def test_frequency_stop_getter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STOP?", b"2.100000e+14\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STOP?", b"2.100000e+14\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.frequency_stop
         assert abs(value - 2.1e14) < 1e-6
 
 
 def test_frequency_step_setter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STEP 1.000000e+12", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STEP 1.000000e+12", None), (b"SYST:ERR?", "0,No error\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.frequency_step = 1e12
 
 
 def test_frequency_step_getter():
-    protocol = init_sequence + [(b":FREQuency:SWEep:STEP?", b"1.000000e+12\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":FREQuency:SWEep:STEP?", b"1.000000e+12\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.frequency_step
         assert abs(value - 1e12) < 1e-6
 
@@ -219,135 +199,135 @@ def test_frequency_step_getter():
 
 
 def test_start_sweep():
-    protocol = init_sequence + [(b":WAVelength:SWEep 1", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep 1", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         assert inst.start_sweep() is None
 
 
 def test_start_repeat():
-    protocol = init_sequence + [(b":WAVelength:SWEep:REPeat", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:REPeat", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         assert inst.start_repeat() is None
 
 
 def test_stop_sweep():
-    protocol = init_sequence + [(b":WAVelength:SWEep 0", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep 0", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         assert inst.stop_sweep() is None
 
 
 def test_sweep_staus():
-    protocol = init_sequence + [(b"WAVelength:SWEep?", b"0\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b"WAVelength:SWEep?", b"0\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_staus
-        assert value == "Stopped"
+        assert value == SweepStatus.STOPPED
 
 
 def test_sweep_mode_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:MODe 1", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        inst.sweep_mode = "Continuous One-way"
+    protocol = [(b":WAVelength:SWEep:MODe 1", None)]
+    with expected_protocol(TSL570, protocol) as inst:
+        inst.sweep_mode = SweepMode.CONTINUOUS_ONE_WAY
 
 
 def test_sweep_mode_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_mode
-        assert value == "Continuous One-way"
+        assert value == SweepMode.CONTINUOUS_ONE_WAY
 
 
 def test_sweep_pattern_setter():
     # Assume the initial sweep_mode is "Stepped Two-way" (mapped from 2).
     # Expect command to change sweep_mode to "Continuous Two-way" (mapped from 3).
-    protocol = init_sequence + [
+    protocol = [
         (b":WAVelength:SWEep:MODe?", b"2\n"),
         (b":WAVelength:SWEep:MODe 3", None),
     ]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        inst.sweep_pattern = "Continuous"
+    with expected_protocol(TSL570, protocol) as inst:
+        inst.sweep_pattern = SweepPattern.CONTINUOUS
 
 
 def test_sweep_pattern_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         # Assuming the sweep_mode getter returns "Continuous One-way" (mapped from 1),
         # then sweep_pattern should be "Continuous".
-        assert inst.sweep_pattern == "Continuous"
+        assert inst.sweep_pattern == SweepPattern.CONTINUOUS
 
 
 def test_sweep_routing_setter():
     # Assume the initial sweep_mode is "Stepped Two-way" (mapped from 2).
     # Expect command to change sweep_mode to "Stepped One-way" (mapped from 0).
-    protocol = init_sequence + [
+    protocol = [
         (b":WAVelength:SWEep:MODe?", b"2\n"),
         (b":WAVelength:SWEep:MODe 0", None),
     ]
-    with expected_protocol(TSL570Test, protocol) as inst:
-        inst.sweep_routing = "One-way"
+    with expected_protocol(TSL570, protocol) as inst:
+        inst.sweep_routing = SweepRouting.ONE_WAY
 
 
 def test_sweep_routing_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:MODe?", b"1\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:MODe?", b"1\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         # Assuming the sweep_mode getter returns "Continuous One-way" (mapped from 1),
         # then sweep_routing should be "Continuous".
-        assert inst.sweep_routing == "One-way"
+        assert inst.sweep_routing == SweepRouting.ONE_WAY
 
 
 def test_sweep_speed_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:SPEed 10", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:SPEed 10", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.sweep_speed = 10
 
 
 def test_sweep_speed_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:SPEed?", b"10\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:SPEed?", b"10\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_speed
         assert value == 10
 
 
 def test_sweep_dwell_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:DWELl 0.5", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:DWELl 0.5", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.sweep_dwell = 0.5
 
 
 def test_sweep_dwell_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:DWELl?", b"0.5\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:DWELl?", b"0.5\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_dwell
         assert abs(value - 0.5) < 1e-12
 
 
 def test_sweep_delay_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:DELay 5", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:DELay 5", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.sweep_delay = 5
 
 
 def test_sweep_delay_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:DELay?", b"1.0\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:DELay?", b"1.0\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_delay
         assert abs(value - 1.0) < 1e-12
 
 
 def test_sweep_cycles_setter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:CYCLes 5", None)]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:CYCLes 5", None)]
+    with expected_protocol(TSL570, protocol) as inst:
         inst.sweep_cycles = 5
 
 
 def test_sweep_cycles_getter():
-    protocol = init_sequence + [(b":WAVelength:SWEep:CYCLes?", b"5\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:CYCLes?", b"5\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_cycles
         assert value == 5
 
 
 def test_sweep_count():
-    protocol = init_sequence + [(b":WAVelength:SWEep:COUNt?", b"3\n")]
-    with expected_protocol(TSL570Test, protocol) as inst:
+    protocol = [(b":WAVelength:SWEep:COUNt?", b"3\n")]
+    with expected_protocol(TSL570, protocol) as inst:
         value = inst.sweep_count
         assert value == 3

--- a/tests/instruments/santec/test_tsl570.py
+++ b/tests/instruments/santec/test_tsl570.py
@@ -1,0 +1,51 @@
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.santec.tsl570 import TSL570
+
+
+# Subclass TSL570 to override check_errors and avoid sending error queries.
+class TSL570Test(TSL570):
+    def check_errors(self):
+        # Bypass error checking during tests.
+        pass
+
+
+# Patch the TSL570Test class methods to ignore the 'check_instr_errors' keyword.
+def _patched_write(self, command, **kwargs):
+    kwargs.pop("check_instr_errors", None)
+    return super(TSL570Test, self).write(command, **kwargs)
+
+
+def _patched_ask(self, command, **kwargs):
+    kwargs.pop("check_instr_errors", None)
+    return super(TSL570Test, self).ask(command, **kwargs)
+
+
+TSL570Test.write = _patched_write
+TSL570Test.ask = _patched_ask
+
+# With check_errors overridden, only the initialization command is expected.
+init_sequence = [
+    (b":SYSTem:COMMunicate:CODe 1", None),
+]
+
+
+def test_init():
+    # This test simply verifies that instantiation sends the init command.
+    with expected_protocol(TSL570Test, init_sequence):
+        pass
+
+
+# --- Wavelength Tests ---
+
+
+def test_wavelength_setter():
+    protocol = init_sequence + [(b":WAVelength 1.550000e-06", None)]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        inst.wavelength = 1.55e-06
+
+
+def test_wavelength_getter():
+    protocol = init_sequence + [(b":WAVelength?", b"1.550000e-06\n")]
+    with expected_protocol(TSL570Test, protocol) as inst:
+        value = inst.wavelength
+        assert abs(value - 1.55e-06) < 1e-12

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -111,7 +111,6 @@ need_init_communication = [
     "IBeamSmart",
     "ANC300Controller",
     "Keithley2281S",
-    "TSL570",
 ]
 # Instruments whose property docstrings are not YET in accordance with the style (Get, Set, Control)
 grandfathered_docstring_instruments = [
@@ -228,7 +227,8 @@ def test_kwargs_to_adapter(cls):
 
 @pytest.mark.parametrize("cls", devices)
 @pytest.mark.filterwarnings(
-    "error:It is deprecated to specify `includeSCPI` implicitly:FutureWarning")
+    "error:It is deprecated to specify `includeSCPI` implicitly:FutureWarning"
+)
 def test_includeSCPI_explicitly_set(cls):
     if cls.__name__ in (*proper_adapters, *need_init_communication):
         pytest.skip(f"{cls.__name__} cannot be tested without communication.")
@@ -241,7 +241,8 @@ def test_includeSCPI_explicitly_set(cls):
 
 @pytest.mark.parametrize("cls", devices)
 @pytest.mark.filterwarnings(
-    "error:Defining SCPI base functionality with `includeSCPI=True` is deprecated:FutureWarning")
+    "error:Defining SCPI base functionality with `includeSCPI=True` is deprecated:FutureWarning"
+)
 def test_includeSCPI_not_set_to_True(cls):
     if cls.__name__ in (*proper_adapters, *need_init_communication):
         pytest.skip(f"{cls.__name__} cannot be tested without communication.")

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -111,6 +111,7 @@ need_init_communication = [
     "IBeamSmart",
     "ANC300Controller",
     "Keithley2281S",
+    "TSL570",
 ]
 # Instruments whose property docstrings are not YET in accordance with the style (Get, Set, Control)
 grandfathered_docstring_instruments = [


### PR DESCRIPTION
Added the Santec TSL-570 Tunable Laser. Provides control over optical power, wavelength, optical-frequency, and sweep settings.

Valid values for wavelength and optical frequency are dependent on device model and settings, so instead of using pymeasure validators properties relating to the control of wavelength and optical-frequency query the device for errors after setting using check_errors from the SCPI mixin. If an error is found, a custom InstrumentError is raised, e.g. "InstrumentError: -222: Data out of range". For testing purposes this feature is patched out as it relies on having access to the instrument.

Properties to split sweep_mode into sweep_pattern and sweep_routing have been created to control these two separate aspects of sweep_mode independently.