### PR TITLE
Rework the Agilent B1500 SMU class to inherit from Channel

### DIFF
--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -443,7 +443,7 @@ class AgilentB1500(SCPIMixin, Instrument):
                 return channel
 
     class _data_formatting_FMT1(_data_formatting_generic):
-        """Data formatting for FMT1 format"""
+        """Data formatting for FMT1 format."""
 
         def __init__(self, smu_names={}, output_format_string="FMT1"):
             super().__init__(smu_names, output_format_string)
@@ -468,13 +468,13 @@ class AgilentB1500(SCPIMixin, Instrument):
             return (status, channel, data_name, value)
 
     class _data_formatting_FMT11(_data_formatting_FMT1):
-        """Data formatting for FMT11 format (based on FMT1)"""
+        """Data formatting for FMT11 format (based on FMT1)."""
 
         def __init__(self, smu_names={}):
             super().__init__(smu_names, "FMT11")
 
     class _data_formatting_FMT21(_data_formatting_generic):
-        """Data formatting for FMT21 format"""
+        """Data formatting for FMT21 format."""
 
         def __init__(self, smu_names={}):
             super().__init__(smu_names, "FMT21")
@@ -884,7 +884,7 @@ class AgilentB1500(SCPIMixin, Instrument):
         return self.query_learn_header(46)
 
     def query_meas_ranges(self):
-        """Read measruement ranging status (32) for all SMUs."""
+        """Read measurement ranging status (32) for all SMUs."""
         return self.query_learn_header(32)
 
 
@@ -896,9 +896,11 @@ class AgilentB1500(SCPIMixin, Instrument):
 class SMU(Channel):
     """Provide specific methods for the SMUs of the Agilent B1500 mainframe.
 
-    :param int slot: Slot number of the SMU
-    :param str smu_type: Type of the SMU
+    :param AgilentB1500 parent: Instance of the B1500 mainframe class
+    :param int index: Index of the SMU
+    :param str type: Type of the SMU
     :param str name: Name of the SMU
+    :param int slot: Slot number of the SMU
     """
 
     def __init__(self, parent, index, type, name, slot, **kwargs):
@@ -1050,7 +1052,7 @@ class SMU(Channel):
         :param int or str source_range: Output range index or name
         :param float output: Source output value in A or V
         :param float comp: Compliance value, defaults to previous setting
-        :param CompliancePolarity comp_polarity: Compliance polairty, defaults to auto
+        :param CompliancePolarity comp_polarity: Compliance polarity, defaults to auto
         :param int or str comp_range: Compliance ranging type, defaults to auto
         """
         if source_type.upper() == "VOLTAGE":
@@ -1092,10 +1094,10 @@ class SMU(Channel):
         Each step is separated by a pause duration.
 
         :param str source_type: Source type (``'Voltage'`` or ``'Current'``)
+        :param int or str source_range: Output range index or name
         :param float target_output: Target output voltage or current
-        :param int irange: Output range index
         :param float comp: Compliance, defaults to previous setting
-        :param CompliancePolarity comp_polarity: Compliance polairty, defaults to auto
+        :param CompliancePolarity comp_polarity: Compliance polarity, defaults to auto
         :param int or str comp_range: Compliance ranging type, defaults to auto
         :param float stepsize: Maximum size of steps
         :param float pause: Duration in seconds to wait between steps
@@ -1554,7 +1556,7 @@ class SPGU(Channel):
         "SPPER?",
         "SPPER %f",
         """Control the pulse period for SPGU channels (``SPPER``) in seconds (float).
-        Applies to all installed SPGU modules""",
+        Applies to all installed SPGU modules.""",
         validator=strict_range,
         values=[2e-8, 10],
     )
@@ -1691,6 +1693,7 @@ class SPGUChannel(Channel):
 
     def get_pulse_timings(self, source=1):
         """Get the timing parameters for the SPGU channel. (``SPT?``)
+
         The SPGU operating mode must be set to PG with the ``SIM 0`` command before getting the
         pulse timings.
 
@@ -1726,7 +1729,7 @@ class CustomIntEnum(IntEnum):
     """
 
     def __str__(self):
-        """Give title case string of enum value"""
+        """Give title case string of enum value."""
         return str(self.name).replace("_", " ").title()
         # str() conversion just because of pylint bug
 
@@ -1744,7 +1747,7 @@ class CustomIntEnum(IntEnum):
 
 
 class ADCType(CustomIntEnum):
-    """ADC Type"""
+    """ADC Type."""
 
     HSADC = (0,)  #: High-speed ADC
     HRADC = (1,)  #: High-resolution ADC
@@ -1756,7 +1759,7 @@ class ADCType(CustomIntEnum):
 
 
 class ADCMode(CustomIntEnum):
-    """ADC Mode"""
+    """ADC Mode."""
 
     AUTO = 0  #:
     MANUAL = 1  #:
@@ -1765,14 +1768,14 @@ class ADCMode(CustomIntEnum):
 
 
 class AutoManual(CustomIntEnum):
-    """Auto/Manual selection"""
+    """Auto/Manual selection."""
 
     AUTO = 0  #:
     MANUAL = 1  #:
 
 
 class ControlMode(CustomIntEnum):
-    """Control mode for the digital I/O ports"""
+    """Control mode for the digital I/O ports."""
 
     GENERAL = 0  #: General purpose control mode (default)
     SMU_PGU_SELECTOR = 1  #: 16440A SMU/PGU selector (B1500A-A04) control mode
@@ -1784,7 +1787,7 @@ class ControlMode(CustomIntEnum):
 
 
 class MeasMode(CustomIntEnum):
-    """Measurement Mode"""
+    """Measurement Mode."""
 
     SPOT = 1  #:
     STAIRCASE_SWEEP = 2  #:
@@ -1792,7 +1795,7 @@ class MeasMode(CustomIntEnum):
 
 
 class MeasOpMode(CustomIntEnum):
-    """Measurement Operation Mode"""
+    """Measurement Operation Mode."""
 
     COMPLIANCE_SIDE = 0
     """
@@ -1802,7 +1805,7 @@ class MeasOpMode(CustomIntEnum):
     VOLTAGE = 2  #:
     FORCE_SIDE = 3  #:
     """
-    Measure current in the current sourceoperation or voltage in the voltage source operation.
+    Measure current in the current source operation or voltage in the voltage source operation.
     """
     COMPLIANCE_AND_FORCE_SIDE = 4
     """
@@ -1812,7 +1815,7 @@ class MeasOpMode(CustomIntEnum):
 
 
 class PgSelectorPort(CustomIntEnum):
-    """Output port of SMU/PG selector"""
+    """Output port of SMU/PG selector."""
 
     OUTPUT_1_FIRST = 0  #: Output 1 on the first selector
     OUTPUT_2_FIRST = 1  #: Output 2 on the first selector
@@ -1821,7 +1824,7 @@ class PgSelectorPort(CustomIntEnum):
 
 
 class PgSelectorConnectionStatus(CustomIntEnum):
-    """Connection status of I/O port"""
+    """Connection status of I/O port."""
 
     NO_CONNECTION = 0  #: All open. Breaks connection. Initial setting
     SMU_ON = 1  #: SMU on. Makes connection to the SMU input.
@@ -1830,7 +1833,7 @@ class PgSelectorConnectionStatus(CustomIntEnum):
 
 
 class SweepMode(CustomIntEnum):
-    """Sweep Mode"""
+    """Sweep Mode."""
 
     LINEAR_SINGLE = 1  #: Linear sweep (single stair, start to stop.)
     LOG_SINGLE = 2  #: Log sweep (single stair, start to stop.)
@@ -1839,7 +1842,7 @@ class SweepMode(CustomIntEnum):
 
 
 class SamplingMode(CustomIntEnum):
-    """Sampling Mode"""
+    """Sampling Mode."""
 
     LINEAR = 1  #:
     LOG_10 = 2  #: Logarithmic 10 data points/decade
@@ -1863,14 +1866,14 @@ class SamplingMode(CustomIntEnum):
 
 
 class SamplingPostOutput(CustomIntEnum):
-    """Output after sampling"""
+    """Output after sampling."""
 
     BASE = 1  #:
     BIAS = 2  #:
 
 
 class SPGUChannelOutputMode(CustomIntEnum):
-    """Output mode of SPGU channel"""
+    """Output mode of SPGU channel."""
 
     DC = 0  #: DC output mode
     SIGNAL_SOURCE_1 = 1  #: 2-level pulse output mode using pulse signal source 1
@@ -1879,7 +1882,7 @@ class SPGUChannelOutputMode(CustomIntEnum):
 
 
 class SPGUSignalSource(CustomIntEnum):
-    """Signal source for SPGU"""
+    """Signal source for SPGU."""
 
     DC = 0  #:
     PULSE_SIGNAL_1 = 1  #:
@@ -1914,21 +1917,21 @@ class SPGUOutputMode(CustomIntEnum):
 
 
 class StaircaseSweepPostOutput(CustomIntEnum):
-    """Output after staircase sweep"""
+    """Output after staircase sweep."""
 
     START = 1  #:
     STOP = 2  #:
 
 
 class CompliancePolarity(CustomIntEnum):
-    """Compliance polarity"""
+    """Compliance polarity."""
 
     AUTO = 0  #:
     MANUAL = 1  #:
 
 
 class WaitTimeType(CustomIntEnum):
-    """Wait time type"""
+    """Wait time type."""
 
     SMU_SOURCE = 1  #: wait before changing the output value
     SMU_MEASUREMENT = 2  #: wait before starting the measurement

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -62,7 +62,7 @@ class AgilentB1500(SCPIMixin, Instrument):
     @property
     def smu_references(self):
         """Return all SMU instances."""
-        return self._smu_references.values()
+        return self.smus.values()
 
     @property
     def smu_names(self):
@@ -138,6 +138,8 @@ class AgilentB1500(SCPIMixin, Instrument):
                     name=f"SMU{i}",
                     channel=channel,
                 )
+                self._smu_references[channel] = self.smus[i]
+                self._smu_names[channel] = self.smus[i].name
                 i += 1
 
     def initialize_all_spgus(self):

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -896,15 +896,15 @@ class AgilentB1500(SCPIMixin, Instrument):
 class SMU(Channel):
     """Provide specific methods for the SMUs of the Agilent B1500 mainframe.
 
-    :param int channel: Channel number of the SMU
+    :param int slot: Slot number of the SMU
     :param str smu_type: Type of the SMU
     :param str name: Name of the SMU
     """
 
-    def __init__(self, parent, number, type, name, channel, **kwargs):
-        super().__init__(parent, channel, **kwargs)
-        channel = strict_discrete_set(channel, range(1, 11))
-        self.channel = channel
+    def __init__(self, parent, index, type, name, slot, **kwargs):
+        super().__init__(parent, slot, **kwargs)
+        slot = strict_discrete_set(slot, range(1, 11))
+        self.channel = slot
         type = strict_discrete_set(
             type,
             [

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -940,7 +940,7 @@ class SMU(Channel):
 
     def query_learn(self, query_type, command):
         """Wrap :meth:`~.AgilentB1500.query_learn` method of B1500."""
-        response = self._b1500.query_learn(query_type)
+        response = self.parent.query_learn(query_type)
         # query_learn returns settings of all smus
         # pick setting for this smu only
         response = response[command + str(self.channel)]
@@ -948,17 +948,17 @@ class SMU(Channel):
 
     def check_errors(self):
         """Wrap :meth:`~.AgilentB1500.check_errors` method of B1500."""
-        return self._b1500.check_errors()
+        return self.parent.check_errors()
 
     ##########################################
 
     def _query_status_raw(self):
-        return self._b1500.query_learn(str(self.channel))
+        return self.parent.query_learn(str(self.channel))
 
     @property
     def status(self):
         """Query status of the SMU."""
-        return self._b1500.query_learn_header(str(self.channel))
+        return self.parent.query_learn_header(str(self.channel))
 
     def enable(self):
         """Enable Source/Measurement Channel (``CN``)"""
@@ -987,7 +987,7 @@ class SMU(Channel):
         """
         # different than other SMU specific settings (grouped by setting)
         # read via raw command
-        response = self._b1500.query_learn(30)
+        response = self.parent.query_learn(30)
         if "FL" in response.keys():
             # only present if filters of all channels are off
             return False

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -25,7 +25,6 @@
 import logging
 import re
 import time
-import weakref
 from collections import Counter, OrderedDict, namedtuple
 from enum import IntEnum
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -955,24 +955,24 @@ class SMU(Channel):
 
     def enable(self):
         """Enable source/measurement channel. (``CN``)"""
-        self.write(f"CN {self.channel}")
+        self.write(f"CN {self.id}")
 
     def disable(self):
         """Disable source/measurement channel. (``CL``)"""
-        self.write(f"CL {self.channel}")
+        self.write(f"CL {self.id}")
 
     def force_gnd(self):
         """Force output to 0 V immediately. (``DZ``)
 
         Current settings can be restored with :meth:`restore_settings`.
         """
-        self.write(f"DZ {self.channel}")
+        self.write(f"DZ {self.id}")
 
     def restore_settings(self):
         """Restore the settings of the channel to the state before
         using :meth:`force_gnd`. (``RZ``)
         """
-        self.write(f"RZ {self.channel}")
+        self.write(f"RZ {self.id}")
 
     @property
     def filter(self):
@@ -994,7 +994,7 @@ class SMU(Channel):
     @filter.setter
     def filter(self, setting):
         setting = strict_discrete_set(int(setting), (0, 1))
-        self.write(f"FL {setting}, {self.channel}")
+        self.write(f"FL {setting}, {self.id}")
         self.check_errors()
 
     @property
@@ -1007,7 +1007,7 @@ class SMU(Channel):
     @series_resistor.setter
     def series_resistor(self, setting):
         setting = strict_discrete_set(int(setting), (0, 1))
-        self.write(f"SSR {self.channel}, {setting}")
+        self.write(f"SSR {self.id}, {setting}")
         self.check_errors()
 
     @property
@@ -1023,7 +1023,7 @@ class SMU(Channel):
     @meas_op_mode.setter
     def meas_op_mode(self, op_mode):
         op_mode = MeasOpMode.get(op_mode)
-        self.write(f"CMM {self.channel}, {op_mode.value}")
+        self.write(f"CMM {self.id}, {op_mode.value}")
         self.check_errors()
 
     @property
@@ -1039,7 +1039,7 @@ class SMU(Channel):
     @adc_type.setter
     def adc_type(self, adc_type):
         adc_type = ADCType.get(adc_type)
-        self.write(f"AAD {self.channel}, {adc_type.value}")
+        self.write(f"AAD {self.id}, {adc_type.value}")
         self.check_errors()
 
     ######################################
@@ -1067,7 +1067,7 @@ class SMU(Channel):
                 comp_range = self.voltage_ranging.meas(comp_range).index
         else:
             raise ValueError("Source Type must be Current or Voltage.")
-        cmd += f" {self.channel}, {source_range}, {output}"
+        cmd += f" {self.id}, {source_range}, {output}"
         if not comp == "":
             cmd += f", {comp}"
             if not comp_polarity == "":
@@ -1104,14 +1104,14 @@ class SMU(Channel):
         """
         if source_type.upper() == "VOLTAGE":
             source_type = "VOLTAGE"
-            cmd = f"DV{self.channel}"
+            cmd = f"DV{self.id}"
             source_range = self.voltage_ranging.output(source_range).index
             unit = "V"
             if not comp_range == "":
                 comp_range = self.current_ranging.meas(comp_range).index
         elif source_type.upper() == "CURRENT":
             source_type = "CURRENT"
-            cmd = f"DI{self.channel}"
+            cmd = f"DI{self.id}"
             source_range = self.current_ranging.output(source_range).index
             unit = "A"
             if not comp_range == "":
@@ -1170,7 +1170,7 @@ class SMU(Channel):
     @meas_range_current.setter
     def meas_range_current(self, meas_range):
         meas_range_index = self.current_ranging.meas(meas_range).index
-        self.write(f"RI {self.channel}, {meas_range_index}")
+        self.write(f"RI {self.id}, {meas_range_index}")
         self.check_errors()
 
     @property
@@ -1187,7 +1187,7 @@ class SMU(Channel):
     @meas_range_voltage.setter
     def meas_range_voltage(self, meas_range):
         meas_range_index = self.voltage_ranging.meas(meas_range).index
-        self.write(f"RV {self.channel}, {meas_range_index}")
+        self.write(f"RV {self.id}, {meas_range_index}")
         self.check_errors()
 
     def meas_range_current_auto(self, mode, rate=50):
@@ -1198,9 +1198,9 @@ class SMU(Channel):
         """
         mode = strict_range(mode, range(1, 4))
         if mode == 1:
-            self.write(f"RM {self.channel}, {mode}")
+            self.write(f"RM {self.id}, {mode}")
         else:
-            self.write(f"RM {self.channel}, {mode}, {rate}")
+            self.write(f"RM {self.id}, {mode}, {rate}")
         self.write
 
     ######################################
@@ -1243,7 +1243,7 @@ class SMU(Channel):
                 raise ValueError("For Log Sweep Start and Stop Values must have the same polarity.")
         steps = strict_range(steps, range(1, 10002))
         # check on comp value not yet implemented
-        cmd += f"{self.channel}, {mode}, {source_range}, {start}, {stop}, {steps}, {comp}"
+        cmd += f"{self.id}, {mode}, {source_range}, {start}, {stop}, {steps}, {comp}"
         if not Pcomp == "":
             cmd += f", {Pcomp}"
         self.write(cmd)
@@ -1271,7 +1271,7 @@ class SMU(Channel):
         else:
             raise ValueError("Source Type must be Current or Voltage.")
         # check on comp value not yet implemented
-        cmd += f"{self.channel}, {source_range}, {start}, {stop}, {comp}"
+        cmd += f"{self.id}, {source_range}, {start}, {stop}, {comp}"
         if not Pcomp == "":
             cmd += f", {Pcomp}"
         self.write(cmd)
@@ -1303,7 +1303,7 @@ class SMU(Channel):
         else:
             raise ValueError("Source Type must be Current or Voltage.")
         # check on comp value not yet implemented
-        cmd += f"{self.channel}, {source_range}, {base}, {bias}, {comp}"
+        cmd += f"{self.id}, {source_range}, {base}, {bias}, {comp}"
         self.write(cmd)
         self.check_errors()
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -138,7 +138,7 @@ class AgilentB1500(SCPIMixin, Instrument):
                     prefix="smu",
                     type=module_type,
                     name=f"SMU{i}",
-                    channel=channel,
+                    slot=channel,
                 )
                 self._smu_references[channel] = self.smus[i]
                 self._smu_names[channel] = self.smus[i].name

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -946,7 +946,7 @@ class SMU(Channel):
         response = self.parent.query_learn(query_type)
         # query_learn returns settings of all smus
         # pick setting for this smu only
-        response = response[command + str(self.channel)]
+        response = response[command + str(self.id)]
         return response
 
     def check_errors(self):
@@ -956,12 +956,12 @@ class SMU(Channel):
     ##########################################
 
     def _query_status_raw(self):
-        return self.parent.query_learn(str(self.channel))
+        return self.parent.query_learn(str(self.id))
 
     @property
     def status(self):
         """Get status of the SMU."""
-        return self.parent.query_learn_header(str(self.channel))
+        return self.parent.query_learn_header(str(self.id))
 
     def enable(self):
         """Enable source/measurement channel. (``CN``)"""
@@ -994,9 +994,9 @@ class SMU(Channel):
             # only present if filters of all channels are off
             return False
         else:
-            if str(self.channel) in response["FL0"]:
+            if str(self.id) in response["FL0"]:
                 return False
-            elif str(self.channel) in response["FL1"]:
+            elif str(self.id) in response["FL1"]:
                 return True
             else:
                 raise NotImplementedError("Filter Value cannot be read!")
@@ -1328,7 +1328,7 @@ class SMU(Channel):
         :param steps: Number of steps for staircase sweep
         :param comp: Compliance current in A. The previous value is used if not set.
         """
-        cmd = _set_cv_parameters_base(self.channel, mode, start, stop, steps, comp)
+        cmd = _set_cv_parameters_base(self.id, mode, start, stop, steps, comp)
         self.write(cmd)
 
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -608,9 +608,7 @@ class AgilentB1500(SCPIMixin, Instrument):
         mode = MeasMode.get(mode)
         cmd = f"MM {mode.value}"
         for smu in args:
-            if isinstance(smu, SMU):
-                cmd += f", {smu.channel}"
-            elif isinstance(smu, CMU):
+            if isinstance(smu, (SMU, CMU)):
                 cmd += f", {smu.id}"
         self.write(cmd)
         self.check_errors()
@@ -1114,14 +1112,14 @@ class SMU(Channel):
         """
         if source_type.upper() == "VOLTAGE":
             source_type = "VOLTAGE"
-            cmd = "DV{ch}"
+            cmd = f"DI{self.id}"
             source_range = self.voltage_ranging.output(source_range).index
             unit = "V"
             if not comp_range == "":
                 comp_range = self.current_ranging.meas(comp_range).index
         elif source_type.upper() == "CURRENT":
             source_type = "CURRENT"
-            cmd = "DI{ch}"
+            cmd = f"DI{self.id}"
             source_range = self.current_ranging.output(source_range).index
             unit = "A"
             if not comp_range == "":
@@ -1211,7 +1209,6 @@ class SMU(Channel):
             self.write(f"RM {{ch}}, {mode}")
         else:
             self.write(f"RM {{ch}}, {mode}, {rate}")
-        self.write
 
     ######################################
     # Staircase Sweep Measurement: (WT, WM -> Instrument)

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -965,24 +965,24 @@ class SMU(Channel):
 
     def enable(self):
         """Enable source/measurement channel. (``CN``)"""
-        self.write(f"CN {self.id}")
+        self.write("CN {ch}")
 
     def disable(self):
         """Disable source/measurement channel. (``CL``)"""
-        self.write(f"CL {self.id}")
+        self.write("CL {ch}")
 
     def force_gnd(self):
         """Force output to 0 V immediately. (``DZ``)
 
         Current settings can be restored with :meth:`restore_settings`.
         """
-        self.write(f"DZ {self.id}")
+        self.write("DZ {ch}")
 
     def restore_settings(self):
         """Restore the settings of the channel to the state before
         using :meth:`force_gnd`. (``RZ``)
         """
-        self.write(f"RZ {self.id}")
+        self.write("RZ {ch}")
 
     @property
     def filter(self):
@@ -1004,7 +1004,7 @@ class SMU(Channel):
     @filter.setter
     def filter(self, setting):
         setting = strict_discrete_set(int(setting), (0, 1))
-        self.write(f"FL {setting}, {self.id}")
+        self.write(f"FL {setting}, {{ch}}")
         self.check_errors()
 
     @property
@@ -1017,7 +1017,7 @@ class SMU(Channel):
     @series_resistor.setter
     def series_resistor(self, setting):
         setting = strict_discrete_set(int(setting), (0, 1))
-        self.write(f"SSR {self.id}, {setting}")
+        self.write(f"SSR {{ch}}, {setting}")
         self.check_errors()
 
     @property
@@ -1033,7 +1033,7 @@ class SMU(Channel):
     @meas_op_mode.setter
     def meas_op_mode(self, op_mode):
         op_mode = MeasOpMode.get(op_mode)
-        self.write(f"CMM {self.id}, {op_mode.value}")
+        self.write(f"CMM {{ch}}, {op_mode.value}")
         self.check_errors()
 
     @property
@@ -1049,7 +1049,7 @@ class SMU(Channel):
     @adc_type.setter
     def adc_type(self, adc_type):
         adc_type = ADCType.get(adc_type)
-        self.write(f"AAD {self.id}, {adc_type.value}")
+        self.write(f"AAD {{ch}}, {adc_type.value}")
         self.check_errors()
 
     ######################################
@@ -1077,7 +1077,7 @@ class SMU(Channel):
                 comp_range = self.voltage_ranging.meas(comp_range).index
         else:
             raise ValueError("Source Type must be Current or Voltage.")
-        cmd += f" {self.id}, {source_range}, {output}"
+        cmd += f" {{ch}}, {source_range}, {output}"
         if not comp == "":
             cmd += f", {comp}"
             if not comp_polarity == "":
@@ -1114,14 +1114,14 @@ class SMU(Channel):
         """
         if source_type.upper() == "VOLTAGE":
             source_type = "VOLTAGE"
-            cmd = f"DV{self.id}"
+            cmd = "DV{ch}"
             source_range = self.voltage_ranging.output(source_range).index
             unit = "V"
             if not comp_range == "":
                 comp_range = self.current_ranging.meas(comp_range).index
         elif source_type.upper() == "CURRENT":
             source_type = "CURRENT"
-            cmd = f"DI{self.id}"
+            cmd = "DI{ch}"
             source_range = self.current_ranging.output(source_range).index
             unit = "A"
             if not comp_range == "":
@@ -1180,7 +1180,7 @@ class SMU(Channel):
     @meas_range_current.setter
     def meas_range_current(self, meas_range):
         meas_range_index = self.current_ranging.meas(meas_range).index
-        self.write(f"RI {self.id}, {meas_range_index}")
+        self.write(f"RI {{ch}}, {meas_range_index}")
         self.check_errors()
 
     @property
@@ -1197,7 +1197,7 @@ class SMU(Channel):
     @meas_range_voltage.setter
     def meas_range_voltage(self, meas_range):
         meas_range_index = self.voltage_ranging.meas(meas_range).index
-        self.write(f"RV {self.id}, {meas_range_index}")
+        self.write(f"RV {{ch}}, {meas_range_index}")
         self.check_errors()
 
     def meas_range_current_auto(self, mode, rate=50):
@@ -1208,9 +1208,9 @@ class SMU(Channel):
         """
         mode = strict_range(mode, range(1, 4))
         if mode == 1:
-            self.write(f"RM {self.id}, {mode}")
+            self.write(f"RM {{ch}}, {mode}")
         else:
-            self.write(f"RM {self.id}, {mode}, {rate}")
+            self.write(f"RM {{ch}}, {mode}, {rate}")
         self.write
 
     ######################################
@@ -1253,7 +1253,7 @@ class SMU(Channel):
                 raise ValueError("For Log Sweep Start and Stop Values must have the same polarity.")
         steps = strict_range(steps, range(1, 10002))
         # check on comp value not yet implemented
-        cmd += f"{self.id}, {mode}, {source_range}, {start}, {stop}, {steps}, {comp}"
+        cmd += f"{{ch}}, {mode}, {source_range}, {start}, {stop}, {steps}, {comp}"
         if not Pcomp == "":
             cmd += f", {Pcomp}"
         self.write(cmd)
@@ -1281,7 +1281,7 @@ class SMU(Channel):
         else:
             raise ValueError("Source Type must be Current or Voltage.")
         # check on comp value not yet implemented
-        cmd += f"{self.id}, {source_range}, {start}, {stop}, {comp}"
+        cmd += f"{{ch}}, {source_range}, {start}, {stop}, {comp}"
         if not Pcomp == "":
             cmd += f", {Pcomp}"
         self.write(cmd)
@@ -1313,7 +1313,7 @@ class SMU(Channel):
         else:
             raise ValueError("Source Type must be Current or Voltage.")
         # check on comp value not yet implemented
-        cmd += f"{self.id}, {source_range}, {base}, {bias}, {comp}"
+        cmd += f"{{ch}}, {source_range}, {base}, {bias}, {comp}"
         self.write(cmd)
         self.check_errors()
 
@@ -1663,7 +1663,7 @@ class SPGUChannel(Channel):
         source = SPGUSignalSource.get(source).value
         base_voltage = strict_range(base_voltage, (-40, 40))
         peak_voltage = strict_range(peak_voltage, (-40, 40))
-        self.write(f"SPV {self.id}, {source}, {base_voltage}, {peak_voltage}")
+        self.write(f"SPV {{ch}}, {source}, {base_voltage}, {peak_voltage}")
 
     def get_output_voltage(self, source=1):
         """Get the output voltage of the specified signal source. (``SPV?``)
@@ -1673,7 +1673,7 @@ class SPGUChannel(Channel):
         :rtype: tuple
         """
         source = SPGUSignalSource.get(source).value
-        response = self.ask(f"SPV? {self.id}, {source}")
+        response = self.ask(f"SPV? {{ch}}, {source}")
         base_voltage, peak_voltage = map(float, response.split(","))
         return base_voltage, peak_voltage
 
@@ -1710,7 +1710,7 @@ class SPGUChannel(Channel):
         source = SPGUSignalSource.get(source)
         if source == SPGUSignalSource.DC:
             raise ValueError("Pulse timings can only be set for pulse sources.")
-        command = f"SPT {self.id}, {source.value}, {delay}, {width}, {rise_time}"
+        command = f"SPT {{ch}}, {source.value}, {delay}, {width}, {rise_time}"
         if fall_time is not None:
             command += f", {fall_time}"
         self.write(command)
@@ -1727,7 +1727,7 @@ class SPGUChannel(Channel):
         :rtype: tuple
         """
         source = SPGUSignalSource.get(source).value
-        response = self.ask(f"SPT? {self.id}, {source}")
+        response = self.ask(f"SPT? {{ch}}, {source}")
         return tuple(map(float, response.split(",")))
 
     def apply_setup(self):
@@ -1738,7 +1738,7 @@ class SPGUChannel(Channel):
         * PG mode: output base voltage set by ``SPV`` command
         * ALWG mode: output initial value of waveform
         """
-        self.write(f"SPUPD {self.id}")
+        self.write("SPUPD {ch}")
 
 
 class CMU(Channel):
@@ -1827,7 +1827,7 @@ class CMU(Channel):
             step_source_trigger_delay_time, [0.0, delay_time]
         )
         self.write(
-            f"WTDCV {self.id}, {hold_time}, {delay_time}, {step_delay_time}, "
+            f"WTDCV {{ch}}, {hold_time}, {delay_time}, {step_delay_time}, "
             f"{step_source_trigger_delay_time}"
         )
 
@@ -1848,7 +1848,7 @@ class CMU(Channel):
         :param voltage: DC bias voltage in V
         """
         voltage = strict_range(voltage, [-100, 100])
-        self.write(f"DCV {self.id}, {voltage}")
+        self.write(f"DCV {{ch}}, {voltage}")
 
     def set_scuu_path(self, path: SCUUPath) -> None:
         """Set the connection path of the SMU CMU unify unit (SCUU). (``SSP``)
@@ -1874,7 +1874,7 @@ class CMU(Channel):
             log_settings_change(
                 0, 20, "100 uA", "Condition before the connection is changed from SMU to MFCMU"
             )
-        self.write(f"SSP {self.id}, {path.value}")
+        self.write(f"SSP {{ch}}, {path.value}")
 
 
 def _set_cv_parameters_base(

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -138,7 +138,7 @@ class AgilentB1500(SCPIMixin, Instrument):
                     i,
                     collection="smus",
                     prefix="smu",
-                    type=module_type,
+                    smu_type=module_type,
                     name=f"SMU{i}",
                     slot=channel,
                 )
@@ -908,17 +908,15 @@ class SMU(Channel):
 
     :param AgilentB1500 parent: Instance of the B1500 mainframe class
     :param int index: Index of the SMU
-    :param str type: Type of the SMU
+    :param str smu_type: Type of the SMU
     :param str name: Name of the SMU
     :param int slot: Slot number of the SMU
     """
 
-    def __init__(self, parent, index, type, name, slot, **kwargs):
-        super().__init__(parent, slot, **kwargs)
+    def __init__(self, parent, index, smu_type, name, slot, **kwargs):
         slot = strict_discrete_set(slot, range(1, 11))
-        self.channel = slot
-        type = strict_discrete_set(
-            type,
+        smu_type = strict_discrete_set(
+            smu_type,
             [
                 "HRSMU",
                 "MPSMU",
@@ -932,10 +930,12 @@ class SMU(Channel):
                 "UHVU",
             ],
         )
-        self.voltage_ranging = SMUVoltageRanging(type)
-        self.current_ranging = SMUCurrentRanging(type)
+        super().__init__(parent, slot, **kwargs)
+        self.channel = slot
+        self.voltage_ranging = SMUVoltageRanging(smu_type)
+        self.current_ranging = SMUCurrentRanging(smu_type)
         self.name = name
-        self.type = type
+        self.type = smu_type
 
     ##########################################
     # Wrappers of B1500 communication methods

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -74,7 +74,7 @@ class AgilentB1500Mock(AgilentB1500):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.spgu1 = SPGU(self, 1)
-        self.smu1 = SMU(self, number=1, type="HRSMU", name="test", channel=1)
+        self.smu1 = SMU(self, index=1, type="HRSMU", name="test", slot=1)
 
 
 class TestSMU:

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -26,6 +26,7 @@ import pytest
 
 from pymeasure.instruments.agilent import AgilentB1500
 from pymeasure.instruments.agilent.agilentB1500 import (
+    SMU,
     SPGU,
     ControlMode,
     PgSelectorConnectionStatus,
@@ -73,6 +74,29 @@ class AgilentB1500Mock(AgilentB1500):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.spgu1 = SPGU(self, 1)
+        self.smu1 = SMU(self, number=1, type="HRSMU", name="test", channel=1)
+
+
+class TestSMU:
+    """Tests for SMU module functionality."""
+
+    channel = 1
+
+    def test_enable(self):
+        """Test enable method."""
+        with expected_protocol(
+            AgilentB1500Mock,
+            [(f"CN {self.channel}", None)],
+        ) as inst:
+            inst.smu1.enable()
+
+    def test_disable(self):
+        """Test disable method."""
+        with expected_protocol(
+            AgilentB1500Mock,
+            [(f"CL {self.channel}", None)],
+        ) as inst:
+            inst.smu1.disable()
 
 
 class TestSPGU:

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -79,7 +79,7 @@ class AgilentB1500Mock(AgilentB1500):
         super().__init__(*args, **kwargs)
         self.spgu1 = SPGU(self, 1)
         self.cmu = CMU(self, 2)
-        self.smu1 = SMU(self, index=1, type="HRSMU", name="test", slot=1)
+        self.smu1 = SMU(self, index=1, smu_type="HRSMU", name="test", slot=1)
 
 
 class TestSMU:


### PR DESCRIPTION
A bit of context about the instrument and the current implementation to help understand this PR.

The instrument has 10 slots that can host various units (SMUs, SPGUs, CMUs, etc.). By querying the instrument, it is possible to determine which unit is installed in each slot. Thus, dynamic initialization of channels is required.

For example, 4 basekit SMUs can be installed in slots 4, 6, 7, 8. Current implementation of `AgilentB1500` class implies that users access SMUs through references such as `.smu1`, `.smu2`, etc. These identifiers do not correspond to the physical slot numbers but rather to the sequential count of detected SMUs. Thus, in the example above, the SMUs would be accessible as `.smu1`, `.smu2`, `.smu3`, `.smu4` respectively. The same approach of counting SMUs starting from the lowest slot number is mentioned in manual and used in Agilent EasyEXPERT Software.

In the PR I reworked the SMU class into the subclass of `Channel`, but kept the same logic of numerating SMUs, by using SMU count number for creating SMU references and SMU slot number for initialization of the SMU itself. This way, SMUs are available by their count number via `.smus[1]` or `.smu1`, but the commands itself use `self.id` = 4 that is the actual slot number.

Existing `AgilentB1500` SMU properties were reworked as well to support backward compatibility.