### PR TITLE
AgilentE5270B: add 'display.enabled' property

### DIFF
--- a/docs/api/instruments/agilent/agilentE5270B.rst
+++ b/docs/api/instruments/agilent/agilentE5270B.rst
@@ -6,6 +6,10 @@ Agilent E5270B SMU mainframe
     :members:
     :show-inheritance:
 
+.. autoclass:: pymeasure.instruments.agilent.agilentE5270B.Display
+    :members:
+    :show-inheritance:
+
 .. autoclass:: pymeasure.instruments.agilent.agilentE5270B.SMUChannel
     :members:
     :show-inheritance:

--- a/pymeasure/instruments/agilent/agilentE5270B.py
+++ b/pymeasure/instruments/agilent/agilentE5270B.py
@@ -35,7 +35,7 @@ class Display(Channel):
 
     enabled = Instrument.setting(
         "RED %d",
-        """Set the display during remote operation (bool).""",
+        """Set whether the display is enabled during remote operation (bool).""",
         map_values=True,
         values={True: 1, False: 0},
         )

--- a/pymeasure/instruments/agilent/agilentE5270B.py
+++ b/pymeasure/instruments/agilent/agilentE5270B.py
@@ -30,6 +30,17 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+class Display(Channel):
+    """A class representing the Agilent E5270B display."""
+
+    enabled = Instrument.setting(
+        "RED %d",
+        """Set the display during remote operation (bool).""",
+        map_values=True,
+        values={True: 1, False: 0},
+        )
+
+
 class SMUChannel(Channel):
     """A class representing the Agilent E5270B SMU channel."""
 
@@ -127,6 +138,8 @@ class AgilentE5270B(SCPIMixin, Instrument):
 
     """
 
+    display = Instrument.ChannelCreator(Display)
+
     def __init__(self, adapter,
                  name="Agilent E5270B",
                  **kwargs):
@@ -171,13 +184,6 @@ class AgilentE5270B(SCPIMixin, Instrument):
                 log.error(f"{self.name}: {error_code}, {error_message}")
                 errors.append(error_code)
         return errors
-
-    display_enabled = Instrument.setting(
-        "RED %d",
-        """Set the display during remote operation (bool).""",
-        map_values=True,
-        values={True: 1, False: 0},
-        )
 
     options = Instrument.measurement(
         "UNT?",

--- a/pymeasure/instruments/agilent/agilentE5270B.py
+++ b/pymeasure/instruments/agilent/agilentE5270B.py
@@ -172,6 +172,13 @@ class AgilentE5270B(SCPIMixin, Instrument):
                 errors.append(error_code)
         return errors
 
+    display_enabled = Instrument.setting(
+        "RED %d",
+        """Set the display during remote operation (bool).""",
+        map_values=True,
+        values={True: 1, False: 0},
+        )
+
     options = Instrument.measurement(
         "UNT?",
         """Get the installed SMUs (list of str).

--- a/tests/instruments/agilent/test_agilentE5270B.py
+++ b/tests/instruments/agilent/test_agilentE5270B.py
@@ -59,16 +59,6 @@ class TestMain:
         ) as inst:
             assert [120, 200] == inst.check_errors()
 
-    @pytest.mark.parametrize("enabled, mapping", [(True, 1), (False, 0)])
-    def test_display_enabled(self, enabled, mapping):
-        with expected_protocol(
-            AgilentE5270B,
-            [INITIALIZATION,
-             (f"RED {mapping}", None),
-             ]
-        ) as inst:
-            inst.display_enabled = enabled
-
     def test_options(self):
         with expected_protocol(
             AgilentE5270B,
@@ -146,3 +136,15 @@ class TestSMU:
              ]
         ) as inst:
             assert -1.234e-6 == inst.smu1.voltage
+
+
+class TestDisplay:
+    @pytest.mark.parametrize("enabled, mapping", [(True, 1), (False, 0)])
+    def test_enabled(self, enabled, mapping):
+        with expected_protocol(
+            AgilentE5270B,
+            [INITIALIZATION,
+             (f"RED {mapping}", None),
+             ]
+        ) as inst:
+            inst.display.enabled = enabled

--- a/tests/instruments/agilent/test_agilentE5270B.py
+++ b/tests/instruments/agilent/test_agilentE5270B.py
@@ -59,6 +59,16 @@ class TestMain:
         ) as inst:
             assert [120, 200] == inst.check_errors()
 
+    @pytest.mark.parametrize("enabled, mapping", [(True, 1), (False, 0)])
+    def test_display_enabled(self, enabled, mapping):
+        with expected_protocol(
+            AgilentE5270B,
+            [INITIALIZATION,
+             (f"RED {mapping}", None),
+             ]
+        ) as inst:
+            inst.display_enabled = enabled
+
     def test_options(self):
         with expected_protocol(
             AgilentE5270B,

--- a/tests/instruments/agilent/test_agilentE5270B_with_device.py
+++ b/tests/instruments/agilent/test_agilentE5270B_with_device.py
@@ -66,12 +66,6 @@ class TestMain:
         assert [100] == e5270b.check_errors()
         assert [] == e5270b.check_errors()
 
-    @pytest.mark.parametrize("enabled", [True, False])
-    def test_display_enabled(self, e5270b, enabled):
-        assert [] == e5270b.check_errors()
-        e5270b.display_enabled = enabled
-        assert [] == e5270b.check_errors()
-
     def test_options(self, e5270b):
         # with pytest.raises(NotImplementedError):
         options = e5270b.options
@@ -97,3 +91,11 @@ class TestSMU:
         # expect 0.2V  (voltage compliance)
         assert e5270b.smu1.voltage == pytest.approx(0.2, rel=1e-3)
         e5270b.smu1.enabled = False
+
+
+class TestDisplay:
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_enabled(self, e5270b, enabled):
+        assert [] == e5270b.check_errors()
+        e5270b.display.enabled = enabled
+        assert [] == e5270b.check_errors()

--- a/tests/instruments/agilent/test_agilentE5270B_with_device.py
+++ b/tests/instruments/agilent/test_agilentE5270B_with_device.py
@@ -66,6 +66,12 @@ class TestMain:
         assert [100] == e5270b.check_errors()
         assert [] == e5270b.check_errors()
 
+    @pytest.mark.parametrize("enabled", [True, False])
+    def test_display_enabled(self, e5270b, enabled):
+        assert [] == e5270b.check_errors()
+        e5270b.display_enabled = enabled
+        assert [] == e5270b.check_errors()
+
     def test_options(self, e5270b):
         # with pytest.raises(NotImplementedError):
         options = e5270b.options


### PR DESCRIPTION
- add property "display_enabled' to AgilentE5270B to allow data display during remote operation