### PR TITLE
Define 'Ohm' in units.py

### DIFF
--- a/examples/Current-Voltage Measurements/iv_keithley.py
+++ b/examples/Current-Voltage Measurements/iv_keithley.py
@@ -60,7 +60,7 @@ class IVProcedure(Procedure):
     delay = FloatParameter('Delay Time', units='ms', default=20)
     voltage_range = FloatParameter('Voltage Range', units='V', default=10)
 
-    DATA_COLUMNS = ['Current (A)', 'Voltage (V)', 'Resistance (Ohm)']
+    DATA_COLUMNS = ['Current (A)', 'Voltage (V)', 'Resistance (ohm)']
 
     def startup(self):
         log.info("Setting up instruments")
@@ -100,7 +100,7 @@ class IVProcedure(Procedure):
             data = {
                 'Current (A)': current,
                 'Voltage (V)': voltage,
-                'Resistance (Ohm)': resistance
+                'Resistance (ohm)': resistance
             }
             self.emit('results', data)
             self.emit('progress', 100. * i / steps)

--- a/examples/Current-Voltage Measurements/iv_yokogawa.py
+++ b/examples/Current-Voltage Measurements/iv_yokogawa.py
@@ -61,7 +61,7 @@ class IVProcedure(Procedure):
     delay = FloatParameter('Delay Time', units='ms', default=20)
     voltage_range = FloatParameter('Voltage Range', units='V', default=10)
 
-    DATA_COLUMNS = ['Current (A)', 'Voltage (V)', 'Resistance (Ohm)']
+    DATA_COLUMNS = ['Current (A)', 'Voltage (V)', 'Resistance (ohm)']
 
     def startup(self):
         log.info("Setting up instruments")
@@ -100,7 +100,7 @@ class IVProcedure(Procedure):
             data = {
                 'Current (A)': current,
                 'Voltage (V)': voltage,
-                'Resistance (Ohm)': resistance
+                'Resistance (ohm)': resistance
             }
             self.emit('results', data)
             self.emit('progress', 100. * i / steps)

--- a/pymeasure/units.py
+++ b/pymeasure/units.py
@@ -25,3 +25,4 @@
 import pint
 
 ureg = pint.get_application_registry()
+ureg.define('@alias ohm = Ohm')

--- a/pymeasure/units.py
+++ b/pymeasure/units.py
@@ -25,4 +25,3 @@
 import pint
 
 ureg = pint.get_application_registry()
-ureg.define('@alias ohm = Ohm')


### PR DESCRIPTION
Define 'Ohm' as an alias for 'ohm'.
This makes the both examples in 'examples/Current-Voltage Measurements' working. Otherwise 'Ohm' has to be replaced by 'Ω' in the examples.