### PR TITLE
Feature/console widget

### DIFF
--- a/docs/api/display/widgets.rst
+++ b/docs/api/display/widgets.rst
@@ -65,3 +65,7 @@ Widget classes
 .. automodule:: pymeasure.display.widgets.table_widget
     :members:
     :show-inheritance:
+
+.. automodule:: pymeasure.display.widgets.console_widget
+    :members:
+    :show-inheritance:

--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -409,7 +409,11 @@ You can expose variables, instruments, and modules to this console by passing a 
             # 1. Create the console widget and expose variables to it
             self.console_widget = ConsoleWidget(
                 "Script Console",
-                namespace={'window': self, 'device': my_instrument, 'np': numpy}
+                namespace={
+                    'window': self, 
+                    'device': '<your_instrument>', # replace with your instrument instance
+                    'np': '<numpy_module>' # replace with numpy if imported
+                }
             )
             
             # 2. Append it manually so it appears as the last tab

--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -380,6 +380,41 @@ In order to get familiar with the mechanism, users can check the following widge
 - :class:`~pymeasure.display.widgets.image_widget.ImageWidget`
 - :class:`~pymeasure.display.widgets.image_widget.DockWidget`
 - :class:`~pymeasure.display.widgets.table_widget.TableWidget`
+- :class:`~pymeasure.display.widgets.console_widget.ConsoleWidget`
+
+Using the interactive Python console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes it is useful to interact with the application live while it is running, to query the state of the instrument or control the instrument. PyMeasure provides a :class:`~pymeasure.display.widgets.console_widget.ConsoleWidget` which can be embedded directly into the :class:`~pymeasure.display.windows.managed_window.ManagedWindow`.
+
+You can expose variables, instruments, and modules to this console by passing a ``namespace`` dictionary during initialization. Because :class:`~pymeasure.display.windows.managed_window.ManagedWindow` places its default widgets (like the plot and log) at the end of the ``widget_list`` parameter, it is common to manually append the :class:`~pymeasure.display.widgets.console_widget.ConsoleWidget` after ``super().__init__()`` if you want it to appear as the right-most tab.
+
+.. code-block:: python
+   :emphasize-lines: 1,15,16,17,18,19,20,22,23
+
+    from pymeasure.display.widgets.console_widget import ConsoleWidget
+
+    class MainWindow(ManagedWindow):
+
+        def __init__(self):
+            super().__init__(
+                procedure_class=RandomProcedure,
+                inputs=['iterations', 'delay', 'seed'],
+                displays=['iterations', 'delay', 'seed'],
+                x_axis='Iteration',
+                y_axis='Random Number',
+            )
+            self.setWindowTitle('GUI Example')
+            
+            # 1. Create the console widget and expose variables to it
+            self.console_widget = ConsoleWidget(
+                "Script Console",
+                namespace={'window': self, 'device': my_instrument, 'np': numpy}
+            )
+            
+            # 2. Append it manually so it appears as the last tab
+            self.widget_list += (self.console_widget,)
+            self.tabs.addTab(self.console_widget, self.console_widget.name)
 
 Using the sequencer
 ~~~~~~~~~~~~~~~~~~~

--- a/pymeasure/display/widgets/console_widget.py
+++ b/pymeasure/display/widgets/console_widget.py
@@ -44,7 +44,7 @@ class ConsoleWidget(TabWidget, PGConsoleWidget):
 
     :param name: Name of the widget. This is the text that will appear on the Tab in the GUI.
     :param parent: The Qt parent widget. Usually left as None or passed as the main window.
-    :param namespace: A dictionary containing the local variables and modules you want to expose 
+    :param namespace: A dictionary containing the local variables and modules you want to expose
         to the console environment. For example, `{'window': self, 'device': your_device}`
         allows you to access the `window` object and your instrument directly in the console.
     :param text: The initial welcome message displayed when the console is first opened.

--- a/pymeasure/display/widgets/console_widget.py
+++ b/pymeasure/display/widgets/console_widget.py
@@ -22,17 +22,31 @@
 # THE SOFTWARE.
 #
 
-from .browser_widget import BrowserWidget
-from .fileinput_widget import FileInputWidget
-from .estimator_widget import EstimatorWidget, EstimatorThread
-from .image_frame import ImageFrame
-from .image_widget import ImageWidget
-from .inputs_widget import InputsWidget
-from .log_widget import LogWidget
-from .plot_frame import PlotFrame
-from .plot_widget import PlotWidget
-from .results_dialog import ResultsDialog
-from .sequencer_widget import SequencerWidget
+import logging
+
+from pyqtgraph.console import ConsoleWidget as PGConsoleWidget
+
 from .tab_widget import TabWidget
-from .table_widget import TableWidget
-from .console_widget import ConsoleWidget
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class ConsoleWidget(TabWidget, PGConsoleWidget):
+    """ Widget to display an interactive Python console in GUI.
+    
+    It allows executing arbitrary Python commands at runtime and debugging the 
+    application.
+
+    It can be included in subclasses of
+    :class:`ManagedWindowBase<pymeasure.display.windows.managed_window.ManagedWindowBase>`
+    by adding it to the widget_list.
+    """
+
+    def __init__(self, name, parent=None, namespace=None, text="Interactive Python Console\n"):
+        super().__init__(
+            name=name,
+            parent=parent,
+            namespace=namespace,
+            text=text
+        )

--- a/pymeasure/display/widgets/console_widget.py
+++ b/pymeasure/display/widgets/console_widget.py
@@ -33,20 +33,22 @@ log.addHandler(logging.NullHandler())
 
 
 class ConsoleWidget(TabWidget, PGConsoleWidget):
-    """ Widget to display an interactive Python console in GUI.
-    
-    It allows executing arbitrary Python commands at runtime and debugging the 
+    """Display an interactive Python console in the GUI.
+
+    It allows executing arbitrary Python commands at runtime and debugging the
     application.
 
     It can be included in subclasses of
     :class:`ManagedWindowBase<pymeasure.display.windows.managed_window.ManagedWindowBase>`
     by adding it to the widget_list.
+
+    :param name: Name of the widget. This is the text that will appear on the Tab in the GUI.
+    :param parent: The Qt parent widget. Usually left as None or passed as the main window.
+    :param namespace: A dictionary containing the local variables and modules you want to expose 
+        to the console environment. For example, `{'window': self, 'device': your_device}`
+        allows you to access the `window` object and your instrument directly in the console.
+    :param text: The initial welcome message displayed when the console is first opened.
     """
 
     def __init__(self, name, parent=None, namespace=None, text="Interactive Python Console\n"):
-        super().__init__(
-            name=name,
-            parent=parent,
-            namespace=namespace,
-            text=text
-        )
+        super().__init__(name=name, parent=parent, namespace=namespace, text=text)

--- a/pymeasure/display/widgets/console_widget.py
+++ b/pymeasure/display/widgets/console_widget.py
@@ -22,33 +22,27 @@
 # THE SOFTWARE.
 #
 
-import logging
-
 from pyqtgraph.console import ConsoleWidget as PGConsoleWidget
 
 from .tab_widget import TabWidget
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 class ConsoleWidget(TabWidget, PGConsoleWidget):
     """Display an interactive Python console in the GUI.
 
-    It allows executing arbitrary Python commands at runtime and debugging the
+    Allow executing arbitrary Python commands at runtime and debugging the
     application.
 
     It can be included in subclasses of
     :class:`ManagedWindowBase<pymeasure.display.windows.managed_window.ManagedWindowBase>`
     by adding it to the widget_list.
 
-    :param name: Name of the widget. This is the text that will appear on the Tab in the GUI.
-    :param parent: The Qt parent widget. Usually left as None or passed as the main window.
-    :param namespace: A dictionary containing the local variables and modules you want to expose
-        to the console environment. For example, `{'window': self, 'device': your_device}`
-        allows you to access the `window` object and your instrument directly in the console.
-    :param text: The initial welcome message displayed when the console is first opened.
+    :param name: Name of the widget, displayed on the tab in the GUI.
+    :param parent: The Qt parent widget.
+    :param namespace: A dictionary of variables and modules to expose
+        to the console. For example,
+        ``{'window': self, 'device': your_device}``.
+    :param text: The initial welcome message displayed in the console.
     """
 
-    def __init__(self, name, parent=None, namespace=None, text="Interactive Python Console\n"):
-        super().__init__(name=name, parent=parent, namespace=namespace, text=text)
+    pass


### PR DESCRIPTION
Introduces ConsoleWidget inheriting from pyqtgraph.console.ConsoleWidget.
Allows live access to instruments.
Includes API documentation and a full tutorial for docs/tutorial/graphical.rst.