### PR TITLE
Replace numeric constants by respective Qt enum values

### DIFF
--- a/tests/display/test_inputs.py
+++ b/tests/display/test_inputs.py
@@ -241,8 +241,8 @@ class TestScientificInput:
             p.assert_called_once_with(5.0)
 
     @pytest.mark.parametrize("locale, decimalSep", [
-        [QtCore.QLocale(31, 7, 224), "."],  # UK locale for period
-        [QtCore.QLocale(30, 7, 151), ","],  # NL locale for comma
+        [QtCore.QLocale(QtCore.QLocale.English, QtCore.QLocale.LatinScript, QtCore.QLocale.UnitedKingdom), "."],
+        [QtCore.QLocale(QtCore.QLocale.Dutch, QtCore.QLocale.LatinScript, QtCore.QLocale.Netherlands), ","],
     ])
     def test_locale_settings(self, qtbot, locale, decimalSep):
         assert locale.decimalPoint() == decimalSep


### PR DESCRIPTION
At least with recent Qt versions, simply using integer numbers instead of enums is no longer acceptable.

Supposed to fix #1261 