### PR TITLE
Fix raise errors to show full stack trace

### DIFF
--- a/pymeasure/display/widgets/results_dialog.py
+++ b/pymeasure/display/widgets/results_dialog.py
@@ -100,8 +100,6 @@ class ResultsDialog(QtWidgets.QFileDialog):
                 results = Results.load(str(filename))
             except ValueError:
                 return
-            except Exception as e:
-                raise e
             for widget in self.preview_widget_list:
                 widget.clear_widget()
                 widget.load(widget.new_curve(results))

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -297,8 +297,6 @@ class ESP300(SCPIUnknownMixin, Instrument):
                     axes.append(item)
             except TypeError:
                 continue
-            except Exception as e:
-                raise e
         return axes
 
     def enable(self):

--- a/pymeasure/instruments/oxfordinstruments/base.py
+++ b/pymeasure/instruments/oxfordinstruments/base.py
@@ -106,7 +106,7 @@ class OxfordInstrumentsBase(Instrument):
                 if e_visa.args == self.timeoutError.args:
                     pass
                 else:
-                    raise e_visa
+                    raise
 
         # No valid response has been received within the maximum allowed number of attempts
         raise OxfordVISAError(f"Retried {self.max_attempts} times without getting a valid "


### PR DESCRIPTION
Raising an error anew (raise exc) will point the stack trace there, better use raise alone or do nothing at all.