### PR TITLE
Add open/close/shutdown and *IDN?-based device-info helpers to SCPIMixin

### DIFF
--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -53,6 +53,11 @@ class Adapter:
         """Close connection upon garbage collection of the device."""
         self.close()
 
+    def open(self):
+        """Reopen the connection."""
+        if self.connection is not None:
+            self.connection.open()
+
     def close(self):
         """Close the connection."""
         if self.connection is not None:

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -25,6 +25,7 @@
 import logging
 
 import pyvisa
+from pyvisa import ResourceManager
 
 from .adapter import Adapter
 from .protocol import ProtocolAdapter
@@ -42,8 +43,12 @@ class VISAAdapter(Adapter):
     :param resource_name: A
         `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
         or GPIB address integer that identifies the target of the connection
-    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library or VisaLibrary spec
-        string (``@py`` or ``@ivi``). If not given, the default for the platform will be used.
+    :param visa_library: PyVISA VisaLibrary Instance, an existing
+        :class:`pyvisa.ResourceManager`, a path of the VISA library, or a
+        VisaLibrary spec string (``@py`` or ``@ivi``). If not given, the
+        default for the platform will be used. Passing an already existing
+        :class:`pyvisa.ResourceManager` allows several instruments to share a
+        single resource manager instead of each creating its own.
     :param log: Parent logger of the 'Adapter' logger.
     :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
 
@@ -87,7 +92,10 @@ class VISAAdapter(Adapter):
             resource_name = "GPIB0::%d::INSTR" % resource_name
 
         self.resource_name = resource_name
-        self.manager = pyvisa.ResourceManager(visa_library)
+        if isinstance(visa_library, ResourceManager):
+            self.manager = visa_library
+        else:
+            self.manager = pyvisa.ResourceManager(visa_library)
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -87,6 +87,7 @@ class VISAAdapter(Adapter):
             self.resource_name = getattr(resource_name, "resource_name", None)
             self.connection = resource_name.connection
             self.manager = resource_name.manager
+            self._owns_manager = False
             return
         elif isinstance(resource_name, int):
             resource_name = "GPIB0::%d::INSTR" % resource_name
@@ -94,8 +95,10 @@ class VISAAdapter(Adapter):
         self.resource_name = resource_name
         if isinstance(visa_library, ResourceManager):
             self.manager = visa_library
+            self._owns_manager = False
         else:
             self.manager = pyvisa.ResourceManager(visa_library)
+            self._owns_manager = True
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type
@@ -122,10 +125,16 @@ class VISAAdapter(Adapter):
 
             This closes the connection to the resource for all adapters using
             it currently (e.g. different adapters using the same GPIB line).
+            The underlying :class:`pyvisa.ResourceManager` is only closed when
+            this adapter created it; a manager passed in via ``visa_library``
+            is left open so that other adapters sharing it remain usable.
         """
         super().close()
         try:
-            if self.manager.visalib.library_path == "unset":
+            if (
+                getattr(self, "_owns_manager", True)
+                and self.manager.visalib.library_path == "unset"
+            ):
                 # if using the pyvisa-sim library the manager has to be also closed.
                 # this works around https://github.com/pyvisa/pyvisa-sim/issues/82
                 self.manager.close()

--- a/pymeasure/instruments/generic_types.py
+++ b/pymeasure/instruments/generic_types.py
@@ -120,28 +120,35 @@ class SCPIMixin:
         ``firmware_ref`` and stores them on the instrument. Note that
         ``self.name`` is overwritten with the model designation reported by
         the device.
+
+        :raises ValueError: If the ``*IDN?`` response does not contain four
+            comma-separated fields.
         """
         resp_str = self.id
-        vendor, name, serial_number, firmware_ref = resp_str.split(",")
-        self.vendor = vendor
-        self.name = name
-        self.serial_number = serial_number
-        self.firmware_ref = firmware_ref
+        parts = [p.strip() for p in resp_str.split(",", 3)]
+        if len(parts) != 4:
+            raise ValueError(f"Unexpected *IDN? response format: {resp_str!r}")
+        self.vendor, self.name, self.serial_number, self.firmware_ref = parts
 
     def check_is_dev_supported(self, instr_list, errMsg):
         """Check whether the connected instrument is in ``instr_list``.
 
-        :param instr_list: Iterable of supported model name substrings, or ``None``
-            to skip the check.
+        Each token in ``instr_list`` is treated as a model-name substring and
+        is searched for in the device name reported by the instrument
+        (typically the model field of ``*IDN?``).
+
+        :param instr_list: Iterable of supported model-name substrings, or
+            ``None`` to skip the check.
         :param errMsg: Message appended to ``self.name`` when raising.
-        :raises AssertionError: If no connection has been opened (``self.name`` is
-            ``None``) or the instrument is not in ``instr_list``.
+        :raises AssertionError: If no connection has been opened
+            (``self.name`` is ``None``) or none of the supported tokens is a
+            substring of the connected device name.
         """
         if self.name is None:
             raise AssertionError("Instrument connection not opened!")
 
         if instr_list is not None:
-            if not (any(self.name in instr for instr in instr_list)):
+            if not any(model in self.name for model in instr_list):
                 self.close()
                 raise AssertionError(self.name + errMsg)
 

--- a/pymeasure/instruments/generic_types.py
+++ b/pymeasure/instruments/generic_types.py
@@ -100,6 +100,51 @@ class SCPIMixin:
                 break
         return errors
 
+    def close(self):
+        """Close the underlying VISA connection."""
+        self.adapter.close()
+
+    def open(self):
+        """Reopen the underlying VISA connection."""
+        self.adapter.open()
+
+    def shutdown(self):
+        """Bring the instrument to a safe and stable state."""
+        self.isShutdown = True
+        log.info("Shutting down %s" % self.name)
+
+    def get_device_info(self):
+        """Query ``*IDN?`` and populate identity attributes.
+
+        Splits the response into ``vendor``, ``name``, ``serial_number`` and
+        ``firmware_ref`` and stores them on the instrument. Note that
+        ``self.name`` is overwritten with the model designation reported by
+        the device.
+        """
+        resp_str = self.id
+        vendor, name, serial_number, firmware_ref = resp_str.split(",")
+        self.vendor = vendor
+        self.name = name
+        self.serial_number = serial_number
+        self.firmware_ref = firmware_ref
+
+    def check_is_dev_supported(self, instr_list, errMsg):
+        """Check whether the connected instrument is in ``instr_list``.
+
+        :param instr_list: Iterable of supported model name substrings, or ``None``
+            to skip the check.
+        :param errMsg: Message appended to ``self.name`` when raising.
+        :raises AssertionError: If no connection has been opened (``self.name`` is
+            ``None``) or the instrument is not in ``instr_list``.
+        """
+        if self.name is None:
+            raise AssertionError("Instrument connection not opened!")
+
+        if instr_list is not None:
+            if not (any(self.name in instr for instr in instr_list)):
+                self.close()
+                raise AssertionError(self.name + errMsg)
+
 
 class SCPIUnknownMixin(SCPIMixin):
     """Mixin which adds SCPI commands to an instrument from which it is not known whether it

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -85,9 +85,10 @@ class Instrument(CommonBase):
                 adapter = VISAAdapter(name, adapter, **kwargs)
             elif isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
-        except ImportError:
-            raise Exception("Invalid Adapter provided for Instrument since"
-                            " PyVISA is not present")
+        except ImportError as err:
+            raise Exception(
+                "Invalid Adapter provided for Instrument since PyVISA is not present"
+            ) from err
         self.adapter = adapter
         if includeSCPI is True:
             warn("Defining SCPI base functionality with `includeSCPI=True` is deprecated, inherit "
@@ -99,7 +100,7 @@ class Instrument(CommonBase):
         self.SCPI = includeSCPI
         self.isShutdown = False
         self.name = name
-        self.resource_name = name
+        self.resource_name = getattr(self.adapter, "resource_name", name)
         self.vendor = ""
         self.serial_number = ""
         self.firmware_ref = ""

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -26,6 +26,8 @@ import logging
 import time
 from warnings import warn
 
+from pyvisa import ResourceManager
+
 from .common_base import CommonBase
 from ..adapters.visa import VISAAdapter
 
@@ -47,6 +49,10 @@ class Instrument(CommonBase):
     defining the target of your connection.
 
     When ``adapter`` is an integer, a GPIB resource name is created based on that.
+    When ``adapter`` is a :class:`pyvisa.ResourceManager`, a
+    :py:class:`~pymeasure.adapters.VISAAdapter` is constructed that reuses this
+    resource manager; in that case ``name`` is interpreted as the VISA resource
+    name for the connection.
     In either case a :py:class:`~pymeasure.adapters.VISAAdapter` is constructed based on that
     resource name.
     Keyword arguments can be used to further configure the connection.
@@ -74,12 +80,14 @@ class Instrument(CommonBase):
     def __init__(self, adapter, name, includeSCPI=None,
                  **kwargs):
         # Setup communication before possible children require the adapter.
-        if isinstance(adapter, (int, str)):
-            try:
+        try:
+            if isinstance(adapter, ResourceManager):
+                adapter = VISAAdapter(name, adapter, **kwargs)
+            elif isinstance(adapter, (int, str)):
                 adapter = VISAAdapter(adapter, **kwargs)
-            except ImportError:
-                raise Exception("Invalid Adapter provided for Instrument since"
-                                " PyVISA is not present")
+        except ImportError:
+            raise Exception("Invalid Adapter provided for Instrument since"
+                            " PyVISA is not present")
         self.adapter = adapter
         if includeSCPI is True:
             warn("Defining SCPI base functionality with `includeSCPI=True` is deprecated, inherit "
@@ -91,6 +99,10 @@ class Instrument(CommonBase):
         self.SCPI = includeSCPI
         self.isShutdown = False
         self.name = name
+        self.resource_name = name
+        self.vendor = ""
+        self.serial_number = ""
+        self.firmware_ref = ""
 
         super().__init__()
 

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -101,9 +101,11 @@ class Instrument(CommonBase):
         self.isShutdown = False
         self.name = name
         self.resource_name = getattr(self.adapter, "resource_name", name)
-        self.vendor = ""
-        self.serial_number = ""
-        self.firmware_ref = ""
+        # Only seed the identity fields on subclasses that don't already
+        # define them as (read-only) properties of their own.
+        for _attr in ("vendor", "serial_number", "firmware_ref"):
+            if not hasattr(type(self), _attr):
+                setattr(self, _attr, "")
 
         super().__init__()
 

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -65,6 +65,15 @@ def test_nested_adapter():
     assert a.manager == a0.manager
 
 
+def test_shared_resource_manager():
+    """``visa_library`` accepts an existing ``pyvisa.ResourceManager`` and reuses it."""
+    rm = pyvisa.ResourceManager('@sim')
+    a1 = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+    a2 = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+    assert a1.manager is rm
+    assert a2.manager is rm
+
+
 def test_ProtocolAdapter():
     with expected_protocol(
             VISAAdapter,

--- a/tests/instruments/test_generic_types.py
+++ b/tests/instruments/test_generic_types.py
@@ -79,6 +79,56 @@ class Test_SCPIMixin:
             assert inst.check_errors() == [[-100, '"Command error"'],
                                            [-222, '"Data out of range"']]
 
+    def test_get_device_info(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,1234,01.42")],
+                name="initial") as inst:
+            inst.get_device_info()
+            assert inst.vendor == "Rohde&Schwarz"
+            assert inst.name == "NGP804"
+            assert inst.serial_number == "1234"
+            assert inst.firmware_ref == "01.42"
+
+    def test_check_is_dev_supported_passes(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "NGP804")
+        inst.check_is_dev_supported(["NGP804", "NGP814"], " not supported")
+
+    def test_check_is_dev_supported_skips_when_list_is_none(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "Anything")
+        inst.check_is_dev_supported(None, " not supported")
+
+    def test_check_is_dev_supported_raises_when_not_in_list(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "Foo")
+        with pytest.raises(AssertionError, match="Foo not supported"):
+            inst.check_is_dev_supported(["NGP804"], " not supported")
+
+    def test_check_is_dev_supported_raises_when_name_is_none(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "test")
+        inst.name = None
+        with pytest.raises(AssertionError, match="not opened"):
+            inst.check_is_dev_supported(["NGP804"], " not supported")
+
+    def test_shutdown_sets_isShutdown(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "test")
+        assert inst.isShutdown is False
+        inst.shutdown()
+        assert inst.isShutdown is True
+
+    def test_close_delegates_to_adapter(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "test")
+        called = {"close": 0}
+        inst.adapter.close = lambda: called.__setitem__("close", called["close"] + 1)
+        inst.close()
+        assert called["close"] == 1
+
+    def test_open_delegates_to_adapter(self):
+        inst = self.SCPIInstrument(ProtocolAdapter(), "test")
+        called = {"open": 0}
+        inst.adapter.open = lambda: called.__setitem__("open", called["open"] + 1)
+        inst.open()
+        assert called["open"] == 1
+
 
 def test_SCPIunknownMixin():
     class SCPIunknownInstrument(SCPIUnknownMixin, Instrument):

--- a/tests/instruments/test_instrument.py
+++ b/tests/instruments/test_instrument.py
@@ -129,6 +129,21 @@ def test_init_visa_fail():
         Instrument("abc", "def", visa_library="@xyz")
 
 
+def test_init_shared_resource_manager():
+    """``adapter`` accepts an existing ``pyvisa.ResourceManager``; ``name`` is used
+    as VISA resource name and the manager is reused by the underlying VISAAdapter."""
+    import pyvisa
+
+    rm = pyvisa.ResourceManager("@sim")
+    instr_a = Instrument(rm, "ASRL1::INSTR", includeSCPI=False)
+    instr_b = Instrument(rm, "ASRL2::INSTR", includeSCPI=False)
+    assert instr_a.adapter.manager is rm
+    assert instr_b.adapter.manager is rm
+    assert instr_a.resource_name == "ASRL1::INSTR"
+    assert instr_b.resource_name == "ASRL2::INSTR"
+    assert instr_a.vendor == "" and instr_a.serial_number == "" and instr_a.firmware_ref == ""
+
+
 def test_init_includeSCPI_implicit_warning():
     with pytest.warns(FutureWarning, match="includeSCPI"):
         Instrument("COM1", "def", visa_library="@sim")


### PR DESCRIPTION
﻿## Summary

Many SCPI drivers re-implement the same handful of helpers: opening and
closing the underlying VISA session, marking the instrument as shut down,
parsing `*IDN?` into vendor / model / serial / firmware, and refusing to
talk to a device that is not in a list of supported models. This PR moves
those helpers into `SCPIMixin` so every SCPI instrument gets them for free.

## Changes

- `pymeasure/adapters/adapter.py`
  - Adds an `Adapter.open()` no-op base implementation, mirroring the
    existing `Adapter.close()`, so `SCPIMixin.open()` has something to
    delegate to in the generic case.
- `pymeasure/instruments/generic_types.py` (`SCPIMixin`)
  - `open()` / `close()` toggle the underlying VISA connection through the
    adapter.
  - `shutdown()` flags the instrument as shut down.
  - `get_device_info()` queries `*IDN?` and populates `vendor`, `name`,
    `serial_number` and `firmware_ref`. Note: `self.name` is overwritten
    with the model designation reported by the device.
  - `check_is_dev_supported(instr_list, errMsg)` raises `AssertionError`
    if the connected model is not in `instr_list`.

## Backwards compatibility

Additive only - no existing method is changed. Drivers that already define
their own `open` / `close` / `shutdown` continue to take precedence via
normal MRO.

## Tests

- `tests/instruments/test_generic_types.py` covers all five helpers,
  including the supported / unsupported model cases.

## Depends on

This branch is stacked on top of #1432
("Allow sharing a single pyvisa.ResourceManager across instruments"),
because `get_device_info()` writes into the identity attributes
(`vendor`, `serial_number`, `firmware_ref`) introduced there.

After PR #1432 is merged I would rebase this branch onto `master`
and force-push, so the diff will shrink to only the SCPIMixin changes.
