### PR TITLE
Remove chunked reading from logic in `Results.data` property and `Results.reload()`

### DIFF
--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -435,8 +435,7 @@ class Results:
     def data(self):
         # Need to update header count for correct referencing
         if self._header_count == -1:
-            self._header_count = len(
-                self.header()[-1].split(Results.LINE_BREAK))
+            self._header_count = len(self.header()[-1].split(Results.LINE_BREAK))
         if self._data is None or len(self._data) == 0:
             # Data has not been read
             try:
@@ -446,44 +445,31 @@ class Results:
                 self._data = pd.DataFrame(columns=self.procedure.DATA_COLUMNS)
         else:  # Concatenate additional data, if any, to already loaded data
             skiprows = len(self._data) + self._header_count
-            chunks = pd.read_csv(
+            tmp_frame = pd.read_csv(
                 self.data_filename,
                 comment=Results.COMMENT,
                 header=0,
                 names=self._data.columns,
-                chunksize=Results.CHUNK_SIZE,
                 skiprows=skiprows,
-                iterator=True,
                 encoding=Results.ENCODING,
             )
-            try:
-                tmp_frame = pd.concat(chunks, ignore_index=True)
-                # only append new data if there is any
-                # if no new data, tmp_frame dtype is object, which override's
-                # self._data's original dtype - this can cause problems plotting
-                # (e.g. if trying to plot int data on a log axis)
-                if len(tmp_frame) > 0:
-                    self._data = pd.concat([self._data, tmp_frame],
-                                           ignore_index=True)
-            except Exception:
-                pass  # All data is up to date
+            # only append new data if there is any
+            # if no new data, tmp_frame dtype is object, which override's
+            # self._data's original dtype - this can cause problems plotting
+            # (e.g. if trying to plot int data on a log axis)
+            if len(tmp_frame) > 0:
+                self._data = pd.concat([self._data, tmp_frame], ignore_index=True)
         return self._data
 
     def reload(self):
-        """ Preforms a full reloading of the file data, neglecting
+        """Preforms a full reloading of the file data, neglecting
         any changes in the comments
         """
-        chunks = pd.read_csv(
+        self._data = pd.read_csv(
             self.data_filename,
             comment=Results.COMMENT,
-            chunksize=Results.CHUNK_SIZE,
-            iterator=True,
             encoding=Results.ENCODING,
         )
-        try:
-            self._data = pd.concat(chunks, ignore_index=True)
-        except Exception:
-            self._data = chunks.read()
 
     def __repr__(self):
         return "<{}(filename='{}',procedure={},shape={})>".format(

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -123,16 +123,16 @@ class TestResults:
         procedure_mock = mock.MagicMock(spec=Procedure)
         result = Results(procedure_mock, 'test.csv')
 
-        read_csv_mock.return_value = [pd.DataFrame(data={
+        read_csv_mock.return_value = pd.DataFrame(data={
             'A': [1, 2, 3, 4, 5, 6, 7],
             'B': [2, 3, 4, 5, 6, 7, 8]
-        })]
+        })
         first_data = result.data
 
         # if no updates, read_csv returns a zero-row dataframe
-        read_csv_mock.return_value = [pd.DataFrame(data={
+        read_csv_mock.return_value = pd.DataFrame(data={
             'A': [], 'B': []
-        }, dtype=object)]
+        }, dtype=object)
         second_data = result.data
 
         assert second_data.iloc[:, 0].dtype is not object


### PR DESCRIPTION
Remove chunked reading from logic in `Results.data` property and `Results.reload()` Previously the file was read in chunks then concat in memory, now it reads the entire file to memory removing unnecessary overhead. 

A benchmark of loading a Results file with 500K rows and 5 columns showed a ~68% time improvement (634.7 ms to 200.3 ms).