### PR TITLE
HP3478A: use write_binary_values() to request calibration data

### DIFF
--- a/pymeasure/instruments/hp/hp3478A.py
+++ b/pymeasure/instruments/hp/hp3478A.py
@@ -491,8 +491,7 @@ class HP3478A(HPLegacyInstrument):
         cal_data = []
         for addr in range(0, 256):
             # To fetch one nibble: 'W<address>', where address is a raw 8-bit number.
-            cmd = bytes([ord('W'), addr])
-            self.write_bytes(cmd)
+            self.write_binary_values('W', [addr], datatype='B', header_fmt="empty")
             rvalue = self.read_bytes(1)[0]
             # 'W' command reads a nibble from the SRAM, but then adds a value of 64 to return
             # it as an ASCII value.


### PR DESCRIPTION
The argument to the "W" command in HP3478A instruments is binary (0x00 through 0xFF). For certain adapters (e.g. Prologix), this requires special handling. Consequently, instead of a plain write_bytes(), use write_binary_values() instead.