### PR TITLE
Implement qtpy

### DIFF
--- a/.github/pymeasure.yml
+++ b/.github/pymeasure.yml
@@ -12,7 +12,7 @@ dependencies:
   - pyvisa=1.13.0
   - pyzmq=24.0.1
   - qt=5.15.6
-  - qtpy=2.4.3
+  - qtpy=2.4.2
 # Development dependencies below
   - pytest-qt=4.2.0
   - pytest-runner=5.2

--- a/.github/pymeasure.yml
+++ b/.github/pymeasure.yml
@@ -12,6 +12,7 @@ dependencies:
   - pyvisa=1.13.0
   - pyzmq=24.0.1
   - qt=5.15.6
+  - qtpy=2.4.3
 # Development dependencies below
   - pytest-qt=4.2.0
   - pytest-runner=5.2

--- a/.github/pymeasure_numpy2.yml
+++ b/.github/pymeasure_numpy2.yml
@@ -12,6 +12,7 @@ dependencies:
   - pyvisa=1.12.0
   - pyzmq=24.0.1
   - qt=5.15.6
+  - qtpy=2.4.3
 # Development dependencies below
   - pytest-qt=4.2.0
   - pytest-runner=5.2

--- a/.github/pymeasure_python312.yml
+++ b/.github/pymeasure_python312.yml
@@ -12,6 +12,7 @@ dependencies:
   - pyvisa=1.14.1
   - pyzmq=25.1.2
   - qt=5.15.8
+  - qtpy=2.4.3
 # Development dependencies below
   - pytest-qt=4.2.0
   - pytest-runner=5.2

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -30,17 +30,6 @@ from qtpy.uic import loadUiType
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-# Should be removed when PySide2 provides QtWidgets.QApplication.exec() or when support for PySide2
-# is dropped (https://doc.qt.io/qtforpython/porting_from2.html#class-function-deprecations)
-if not hasattr(QtWidgets.QApplication, 'exec'):
-    QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
-if not hasattr(QtCore.QCoreApplication, 'exec'):
-    QtCore.QCoreApplication.exec = QtCore.QCoreApplication.exec_
-if not hasattr(QtWidgets.QMenu, 'exec'):
-    def exec(self, *args, **kwargs):
-        self.exec_(*args, **kwargs)
-    QtWidgets.QMenu.exec = exec
-
 
 def fromUi(*args, **kwargs):
     """ Returns a Qt object constructed using loadUiType

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -24,7 +24,8 @@
 
 import logging
 
-from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType  # noqa: F401
+from qtpy import QtCore, QtGui, QtWidgets  # noqa: F401
+from qtpy.uic import loadUiType
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,9 @@ line-length = 100
 
 [tool.isort]
 profile = "black"
+
+[tool.pyright.defineConstant]
+PYQT5 = true
+PYSIDE2 = false
+PYQT6 = false
+PYSIDE6 = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pyvisa>=1.9",
     "pyserial>=2.7",
     "pyqtgraph>=0.12",
+    "qtpy>=2.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
These changes should be enough to implement qtpy on the whole project. Technically pyqtgraph uses its own Qt bindings, so issues are possible, but unlikely if one keeps only one Qt installation.

I don't know how dependencies are added for conda-forge, though, so that's missing.