### PR TITLE
Dev/srs860 improvement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Upcoming Release
+================
+
+Deprecated
+----------
+- Replaced :code:`sensitvity` attribute of :code:`pymeasure/instruments/srs/SR860.py` by :code:`sensitivity`
+- Replaced :code:`filer_synchronous` attribute of :code:`pymeasure/instruments/srs/SR860.py` by :code:`filter_synchronous`
+
 Version 0.15.0 (2025-01-15)
 ===========================
 Main items of this new release:

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -30,10 +30,10 @@ from pymeasure.instruments import Instrument, SCPIUnknownMixin
 class SR860(SCPIUnknownMixin, Instrument):
 
     SENSITIVITIES = [
-        1e-9, 2e-9, 5e-9, 10e-9, 20e-9, 50e-9, 100e-9, 200e-9,
-        500e-9, 1e-6, 2e-6, 5e-6, 10e-6, 20e-6, 50e-6, 100e-6,
-        200e-6, 500e-6, 1e-3, 2e-3, 5e-3, 10e-3, 20e-3,
-        50e-3, 100e-3, 200e-3, 500e-3, 1
+        1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002,
+        0.001, 0.0005, 0.0002, 0.0001, 5e-05, 2e-05, 1e-05,
+        5e-06, 2e-06, 1e-06, 5e-07, 2e-07, 1e-07, 5e-08,
+        2e-08, 1e-08, 5e-09, 2e-09, 1e-09
     ]
     TIME_CONSTANTS = [
         1e-6, 3e-6, 10e-6, 30e-6, 100e-6, 300e-6, 1e-3, 3e-3, 10e-3,

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -207,7 +207,7 @@ class SR860(SCPIUnknownMixin, Instrument):
         values=INPUT_GAIN,
         map_values=True
     )
-    sensitvity = Instrument.control(
+    sensitivity = Instrument.control(
         "SCAL?", "SCAL %d",
         """ A floating point property that controls the sensitivity in Volts,
         which can take discrete values from 2 nV to 1 V. Values are truncated
@@ -231,9 +231,9 @@ class SR860(SCPIUnknownMixin, Instrument):
         """A integer property that sets the filter slope to 6 dB/oct(i=0), 12 DB/oct(i=1),
         18 dB/oct(i=2), 24 dB/oct(i=3).""",
         validator=strict_discrete_set,
-        values=range(0, 3)
+        values=range(0, 4)
     )
-    filer_synchronous = Instrument.control(
+    filter_synchronous = Instrument.control(
         "SYNC?", "SYNC %d",
         """A string property that represents the synchronous filter.
         This property can be set. Allowed values are:{}""".format(INPUT_FILTER),

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -151,6 +151,8 @@ class SR860(SCPIUnknownMixin, Instrument):
         values=INPUT_REFERENCETRIGGERMODE,
         map_values=True
     )
+    reference_source_trigger = reference_triggermode
+
     reference_externalinput = Instrument.control(
         "REFZ?", "REFZ&d",
         """A string property that represents the external reference input.
@@ -175,6 +177,8 @@ class SR860(SCPIUnknownMixin, Instrument):
         values=INPUT_VOLTAGE_MODE,
         map_values=True
     )
+    input_config = input_voltage_mode
+
     input_coupling = Instrument.control(
         "ICPL?", "ICPL %d",
         """A string property that represents the input coupling.
@@ -191,6 +195,8 @@ class SR860(SCPIUnknownMixin, Instrument):
         values=INPUT_SHIELDS,
         map_values=True
     )
+    input_grounding = input_shields
+
     input_range = Instrument.control(
         "IRNG?", "IRNG %d",
         """A string property that represents the input range.

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -228,7 +228,7 @@ class SR860(Instrument):
     def sensitvity(self):
         """Access sensitivity attribute with sensitvity (sic) property.
 
-        .. deprecated:: 0.15.0
+        .. deprecated:: 0.16.0
             Use sensitivity instead.
         """
         warnings.warn(
@@ -267,7 +267,7 @@ class SR860(Instrument):
     def filer_synchronous(self):
         """Access filter_synchronous attribute with filer_synchronous (sic) property.
 
-        .. deprecated:: 0.15.0
+        .. deprecated:: 0.16.0
             Use filter_synchronous instead.
         """
         warnings.warn(

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -476,6 +476,14 @@ class SR860(SCPIUnknownMixin, Instrument):
                 cast=float,
             )
 
+    def snap_all(self):
+        """snap X,Y,R,THETA parameters at once"""
+        return self.values(
+            command="SNAPD?",
+            separator=",",
+            cast=float,
+        )
+
     gettimebase = Instrument.measurement(
         "TBSTAT?",
         """Returns the current 10 MHz timebase source."""

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -24,10 +24,10 @@
 
 from pymeasure.instruments.validators import strict_discrete_set, \
     truncated_discrete_set, truncated_range
-from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments import Instrument
 
 
-class SR860(SCPIUnknownMixin, Instrument):
+class SR860(Instrument):
 
     SENSITIVITIES = [
         1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002,
@@ -604,5 +604,6 @@ class SR860(SCPIUnknownMixin, Instrument):
         super().__init__(
             adapter,
             name,
+            includeSCPI=False,
             **kwargs
         )

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -25,6 +25,7 @@
 from pymeasure.instruments.validators import strict_discrete_set, \
     truncated_discrete_set, truncated_range
 from pymeasure.instruments import Instrument
+import warnings
 
 
 class SR860(Instrument):
@@ -222,6 +223,17 @@ class SR860(Instrument):
         values=SENSITIVITIES,
         map_values=True
     )
+    
+    @property
+    def sensitvity(self):
+        """Access sensitivity attribute with sensitvity (sic) property.
+        
+        .. deprecated:: 0.15.0
+            Use sensitivity instead.
+        """
+        warnings.warn("`sensitvity` is deprecated, use sensitivity instead", FutureWarning)
+        return self.sensitivity
+
     time_constant = Instrument.control(
         "OFLT?", "OFLT %d",
         """ A floating point property that controls the time constant
@@ -247,6 +259,17 @@ class SR860(Instrument):
         values=INPUT_FILTER,
         map_values=True
     )
+
+    @property
+    def filer_synchronous(self):
+        """Access filter_synchronous attribute with filer_synchronous (sic) property.
+        
+        .. deprecated:: 0.15.0
+            Use filter_synchronous instead.
+        """
+        warnings.warn("`filer_synchronous` is deprecated, use filter_synchronous instead", FutureWarning)
+        return self.filter_synchronous
+
     filter_advanced = Instrument.control(
         "ADVFILT?", "ADVFIL %d",
         """A string property that represents the advanced filter.

--- a/pymeasure/instruments/srs/sr860.py
+++ b/pymeasure/instruments/srs/sr860.py
@@ -223,15 +223,18 @@ class SR860(Instrument):
         values=SENSITIVITIES,
         map_values=True
     )
-    
+
     @property
     def sensitvity(self):
         """Access sensitivity attribute with sensitvity (sic) property.
-        
+
         .. deprecated:: 0.15.0
             Use sensitivity instead.
         """
-        warnings.warn("`sensitvity` is deprecated, use sensitivity instead", FutureWarning)
+        warnings.warn(
+            "`sensitvity` is deprecated, use sensitivity instead",
+            FutureWarning
+            )
         return self.sensitivity
 
     time_constant = Instrument.control(
@@ -263,11 +266,14 @@ class SR860(Instrument):
     @property
     def filer_synchronous(self):
         """Access filter_synchronous attribute with filer_synchronous (sic) property.
-        
+
         .. deprecated:: 0.15.0
             Use filter_synchronous instead.
         """
-        warnings.warn("`filer_synchronous` is deprecated, use filter_synchronous instead", FutureWarning)
+        warnings.warn(
+            "`filer_synchronous` is deprecated, use filter_synchronous instead",
+            FutureWarning
+            )
         return self.filter_synchronous
 
     filter_advanced = Instrument.control(


### PR DESCRIPTION
This pull request refactors and enhances the `SR860` class in the `pymeasure` library by removing unknown mixins, fixing typos, adding new properties, and introducing a new method for retrieving multiple parameters simultaneously. Below is a summary of the most important changes:

### Refactoring and Cleanup:
* Removed the `SCPIUnknownMixin` from the `SR860` class, as it is no longer needed. Updated the `__init__` method to exclude SCPI-specific functionality by setting `includeSCPI=False`. Because some of the methods in SCPIMixin class is proved to be unsupported by SR860.

### Enhancements to Class Properties:
* Added new aliases for existing properties to provide compatibility with the SR830 driver on some basic functionalities:
  - `reference_source_trigger` as an alias for `reference_triggermode`.
  - `input_config` as an alias for `input_voltage_mode`.
  - `input_grounding` as an alias for `input_shields`.

### Bug Fixes:
* Corrected a typo in the `sensitivity` property name (previously misspelled as `sensitvity`). NOTE: **The original wrongly spelled parameters are removed, meaning this is a breaking change**.
* Fixed the range of valid values for the `filter_synchronous` property to include 24 dB/octave (adjusted from `range(0, 3)` to `range(0, 4)`).
* Reverse the order of the mapping list of sensitivity according to the manual of SR860.

### New Method:
* Added the `snap_all` method to retrieve (`X`, `Y`, `R`, `THETA`) in a single command, improving efficiency for users requiring these values simultaneously. While the `snap` method can only fetch up to 3 of them.