### PR TITLE
SCPI mixin test

### DIFF
--- a/docs/dev/adding_instruments/instrument.rst
+++ b/docs/dev/adding_instruments/instrument.rst
@@ -139,6 +139,7 @@ For example, if an instrument complies to SCPI standards, you can add :class:`~p
 
 This mixin adds default SCPI properties like :attr:`~pymeasure.instruments.generic_types.SCPIMixin.id`, :attr:`~pymeasure.instruments.generic_types.SCPIMixin.status` and default methods like :meth:`~pymeasure.instruments.generic_types.SCPIMixin.clear` and :meth:`~pymeasure.instruments.generic_types.SCPIMixin.reset` to :code:`SomeSCPIInstrument`.
 
+You can check whether your instrument can safely inherit from :class:`~pymeasure.instruments.generic_types.SCPIMixin` by running :code:`pytest -k scpi_mixin --device-address "<instrument-address>"`.
 
 Frequent properties
 -------------------

--- a/docs/dev/adding_instruments/tests.rst
+++ b/docs/dev/adding_instruments/tests.rst
@@ -229,6 +229,6 @@ In this case, do not specify the fixture's scope, so it is called again for ever
 
 To run the test, specify the address of the device to be used via the :code:`--device-address` command line argument and limit pytest to the relevant tests.
 You can filter tests with the :code:`-k` option or you can specify the filename.
-For example, if your tests are in a file called :code:`test_extreme5000_with_device.py`, invoke pytest with :code:`pytest -k extreme5000 --device-address TCPIP::192.168.0.123::INSTR"`.
+For example, if your tests are in a file called :code:`test_extreme5000_with_device.py`, invoke pytest with :code:`pytest -k extreme5000 --device-address "TCPIP::192.168.0.123::INSTR"`.
 
 There might also be tests where manual intervention is necessary. In this case, skip the test by prepending the test function with a :code:`@pytest.mark.skip(reason="A human needs to press a button.")` decorator.

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -132,7 +132,6 @@ grandfathered_docstring_instruments = [
     "KeysightDSOX1102G",
     "IPS120_10",
     "ITC503",
-    "TSL550",
     "PS120_10",
     "SFM",
     "SG380",

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -132,6 +132,7 @@ grandfathered_docstring_instruments = [
     "KeysightDSOX1102G",
     "IPS120_10",
     "ITC503",
+    "TSL550",
     "PS120_10",
     "SFM",
     "SG380",

--- a/tests/instruments/test_scpi_mixin_with_device.py
+++ b/tests/instruments/test_scpi_mixin_with_device.py
@@ -1,0 +1,65 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+import pytest
+
+from pymeasure.instruments import Instrument, SCPIMixin
+
+
+class SCPIDevice(SCPIMixin, Instrument):
+    def __init__(self, adapter, name="SCPI Compatible Device", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
+
+@pytest.fixture(scope="module")
+def scpi_device(connected_device_address):
+    scpi_device = SCPIDevice(connected_device_address)
+    scpi_device.clear()
+    return scpi_device
+
+
+def test_complete(scpi_device):
+    assert scpi_device.complete == "1"
+
+
+def test_status(scpi_device):
+    assert scpi_device.status
+
+
+def test_options(scpi_device):
+    assert scpi_device.options
+
+
+def test_id(scpi_device):
+    assert scpi_device.id
+
+
+def test_next_error(scpi_device):
+    err = scpi_device.next_error
+    assert int(err[0]) == 0
+
+
+def test_reset(scpi_device):
+    scpi_device.reset()


### PR DESCRIPTION
Added a pytest module to test whether a generic device can safely inherit from SCPIMixin. Can be run using `pytest -k scpi_mixin --device-address "GPIB0::0"`. Added a section in the documentation to explain this.

The motivation here is that there are devices that, while not conforming *exactly* to IEEE 488.2, have enough compatibility to warrant inheriting from SCPIMixin. This test provides an easy way for developers to check this.