### PR TITLE
Dev/lake shore340

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -103,3 +103,4 @@ Jörg Wunsch
 Falk Korndörfer
 Henk Vergone
 Sergey Ilyev
+Alfons Schuck

--- a/docs/api/instruments/lakeshore/index.rst
+++ b/docs/api/instruments/lakeshore/index.rst
@@ -12,6 +12,7 @@ This section contains specific documentation on the Lake Shore Cryogenics instru
    lakeshore211
    lakeshore224
    lakeshore331
+   lakeshore340
    lakeshore421
    lakeshore425
 

--- a/docs/api/instruments/lakeshore/lakeshore340.rst
+++ b/docs/api/instruments/lakeshore/lakeshore340.rst
@@ -1,0 +1,7 @@
+#####################################
+Lake Shore 340 Temperature Controller
+#####################################
+
+.. autoclass:: pymeasure.instruments.lakeshore.LakeShore340
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/lakeshore/__init__.py
+++ b/pymeasure/instruments/lakeshore/__init__.py
@@ -24,5 +24,6 @@
 from .lakeshore211 import LakeShore211
 from .lakeshore224 import LakeShore224
 from .lakeshore331 import LakeShore331
+from .lakeshore340 import LakeShore340
 from .lakeshore421 import LakeShore421
 from .lakeshore425 import LakeShore425

--- a/pymeasure/instruments/lakeshore/lakeshore340.py
+++ b/pymeasure/instruments/lakeshore/lakeshore340.py
@@ -1,0 +1,95 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments.lakeshore.lakeshore_base import LakeShoreTemperatureChannel, \
+    LakeShoreHeaterChannel
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class LakeShore340(SCPIUnknownMixin, Instrument):
+    """ Represents the Lake Shore 340/350 Temperature Controller and provides
+    a high-level interface for interacting with the instrument. 
+    In addition to the :ref:`lakeshore331`, multiple input-and output options are implemented.
+    Not all channels exist in all device versions!
+
+    Note that the 340 provides two input channels (A and B) and one output channel.
+    Additional input option cards can be used to add input channels.
+    - 3465 Single Capacitance Input Option Card adds one channel (C)
+    - 3462 Dual Standard Input Option Card or 3464 Dual Thermocouple Input Option Card 
+        adds two channels (C and D).
+    - 3468 Eight Channel Input Option Card adds eight channels (C1-C4, D1-D4)
+
+    The LS 350 can power four output channels (1-4).
+    - 3062 4-Channel Scanner option is installed in the Model 350, 
+        4 additional channels, D2, D3, D4, and D5, become available for use.
+
+    This driver makes use of the :ref:`LakeShoreChannels`.
+
+    .. code-block:: python
+
+        controller = LakeShore340("GPIB::1")
+
+        print(controller.output_1.setpoint)         # Print the current setpoint for loop 1
+        controller.output_1.setpoint = 50           # Change the loop 1 setpoint to 50 K
+        controller.output_1.heater_range = 'low'    # Change the heater range to low.
+        controller.input_A.wait_for_temperature()   # Wait for the temperature to stabilize.
+        print(controller.input_A.temperature)       # Print the temperature at sensor A.
+    """
+    input_A = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'A')
+
+    input_B = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'B')
+
+    input_C = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'C')
+
+    input_D = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D')
+
+    input_C1 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'C1')
+    input_C2 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'C2')
+    input_C3 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'C3')
+    input_C4 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'C4')
+
+    input_D1 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D1')
+    input_D2 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D2')
+    input_D3 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D3')
+    input_D4 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D4')
+    input_D5 = Instrument.ChannelCreator(LakeShoreTemperatureChannel, 'D5')
+
+    output_1 = Instrument.ChannelCreator(LakeShoreHeaterChannel, 1)
+    output_2 = Instrument.ChannelCreator(LakeShoreHeaterChannel, 2)
+    output_3 = Instrument.ChannelCreator(LakeShoreHeaterChannel, 3)
+    output_4 = Instrument.ChannelCreator(LakeShoreHeaterChannel, 4)
+
+
+    def __init__(self, adapter, name="Lakeshore Model 336 Temperature Controller", **kwargs):
+        kwargs.setdefault('read_termination', "\r\n")
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )


### PR DESCRIPTION
Dear maintainers of pymeasure,

LakeShore Temperature Controllers can have more options (inputs and outputs) than implemented in the LakeShore331 device class.

As the naming for the implemented channels depends on the installed options (Input Option Cards) and the number of output channels varies between different series, one could implement multiple quite similar device classes or one to "rule them all".

I'm not sure about your conventions so I've added the LakeShore340 with respect to the up to four possible outputs in the 350 series. A better solution might be to replace the device class LakeShore331 with a new one (like this LakeShore340) and name it LakeShore3xx but I didn't want to break the already implemented measurement routines based on LakeShore331 which might be obsolete having the 340.

Thank you and kind regards.