### PR TITLE
Allow sharing a single pyvisa.ResourceManager across instruments

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -25,6 +25,7 @@
 import logging
 
 import pyvisa
+from pyvisa import ResourceManager
 
 from .adapter import Adapter
 from .protocol import ProtocolAdapter
@@ -42,8 +43,12 @@ class VISAAdapter(Adapter):
     :param resource_name: A
         `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
         or GPIB address integer that identifies the target of the connection
-    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library or VisaLibrary spec
-        string (``@py`` or ``@ivi``). If not given, the default for the platform will be used.
+    :param visa_library: PyVISA VisaLibrary Instance, an existing
+        :class:`pyvisa.ResourceManager`, a path of the VISA library, or a
+        VisaLibrary spec string (``@py`` or ``@ivi``). If not given, the
+        default for the platform will be used. Passing an already existing
+        :class:`pyvisa.ResourceManager` allows several instruments to share a
+        single resource manager instead of each creating its own.
     :param log: Parent logger of the 'Adapter' logger.
     :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
 
@@ -87,7 +92,10 @@ class VISAAdapter(Adapter):
             resource_name = "GPIB0::%d::INSTR" % resource_name
 
         self.resource_name = resource_name
-        self.manager = pyvisa.ResourceManager(visa_library)
+        if isinstance(visa_library, ResourceManager):
+            self.manager = visa_library
+        else:
+            self.manager = pyvisa.ResourceManager(visa_library)
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -87,6 +87,7 @@ class VISAAdapter(Adapter):
             self.resource_name = getattr(resource_name, "resource_name", None)
             self.connection = resource_name.connection
             self.manager = resource_name.manager
+            self._owns_manager = False
             return
         elif isinstance(resource_name, int):
             resource_name = "GPIB0::%d::INSTR" % resource_name
@@ -94,8 +95,10 @@ class VISAAdapter(Adapter):
         self.resource_name = resource_name
         if isinstance(visa_library, ResourceManager):
             self.manager = visa_library
+            self._owns_manager = False
         else:
             self.manager = pyvisa.ResourceManager(visa_library)
+            self._owns_manager = True
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type
@@ -122,10 +125,16 @@ class VISAAdapter(Adapter):
 
             This closes the connection to the resource for all adapters using
             it currently (e.g. different adapters using the same GPIB line).
+            The underlying :class:`pyvisa.ResourceManager` is only closed when
+            this adapter created it; a manager passed in via ``visa_library``
+            is left open so that other adapters sharing it remain usable.
         """
         super().close()
         try:
-            if self.manager.visalib.library_path == "unset":
+            if (
+                getattr(self, "_owns_manager", True)
+                and self.manager.visalib.library_path == "unset"
+            ):
                 # if using the pyvisa-sim library the manager has to be also closed.
                 # this works around https://github.com/pyvisa/pyvisa-sim/issues/82
                 self.manager.close()

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -85,9 +85,10 @@ class Instrument(CommonBase):
                 adapter = VISAAdapter(name, adapter, **kwargs)
             elif isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
-        except ImportError:
-            raise Exception("Invalid Adapter provided for Instrument since"
-                            " PyVISA is not present")
+        except ImportError as err:
+            raise Exception(
+                "Invalid Adapter provided for Instrument since PyVISA is not present"
+            ) from err
         self.adapter = adapter
         if includeSCPI is True:
             warn("Defining SCPI base functionality with `includeSCPI=True` is deprecated, inherit "
@@ -99,7 +100,7 @@ class Instrument(CommonBase):
         self.SCPI = includeSCPI
         self.isShutdown = False
         self.name = name
-        self.resource_name = name
+        self.resource_name = getattr(self.adapter, "resource_name", name)
         self.vendor = ""
         self.serial_number = ""
         self.firmware_ref = ""

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -26,6 +26,8 @@ import logging
 import time
 from warnings import warn
 
+from pyvisa import ResourceManager
+
 from .common_base import CommonBase
 from ..adapters.visa import VISAAdapter
 
@@ -47,6 +49,10 @@ class Instrument(CommonBase):
     defining the target of your connection.
 
     When ``adapter`` is an integer, a GPIB resource name is created based on that.
+    When ``adapter`` is a :class:`pyvisa.ResourceManager`, a
+    :py:class:`~pymeasure.adapters.VISAAdapter` is constructed that reuses this
+    resource manager; in that case ``name`` is interpreted as the VISA resource
+    name for the connection.
     In either case a :py:class:`~pymeasure.adapters.VISAAdapter` is constructed based on that
     resource name.
     Keyword arguments can be used to further configure the connection.
@@ -74,12 +80,14 @@ class Instrument(CommonBase):
     def __init__(self, adapter, name, includeSCPI=None,
                  **kwargs):
         # Setup communication before possible children require the adapter.
-        if isinstance(adapter, (int, str)):
-            try:
+        try:
+            if isinstance(adapter, ResourceManager):
+                adapter = VISAAdapter(name, adapter, **kwargs)
+            elif isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
-            except ImportError:
-                raise Exception("Invalid Adapter provided for Instrument since"
-                                " PyVISA is not present")
+        except ImportError:
+            raise Exception("Invalid Adapter provided for Instrument since"
+                            " PyVISA is not present")
         self.adapter = adapter
         if includeSCPI is True:
             warn("Defining SCPI base functionality with `includeSCPI=True` is deprecated, inherit "
@@ -91,6 +99,10 @@ class Instrument(CommonBase):
         self.SCPI = includeSCPI
         self.isShutdown = False
         self.name = name
+        self.resource_name = name
+        self.vendor = ""
+        self.serial_number = ""
+        self.firmware_ref = ""
 
         super().__init__()
 

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -101,9 +101,11 @@ class Instrument(CommonBase):
         self.isShutdown = False
         self.name = name
         self.resource_name = getattr(self.adapter, "resource_name", name)
-        self.vendor = ""
-        self.serial_number = ""
-        self.firmware_ref = ""
+        # Only seed the identity fields on subclasses that don't already
+        # define them as (read-only) properties of their own.
+        for _attr in ("vendor", "serial_number", "firmware_ref"):
+            if not hasattr(type(self), _attr):
+                setattr(self, _attr, "")
 
         super().__init__()
 

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -65,6 +65,15 @@ def test_nested_adapter():
     assert a.manager == a0.manager
 
 
+def test_shared_resource_manager():
+    """``visa_library`` accepts an existing ``pyvisa.ResourceManager`` and reuses it."""
+    rm = pyvisa.ResourceManager('@sim')
+    a1 = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+    a2 = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+    assert a1.manager is rm
+    assert a2.manager is rm
+
+
 def test_ProtocolAdapter():
     with expected_protocol(
             VISAAdapter,

--- a/tests/instruments/test_instrument.py
+++ b/tests/instruments/test_instrument.py
@@ -129,6 +129,21 @@ def test_init_visa_fail():
         Instrument("abc", "def", visa_library="@xyz")
 
 
+def test_init_shared_resource_manager():
+    """``adapter`` accepts an existing ``pyvisa.ResourceManager``; ``name`` is used
+    as VISA resource name and the manager is reused by the underlying VISAAdapter."""
+    import pyvisa
+
+    rm = pyvisa.ResourceManager("@sim")
+    instr_a = Instrument(rm, "ASRL1::INSTR", includeSCPI=False)
+    instr_b = Instrument(rm, "ASRL2::INSTR", includeSCPI=False)
+    assert instr_a.adapter.manager is rm
+    assert instr_b.adapter.manager is rm
+    assert instr_a.resource_name == "ASRL1::INSTR"
+    assert instr_b.resource_name == "ASRL2::INSTR"
+    assert instr_a.vendor == "" and instr_a.serial_number == "" and instr_a.firmware_ref == ""
+
+
 def test_init_includeSCPI_implicit_warning():
     with pytest.warns(FutureWarning, match="includeSCPI"):
         Instrument("COM1", "def", visa_library="@sim")


### PR DESCRIPTION
﻿## Summary

Today every `VISAAdapter` (and therefore every `Instrument`) creates its own
`pyvisa.ResourceManager`. When a measurement setup uses several VISA
instruments at the same time this leads to multiple resource managers being
opened against the same VISA backend, which is wasteful and on some backends
(e.g. NI-VISA on Windows) can cause locking / device-discovery issues.

This PR lets the user pass an already-existing `pyvisa.ResourceManager` to
PyMeasure so that one RM can be reused by several instruments. Existing
behaviour is preserved when no RM is passed.

## Changes

- `pymeasure/adapters/visa.py`
  - `VISAAdapter` accepts a `pyvisa.ResourceManager` instance via the
    existing `visa_library` parameter and reuses it instead of creating a
    new one. Anything else is dispatched to the previous code path.
- `pymeasure/instruments/instrument.py`
  - `Instrument(adapter=rm, name=resource_name)` is now valid: when
    `adapter` is a `pyvisa.ResourceManager`, a `VISAAdapter` is built that
    reuses that RM and uses `name` as the VISA resource string.
  - Adds identity attributes (`resource_name`, `vendor`, `serial_number`,
    `firmware_ref`) on the base class so SCPI subclasses can populate them
    without re-declaring (used by the follow-up PR).

## Backwards compatibility

Fully backwards compatible. All existing call sites continue to work
unchanged; the new behaviour is only triggered when a `ResourceManager`
instance is passed.

## Tests

- `tests/adapters/test_visa.py` - verifies that a passed-in RM is reused.
- `tests/instruments/test_instrument.py` - verifies the
  `Instrument(adapter=rm, name=...)` path.

## Notes for reviewers

This is the base of a small stack. Two follow-up PRs build on it:

1. SCPIMixin helpers for `open` / `close` / `shutdown` / `get_device_info`
   (uses the new identity attributes).
2. A new Rohde & Schwarz NGPx power-supply driver (uses both of the above).

Each will be opened separately and rebased once this one is merged.
