### PR TITLE
Add file size checking to `Results.data` property to skip reading file if data hasn't changed.

### DIFF
--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -217,6 +217,7 @@ class Results:
         self.parameters = procedure.parameter_objects()
         self._header_count = -1
         self._metadata_count = -1
+        self._last_file_size = 0
 
         self.formatter = CSVFormatter(columns=self.procedure.DATA_COLUMNS)
 
@@ -445,6 +446,11 @@ class Results:
                 # Empty dataframe
                 self._data = pd.DataFrame(columns=self.procedure.DATA_COLUMNS)
         else:  # Concatenate additional data, if any, to already loaded data
+            # Get current filesize, if same as _last_file_size, return data
+            current_size = os.path.getsize(self.data_filename)
+            if current_size == self._last_file_size:
+                return self._data
+            
             skiprows = len(self._data) + self._header_count
             chunks = pd.read_csv(
                 self.data_filename,
@@ -467,6 +473,9 @@ class Results:
                                            ignore_index=True)
             except Exception:
                 pass  # All data is up to date
+            
+            # Update _last_file_size
+            self._last_file_size = current_size
         return self._data
 
     def reload(self):

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -450,7 +450,6 @@ class Results:
             current_size = os.path.getsize(self.data_filename)
             if current_size == self._last_file_size:
                 return self._data
-            
             skiprows = len(self._data) + self._header_count
             chunks = pd.read_csv(
                 self.data_filename,
@@ -473,7 +472,6 @@ class Results:
                                            ignore_index=True)
             except Exception:
                 pass  # All data is up to date
-            
             # Update _last_file_size
             self._last_file_size = current_size
         return self._data

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -447,7 +447,10 @@ class Results:
                 self._data = pd.DataFrame(columns=self.procedure.DATA_COLUMNS)
         else:  # Concatenate additional data, if any, to already loaded data
             # Get current filesize, if same as _last_file_size, return data
-            current_size = os.path.getsize(self.data_filename)
+            try:
+                current_size = os.path.getsize(self.data_filename)
+            except OSError:
+                return self._data
             if current_size == self._last_file_size:
                 return self._data
             skiprows = len(self._data) + self._header_count

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -116,9 +116,11 @@ class TestResults:
 
     @mock.patch('pymeasure.experiment.results.open', mock.mock_open(), create=True)
     @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.path.getsize', return_value=0)
     @mock.patch('pymeasure.experiment.results.pd.read_csv')
     def test_regression_attr_data_when_up_to_date_should_retain_dtype(self,
                                                                       read_csv_mock,
+                                                                      getsize_mock,
                                                                       path_exists_mock):
         procedure_mock = mock.MagicMock(spec=Procedure)
         result = Results(procedure_mock, 'test.csv')


### PR DESCRIPTION
Add file size checking to `Results.data` property. When there is potentially new data, first check to see if the size of the file has changed. If it hasn't, there is no new data, return current _data.

`Results.data` is frequently polled by display widgets. For example, the default `PlotWidget` creates `PlotFrame` with a `refresh_time` of 0.2 seconds. On each tick, `PlotFrame.update_curves()` calls `ResultsCurve.update_data()`, which accesses `Results.data`. This change prevents the file being read if there are no changes.