### PR TITLE
Replace load_module() by exec_module()

### DIFF
--- a/pymeasure/experiment/procedure.py
+++ b/pymeasure/experiment/procedure.py
@@ -26,7 +26,7 @@ import logging
 import sys
 import inspect
 from copy import deepcopy
-from importlib.machinery import SourceFileLoader
+import importlib.util
 import re
 from pint import UndefinedUnitError
 
@@ -352,7 +352,10 @@ class ProcedureWrapper:
         self.__dict__.update(state)
 
         # Restore the procedure
-        module = SourceFileLoader(self._module, self._file).load_module()
+        spec = importlib.util.spec_from_file_location(self._module, self._file)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[self._module] = module
+        spec.loader.exec_module(module)
         cls = getattr(module, self._class)
 
         self.procedure = cls()

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -28,7 +28,7 @@ import os
 import re
 import sys
 from importlib import import_module
-from importlib.machinery import SourceFileLoader
+import importlib.util
 from datetime import datetime
 from string import Formatter
 
@@ -257,7 +257,10 @@ class Results:
         self.__dict__.update(state)
 
         # Restore the procedure
-        module = SourceFileLoader(self._module, self._file).load_module()
+        spec = importlib.util.spec_from_file_location(self._module, self._file)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[self._module] = module
+        spec.loader.exec_module(module)
         cls = getattr(module, self._class)
 
         self.procedure = cls()


### PR DESCRIPTION
Method "load_module()" is deprecated and will be removed in Python 3.15. It is replaced by "exec_module" method.
Affected files:
 - experiment/procedure.py
 - experiment/results.py

The code modification was supported by Mistral.ai