### PR TITLE
Updating Read the Docs to Ubuntu 24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "mambaforge-4.10"
 


### PR DESCRIPTION
This PR bumps the Read the Docs image to Ubuntu 24.04 to address the following:

> We are announcing the deprecation of the Ubuntu 20.04 LTS build image (build.os: ubuntu-20.04) on Read the Docs. After June 1, 2026, projects still using this image will fail when building until they are updated to a supported Ubuntu image.

https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/