### PR TITLE
Fix image_gui.py example

### DIFF
--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -107,8 +107,7 @@ class TestImageGUI(ManagedImageWindow):
             inputs=['X_start', 'X_end', 'X_step', 'Y_start', 'Y_end', 'Y_step',
                     'delay'],
             displays=['X_start', 'X_end', 'Y_start', 'Y_end', 'delay'],
-            filename_input=False,
-            directory_input=False,
+            enable_file_input=False,
         )
         self.setWindowTitle('PyMeasure Image Test')
 


### PR DESCRIPTION
Replaced `filename_input` and `directory_input` by `enable_file_input`. Now the example is working again.