### PR TITLE
Make 'get_process_list' dynamic

### DIFF
--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -105,6 +105,7 @@ class CommonBase:
                          'values',
                          'map_values',
                          'get_process',
+                         'get_process_list',
                          'command_process',
                          'check_get_errors')
 
@@ -535,6 +536,7 @@ class CommonBase:
                  values=values,
                  map_values=map_values,
                  get_process=get_process,
+                 get_process_list=get_process_list,
                  command_process=command_process,
                  check_get_errors=check_get_errors,
                  ):

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -695,7 +695,7 @@ def test_control_get_process_list(dynamic):
             dynamic=dynamic,
         )
 
-    # override the get_process_list should only work when dynamic
+    # override get_process_list should only work when dynamic
     Fake.x_get_process_list = lambda v: [0, "2"]
 
     with expected_protocol(Fake, [("G", "0, 1, 2, 3.4")]) as inst:

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -695,8 +695,14 @@ def test_control_get_process_list(dynamic):
             dynamic=dynamic,
         )
 
+    # override the get_process_list should only work when dynamic
+    Fake.x_get_process_list = lambda v: [0, "2"]
+
     with expected_protocol(Fake, [("G", "0, 1, 2, 3.4")]) as inst:
-        assert inst.x == [1, 0, 1, 2, 3.4, 4]
+        if dynamic:
+            assert inst.x == [0, "2"]
+        else:
+            assert inst.x == [1, 0, 1, 2, 3.4, 4]
 
 
 @pytest.mark.parametrize("dynamic", [False, True])


### PR DESCRIPTION
Add 'get_process_list' to the list of dynamic parameters for instrument properties.