### PR TITLE
Allow procedures to emit results in batches

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -98,3 +98,4 @@ Johannes Rothmayr
 Fred Gillard
 Dimitrios Simatos
 Dongkai Pan
+Julian van Doorn

--- a/docs/tutorial/procedure.rst
+++ b/docs/tutorial/procedure.rst
@@ -129,6 +129,25 @@ We define the data columns that will be recorded in a list stored in :python:`DA
 
 The :python:`execute` methods defines the main body of the procedure. Our example method consists of a loop over the number of iterations, in which we emit the data to be recorded (the Iteration number). The data is broadcast to any number of listeners by using the :code:`emit` method, which takes a topic as the first argument. Data with the :python:`'results'` topic and the proper data columns will be recorded to a file. The sleep function in our example provides two very useful features. The first is to delay the execution of the next lines of code by the time argument in units of seconds. The seconds is that during this delay time, the CPU is free to perform other code. Successful measurements often require the intelligent use of sleep to deal with instrument delays and ensure that the CPU is not hogged by a single script. After our delay, we check to see if the Procedure should stop by calling :python:`self.should_stop()`. By checking this flag, the Procedure will react to a user canceling the procedure execution.
 
+.. note::
+   Instead of emitting results one by one, it is also possible to emit results in batch. As an example consider a device that returns multiple points for each measurement (such as an oscilloscope or a CCD): ::
+
+    intensities = self.ccd.capture()  # Assume this function returns a list of intensities for each pixel
+    pixels = np.arange(len(intensities))
+
+    for pixel, intensity in zip(pixels, intensities):
+        self.emit('results', {'Pixel': pixel, 'Intensity': intensity})
+
+   The downside to this method is that it is cumbersome to write and can be slow when the array of data is large. Instead it is possible to emit the data as as a whole: ::
+
+    intensities = self.ccd.capture()  # Assume this function returns a list of intensities for each pixel
+    pixels = np.arange(len(intensities))
+
+    self.emit('batch results', {'Pixel': pixels, 'Intensity': intensities})
+
+   Please note that you have to use :python:`'batch results'` as the topic when emitting results this way.
+
+
 This covers the basic requirements of a Procedure object. Now let's construct our SimpleProcedure object with 100 iterations. ::
 
     procedure = SimpleProcedure()

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -122,12 +122,16 @@ class Worker(StoppableThread):
             self.recorder.handle(record)
         elif topic == 'batch results':
             if isinstance(record, pd.DataFrame):
-                log.error('Support for DataFrames when emitting batch results is not available yet.')
+                log.error(
+                    'Support for DataFrames when emitting batch results is not available yet.')
                 self.stop()
             elif self._is_dictionary_of_sequences(record):
                 lengths = [len(value) for value in record.values()]
                 if not all(length == lengths[0] for length in lengths):
-                    log.warning(f'Potential data loss: not all data columns have the same length (check your emitted results)')
+                    log.warning(
+                        'Potential data loss: not all data columns have the same length '
+                        '(check your emitted results)'
+                    )
 
                 for index in range(lengths[0]):
                     # Handle the records one by one.
@@ -141,15 +145,17 @@ class Worker(StoppableThread):
 
     def _is_dictionary_of_sequences(self, record: Any) -> bool:
         """
-        Checks if the record is a dictionary of sequences, there are a couple data types that we do not want to treat as
-        sequences, such as strings and bytes. This function will return False if any of the values in the dictionary are
-        strings or bytes or not a sequence.
+        Checks if the record is a dictionary of sequences, there are a couple data types that we do
+        not want to treat as sequences, such as strings and bytes. This function will return False
+        if any of the values in the dictionary are strings or bytes or not a sequence.
         """
         sequence_types = (Sequence, np.ndarray)
         type_exceptions = (str, bytes)
         if not isinstance(record, dict):
             return False
-        return all(isinstance(value, sequence_types) and not isinstance(value, type_exceptions) for value in record.values())
+        return all(
+            isinstance(value, sequence_types) and not isinstance(value, type_exceptions) for value
+            in record.values())
 
     def handle_abort(self):
         log.exception("User stopped Worker execution prematurely")

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -21,12 +21,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from __future__ import annotations
 
 import logging
 import time
 import traceback
 from queue import Queue
-from typing import Any, Sequence, Dict
+from typing import Any, Sequence
 
 import numpy as np
 
@@ -98,7 +99,7 @@ class Worker(StoppableThread):
                 self.context = None
                 self.publisher = None
 
-    def join(self, timeout=0):
+    def join(self, timeout: int = 0):
         try:
             super().join(timeout)
         except (KeyboardInterrupt, SystemExit):
@@ -106,7 +107,7 @@ class Worker(StoppableThread):
             self.stop()
             super().join(0)
 
-    def emit(self, topic, record):
+    def emit(self, topic: str, record: Any):
         """ Emits data of some topic over TCP """
         log.debug("Emitting message: %s %s", topic, record)
 
@@ -124,10 +125,10 @@ class Worker(StoppableThread):
         elif topic == 'status' or topic == 'progress':
             self.monitor_queue.put((topic, record))
 
-    def handle_record(self, record: Dict[str, Any]) -> None:
+    def handle_record(self, record: dict[str, Any]):
         self.recorder.handle(record)
 
-    def handle_batch_record(self, record: Any) -> None:
+    def handle_batch_record(self, record: Any):
         if self._is_dictionary_of_sequences(record):
             lengths = list(len(value) for value in record.values())
             if not all(length == lengths[0] for length in lengths):
@@ -173,7 +174,7 @@ class Worker(StoppableThread):
     def is_last(self):
         raise NotImplementedError('should be monkey patched by a manager')
 
-    def update_status(self, status):
+    def update_status(self, status: int):
         self.procedure.status = status
         self.emit('status', status)
 

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -121,11 +121,7 @@ class Worker(StoppableThread):
         if topic == 'results':
             self.recorder.handle(record)
         elif topic == 'batch results':
-            if isinstance(record, pd.DataFrame):
-                log.error(
-                    'Support for DataFrames when emitting batch results is not available yet.')
-                self.stop()
-            elif self._is_dictionary_of_sequences(record):
+            if self._is_dictionary_of_sequences(record):
                 lengths = [len(value) for value in record.values()]
                 if not all(length == lengths[0] for length in lengths):
                     log.warning(

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -26,6 +26,10 @@ import logging
 import time
 import traceback
 from queue import Queue
+from typing import Any, Sequence
+
+import numpy as np
+import pandas as pd
 
 from .listeners import Recorder
 from .procedure import Procedure
@@ -116,8 +120,36 @@ class Worker(StoppableThread):
             pass  # No dumps defined
         if topic == 'results':
             self.recorder.handle(record)
+        elif topic == 'batch results':
+            if isinstance(record, pd.DataFrame):
+                log.error('Support for DataFrames when emitting batch results is not available yet.')
+                self.stop()
+            elif self._is_dictionary_of_sequences(record):
+                lengths = [len(value) for value in record.values()]
+                if not all(length == lengths[0] for length in lengths):
+                    log.warning(f'Potential data loss: not all data columns have the same length (check your emitted results)')
+
+                for index in range(lengths[0]):
+                    # Handle the records one by one.
+                    data = {key: value[index] for key, value in record.items()}
+                    self.recorder.handle(data)
+            else:
+                log.error(f'Unsupported type ({type(record)}) for batch results.')
+                self.stop()
         elif topic == 'status' or topic == 'progress':
             self.monitor_queue.put((topic, record))
+
+    def _is_dictionary_of_sequences(self, record: Any) -> bool:
+        """
+        Checks if the record is a dictionary of sequences, there are a couple data types that we do not want to treat as
+        sequences, such as strings and bytes. This function will return False if any of the values in the dictionary are
+        strings or bytes or not a sequence.
+        """
+        sequence_types = (Sequence, np.ndarray)
+        type_exceptions = (str, bytes)
+        if not isinstance(record, dict):
+            return False
+        return all(isinstance(value, sequence_types) and not isinstance(value, type_exceptions) for value in record.values())
 
     def handle_abort(self):
         log.exception("User stopped Worker execution prematurely")

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -29,7 +29,6 @@ from queue import Queue
 from typing import Any, Sequence
 
 import numpy as np
-import pandas as pd
 
 from .listeners import Recorder
 from .procedure import Procedure

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -26,7 +26,7 @@ import logging
 import time
 import traceback
 from queue import Queue
-from typing import Any, Sequence
+from typing import Any, Sequence, Dict
 
 import numpy as np
 
@@ -124,7 +124,7 @@ class Worker(StoppableThread):
         elif topic == 'status' or topic == 'progress':
             self.monitor_queue.put((topic, record))
 
-    def handle_record(self, record: dict[str, Any]) -> None:
+    def handle_record(self, record: Dict[str, Any]) -> None:
         self.recorder.handle(record)
 
     def handle_batch_record(self, record: Any) -> None:
@@ -157,7 +157,8 @@ class Worker(StoppableThread):
             return False
         return all(
             isinstance(value, sequence_types) and not isinstance(value, type_exceptions) for value
-            in record.values())
+            in record.values()
+        )
 
     def handle_abort(self):
         log.exception("User stopped Worker execution prematurely")


### PR DESCRIPTION
This PR supersedes #1252, in addition it incorporates the feedback given there. In summary in addition to emitting results one by one, this PR adds the ability to emit a dictionary of sequences allowing the user to emit a lot of data at once. To demonstrate this ability see the example below.

```python
import logging
from itertools import count
from time import time

import numpy as np

log = logging.getLogger(__name__)
log.addHandler(logging.NullHandler())

import sys
import random
from pymeasure.display.Qt import QtWidgets
from pymeasure.display.windows import ManagedWindow
from pymeasure.experiment import BooleanParameter, Procedure
from pymeasure.experiment import IntegerParameter, Parameter

class RandomProcedure(Procedure):

    runs = IntegerParameter('Number of Runs', default=1)
    iterations = IntegerParameter('Loop Iterations', default=100)
    use_batches = BooleanParameter('Use Batches', default=False)
    seed = Parameter('Random Seed', default='12345')

    DATA_COLUMNS = ['Index', 'Random Number']

    def startup(self):
        log.info("Setting the seed of the random number generator")
        random.seed(self.seed)

    def execute(self):
        log.info("Starting the loop of %d iterations" % self.iterations)
        start_time = time()

        index_counter = count()
        for j in range(self.runs):
            indices = np.fromiter([next(index_counter) for _ in range(self.iterations)], dtype=int)
            values = np.fromiter([random.random() for _ in range(self.iterations)], dtype=float)

            if not self.use_batches:
                for i in range(self.iterations):
                    data = {
                        "Index": indices[i],
                        "Random Number": values[i]
                    }
                    self.emit('results', data)

            if self.should_stop():
                log.warning("Caught the stop flag in the procedure")
                break

            if self.use_batches:
                data = {
                    "Index": indices,
                    "Random Number": values
                }
                self.emit('batch results', data)
            self.emit('progress', 100 * (j + 1) / self.runs)

        end_time = time()
        log.info(f"Average time per data point: {(end_time - start_time) / (self.iterations * self.runs) * 1E6:.2f} µs")


class MainWindow(ManagedWindow):

    def __init__(self):
        super().__init__(
            procedure_class=RandomProcedure,
            inputs=['runs', 'iterations', 'use_batches', 'seed'],
            displays=['runs', 'iterations', 'use_batches', 'seed'],
            x_axis='Index',
            y_axis='Random Number'
        )
        self.setWindowTitle('GUI Example')


if __name__ == "__main__":
    app = QtWidgets.QApplication(sys.argv)
    window = MainWindow()
    window.show()
    sys.exit(app.exec())
```

## Comments on previous feedback (see #1252)
@CasperSchippers 

> I have to admit that I find the simplicity and effectiveness quite striking.
> 
> I think making it a bit more explicit could be nice, but then I think I'm happy to include it; I do have two options/suggestions and wonder what your thoughts are?
> 
> 1. Would it be a good idea to make a different "topic" (such as `"batch results"` such that you can `self.emit("batch results",  data)`), to make it more explicit? In that case I think we should somehow handle unequal length series (i.e., what you warn for in line 127).

Agreed, gives the user much more control and might avoid issues with certain edge cases.

> 2. Another option could be to choose handling based on wheter you emit a dict (for a single datapoint) or a pandas dataframe (for a series); this also ensures that all entries are equally long for the series option.

This sounds like a good idea, however since I never really use Pandas I currently only added a check if it is a dataframe and if so tells the user it is not supported. 

