### PR TITLE
Wait for sweep completer timeout

### DIFF
--- a/pymeasure/instruments/yokogawa/aq6370series.py
+++ b/pymeasure/instruments/yokogawa/aq6370series.py
@@ -127,11 +127,12 @@ class AQ6370Series(SCPIMixin, Instrument):
         get_process=lambda x: bool(int(x) & 1),
     )
 
-    def wait_for_sweep_complete(self, should_stop=lambda: False, timeout=3600):
+    def wait_for_sweep_complete(self, should_stop=lambda: False, timeout=3600, delay=0):
         """Block the program, waiting for the sweep to complete.
 
         :param should_stop: Function that returns True to stop waiting.
         :param timeout: Maximum waiting time, in seconds.
+        :param delay: Delay between checks for sweep completion, in seconds.
         :return: True when sweep completed, False if stopped by should_stop.
         :raises TimeoutError: If the sweep does not complete within the timeout period.
         """


### PR DESCRIPTION
Increased timeout to 1 hour for `wait_for_sweep_complete` as these sweeps can take a very long time
Corrected the corresponding docstring (previously referenced temperature for no reason)