### PR TITLE
Refactor keithlydaq6510 and add diode measurement

### DIFF
--- a/pymeasure/instruments/keithley/keithleyDAQ6510.py
+++ b/pymeasure/instruments/keithley/keithleyDAQ6510.py
@@ -175,6 +175,29 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         but increases the number of usable digits. """
     )
 
+
+
+    ####################
+    # Diode (V)       #
+    ####################
+
+    diode_bias = Instrument.control(
+        ":SENS:DIOD:BIAS:LEV?",
+        ":SENS:DIOD:BIAS:LEV %g",
+        '''Control the diode bias in Amps.
+            Options are 1e-5, 1e-4, 1e-3, and 1e-2.
+        ''',
+        validator=strict_discrete_set,
+        values=[1e-5, 1e-4, 1e-3, 1e-2]                         
+    )
+
+    diode = Instrument.measurement(
+        ":MEAS:DIOD?",
+        '''Read the diode voltage (Volts) if configured for this reading.'''
+    )
+
+
+
     ####################
     # Methods        #
     ####################
@@ -232,6 +255,21 @@ class KeithleyDAQ6510(KeithleyBuffer, SCPIMixin, Instrument):
         else:
             self.current_range = current
         self.check_errors()
+
+
+    
+    def measure_diode(self, bias=1e-3):
+        """ Configure the measurement of Diode.
+
+        :param bias: Diode bias setting for measurement in Amps. Options are 1e-5, 1e-4, 1e-3, and 1e-2.
+                        Default diode bias is 1 mA.
+        """
+        
+        self.write(':SENS:FUNC "DIOD";')
+        self.diode_bias = bias
+        self.check_errors()
+
+
 
     def open_channel(self, channel):
         """


### PR DESCRIPTION
This is a somewhat significant refactor of the Keithly DAQ6510 driver.

This breaks backwards compatibility by removing some measurement functions that did not actually function as described.
Closes https://github.com/pymeasure/pymeasure/issues/1314 

This PR:

- Adds diode measurement functionality
- Removes `KeithleyDAQ6510.voltage`, `KeithleyDAQ6510.current`, `KeithleyDAQ6510.resistance` properties. This breaks backwards compatibility.
- Implements all measurement functions with full "setup + measure" functionality. 
- adds `configure_X_measurement` functions
- Adds awareness to expansion cards and mux channels as nested objects.
  - This means that:
    - `daq.mux_channels` will list all available channels provided through cards. Also a "front_panel" channel.
    - `daq.mux_channels[101].closed = True/False` will open/close channel or get state.
    - `daq.mux_channels[101].measure_voltage()` will measure the voltage or other parameter of that specific channel. And close the required measurement path automatically. 
  - `daq.cards["slot1"].id` gets model of expansion card. The card object also pulls number of mux channels, serial number, and other info.
- More to come.

