### PR TITLE
Add _write_bytes() and _read_bytes() for Prologix adapter

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -99,3 +99,4 @@ Fred Gillard
 Dimitrios Simatos
 Dongkai Pan
 Julian van Doorn
+Jörg Wunsch

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -283,6 +283,14 @@ class PrologixAdapter(VISAAdapter):
         return super()._read()
 
     def _read_bytes(self, count, break_on_termchar=False, **kwargs):
+        """Read bytes from the instrument.
+
+        :param int count: Number of bytes to read. A value of -1 indicates to
+            read from the whole read buffer.
+        :param bool break_on_termchar: Stop reading at a termination character.
+        :param \\**kwargs: Keyword arguments for the connection itself.
+        :returns bytes: Bytes response of the instrument (including termination).
+        """
         self.write("++read eoi")
         return super()._read_bytes(count, break_on_termchar, **kwargs)
 

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -25,6 +25,7 @@ import time
 from warnings import warn
 
 from pymeasure.adapters import VISAAdapter
+from pyvisa.constants import *
 
 
 class PrologixAdapter(VISAAdapter):
@@ -291,7 +292,10 @@ class PrologixAdapter(VISAAdapter):
         :param \\**kwargs: Keyword arguments for the connection itself.
         :returns bytes: Bytes response of the instrument (including termination).
         """
-        self.write("++read eoi")
+        avail = self.connection.get_visa_attribute(VI_ATTR_ASRL_AVAIL_NUM)
+        if avail == 0:
+            # nothing buffered, need to request data from Prologix
+            self.write("++read eoi")
         return super()._read_bytes(count, break_on_termchar, **kwargs)
 
     def gpib(self, address, **kwargs):

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -229,6 +229,12 @@ class PrologixAdapter(VISAAdapter):
             super().write("++addr %d" % self.address, **kwargs)
         super().write(command, **kwargs)
 
+    def _write_bytes(self, content, **kwargs):
+        if self.address is not None:
+            super().write("++addr %d" % self.address, **kwargs)
+        content += b'\x0d'
+        return super()._write_bytes(content, **kwargs)
+
     def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt="ieee"):
         """Format values in binary format, used internally in :meth:`.write_binary_values`.
 
@@ -281,6 +287,10 @@ class PrologixAdapter(VISAAdapter):
         if not prologix:
             self.write("++read eoi")
         return super()._read()
+
+    def _read_bytes(self, count, break_on_termchar=False, **kwargs):
+        self.write("++read eoi")
+        return super()._read_bytes(count, break_on_termchar, **kwargs)
 
     def gpib(self, address, **kwargs):
         """ Return a PrologixAdapter object that references the GPIB

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -25,7 +25,7 @@ import time
 from warnings import warn
 
 from pymeasure.adapters import VISAAdapter
-from pyvisa.constants import *
+from pyvisa.constants import VI_ATTR_ASRL_AVAIL_NUM
 
 
 class PrologixAdapter(VISAAdapter):

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -229,12 +229,6 @@ class PrologixAdapter(VISAAdapter):
             super().write("++addr %d" % self.address, **kwargs)
         super().write(command, **kwargs)
 
-    def _write_bytes(self, content, **kwargs):
-        if self.address is not None:
-            super().write("++addr %d" % self.address, **kwargs)
-        content += b'\x0d'
-        return super()._write_bytes(content, **kwargs)
-
     def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt="ieee"):
         """Format values in binary format, used internally in :meth:`.write_binary_values`.
 

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -104,7 +104,7 @@ def test_write_bytes():
             [("++auto 0", None), ("++eoi 1", None), ("++eos 2", None),
              (b"something", None)],
     ) as adapter:
-        adapter.write_bytes(b"something")
+        adapter.write_bytes(b"something\r")
 
 
 @pytest.mark.parametrize(

--- a/tests/adapters/test_prologix.py
+++ b/tests/adapters/test_prologix.py
@@ -104,7 +104,7 @@ def test_write_bytes():
             [("++auto 0", None), ("++eoi 1", None), ("++eos 2", None),
              (b"something", None)],
     ) as adapter:
-        adapter.write_bytes(b"something\r")
+        adapter.write_bytes(b"something")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As in plain `write()`, `_write_bytes()` possibly needs to emit the `++addr` command first. Also, it must always append one CR in order for the Prologix adapter to actually transfer the data to the target.

In order to read something from a Prologix adapter, it is necessary to first emit a `++read` command, thus the default `_read_bytes` method alone is not sufficient.