### PR TITLE
HP3478a calibration data are binary

### DIFF
--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -229,6 +229,12 @@ class PrologixAdapter(VISAAdapter):
             super().write("++addr %d" % self.address, **kwargs)
         super().write(command, **kwargs)
 
+    def _write_bytes(self, content, **kwargs):
+        if self.address is not None:
+            super().write("++addr %d" % self.address, **kwargs)
+        content += b'\x0d'
+        return super()._write_bytes(content, **kwargs)
+
     def _format_binary_values(self, values, datatype='f', is_big_endian=False, header_fmt="ieee"):
         """Format values in binary format, used internally in :meth:`.write_binary_values`.
 
@@ -281,6 +287,10 @@ class PrologixAdapter(VISAAdapter):
         if not prologix:
             self.write("++read eoi")
         return super()._read()
+
+    def _read_bytes(self, count, break_on_termchar=False, **kwargs):
+        self.write("++read eoi")
+        return super()._read_bytes(count, break_on_termchar, **kwargs)
 
     def gpib(self, address, **kwargs):
         """ Return a PrologixAdapter object that references the GPIB

--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -491,8 +491,7 @@ class HP3478A(HPLegacyInstrument):
         cal_data = []
         for addr in range(0, 256):
             # To fetch one nibble: 'W<address>', where address is a raw 8-bit number.
-            cmd = bytes([ord('W'), addr])
-            self.write_bytes(cmd)
+            self.write_binary_values("W", [addr], datatype='B', header_fmt="empty")
             rvalue = self.read_bytes(1)[0]
             # 'W' command reads a nibble from the SRAM, but then adds a value of 64 to return
             # it as an ASCII value.


### PR DESCRIPTION
When reading calibration data, treat the command as binary

Just using `write_bytes()` fails to call `_format_binary_values()`
on the data to send. Using this is crucial on Prologix adapters
as they need special escaping of certain binary values.

Thus, rather use `write_binary_values()` instead.
