### PR TITLE
Update the custom_ui example

### DIFF
--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -87,28 +87,28 @@ class MainWindow(ManagedWindow):
             procedure_class=TestProcedure,
             displays=['iterations', 'delay', 'seed'],
             x_axis='Iteration',
-            y_axis='Random Number'
+            y_axis='Random Number',
+            sequencer=True,
         )
         self.setWindowTitle('GUI Example')
 
     def _setup_ui(self):
+        # After the default setup_ui method, replace the inputs widget with
+        # the custom widget
         super()._setup_ui()
         self.inputs.hide()
         self.inputs = fromUi('gui_custom_inputs.ui')
 
-    def queue(self):
-        filename = tempfile.mktemp()
-
+    def make_procedure(self):
+        # Overwrite the make_procedure method that creates the procedure and
+        # sets the parameters based on the custom input-widget
         procedure = TestProcedure()
+
         procedure.seed = str(self.inputs.seed.text())
         procedure.iterations = self.inputs.iterations.value()
         procedure.delay = self.inputs.delay.value()
 
-        results = Results(procedure, filename)
-
-        experiment = self.new_experiment(results)
-
-        self.manager.queue(experiment)
+        return procedure
 
 
 if __name__ == "__main__":

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -36,11 +36,9 @@ python gui_custom_inputs.py
 
 import sys
 import random
-import tempfile
 from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
-from pymeasure.experiment import Results
 from pymeasure.display.Qt import QtWidgets, fromUi
 from pymeasure.display.windows import ManagedWindow
 


### PR DESCRIPTION
Update the custom_ui example to use the standard implementation of the queue method.

Incited by #1262.

Since nowadays there is a default implementation of the `queue` method, I think it is better to re-implement the `make_procedure` method than the `queue` method: this is typically a smaller method that _only_ handles creating the procedure instance and assigning the parameters from the ui. Therefore, this seems like the logical place to also handle getting the values from the custom UI. Finally, since this method is also used by e.g. the SequencerWidget, this approach also enables using the SequencerWidget in combination with a custom ui.