### PR TITLE
Basic keysightB2912A PSMU Implementation

### DIFF
--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -18,3 +18,4 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysightE3631A
    keysight81160A
    keysightPNA
+   keysightB2912A

--- a/docs/api/instruments/keysight/keysightB2912A.rst
+++ b/docs/api/instruments/keysight/keysightB2912A.rst
@@ -1,0 +1,11 @@
+##############################################
+Keysight B2912A Precision Source Measure Units
+##############################################
+
+.. autoclass:: pymeasure.instruments.keysight.KeysightB2912A
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightB2912A.KeysightB2912AChannel
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -23,6 +23,7 @@
 #
 
 from .keysight81160A import Keysight81160A
+from .keysightB2912A import KeysightB2912A
 from .keysightDSOX1102G import KeysightDSOX1102G
 from .keysightE3631A import KeysightE3631A
 from .keysightE36312A import KeysightE36312A

--- a/pymeasure/instruments/keysight/keysightB2912A.py
+++ b/pymeasure/instruments/keysight/keysightB2912A.py
@@ -245,21 +245,25 @@ class KeysightB2912AChannel(Channel):
         """Fetch the a measurement array as float64"""
         old_format = self.ask(":form?").strip()
         self.write(":form REAL,64")
-        self.write(f":fetc:arr:{v_or_c}? (@{self.id})")
-        # We can't use instrument `binary_values` since we need to set
-        # break_on_termchar=True.
-        raw_bytes = self.read_bytes(-1, break_on_termchar=True)
-        assert chr(raw_bytes[0]) == "#"
+        try:
+            self.write(f":fetc:arr:{v_or_c}? (@{self.id})")
+            # We can't use instrument `binary_values` since we need to set
+            # break_on_termchar=True.
+            raw_bytes = self.read_bytes(-1, break_on_termchar=True)
+        finally:
+            self.write(f":form {old_format}")
+
+        if not raw_bytes.startswith(b"#"):
+            raise ValueError("Invalid IEEE-488.2 block header")
         size_nbytes = int(chr(raw_bytes[1]))  # size of the size integer
         nbytes = int(raw_bytes[2:2 + size_nbytes].decode())
-        self.write(f":form {old_format}")
-        # breakpoint()
         raw_bytes = raw_bytes[2 + size_nbytes:-1]  # remove headers + newline byte
         values = np.frombuffer(
             raw_bytes,
             dtype=np.dtype(">d"),
         ).astype(np.float64)
-        assert values.size == nbytes // 8
+        if values.size != nbytes // 8:
+            raise ValueError("Binary block length does not match float64 payload size")
         return values
 
     trigger_source = Channel.setting(
@@ -307,20 +311,20 @@ class KeysightB2912AChannel(Channel):
     )
 
     source_trigger_count = Channel.setting(
-        ":trig{ch}:tran:coun %g",
+        ":trig{ch}:tran:coun %d",
         """Set the trigger count of the source trigger (from 1 to 100000 or 2147483647).
         Note that this is not readable. Set to 2147483647 for infinite.
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
-        values=[[1, 100000], 2147483647],
+        values=[[1, 100000], [2147483647]],
     )
 
     measurement_trigger_count = Channel.setting(
-        ":trig{ch}:acq:coun %g",
+        ":trig{ch}:acq:coun %d",
         """Set the trigger count of the measurement trigger. Note that this is not readable.
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
-        values=[[1, 100000], 2147483647],
+        values=[[1, 100000], [2147483647]],
     )
 
     def initiate(self):
@@ -331,7 +335,7 @@ class KeysightB2912AChannel(Channel):
         ":idle{ch}:all?",
         """Get whether the triggering system is idle
         (i.e. all source & measurements are complete)""",
-        cast=bool,
+        cast=lambda value: bool(int(value)),
     )
 
     def wait_idle(self, timeout=1):

--- a/pymeasure/instruments/keysight/keysightB2912A.py
+++ b/pymeasure/instruments/keysight/keysightB2912A.py
@@ -1,0 +1,425 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+from datetime import datetime, timedelta
+
+import numpy as np
+from pyvisa import VisaIOError
+
+from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range, joined_validators
+
+
+class KeysightB2912AChannel(Channel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    #######################################################################
+    #                           source functions                          #
+    #######################################################################
+
+    source_output_enabled = Channel.control(
+        ":outp{ch}?",
+        ":outp{ch} %s",
+        """Control whether to enable source output (bool).
+        """,
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: 0.0, True: 1.0},
+    )
+
+    source_output_mode = Channel.control(
+        ":sour{ch}:func:mode?",
+        ":sour{ch}:func:mode %s",
+        """Control the source output mode (str). Options are "CURR" or "VOLT".
+        """,
+        validator=strict_discrete_set,
+        values=["CURR", "VOLT"],
+    )
+
+    source_output_shape = Channel.control(
+        ":sour{ch}:func:shap?",
+        ":sour{ch}:func:shap %s",
+        """Control the source output mode (str). Options are "DC" or "PULS".
+        """,
+        validator=strict_discrete_set,
+        values=["DC", "PULS"],
+    )
+
+    source_current = Channel.control(
+        ":sour{ch}:curr?",
+        ":sour{ch}:curr %g",
+        """Control the source current (float). This takes immediate
+        effect. `source_output_mode` needs to be set to "CURR".  """,
+        validator=strict_range,
+        values=[-3, 3],
+    )
+
+    source_current_triggered = Channel.control(
+        ":sour{ch}:curr:trig?",
+        ":sour{ch}:curr:trig %g",
+        """Control the /triggered/ source current (float). This takes immediate
+        effect. `source_output_mode` needs to be set to "CURR".  """,
+        validator=strict_range,
+        values=[-3, 3],
+    )
+
+    source_voltage = Channel.control(
+        ":sour{ch}:volt?",
+        ":sour{ch}:volt %g",
+        """Control the source voltage (float). This takes immediate
+        effect. `source_output_mode` needs to be set to "VOLT". See also `
+        source_voltage_triggered`. """,
+        validator=strict_range,
+        values=[-210, 210],
+    )
+
+    source_voltage_triggered = Channel.control(
+        ":sour{ch}:volt:trig?",
+        ":sour{ch}:volt:trig %g",
+        """Control the /triggered/ source voltage (float). This takes immediate
+        effect. `source_output_mode` needs to be set to "VOLT".  """,
+        validator=strict_range,
+        values=[-210, 210],
+    )
+
+    output_protection_enabled = Channel.control(
+        ":outp{ch}:prot?",
+        ":outp{ch}:prot %s",
+        """Control whether, when the compliance value is hit, the channel is
+        disabled. """,
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: 0.0, True: 1.0},
+    )
+
+    compliance_current = Channel.control(
+        ":sens{ch}:curr:prot?",
+        ":sens{ch}:curr:prot %g",
+        """Control the compliance current (float).""",
+        validator=strict_range,
+        values=[-3, 3],
+    )
+
+    compliance_voltage = Channel.control(
+        ":sens{ch}:volt:prot?",
+        ":sens{ch}:volt:prot %g",
+        """Control the compliance voltage (float).""",
+        validator=strict_range,
+        values=[-210, 210],
+    )
+
+    pulse_delay = Channel.control(
+        ":sour{ch}:pulse:del?",
+        ":sour{ch}:pulse:del %g",
+        """Control the pulse delay in s (float).""",
+        validator=strict_range,
+        values=[0, 99999],
+    )
+
+    pulse_width = Channel.control(
+        ":sour{ch}:pulse:widt?",
+        ":sour{ch}:pulse:widt %g",
+        """Control the pulse width in s (float).""",
+        validator=strict_range,
+        values=[0, 99999],
+    )
+
+    #######################################################################
+    #                          measure functions                          #
+    #######################################################################
+
+    current_measurement_range_auto = Channel.control(
+        ":sens{ch}:curr:range:auto?",
+        ":sens{ch}:curr:range:auto %s",
+        """Control whether the current measurement range is automatically determined.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: 0.0, True: 1.0},
+    )
+
+    current_measurement_range = Channel.control(
+        ":sens{ch}:curr:rang?",
+        ":sens{ch}:curr:range %g",
+        """Control the the range of a current measurement. Ensure that
+        `current_measurement_range_auto` is set to false before use.""",
+    )
+
+    current_measurement_speed = Channel.control(
+        ":sens{ch}:curr:aper?",
+        ":sens{ch}:curr:aper %g",
+        """Control the measurement speed for a current measurement in seconds.
+        This the integration time of a single measurement.
+        Consider also the alternative `current_measurement_speed_nplc`
+        """,
+    )
+
+    current_measurement_speed_nplc = Channel.control(
+        ":sens{ch}:curr:nplc?",
+        ":sens{ch}:curr:nplc %g",
+        """Control the measurement speed for a current measurement in #powerline cycles.
+        This the integration time of a single measurement.
+        Consider also the alternative `current_measurement_speed`.
+        """,
+        validator=strict_range,
+        values=[4.8e-4, 120],  # 60-Hz system
+    )
+
+    measured_current = Channel.measurement(
+        ":meas:curr? (@{ch})",
+        """Measure current (perform a spot measurement)""",
+    )
+
+    @property
+    def measured_current_array(self):
+        """Get the measured current array (as float64)"""
+        return self._get_measured_array("curr")
+
+    voltage_measurement_range_auto = Channel.control(
+        ":sens{ch}:volt:range:auto?",
+        ":sens{ch}:volt:range:auto %s",
+        """Control whether the voltage measurement range is automatically determined.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={False: 0.0, True: 1.0},
+    )
+
+    voltage_measurement_range = Channel.control(
+        ":sens{ch}:volt:rang?",
+        ":sens{ch}:volt:range %g",
+        """Control the the range of a voltage measurement. Ensure that
+        `voltage_measurement_range_auto` is set to false before use.""",
+    )
+
+    voltage_measurement_speed = Channel.control(
+        ":sens{ch}:volt:aper?",
+        ":sens{ch}:volt:aper %g",
+        """Set the measurement speed for a voltage measurement in seconds.
+        This the integration time of a single measurement.
+        Consider also the alternative `voltage_measurement_speed_nplc`.
+        """,
+    )
+
+    voltage_measurement_speed_nplc = Channel.control(
+        ":sens{ch}:volt:nplc?",
+        ":sens{ch}:volt:nplc %g",
+        """Control the measurement speed for a current measurement in #powerline cycles.
+        This the integration time of a single measurement.
+        Consider also the alternative `voltage_measurement_speed`.
+        """,
+        validator=strict_range,
+        values=[4.8e-4, 120],  # 60-Hz system
+    )
+
+    measured_voltage = Channel.measurement(
+        ":meas:volt? (@{ch})",
+        """Measure voltage (perform spot measurement)""",
+    )
+
+    @property
+    def measured_voltage_array(self):
+        """Get the measured voltage array (as float64)"""
+        return self._get_measured_array("volt")
+
+    def _get_measured_array(self, v_or_c):
+        """Fetch the a measurement array as float64"""
+        old_format = self.ask(":form?").strip()
+        self.write(":form REAL,64")
+        self.write(f":fetc:arr:{v_or_c}? (@{self.id})")
+        # We can't use instrument `binary_values` since we need to set
+        # break_on_termchar=True.
+        raw_bytes = self.read_bytes(-1, break_on_termchar=True)
+        assert chr(raw_bytes[0]) == "#"
+        size_nbytes = int(chr(raw_bytes[1]))  # size of the size integer
+        nbytes = int(raw_bytes[2:2 + size_nbytes].decode())
+        self.write(f":form {old_format}")
+        # breakpoint()
+        raw_bytes = raw_bytes[2 + size_nbytes:-1]  # remove headers + newline byte
+        values = np.frombuffer(
+            raw_bytes,
+            dtype=np.dtype(">d"),
+        ).astype(np.float64)
+        assert values.size == nbytes // 8
+        return values
+
+    trigger_source = Channel.setting(
+        ":trig{ch}:sour %s",
+        """Set the trigger source. Currently supported options are "TIM" (internal timer) and "AINT"
+        (auto). Note that this is not readable.
+
+        If switching from an active triggering sequence (i.e. auto (AINT) & trigger count set to
+        infinite), you'll need to call the abort() method first to avoid an error.  """,
+        validator=strict_discrete_set,
+        values=["TIM", "AINT"],  # "AUTO", "BUS", "INT1" "INT2", "LAN"
+    )
+
+    source_trigger_delay = Channel.control(
+        ":trig{ch}:tran:del?",
+        ":trig{ch}:tran:del %g",
+        """Control the source delay time.
+        """,
+    )
+
+    measurement_trigger_delay = Channel.control(
+        ":trig{ch}:acq:del?",
+        ":trig{ch}:acq:del %g",
+        """Control the measurement delay time.
+        """,
+    )
+
+    source_trigger_timer_period = Channel.setting(
+        ":trig{ch}:tran:tim %s",
+        """Control the trigger period. `trigger_source` needs to be set to "TIM".
+        Note that this is not readable.
+        """,
+        validator=joined_validators(strict_range, strict_discrete_set),
+        values=[[1e-5, 1e5], ["MIN", "MAX", "DEF"]],
+        set_process=lambda v: v if isinstance(v, str) else f"{v:g}",
+    )
+
+    measurement_trigger_timer_period = Channel.setting(
+        ":trig{ch}:acq:tim %s",
+        """Set the trigger period of the measurement trigger. `trigger_source`
+        needs to be set to "TIM". Note that this is not readable.""",
+        validator=joined_validators(strict_range, strict_discrete_set),
+        values=[[1e-5, 1e5], ["MIN", "MAX", "DEF"]],
+        set_process=lambda v: v if isinstance(v, str) else f"{v:g}",
+    )
+
+    source_trigger_count = Channel.setting(
+        ":trig{ch}:tran:coun %g",
+        """Set the trigger count of the source trigger (from 1 to 100000 or 2147483647).
+        Note that this is not readable. Set to 2147483647 for infinite.
+        """,
+        validator=joined_validators(strict_range, strict_discrete_set),
+        values=[[1, 100000], 2147483647],
+    )
+
+    measurement_trigger_count = Channel.setting(
+        ":trig{ch}:acq:coun %g",
+        """Set the trigger count of the measurement trigger. Note that this is not readable.
+        """,
+        validator=joined_validators(strict_range, strict_discrete_set),
+        values=[[1, 100000], 2147483647],
+    )
+
+    def initiate(self):
+        """This is the B2912A manual's terminology for triggering."""
+        self.write(":INIT (@{ch})")
+
+    idle = Channel.measurement(
+        ":idle{ch}:all?",
+        """Get whether the triggering system is idle
+        (i.e. all source & measurements are complete)""",
+        cast=bool,
+    )
+
+    def wait_idle(self, timeout=1):
+        """Block until all device actions (source and measurements) are complete.
+
+        Parameters
+        ----------
+        timeout : float
+            Timeout in seconds (default 1).
+
+        Raises
+        ------
+        ValueError
+            If the timeout is reached before the channel becomes idle.
+        """
+        end = datetime.now() + timedelta(seconds=timeout)
+        err = ValueError("timeout waiting for idle")
+        while True:
+            try:
+                if self.idle:
+                    return
+                if datetime.now() >= end:
+                    raise err
+            except VisaIOError as e:
+                err = e
+                if datetime.now() >= end:
+                    raise err
+
+    def abort(self):
+        """Abort any acquisition our source output device actions."""
+        self.write(":ABOR:ALL (@{ch})")
+
+
+class KeysightB2912A(SCPIMixin, Instrument):
+    """Represents the Keysight B2912A Precision Source/Measure Unit.
+
+    .. code-block:: python
+
+        psmu = KeysightB2912A(resource)
+    """
+
+    ch1 = Instrument.ChannelCreator(KeysightB2912AChannel, 1)
+    ch2 = Instrument.ChannelCreator(KeysightB2912AChannel, 2)
+
+    def __init__(self, adapter, name="Keysight B2912A PSMU", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
+    def wait_for_complete(self, timeout=1):
+        """Like the `SCPIMixin.complete` property, but tries until the
+        `timeout` (in seconds) has passed. Note that this does not
+        block until the trigger IDLE state (i.e. it does not wait for
+        measurements to be complete)
+
+        """
+        end = datetime.now() + timedelta(seconds=timeout)
+        err = ValueError("timeout is too short.")
+        need_to_clear = False
+        while True:
+            try:
+                retval = self.complete
+                if need_to_clear:
+                    self.clear()
+                if int(retval) == 1:
+                    return retval
+                # Not complete yet, check timeout before next poll
+                if datetime.now() >= end:
+                    raise err
+            except VisaIOError as e:
+                # an error in the isntr is generated if the communication times
+                # out. the need_to_clear flag keeps tracks of this and clears
+                # it. TODO should we call check_error instead to ensure there
+                # are no other errors?
+                need_to_clear = True
+                err = e
+                if datetime.now() >= end:
+                    raise err
+
+    def pop_err(self):
+        """Pop an error off the device's error queue. Returns a tuple
+        containing the code and error description. An error code 0
+        indicates success.
+
+        The Error queue can be cleared using the standard SCPI
+        ``KeysightB2912A.clear()`` method.
+
+        """
+        error_str = self.ask("SYST:ERR?").strip()
+        error_code_str, error_desc_str = error_str.split(",")
+        error_code = int(error_code_str)
+        error_desc = error_desc_str.strip('"')
+        return error_code, error_desc

--- a/pymeasure/instruments/keysight/keysightB2912A.py
+++ b/pymeasure/instruments/keysight/keysightB2912A.py
@@ -31,9 +31,6 @@ from pymeasure.instruments.validators import strict_discrete_set, strict_range, 
 
 
 class KeysightB2912AChannel(Channel):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     #######################################################################
     #                           source functions                          #
     #######################################################################
@@ -60,7 +57,7 @@ class KeysightB2912AChannel(Channel):
     source_output_shape = Channel.control(
         ":sour{ch}:func:shap?",
         ":sour{ch}:func:shap %s",
-        """Control the source output mode (str). Options are "DC" or "PULS".
+        """Control the source output shape (str). Options are "DC" or "PULS".
         """,
         validator=strict_discrete_set,
         values=["DC", "PULS"],
@@ -161,7 +158,7 @@ class KeysightB2912AChannel(Channel):
     current_measurement_range = Channel.control(
         ":sens{ch}:curr:rang?",
         ":sens{ch}:curr:range %g",
-        """Control the the range of a current measurement. Ensure that
+        """Control the range of a current measurement. Ensure that
         `current_measurement_range_auto` is set to false before use.""",
     )
 
@@ -207,14 +204,14 @@ class KeysightB2912AChannel(Channel):
     voltage_measurement_range = Channel.control(
         ":sens{ch}:volt:rang?",
         ":sens{ch}:volt:range %g",
-        """Control the the range of a voltage measurement. Ensure that
+        """Control the range of a voltage measurement. Ensure that
         `voltage_measurement_range_auto` is set to false before use.""",
     )
 
     voltage_measurement_speed = Channel.control(
         ":sens{ch}:volt:aper?",
         ":sens{ch}:volt:aper %g",
-        """Set the measurement speed for a voltage measurement in seconds.
+        """Control the measurement speed for a voltage measurement in seconds.
         This the integration time of a single measurement.
         Consider also the alternative `voltage_measurement_speed_nplc`.
         """,
@@ -293,7 +290,7 @@ class KeysightB2912AChannel(Channel):
 
     source_trigger_timer_period = Channel.setting(
         ":trig{ch}:tran:tim %s",
-        """Control the trigger period. `trigger_source` needs to be set to "TIM".
+        """Set the trigger period. `trigger_source` needs to be set to "TIM".
         Note that this is not readable.
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
@@ -362,10 +359,10 @@ class KeysightB2912AChannel(Channel):
             except VisaIOError as e:
                 err = e
                 if datetime.now() >= end:
-                    raise err
+                    raise e from None
 
     def abort(self):
-        """Abort any acquisition our source output device actions."""
+        """Abort any acquisition or source output device actions."""
         self.write(":ABOR:ALL (@{ch})")
 
 
@@ -411,7 +408,7 @@ class KeysightB2912A(SCPIMixin, Instrument):
                 need_to_clear = True
                 err = e
                 if datetime.now() >= end:
-                    raise err
+                    raise e from None
 
     def pop_err(self):
         """Pop an error off the device's error queue. Returns a tuple

--- a/pymeasure/instruments/keysight/keysightB2912A.py
+++ b/pymeasure/instruments/keysight/keysightB2912A.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2025 PyMeasure Developers
+# Copyright (c) 2013-2026 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,10 +24,12 @@
 from datetime import datetime, timedelta
 
 import numpy as np
-from pyvisa import VisaIOError
-
 from pymeasure.instruments import Channel, Instrument, SCPIMixin
-from pymeasure.instruments.validators import strict_discrete_set, strict_range, joined_validators
+from pymeasure.instruments.validators import (
+    joined_validators,
+    strict_discrete_set,
+    strict_range,
+)
 
 
 class KeysightB2912AChannel(Channel):
@@ -66,8 +68,8 @@ class KeysightB2912AChannel(Channel):
     source_current = Channel.control(
         ":sour{ch}:curr?",
         ":sour{ch}:curr %g",
-        """Control the source current (float). This takes immediate
-        effect. `source_output_mode` needs to be set to "CURR".  """,
+        """Control the source current in Amps (float). This takes immediate
+        effect. :attr:`source_output_mode` needs to be set to "CURR".  """,
         validator=strict_range,
         values=[-3, 3],
     )
@@ -75,8 +77,8 @@ class KeysightB2912AChannel(Channel):
     source_current_triggered = Channel.control(
         ":sour{ch}:curr:trig?",
         ":sour{ch}:curr:trig %g",
-        """Control the /triggered/ source current (float). This takes immediate
-        effect. `source_output_mode` needs to be set to "CURR".  """,
+        """Control the *triggered* source current in Amps (float). This takes immediate
+        effect. :attr:`source_output_mode` needs to be set to "CURR".  """,
         validator=strict_range,
         values=[-3, 3],
     )
@@ -84,9 +86,9 @@ class KeysightB2912AChannel(Channel):
     source_voltage = Channel.control(
         ":sour{ch}:volt?",
         ":sour{ch}:volt %g",
-        """Control the source voltage (float). This takes immediate
-        effect. `source_output_mode` needs to be set to "VOLT". See also `
-        source_voltage_triggered`. """,
+        """Control the source voltage in Volts (float). This takes immediate
+        effect. :attr:`source_output_mode` needs to be set to "VOLT". See also
+        :attr:`source_voltage_triggered`. """,
         validator=strict_range,
         values=[-210, 210],
     )
@@ -94,8 +96,8 @@ class KeysightB2912AChannel(Channel):
     source_voltage_triggered = Channel.control(
         ":sour{ch}:volt:trig?",
         ":sour{ch}:volt:trig %g",
-        """Control the /triggered/ source voltage (float). This takes immediate
-        effect. `source_output_mode` needs to be set to "VOLT".  """,
+        """Control the *triggered* source voltage in Volts (float). This takes immediate
+        effect. :attr:`source_output_mode` needs to be set to "VOLT".  """,
         validator=strict_range,
         values=[-210, 210],
     )
@@ -113,7 +115,7 @@ class KeysightB2912AChannel(Channel):
     compliance_current = Channel.control(
         ":sens{ch}:curr:prot?",
         ":sens{ch}:curr:prot %g",
-        """Control the compliance current (float).""",
+        """Control the compliance current in Amps (float).""",
         validator=strict_range,
         values=[-3, 3],
     )
@@ -121,7 +123,7 @@ class KeysightB2912AChannel(Channel):
     compliance_voltage = Channel.control(
         ":sens{ch}:volt:prot?",
         ":sens{ch}:volt:prot %g",
-        """Control the compliance voltage (float).""",
+        """Control the compliance voltage in Volts (float).""",
         validator=strict_range,
         values=[-210, 210],
     )
@@ -129,7 +131,7 @@ class KeysightB2912AChannel(Channel):
     pulse_delay = Channel.control(
         ":sour{ch}:pulse:del?",
         ":sour{ch}:pulse:del %g",
-        """Control the pulse delay in s (float).""",
+        """Control the pulse delay in seconds (float).""",
         validator=strict_range,
         values=[0, 99999],
     )
@@ -137,7 +139,7 @@ class KeysightB2912AChannel(Channel):
     pulse_width = Channel.control(
         ":sour{ch}:pulse:widt?",
         ":sour{ch}:pulse:widt %g",
-        """Control the pulse width in s (float).""",
+        """Control the pulse width in seconds (float).""",
         validator=strict_range,
         values=[0, 99999],
     )
@@ -244,54 +246,56 @@ class KeysightB2912AChannel(Channel):
         self.write(":form REAL,64")
         try:
             self.write(f":fetc:arr:{v_or_c}? (@{self.id})")
-            # We can't use instrument `binary_values` since we need to set
-            # break_on_termchar=True.
-            raw_bytes = self.read_bytes(-1, break_on_termchar=True)
+            # Parse the IEEE-488.2 definite-length block by reading its header
+            # first, so we can read exactly the advertised number of payload
+            # bytes. This is more robust than reading the whole message with
+            # break_on_termchar=True, since the binary payload may itself contain
+            # bytes equal to the termination character.
+            header = self.read_bytes(2)  # "#" and the size-of-size digit
+            if not header.startswith(b"#"):
+                raise ValueError("Invalid IEEE-488.2 block header")
+            size_nbytes = int(chr(header[1]))  # size of the size integer
+            nbytes = int(self.read_bytes(size_nbytes).decode())
+            raw_bytes = self.read_bytes(nbytes)
+            if len(raw_bytes) != nbytes:
+                raise ValueError("Incomplete IEEE-488.2 payload")
+            self.read_bytes(1)  # consume the trailing termination character
         finally:
             self.write(f":form {old_format}")
 
-        if not raw_bytes.startswith(b"#"):
-            raise ValueError("Invalid IEEE-488.2 block header")
-        size_nbytes = int(chr(raw_bytes[1]))  # size of the size integer
-        nbytes = int(raw_bytes[2:2 + size_nbytes].decode())
-        raw_bytes = raw_bytes[2 + size_nbytes:-1]  # remove headers + newline byte
-        values = np.frombuffer(
+        return np.frombuffer(
             raw_bytes,
             dtype=np.dtype(">d"),
         ).astype(np.float64)
-        if values.size != nbytes // 8:
-            raise ValueError("Binary block length does not match float64 payload size")
-        return values
 
     trigger_source = Channel.setting(
         ":trig{ch}:sour %s",
         """Set the trigger source. Currently supported options are "TIM" (internal timer) and "AINT"
-        (auto). Note that this is not readable.
+        (auto).
 
         If switching from an active triggering sequence (i.e. auto (AINT) & trigger count set to
-        infinite), you'll need to call the abort() method first to avoid an error.  """,
+        infinite), you'll need to call the :meth:`abort()` method first to avoid an error.  """,
         validator=strict_discrete_set,
-        values=["TIM", "AINT"],  # "AUTO", "BUS", "INT1" "INT2", "LAN"
+        values=["TIM", "AINT"],  # instrument also supports "BUS", "INT1" "INT2", "LAN"
     )
 
     source_trigger_delay = Channel.control(
         ":trig{ch}:tran:del?",
         ":trig{ch}:tran:del %g",
-        """Control the source delay time.
+        """Control the source delay time in seconds.
         """,
     )
 
     measurement_trigger_delay = Channel.control(
         ":trig{ch}:acq:del?",
         ":trig{ch}:acq:del %g",
-        """Control the measurement delay time.
+        """Control the measurement delay time in seconds.
         """,
     )
 
     source_trigger_timer_period = Channel.setting(
         ":trig{ch}:tran:tim %s",
-        """Set the trigger period. `trigger_source` needs to be set to "TIM".
-        Note that this is not readable.
+        """Set the trigger period. :attr:`trigger_source` needs to be set to "TIM".
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
         values=[[1e-5, 1e5], ["MIN", "MAX", "DEF"]],
@@ -300,8 +304,8 @@ class KeysightB2912AChannel(Channel):
 
     measurement_trigger_timer_period = Channel.setting(
         ":trig{ch}:acq:tim %s",
-        """Set the trigger period of the measurement trigger. `trigger_source`
-        needs to be set to "TIM". Note that this is not readable.""",
+        """Set the trigger period of the measurement trigger. :attr:`trigger_source`
+        needs to be set to "TIM".""",
         validator=joined_validators(strict_range, strict_discrete_set),
         values=[[1e-5, 1e5], ["MIN", "MAX", "DEF"]],
         set_process=lambda v: v if isinstance(v, str) else f"{v:g}",
@@ -310,7 +314,7 @@ class KeysightB2912AChannel(Channel):
     source_trigger_count = Channel.setting(
         ":trig{ch}:tran:coun %d",
         """Set the trigger count of the source trigger (from 1 to 100000 or 2147483647).
-        Note that this is not readable. Set to 2147483647 for infinite.
+        Set to 2147483647 for infinite.
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
         values=[[1, 100000], [2147483647]],
@@ -318,24 +322,27 @@ class KeysightB2912AChannel(Channel):
 
     measurement_trigger_count = Channel.setting(
         ":trig{ch}:acq:coun %d",
-        """Set the trigger count of the measurement trigger. Note that this is not readable.
+        """Set the trigger count of the measurement trigger.
         """,
         validator=joined_validators(strict_range, strict_discrete_set),
         values=[[1, 100000], [2147483647]],
     )
 
     def initiate(self):
-        """This is the B2912A manual's terminology for triggering."""
+        """Initiate the measurement sequence by arming the trigger."""
         self.write(":INIT (@{ch})")
 
-    idle = Channel.measurement(
-        ":idle{ch}:all?",
+    @property
+    def idle(self):
         """Get whether the triggering system is idle
-        (i.e. all source & measurements are complete)""",
-        cast=lambda value: bool(int(value)),
-    )
+        (i.e. all source & measurements are complete)"""
+        reg_val = int(self.ask("STAT:OPER:COND?"))
+        ch_offset = 0 if self.id == 1 else 6
+        acquire_idle = bool(reg_val & (1 << (1 + ch_offset)))
+        transition_idle = bool(reg_val & (1 << (4 + ch_offset)))
+        return acquire_idle and transition_idle
 
-    def wait_idle(self, timeout=1):
+    def wait_for_idle(self, timeout=1):
         """Block until all device actions (source and measurements) are complete.
 
         Parameters
@@ -349,17 +356,11 @@ class KeysightB2912AChannel(Channel):
             If the timeout is reached before the channel becomes idle.
         """
         end = datetime.now() + timedelta(seconds=timeout)
-        err = ValueError("timeout waiting for idle")
         while True:
-            try:
-                if self.idle:
-                    return
-                if datetime.now() >= end:
-                    raise err
-            except VisaIOError as e:
-                err = e
-                if datetime.now() >= end:
-                    raise e from None
+            if self.idle:
+                return
+            elif datetime.now() >= end:
+                raise ValueError("timeout waiting for idle")
 
     def abort(self):
         """Abort any acquisition or source output device actions."""
@@ -380,47 +381,27 @@ class KeysightB2912A(SCPIMixin, Instrument):
     def __init__(self, adapter, name="Keysight B2912A PSMU", **kwargs):
         super().__init__(adapter, name, **kwargs)
 
-    def wait_for_complete(self, timeout=1):
-        """Like the `SCPIMixin.complete` property, but tries until the
-        `timeout` (in seconds) has passed. Note that this does not
-        block until the trigger IDLE state (i.e. it does not wait for
-        measurements to be complete)
+    @property
+    def idle(self):
+        """Measure whether all device actions (source and measurements) are complete."""
+        return self.ch1.idle and self.ch2.idle
 
+    def wait_for_idle(self, timeout=1):
+        """Block until `self.idle` is true.
+
+        Parameters
+        ----------
+        timeout : float
+            Timeout in seconds (default 1).
+
+        Raises
+        ------
+        ValueError
+            If the timeout is reached before the instrument becomes idle.
         """
         end = datetime.now() + timedelta(seconds=timeout)
-        err = ValueError("timeout is too short.")
-        need_to_clear = False
         while True:
-            try:
-                retval = self.complete
-                if need_to_clear:
-                    self.clear()
-                if int(retval) == 1:
-                    return retval
-                # Not complete yet, check timeout before next poll
-                if datetime.now() >= end:
-                    raise err
-            except VisaIOError as e:
-                # an error in the isntr is generated if the communication times
-                # out. the need_to_clear flag keeps tracks of this and clears
-                # it. TODO should we call check_error instead to ensure there
-                # are no other errors?
-                need_to_clear = True
-                err = e
-                if datetime.now() >= end:
-                    raise e from None
-
-    def pop_err(self):
-        """Pop an error off the device's error queue. Returns a tuple
-        containing the code and error description. An error code 0
-        indicates success.
-
-        The Error queue can be cleared using the standard SCPI
-        ``KeysightB2912A.clear()`` method.
-
-        """
-        error_str = self.ask("SYST:ERR?").strip()
-        error_code_str, error_desc_str = error_str.split(",")
-        error_code = int(error_code_str)
-        error_desc = error_desc_str.strip('"')
-        return error_code, error_desc
+            if self.idle:
+                return
+            elif datetime.now() >= end:
+                raise ValueError("timeout waiting for idle")

--- a/tests/instruments/keysight/test_keysightB2912A.py
+++ b/tests/instruments/keysight/test_keysightB2912A.py
@@ -1,0 +1,484 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.keysight.keysightB2912A import KeysightB2912A
+
+
+# ──────────────────────── source functions ────────────────────────
+
+
+def test_source_output_enabled():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":outp1 1.0", None),
+            (":outp1?", "1.0"),
+        ],
+    ) as inst:
+        inst.ch1.source_output_enabled = True
+        assert inst.ch1.source_output_enabled is True
+
+
+def test_source_output_enabled_ch2():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":outp2 0.0", None),
+            (":outp2?", "0.0"),
+        ],
+    ) as inst:
+        inst.ch2.source_output_enabled = False
+        assert inst.ch2.source_output_enabled is False
+
+
+def test_source_output_mode():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour1:func:mode CURR", None),
+            (":sour1:func:mode?", "CURR"),
+        ],
+    ) as inst:
+        inst.ch1.source_output_mode = "CURR"
+        assert inst.ch1.source_output_mode == "CURR"
+
+
+def test_source_output_mode_invalid():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.source_output_mode = "INVALID"
+
+
+def test_source_output_shape():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour2:func:shap PULS", None),
+            (":sour2:func:shap?", "PULS"),
+        ],
+    ) as inst:
+        inst.ch2.source_output_shape = "PULS"
+        assert inst.ch2.source_output_shape == "PULS"
+
+
+def test_source_current():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour1:curr 0.001", None),
+            (":sour1:curr?", "0.001"),
+        ],
+    ) as inst:
+        inst.ch1.source_current = 1e-3
+        assert inst.ch1.source_current == 1e-3
+
+
+def test_source_current_out_of_range():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.source_current = 5
+
+
+def test_source_current_triggered():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour1:curr:trig 0.002", None),
+            (":sour1:curr:trig?", "0.002"),
+        ],
+    ) as inst:
+        inst.ch1.source_current_triggered = 2e-3
+        assert inst.ch1.source_current_triggered == 2e-3
+
+
+def test_source_voltage():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour2:volt 1.5", None),
+            (":sour2:volt?", "1.5"),
+        ],
+    ) as inst:
+        inst.ch2.source_voltage = 1.5
+        assert inst.ch2.source_voltage == 1.5
+
+
+def test_source_voltage_out_of_range():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.source_voltage = 300
+
+
+def test_source_voltage_triggered():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour1:volt:trig 1.11", None),
+            (":sour1:volt:trig?", "1.11"),
+        ],
+    ) as inst:
+        inst.ch1.source_voltage_triggered = 1.11
+        assert inst.ch1.source_voltage_triggered == 1.11
+
+
+# ───────────────────── output protection ──────────────────────
+
+
+def test_output_protection_enabled():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":outp1:prot 1.0", None),
+            (":outp1:prot?", "1.0"),
+        ],
+    ) as inst:
+        inst.ch1.output_protection_enabled = True
+        assert inst.ch1.output_protection_enabled is True
+
+
+def test_compliance_current():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:curr:prot 1e-06", None),
+            (":sens1:curr:prot?", "1e-06"),
+        ],
+    ) as inst:
+        inst.ch1.compliance_current = 1e-6
+        assert inst.ch1.compliance_current == 1e-6
+
+
+def test_compliance_voltage():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens2:volt:prot 4", None),
+            (":sens2:volt:prot?", "4"),
+        ],
+    ) as inst:
+        inst.ch2.compliance_voltage = 4
+        assert inst.ch2.compliance_voltage == 4
+
+
+# ───────────────────── pulse configuration ────────────────────
+
+
+def test_pulse_delay():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour1:pulse:del 0.001", None),
+            (":sour1:pulse:del?", "0.001"),
+        ],
+    ) as inst:
+        inst.ch1.pulse_delay = 1e-3
+        assert inst.ch1.pulse_delay == 1e-3
+
+
+def test_pulse_width():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sour2:pulse:widt 0.5", None),
+            (":sour2:pulse:widt?", "0.5"),
+        ],
+    ) as inst:
+        inst.ch2.pulse_width = 0.5
+        assert inst.ch2.pulse_width == 0.5
+
+
+# ──────────────────── measurement functions ───────────────────
+
+
+def test_current_measurement_range_auto():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:curr:range:auto 0.0", None),
+            (":sens1:curr:range:auto?", "0.0"),
+        ],
+    ) as inst:
+        inst.ch1.current_measurement_range_auto = False
+        assert inst.ch1.current_measurement_range_auto is False
+
+
+def test_current_measurement_range():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:curr:range 0.1", None),
+            (":sens1:curr:rang?", "0.1"),
+        ],
+    ) as inst:
+        inst.ch1.current_measurement_range = 0.1
+        assert inst.ch1.current_measurement_range == 0.1
+
+
+def test_current_measurement_speed():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:curr:aper 0.0001", None),
+            (":sens1:curr:aper?", "0.0001"),
+        ],
+    ) as inst:
+        inst.ch1.current_measurement_speed = 1e-4
+        assert inst.ch1.current_measurement_speed == 1e-4
+
+
+def test_current_measurement_speed_nplc():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:curr:nplc 1", None),
+            (":sens1:curr:nplc?", "1"),
+        ],
+    ) as inst:
+        inst.ch1.current_measurement_speed_nplc = 1
+        assert inst.ch1.current_measurement_speed_nplc == 1
+
+
+def test_current_measurement_speed_nplc_out_of_range():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.current_measurement_speed_nplc = 200
+
+
+def test_measured_current():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":meas:curr? (@1)", "1.234e-3")],
+    ) as inst:
+        assert inst.ch1.measured_current == pytest.approx(1.234e-3)
+
+
+def test_voltage_measurement_range_auto():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens2:volt:range:auto 1.0", None),
+            (":sens2:volt:range:auto?", "1.0"),
+        ],
+    ) as inst:
+        inst.ch2.voltage_measurement_range_auto = True
+        assert inst.ch2.voltage_measurement_range_auto is True
+
+
+def test_voltage_measurement_range():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:volt:range 0.2", None),
+            (":sens1:volt:rang?", "0.2"),
+        ],
+    ) as inst:
+        inst.ch1.voltage_measurement_range = 0.2
+        assert inst.ch1.voltage_measurement_range == 0.2
+
+
+def test_voltage_measurement_speed():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens2:volt:aper 0.0001", None),
+            (":sens2:volt:aper?", "0.0001"),
+        ],
+    ) as inst:
+        inst.ch2.voltage_measurement_speed = 1e-4
+        assert inst.ch2.voltage_measurement_speed == 1e-4
+
+
+def test_voltage_measurement_speed_nplc():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":sens1:volt:nplc 10", None),
+            (":sens1:volt:nplc?", "10"),
+        ],
+    ) as inst:
+        inst.ch1.voltage_measurement_speed_nplc = 10
+        assert inst.ch1.voltage_measurement_speed_nplc == 10
+
+
+def test_measured_voltage():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":meas:volt? (@2)", "0.456")],
+    ) as inst:
+        assert inst.ch2.measured_voltage == pytest.approx(0.456)
+
+
+# ──────────────── trigger configuration ───────────────────────
+
+
+def test_trigger_source():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig1:sour TIM", None)],
+    ) as inst:
+        inst.ch1.trigger_source = "TIM"
+
+
+def test_trigger_source_invalid():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.trigger_source = "INVALID"
+
+
+def test_source_trigger_delay():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":trig1:tran:del 0.5", None),
+            (":trig1:tran:del?", "0.5"),
+        ],
+    ) as inst:
+        inst.ch1.source_trigger_delay = 0.5
+        assert inst.ch1.source_trigger_delay == 0.5
+
+
+def test_measurement_trigger_delay():
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":trig2:acq:del 0.1", None),
+            (":trig2:acq:del?", "0.1"),
+        ],
+    ) as inst:
+        inst.ch2.measurement_trigger_delay = 0.1
+        assert inst.ch2.measurement_trigger_delay == 0.1
+
+
+def test_source_trigger_timer_period():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig1:tran:tim 0.01", None)],
+    ) as inst:
+        inst.ch1.source_trigger_timer_period = 0.01
+
+
+def test_source_trigger_timer_period_string():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig1:tran:tim MIN", None)],
+    ) as inst:
+        inst.ch1.source_trigger_timer_period = "MIN"
+
+
+def test_measurement_trigger_timer_period():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig2:acq:tim 1", None)],
+    ) as inst:
+        inst.ch2.measurement_trigger_timer_period = 1
+
+
+def test_source_trigger_count():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig1:tran:coun 100", None)],
+    ) as inst:
+        inst.ch1.source_trigger_count = 100
+
+
+def test_source_trigger_count_infinite():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig1:tran:coun 2147483647", None)],
+    ) as inst:
+        inst.ch1.source_trigger_count = 2147483647
+
+
+def test_measurement_trigger_count():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":trig2:acq:coun 50", None)],
+    ) as inst:
+        inst.ch2.measurement_trigger_count = 50
+
+
+def test_source_trigger_count_out_of_range():
+    with expected_protocol(KeysightB2912A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.source_trigger_count = 200000
+
+
+# ───────────────────── channel methods ────────────────────────
+
+
+def test_initiate():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":INIT (@1)", None)],
+    ) as inst:
+        inst.ch1.initiate()
+
+
+def test_abort():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":ABOR:ALL (@2)", None)],
+    ) as inst:
+        inst.ch2.abort()
+
+
+def test_idle():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":idle1:all?", "1")],
+    ) as inst:
+        assert inst.ch1.idle is True
+
+
+def test_idle_not_idle():
+    with expected_protocol(
+        KeysightB2912A,
+        [(":idle2:all?", "0")],
+    ) as inst:
+        assert inst.ch2.idle is False
+
+
+# ───────────────── instrument-level methods ───────────────────
+
+
+def test_pop_err_no_error():
+    with expected_protocol(
+        KeysightB2912A,
+        [("SYST:ERR?", '0,"No error"')],
+    ) as inst:
+        code, desc = inst.pop_err()
+        assert code == 0
+        assert desc == "No error"
+
+
+def test_pop_err_with_error():
+    with expected_protocol(
+        KeysightB2912A,
+        [("SYST:ERR?", '-100,"Command error"')],
+    ) as inst:
+        code, desc = inst.pop_err()
+        assert code == -100
+        assert desc == "Command error"

--- a/tests/instruments/keysight/test_keysightB2912A.py
+++ b/tests/instruments/keysight/test_keysightB2912A.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2025 PyMeasure Developers
+# Copyright (c) 2013-2026 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -331,6 +331,49 @@ def test_measured_voltage():
         assert inst.ch2.measured_voltage == pytest.approx(0.456)
 
 
+# below tests captured from hardware B2912A via a
+# pymeasure.generator.Generator
+
+def test_measured_current_array():
+    block = (
+        b"#232\xbd\xce<\x8f\xd6\x06\xeaM\xbd\xd80s\x11\x9f!\xd7"
+        b"\xbd\xd9\x03\x8eC\xadH\xd0\xbd\xd9\x03\x8eC\xadH\xd0\n"
+    )
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":form?", "ASC"),
+            (":form REAL,64", None),
+            (":fetc:arr:curr? (@1)", block),
+            (":form ASC", None),
+        ],
+    ) as inst:
+        values = inst.ch1.measured_current_array
+        assert values.dtype.kind == "f"
+        assert values.dtype.itemsize == 8
+        assert values == pytest.approx([-5.5e-11, -8.8e-11, -9.1e-11, -9.1e-11])
+
+
+def test_measured_voltage_array():
+    block = (
+        b"#232?\xb9\x99\x9bG\x18\xc3E?\xb9\x99\x99\x99\x99\x99\x99"
+        b"?\xb9\x99\x99\x99\x99\x99\x99?\xb9\x99\x97\xec\x1ao\xed\n"
+    )
+    with expected_protocol(
+        KeysightB2912A,
+        [
+            (":form?", "ASC"),
+            (":form REAL,64", None),
+            (":fetc:arr:volt? (@2)", block),
+            (":form ASC", None),
+        ],
+    ) as inst:
+        values = inst.ch2.measured_voltage_array
+        assert values.dtype.kind == "f"
+        assert values.dtype.itemsize == 8
+        assert values == pytest.approx([0.1000001, 0.1, 0.1, 0.0999999])
+
+
 # ──────────────── trigger configuration ───────────────────────
 
 
@@ -445,40 +488,91 @@ def test_abort():
         inst.ch2.abort()
 
 
-def test_idle():
-    with expected_protocol(
-        KeysightB2912A,
-        [(":idle1:all?", "1")],
-    ) as inst:
+# ──────────────────── channel idle property ───────────────────
+# ch1: acquire_idle=bit1 (2), transition_idle=bit4 (16) → both set = 18
+# ch2: acquire_idle=bit7 (128), transition_idle=bit10 (1024) → both set = 1152
+
+
+def test_ch1_idle_true():
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "18")]) as inst:
         assert inst.ch1.idle is True
 
 
-def test_idle_not_idle():
-    with expected_protocol(
-        KeysightB2912A,
-        [(":idle2:all?", "0")],
-    ) as inst:
+def test_ch1_idle_false():
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "0")]) as inst:
+        assert inst.ch1.idle is False
+
+
+def test_ch1_idle_partial():
+    # acquire_idle bit set but transition_idle not → False
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "2")]) as inst:
+        assert inst.ch1.idle is False
+
+
+def test_ch2_idle_true():
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "1152")]) as inst:
+        assert inst.ch2.idle is True
+
+
+def test_ch2_idle_false():
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "0")]) as inst:
         assert inst.ch2.idle is False
 
 
-# ───────────────── instrument-level methods ───────────────────
+# ───────────────── instrument-level idle property ─────────────
 
 
-def test_pop_err_no_error():
+def test_inst_idle_true():
+    # ch1 idle, then ch2 idle → both queried
     with expected_protocol(
         KeysightB2912A,
-        [("SYST:ERR?", '0,"No error"')],
+        [("STAT:OPER:COND?", "18"), ("STAT:OPER:COND?", "1152")],
     ) as inst:
-        code, desc = inst.pop_err()
-        assert code == 0
-        assert desc == "No error"
+        assert inst.idle is True
 
 
-def test_pop_err_with_error():
+def test_inst_idle_false_ch1():
+    # ch1 not idle → short-circuit, ch2 never queried
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "0")]) as inst:
+        assert inst.idle is False
+
+
+def test_inst_idle_false_ch2():
+    # ch1 idle, ch2 not → both queried
     with expected_protocol(
         KeysightB2912A,
-        [("SYST:ERR?", '-100,"Command error"')],
+        [("STAT:OPER:COND?", "18"), ("STAT:OPER:COND?", "0")],
     ) as inst:
-        code, desc = inst.pop_err()
-        assert code == -100
-        assert desc == "Command error"
+        assert inst.idle is False
+
+
+# ──────────────────── wait_for_idle ───────────────────────────
+
+
+def test_ch_wait_for_idle_returns():
+    # ch1 already idle → returns immediately after one poll
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "18")]) as inst:
+        inst.ch1.wait_for_idle()
+
+
+def test_ch_wait_for_idle_timeout():
+    # ch1 not idle and timeout=0 → raises ValueError after first poll
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "0")]) as inst:
+        with pytest.raises(ValueError):
+            inst.ch1.wait_for_idle(timeout=0)
+
+
+def test_inst_wait_for_idle_returns():
+    # both channels idle → returns after two polls
+    with expected_protocol(
+        KeysightB2912A,
+        [("STAT:OPER:COND?", "18"), ("STAT:OPER:COND?", "1152")],
+    ) as inst:
+        inst.wait_for_idle()
+
+
+def test_inst_wait_for_idle_timeout():
+    # ch1 not idle, timeout=0 → raises ValueError after first poll
+    with expected_protocol(KeysightB2912A, [("STAT:OPER:COND?", "0")]) as inst:
+        with pytest.raises(ValueError):
+            inst.wait_for_idle(timeout=0)

--- a/tests/instruments/keysight/test_keysightB2912A_with_device.py
+++ b/tests/instruments/keysight/test_keysightB2912A_with_device.py
@@ -1,0 +1,248 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Tested using ethernet. call signature:
+#    pytest test_keysightB2912A_with_device.py --device-address 'TCPIP::192.168.2.232::INSTR'
+
+import pytest
+from pymeasure.instruments.keysight.keysightB2912A import KeysightB2912A
+# from pyvisa.errors import VisaIOError
+
+# pytest.skip("Only work with connected hardware", allow_module_level=True)
+
+
+@pytest.fixture(scope="module")
+def keysightB2912A(connected_device_address):
+    instr = KeysightB2912A(connected_device_address)
+    instr.clear()
+    # ensure the device is in a defined state, e.g. by resetting it.
+    yield instr
+    instr.ch1.source_output_enabled = False  # pyright:ignore
+    instr.ch2.source_output_enabled = False  # pyright:ignore
+
+
+def test_source_output_enabled(keysightB2912A):
+    keysightB2912A.ch1.source_output_enabled = True
+    assert keysightB2912A.ch1.source_output_enabled
+    keysightB2912A.ch2.source_output_enabled = True
+    assert keysightB2912A.ch2.source_output_enabled
+
+
+def test_source_output_mode(keysightB2912A):
+    keysightB2912A.ch1.source_output_mode = "CURR"
+    assert keysightB2912A.ch1.source_output_mode == "CURR"
+    keysightB2912A.ch2.source_output_mode = "CURR"
+    assert keysightB2912A.ch2.source_output_mode == "CURR"
+
+
+def test_source_output_shape(keysightB2912A):
+    keysightB2912A.ch1.source_output_shape = "DC"
+    assert keysightB2912A.ch1.source_output_shape == "DC"
+    keysightB2912A.ch2.source_output_shape = "PULS"
+    assert keysightB2912A.ch2.source_output_shape == "PULS"
+
+
+def test_source_current(keysightB2912A):
+    keysightB2912A.ch1.source_current = 1e-3
+    assert keysightB2912A.ch1.source_current == 1e-3
+    keysightB2912A.ch2.source_current = 1e-3
+    assert keysightB2912A.ch2.source_current == 1e-3
+
+
+def test_triggered_source_current(keysightB2912A):
+    keysightB2912A.ch1.triggered_source_current = 2e-3
+    assert keysightB2912A.ch1.triggered_source_current == 2e-3
+    keysightB2912A.ch2.triggered_source_current = 3e-3
+    assert keysightB2912A.ch2.triggered_source_current == 3e-3
+
+
+def test_source_voltage(keysightB2912A):
+    keysightB2912A.ch1.source_voltage = 123e-3
+    assert keysightB2912A.ch1.source_voltage == 123e-3
+    keysightB2912A.ch2.source_voltage = 123e-3
+    assert keysightB2912A.ch2.source_voltage == 123e-3
+
+
+def test_triggered_source_voltage(keysightB2912A):
+    keysightB2912A.ch1.triggered_source_voltage = 1.11
+    assert keysightB2912A.ch1.triggered_source_voltage == 1.11
+    keysightB2912A.ch2.triggered_source_voltage = 2.34
+    assert keysightB2912A.ch2.triggered_source_voltage == 2.34
+
+
+def test_pulse_delay(keysightB2912A):
+    keysightB2912A.ch1.pulse_delay = 1
+    assert keysightB2912A.ch1.pulse_delay == 1
+    keysightB2912A.ch2.pulse_delay = 1e-3
+    assert keysightB2912A.ch2.pulse_delay == 1e-3
+
+
+def test_pulse_width(keysightB2912A):
+    keysightB2912A.ch1.pulse_width = 1
+    assert keysightB2912A.ch1.pulse_width == 1
+    keysightB2912A.ch2.pulse_width = 1e-3
+    assert keysightB2912A.ch2.pulse_width == 1e-3
+
+
+# def test_measurement_mode(keysightB2912A):
+#     keysightB2912A.ch1.measurement_mode = "CURR"
+#     assert keysightB2912A.ch1.measurement_mode == "CURR"
+#     keysightB2912A.ch2.measurement_mode = "CURR"
+#     assert keysightB2912A.ch2.measurement_mode == "CURR"
+
+
+def test_current_measurement_range_auto(keysightB2912A):
+    keysightB2912A.ch1.current_measurement_range_auto = False
+    assert not keysightB2912A.ch1.current_measurement_range_auto
+    keysightB2912A.ch2.current_measurement_range_auto = False
+    assert not keysightB2912A.ch2.current_measurement_range_auto
+
+
+def test_current_measurement_range(keysightB2912A):
+    keysightB2912A.current_measurement_range_auto = False
+    keysightB2912A.ch1.current_measurement_range = 0.1
+    assert keysightB2912A.ch1.current_measurement_range == 0.1
+    keysightB2912A.ch2.current_measurement_range = 0.1
+    assert keysightB2912A.ch2.current_measurement_range == 0.1
+
+
+def test_current_measurement_speed(keysightB2912A):
+    keysightB2912A.ch1.current_measurement_speed = 1e-4
+    assert keysightB2912A.ch1.current_measurement_speed == 1e-4
+    keysightB2912A.ch2.current_measurement_speed = 1e-4
+    assert keysightB2912A.ch2.current_measurement_speed == 1e-4
+
+
+def test_measured_current(keysightB2912A):
+    c = keysightB2912A.ch1.measured_current
+    assert isinstance(c, float)
+    c = keysightB2912A.ch2.measured_current
+    assert isinstance(c, float)
+
+
+def test_measured_current_array(keysightB2912A):
+    keysightB2912A.ch1.measured_current_array
+    keysightB2912A.ch2.measured_current_array
+    assert keysightB2912A.ask(":form?").strip() == "ASC"
+
+
+def test_voltage_measurement_range_auto(keysightB2912A):
+    keysightB2912A.ch1.voltage_measurement_range_auto = False
+    assert not keysightB2912A.ch1.voltage_measurement_range_auto
+    keysightB2912A.ch2.voltage_measurement_range_auto = False
+    assert not keysightB2912A.ch2.voltage_measurement_range_auto
+
+
+def test_voltage_measurement_range(keysightB2912A):
+    keysightB2912A.ch1.voltage_measurement_range_auto = False
+    keysightB2912A.ch1.voltage_measurement_range = 0.2
+    assert keysightB2912A.ch1.voltage_measurement_range == 0.2
+    keysightB2912A.ch2.voltage_measurement_range_auto = False
+    keysightB2912A.ch2.voltage_measurement_range = 0.2
+    assert keysightB2912A.ch2.voltage_measurement_range == 0.2
+
+
+def test_voltage_measurement_speed(keysightB2912A):
+    keysightB2912A.ch1.voltage_measurement_speed = 1e-4
+    assert keysightB2912A.ch1.voltage_measurement_speed == 1e-4
+    keysightB2912A.ch2.voltage_measurement_speed = 1e-4
+    assert keysightB2912A.ch2.voltage_measurement_speed == 1e-4
+
+
+def test_measured_voltage(keysightB2912A):
+    v = keysightB2912A.ch1.measured_voltage
+    assert isinstance(v, float)
+    v = keysightB2912A.ch2.measured_voltage
+    assert isinstance(v, float)
+
+
+def test_measured_voltage_array(keysightB2912A):
+    keysightB2912A.ch1.measured_voltage_array
+    keysightB2912A.ch2.measured_voltage_array
+    assert keysightB2912A.ask(":form?").strip() == "ASC"
+
+
+def test_output_protection_enabled(keysightB2912A):
+    keysightB2912A.ch1.output_protection_enabled = True
+    assert keysightB2912A.ch1.output_protection_enabled
+    keysightB2912A.ch2.output_protection_enabled = True
+    assert keysightB2912A.ch2.output_protection_enabled
+    keysightB2912A.ch1.output_protection_enabled = False
+    assert not keysightB2912A.ch1.output_protection_enabled
+    keysightB2912A.ch2.output_protection_enabled = False
+    assert not keysightB2912A.ch2.output_protection_enabled
+
+
+def test_compliance(keysightB2912A):
+    keysightB2912A.ch1.compliance_voltage = 4
+    assert keysightB2912A.ch1.compliance_voltage == 4
+    keysightB2912A.ch1.compliance_current = 1e-6
+    assert keysightB2912A.ch1.compliance_current == 1e-6
+    keysightB2912A.ch2.compliance_voltage = 4
+    assert keysightB2912A.ch2.compliance_voltage == 4
+    keysightB2912A.ch2.compliance_current = 1e-6
+    assert keysightB2912A.ch2.compliance_current == 1e-6
+
+
+def test_reset(keysightB2912A):
+    keysightB2912A.reset()
+
+
+def test_trig_src(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.trigger_source = "TIM"
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+
+
+def test_trig_del(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.source_trigger_delay = 1
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        ch.measurement_trigger_delay = 1
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+
+
+def test_trig_count(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.trigger_timer_count = 1
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+
+
+def test_trig_period(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.trigger_timer_period = 1
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+
+
+def test_wait_for_complete(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.trigger_source = "TIM"
+        ch.source_trigger_delay = 0
+        ch.measurement_trigger_delay = 0
+        ch.trigger_timer_period = 1
+        ch.trigger_timer_count = 10
+        keysightB2912A.wait_for_complete(10)
+        ch.initiate()
+        keysightB2912A.wait_for_complete(11)
+        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?

--- a/tests/instruments/keysight/test_keysightB2912A_with_device.py
+++ b/tests/instruments/keysight/test_keysightB2912A_with_device.py
@@ -36,17 +36,21 @@ from pymeasure.instruments.keysight.keysightB2912A import KeysightB2912A
 def keysightB2912A(connected_device_address):
     instr = KeysightB2912A(connected_device_address)
     instr.clear()
-    # ensure the device is in a defined state, e.g. by resetting it.
+    instr.reset()
     yield instr
     instr.ch1.source_output_enabled = False  # pyright:ignore
     instr.ch2.source_output_enabled = False  # pyright:ignore
 
 
 def test_source_output_enabled(keysightB2912A):
-    keysightB2912A.ch1.source_output_enabled = True
-    assert keysightB2912A.ch1.source_output_enabled
-    keysightB2912A.ch2.source_output_enabled = True
-    assert keysightB2912A.ch2.source_output_enabled
+    try:
+        keysightB2912A.ch1.source_output_enabled = True
+        assert keysightB2912A.ch1.source_output_enabled
+        keysightB2912A.ch2.source_output_enabled = True
+        assert keysightB2912A.ch2.source_output_enabled
+    finally:
+        keysightB2912A.ch1.source_output_enabled = False
+        keysightB2912A.ch2.source_output_enabled = False
 
 
 def test_source_output_mode(keysightB2912A):
@@ -71,10 +75,10 @@ def test_source_current(keysightB2912A):
 
 
 def test_triggered_source_current(keysightB2912A):
-    keysightB2912A.ch1.triggered_source_current = 2e-3
-    assert keysightB2912A.ch1.triggered_source_current == 2e-3
-    keysightB2912A.ch2.triggered_source_current = 3e-3
-    assert keysightB2912A.ch2.triggered_source_current == 3e-3
+    keysightB2912A.ch1.source_current_triggered = 2e-3
+    assert keysightB2912A.ch1.source_current_triggered == 2e-3
+    keysightB2912A.ch2.source_current_triggered = 3e-3
+    assert keysightB2912A.ch2.source_current_triggered == 3e-3
 
 
 def test_source_voltage(keysightB2912A):
@@ -85,10 +89,10 @@ def test_source_voltage(keysightB2912A):
 
 
 def test_triggered_source_voltage(keysightB2912A):
-    keysightB2912A.ch1.triggered_source_voltage = 1.11
-    assert keysightB2912A.ch1.triggered_source_voltage == 1.11
-    keysightB2912A.ch2.triggered_source_voltage = 2.34
-    assert keysightB2912A.ch2.triggered_source_voltage == 2.34
+    keysightB2912A.ch1.source_voltage_triggered = 1.11
+    assert keysightB2912A.ch1.source_voltage_triggered == 1.11
+    keysightB2912A.ch2.source_voltage_triggered = 2.34
+    assert keysightB2912A.ch2.source_voltage_triggered == 2.34
 
 
 def test_pulse_delay(keysightB2912A):
@@ -120,9 +124,10 @@ def test_current_measurement_range_auto(keysightB2912A):
 
 
 def test_current_measurement_range(keysightB2912A):
-    keysightB2912A.current_measurement_range_auto = False
+    keysightB2912A.ch1.current_measurement_range_auto = False
     keysightB2912A.ch1.current_measurement_range = 0.1
     assert keysightB2912A.ch1.current_measurement_range == 0.1
+    keysightB2912A.ch2.current_measurement_range_auto = False
     keysightB2912A.ch2.current_measurement_range = 0.1
     assert keysightB2912A.ch2.current_measurement_range == 0.1
 
@@ -142,8 +147,10 @@ def test_measured_current(keysightB2912A):
 
 
 def test_measured_current_array(keysightB2912A):
-    keysightB2912A.ch1.measured_current_array
-    keysightB2912A.ch2.measured_current_array
+    ch1_values = keysightB2912A.ch1.measured_current_array
+    ch2_values = keysightB2912A.ch2.measured_current_array
+    assert ch1_values.dtype.kind == "f"
+    assert ch2_values.dtype.kind == "f"
     assert keysightB2912A.ask(":form?").strip() == "ASC"
 
 
@@ -178,8 +185,10 @@ def test_measured_voltage(keysightB2912A):
 
 
 def test_measured_voltage_array(keysightB2912A):
-    keysightB2912A.ch1.measured_voltage_array
-    keysightB2912A.ch2.measured_voltage_array
+    ch1_values = keysightB2912A.ch1.measured_voltage_array
+    ch2_values = keysightB2912A.ch2.measured_voltage_array
+    assert ch1_values.dtype.kind == "f"
+    assert ch2_values.dtype.kind == "f"
     assert keysightB2912A.ask(":form?").strip() == "ASC"
 
 
@@ -225,13 +234,15 @@ def test_trig_del(keysightB2912A):
 
 def test_trig_count(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
-        ch.trigger_timer_count = 1
+        ch.source_trigger_count = 1
+        ch.measurement_trigger_count = 1
         assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
 
 
 def test_trig_period(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
-        ch.trigger_timer_period = 1
+        ch.source_trigger_timer_period = 1
+        ch.measurement_trigger_timer_period = 1
         assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
 
 
@@ -240,8 +251,10 @@ def test_wait_for_complete(keysightB2912A):
         ch.trigger_source = "TIM"
         ch.source_trigger_delay = 0
         ch.measurement_trigger_delay = 0
-        ch.trigger_timer_period = 1
-        ch.trigger_timer_count = 10
+        ch.source_trigger_timer_period = 1
+        ch.measurement_trigger_timer_period = 1
+        ch.source_trigger_count = 10
+        ch.measurement_trigger_count = 10
         keysightB2912A.wait_for_complete(10)
         ch.initiate()
         keysightB2912A.wait_for_complete(11)

--- a/tests/instruments/keysight/test_keysightB2912A_with_device.py
+++ b/tests/instruments/keysight/test_keysightB2912A_with_device.py
@@ -1,7 +1,7 @@
 #
 # This file is part of the PyMeasure package.
 #
-# Copyright (c) 2013-2025 PyMeasure Developers
+# Copyright (c) 2013-2026 PyMeasure Developers
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,9 +27,6 @@
 
 import pytest
 from pymeasure.instruments.keysight.keysightB2912A import KeysightB2912A
-# from pyvisa.errors import VisaIOError
-
-# pytest.skip("Only work with connected hardware", allow_module_level=True)
 
 
 @pytest.fixture(scope="module")
@@ -107,13 +104,6 @@ def test_pulse_width(keysightB2912A):
     assert keysightB2912A.ch1.pulse_width == 1
     keysightB2912A.ch2.pulse_width = 1e-3
     assert keysightB2912A.ch2.pulse_width == 1e-3
-
-
-# def test_measurement_mode(keysightB2912A):
-#     keysightB2912A.ch1.measurement_mode = "CURR"
-#     assert keysightB2912A.ch1.measurement_mode == "CURR"
-#     keysightB2912A.ch2.measurement_mode = "CURR"
-#     assert keysightB2912A.ch2.measurement_mode == "CURR"
 
 
 def test_current_measurement_range_auto(keysightB2912A):
@@ -221,32 +211,32 @@ def test_reset(keysightB2912A):
 def test_trig_src(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
         ch.trigger_source = "TIM"
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        assert len(keysightB2912A.check_errors()) == 0
 
 
 def test_trig_del(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
         ch.source_trigger_delay = 1
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        assert len(keysightB2912A.check_errors()) == 0
         ch.measurement_trigger_delay = 1
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        assert len(keysightB2912A.check_errors()) == 0
 
 
 def test_trig_count(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
         ch.source_trigger_count = 1
         ch.measurement_trigger_count = 1
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        assert len(keysightB2912A.check_errors()) == 0
 
 
 def test_trig_period(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
         ch.source_trigger_timer_period = 1
         ch.measurement_trigger_timer_period = 1
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        assert len(keysightB2912A.check_errors()) == 0
 
 
-def test_wait_for_complete(keysightB2912A):
+def test_wait_for_idle(keysightB2912A):
     for ch in keysightB2912A.ch1, keysightB2912A.ch2:
         ch.trigger_source = "TIM"
         ch.source_trigger_delay = 0
@@ -255,7 +245,23 @@ def test_wait_for_complete(keysightB2912A):
         ch.measurement_trigger_timer_period = 1
         ch.source_trigger_count = 10
         ch.measurement_trigger_count = 10
-        keysightB2912A.wait_for_complete(10)
+        keysightB2912A.wait_for_idle(10)
         ch.initiate()
-        keysightB2912A.wait_for_complete(11)
-        assert len(keysightB2912A.check_errors()) == 0  # TODO is this correct?
+        keysightB2912A.wait_for_idle(11)
+        assert len(keysightB2912A.check_errors()) == 0
+
+
+def test_wait_for_idle_timeout(keysightB2912A):
+    for ch in keysightB2912A.ch1, keysightB2912A.ch2:
+        ch.trigger_source = "TIM"
+        ch.source_trigger_delay = 0
+        ch.measurement_trigger_delay = 0
+        ch.source_trigger_timer_period = 1
+        ch.measurement_trigger_timer_period = 1
+        ch.source_trigger_count = 10
+        ch.measurement_trigger_count = 10
+        keysightB2912A.wait_for_idle(10)
+        ch.initiate()
+        with pytest.raises(ValueError):  # expect a timeout
+            keysightB2912A.wait_for_idle(1)
+        keysightB2912A.wait_for_idle(11)  # don't exit until idle


### PR DESCRIPTION
Hi, I have basic functionality for the Keysight B2900 series PSMUs. I see, in hindsight, that PR #1293 is already open for this series, but it looks stale (1 year old). The Programming Manual I referenced is for all "B2900 Series", but limits are set by sub-name (i.e., B2901C), and I only had the Keysight B2912A on hand, so maybe a future PR can refactor to set limits properly by sub-name?

If this looks ok, I will write tests that aren't just targeting _with_device.py

Thanks,
Alec