### PR TITLE
Add handling of SerialException in list_resources()

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -101,3 +101,4 @@ Dongkai Pan
 Julian van Doorn
 Jörg Wunsch
 Falk Korndörfer
+Henk Vergonet

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -24,6 +24,7 @@
 
 import pyvisa
 from serial.tools import list_ports
+from serial.serialutil import SerialException
 
 
 def list_resources():
@@ -56,6 +57,9 @@ def list_resources():
                 print(n, ":", instr, ":", idn)
         except pyvisa.VisaIOError as e:
             print(n, ":", instr, ":", "Visa IO Error: check connections")
+            print(e)
+        except SerialException as e:
+            print(n, ":", instr, ":", "Serial port Error")
             print(e)
     rm.close()
     return instrs


### PR DESCRIPTION
Prevent opening an unused or unavailable serial port from throwing an exception.

old behavior:
```python
resources = list_resources()
...
    raise SerialException("Could not configure port: {}".format(msg))
serial.serialutil.SerialException: Could not configure port: (5, 'Input/output error')
```
new behavior:
```python
resources = list_resources()
...
0 : ASRL/dev/ttyS2::INSTR : Setial port error
Could not configure port: (5, 'Input/output error')
1 : ASRL/dev/ttyS3::INSTR : Setial port error
Could not configure port: (5, 'Input/output error')
2 : ASRL/dev/ttyS0::INSTR : Not known
3 : ASRL/dev/ttyS1::INSTR : Not known
4 : USB0::18499::14165::000000000::0::INSTR : Eucol Electronic Tech.;U2832;000000000;V1.13.2106E-02
```

