### PR TITLE
Add Keysight 35670A dynamic signal analyzer

### DIFF
--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -17,5 +17,6 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysightE36312A
    keysightE3631A
    keysight81160A
+   keysight35670A
    keysight33250A
    keysightPNA

--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -16,6 +16,7 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysightN7776C
    keysightE36312A
    keysightE3631A
-   keysight81160A
-   keysight35670A
-   keysightPNA
+    keysight81160A
+    keysight35670A
+    keysight33250A
+    keysightPNA

--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -17,4 +17,5 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysightE36312A
    keysightE3631A
    keysight81160A
+   keysight35670A
    keysightPNA

--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -16,7 +16,7 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysightN7776C
    keysightE36312A
    keysightE3631A
-    keysight81160A
-    keysight35670A
-    keysight33250A
-    keysightPNA
+   keysight81160A
+   keysight35670A
+   keysight33250A
+   keysightPNA

--- a/docs/api/instruments/keysight/keysight35670A.rst
+++ b/docs/api/instruments/keysight/keysight35670A.rst
@@ -1,0 +1,44 @@
+##########################################
+Keysight 35670A Dynamic Signal Analyzer
+##########################################
+
+.. code-block:: python
+
+    from pymeasure.instruments.keysight import Keysight35670A
+
+The Keysight/Agilent/HP 35670A driver provides a dynamic signal analyzer API for
+measurement and configuration workflows.
+It supports 2 or 4 input channels depending on option AY6, trace boxes 1..4,
+source-output control, and block transfer helpers for binary/definite-block
+data paths.
+Destructive memory, system, and program operations require explicit
+confirmation arguments.
+
+.. autoclass:: pymeasure.instruments.keysight.Keysight35670A
+    :members:
+    :show-inheritance:
+    :inherited-members:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670AInputChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670ASenseWindow
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670ADisplayWindow
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670AWindow
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670AOrderTrack
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysight35670A.Keysight35670ATrace
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -23,6 +23,7 @@
 #
 
 from .keysight81160A import Keysight81160A
+from .keysight35670A import Keysight35670A
 from .keysightDSOX1102G import KeysightDSOX1102G
 from .keysightE3631A import KeysightE3631A
 from .keysightE36312A import KeysightE36312A

--- a/pymeasure/instruments/keysight/keysight35670A.py
+++ b/pymeasure/instruments/keysight/keysight35670A.py
@@ -1,0 +1,4959 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from csv import reader
+from io import StringIO
+from typing import Optional
+
+from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+SOURCE_FUNCTIONS = {
+    "sine": "SIN",
+    "random": "RAND",
+    "burst_random": "BRAN",
+    "periodic_chirp": "PCH",
+    "burst_chirp": "BCH",
+    "pink": "PINK",
+    "user": "USER",
+    "capture": "CAPT",
+}
+
+SOURCE_USER_REGISTERS = {
+    1: "D1",
+    2: "D2",
+    3: "D3",
+    4: "D4",
+    5: "D5",
+    6: "D6",
+    7: "D7",
+    8: "D8",
+}
+
+SOURCE_REFERENCE_CHANNELS = {
+    1: "INP1",
+    2: "INP2",
+    3: "INP3",
+    4: "INP4",
+}
+
+INSTRUMENT_MODES = {
+    "fft": "FFT",
+    "correlation": "CORR",
+    "histogram": "HIST",
+    "octave": "OCT",
+    "order": "ORD",
+    "swept_sine": "SINE",
+}
+
+TRACE_FEEDS = {
+    "data_register_1": "D1",
+    "data_register_2": "D2",
+    "data_register_3": "D3",
+    "data_register_4": "D4",
+    "power_spectrum_ch1": "XFR:POW 1",
+    "power_spectrum_ch2": "XFR:POW 2",
+    "linear_spectrum_ch1": "XFR:POW:LIN 1",
+    "linear_spectrum_ch2": "XFR:POW:LIN 2",
+    "frequency_response_2_1": "XFR:POW:RAT 2,1",
+    "coherence_1_2": "XFR:POW:COH 1,2",
+    "cross_spectrum_1_2": "XFR:POW:CROS 1,2",
+    "time_ch1": "XTIM:VOLT 1",
+    "time_ch2": "XTIM:VOLT 2",
+    "windowed_time_ch1": "XTIM:VOLT:WIND 1",
+    "windowed_time_ch2": "XTIM:VOLT:WIND 2",
+}
+
+TRACE_ACTIVE_VALUES = {
+    "a": "A",
+    "b": "B",
+    "c": "C",
+    "d": "D",
+    "ab": "AB",
+    "cd": "CD",
+    "abcd": "ABCD",
+}
+
+TRACE_DISPLAY_FORMATS = {
+    "linear_magnitude": "MLIN",
+    "log_magnitude": "MLOG",
+    "phase": "PHAS",
+    "real": "REAL",
+    "imaginary": "IMAG",
+    "nyquist": "NYQ",
+    "unwrapped_phase": "UPH",
+    "group_delay": "GDEL",
+    "polar": "POL",
+}
+
+AVERAGE_TYPES = {
+    "maximum": "MAX",
+    "rms": "RMS",
+    "time": "TIME",
+    "vector": "VECT",
+    "equal_confidence": "ECON",
+}
+
+AVERAGE_TCONTROLS = {
+    "freeze": "FREE",
+    "repeat": "REP",
+    "exponential": "EXP",
+}
+
+AVERAGE_HOLD_VALUES = {
+    "off": "OFF",
+    "maximum": "MAX",
+    "minimum": "MIN",
+}
+
+AVERAGE_PREVIEW_VALUES = {
+    "off": "OFF",
+    "manual": "MAN",
+    "timed": "TIM",
+}
+
+REFERENCE_CHANNEL_VALUES = {
+    "single": "SING",
+    "pair": "PAIR",
+}
+
+WINDOW_TYPES = {
+    "hanning": "HANN",
+    "flattop": "FLAT",
+    "uniform": "UNIF",
+    "force": "FORC",
+    "exponential": "EXP",
+    "lag": "LAG",
+    "llag": "LLAG",
+}
+
+TRIGGER_SOURCES = {
+    "immediate": "IMM",
+    "external": "EXT",
+    "internal1": "INT1",
+    "internal2": "INT2",
+    "internal3": "INT3",
+    "internal4": "INT4",
+    "output": "OUTP",
+    "bus": "BUS",
+}
+
+TRIGGER_SLOPES = {
+    "positive": "POS",
+    "negative": "NEG",
+}
+
+TACHOMETER_SLOPES = {
+    "positive": "POS",
+    "negative": "NEG",
+}
+
+ARM_SOURCES = {
+    "immediate": "IMM",
+    "manual": "MAN",
+    "rpm": "RPM",
+    "timer": "TIM",
+}
+
+ARM_RPM_MODES = {
+    "off": "OFF",
+    "up": "UP",
+    "down": "DOWN",
+}
+
+EXTERNAL_TRIGGER_RANGES = {
+    "high": "HIGH",
+    "low": "LOW",
+}
+
+TACHOMETER_TRIGGER_RANGES = {
+    "high": "HIGH",
+    "low": "LOW",
+}
+
+DISPLAY_FORMATS = {
+    "single": "SING",
+    "upper_lower": "ULOW",
+    "feedback": "FBAC",
+    "subl": "SUBL",
+    "upper_lower_feedback": "ULFB",
+    "quad": "QUAD",
+}
+
+DISPLAY_VIEWS = {
+    "trace": "TRAC",
+    "measurement_state": "MSTAT",
+    "mass_memory": "MMEM",
+    "state_table": "STAB",
+    "calc_table": "CTAB",
+    "frequency_table": "FTAB",
+    "time_table": "TTAB",
+    "memory": "MEM",
+    "option": "OPT",
+    "capture": "CAPT",
+    "instrument_state": "IST",
+    "message": "MESS",
+}
+
+DISPLAY_PROGRAM_MODES = {
+    "off": "OFF",
+    "full": "FULL",
+    "upper": "UPP",
+    "lower": "LOW",
+}
+
+TRACE_X_AUTOSCALE = {
+    "off": "OFF",
+    "once": "ONCE",
+}
+
+TRACE_Y_AUTOSCALE = {
+    "off": "OFF",
+    "on": "ON",
+    "once": "ONCE",
+}
+
+DISPLAY_AXIS_SPACING_VALUES = {
+    "linear": "LIN",
+    "logarithmic": "LOG",
+}
+
+DISPLAY_TRACE_Y_REFERENCE_VALUES = {
+    "top": "TOP",
+    "center": "CENT",
+    "bottom": "BOTT",
+    "range": "RANG",
+}
+
+TRACE_AMPLITUDE_UNITS = ("PEAK", "PP", "RMS")
+
+TRACE_ANGLE_UNITS = {
+    "degree": "DEG",
+    "radian": "RAD",
+}
+
+TRACE_X_UNITS = {
+    "hertz": "HZ",
+    "cycles_per_minute": "CPM",
+    "orders": "ORD",
+    "user": "USER",
+}
+
+DB_REFERENCE_UNITS = {
+    "dbv": "DBV",
+    "dbm": "DBM",
+    "dbspl": "DBSPL",
+    "dbuser": "DBUSER",
+    "user": "USER",
+}
+
+TRACE_MECHANICAL_UNITS = (
+    "G",
+    "M/S2",
+    "M/S",
+    "M",
+    "INCH/S2",
+    "INCH/S",
+    "INCH",
+    "MILS",
+)
+
+TRACE_VOLTAGE_UNITS = (
+    "V",
+    "V2",
+    "V/RTHZ",
+    "V2/HZ",
+    "V2S/HZ",
+)
+
+MARKER_FUNCTION_VALUES = {
+    "off": "OFF",
+    "harmonic_power": "HPOW",
+    "thd": "THD",
+    "band_power": "BPOW",
+    "band_rms": "BRMS",
+    "spectrum_power": "SPOW",
+    "overshoot": "OVER",
+    "rise_time": "RTIM",
+    "settling_time": "STIM",
+    "delay_time": "DTIM",
+    "steady_state_level": "SSL",
+    "gain_margin": "GMAR",
+    "phase_margin": "PMAR",
+    "gain_crossover": "GCR",
+    "phase_crossover": "PCR",
+    "frequency": "FREQ",
+    "damping": "DAMP",
+    "s_info": "SINF",
+    "weight": "WEIG",
+    "total_power": "TPOW",
+    "weighted_power": "WPOW",
+}
+
+MARKER_MODE_VALUES = {
+    "absolute": "ABS",
+    "relative": "REL",
+}
+
+MATH_SELECTED_FUNCTION_VALUES = ("F1", "F2", "F3", "F4", "F5")
+SYNTHESIS_SPACING_VALUES = {
+    "linear": "LIN",
+    "logarithmic": "LOG",
+}
+SYNTHESIS_TABLE_TYPE_VALUES = {
+    "pole_zero": "PZER",
+    "pole_fraction": "PFR",
+    "polynomial": "POLY",
+}
+
+BOOL_VALUES = {True: 1, False: 0}
+STATUS_MASK_VALUES = [0, 32767]
+DATA_RANGE_VALUES = [1.0e-20, 1.0e20]
+LIMIT_VALUE_RANGE = [-9.9e37, 9.9e37]
+SENSE_FEED_VALUES = {
+    "input": "INP",
+    "time_capture": "TCAP",
+}
+FREQUENCY_RESOLUTION_OCTAVE_VALUES = {
+    "third": "THIR",
+    "full": "FULL",
+    "twelfth": "TWEL",
+}
+FREQUENCY_SPAN_LINK_VALUES = {
+    "start": "STAR",
+    "center": "CENT",
+}
+SWEEP_DIRECTION_VALUES = {
+    "up": "UP",
+    "down": "DOWN",
+}
+SWEEP_MODE_VALUES = {
+    "auto": "AUTO",
+    "manual": "MAN",
+}
+SWEEP_SPACING_VALUES = {
+    "linear": "LIN",
+    "logarithmic": "LOG",
+}
+AUTORANGE_DIRECTION_VALUES = {
+    "up": "UP",
+    "either": "EITH",
+}
+INPUT_RANGE_TRANSDUCER_LABELS = (
+    "PA",
+    "G",
+    "M/S2",
+    "M/S",
+    "M",
+    "KG",
+    "N",
+    "DYN",
+    "INCH/S2",
+    "INCH/S",
+    "INCH",
+    "MIL",
+    "LB",
+    "USER",
+)
+SERIAL_BAUD_RATES = (300, 1200, 2400, 4800, 9600)
+SERIAL_BITS = (5, 6, 7, 8)
+SERIAL_STOP_BITS = (1, 2)
+SERIAL_RECEIVE_PACE_VALUES = {
+    "none": "NONE",
+    "xon": "XON",
+}
+SERIAL_PARITY_VALUES = {
+    "none": "NONE",
+    "even": "EVEN",
+    "odd": "ODD",
+}
+SERIAL_TRANSMIT_PACE_VALUES = {
+    "none": "NONE",
+    "xon": "XON",
+    "dsr": "DSR",
+}
+DATA_FORMAT_VALUES = {
+    "ascii": "ASC",
+    "real": "REAL",
+}
+FAN_STATE_VALUES = {
+    "off": "OFF",
+    "full": "FULL",
+    "auto": "AUTO",
+}
+SYSTEM_DATE_VALUES = ([0, 9999], [1, 12], [1, 31])
+SYSTEM_TIME_VALUES = ([0, 23], [0, 59], [0, 60])
+HARDCOPY_DEVICE_LANGUAGE_VALUES = ("HPGL", "PCL", "PHPGL")
+HARDCOPY_PAGE_POINT_VALUES = ([-32767, 32767], [-32767, 32767])
+HARDCOPY_DESTINATION_VALUES = ("MMEM", "SYST:COMM:GPIB:RDEV", "SYST:COMM:CENT", "SYST:COMM:SER")
+HARDCOPY_SOURCE_VALUES = ("ALL", "TRAC", "MARK", "REF", "GRID")
+HARDCOPY_LINE_TYPE_STYLE_RANGE = [0, 12]
+HARDCOPY_LABEL_COLOR_RANGE = [0, 16]
+HARDCOPY_TIMESTAMP_FORMAT_VALUES = ("FORM1", "FORM2", "FORM3", "FORM4", "FORM5")
+MEMORY_CATALOG_ITEM_VALUES = {
+    "time_capture": "TCAPture",
+    "waterfall": "WATerfall",
+    "waterfall_register": "WREGister",
+    "program": "PROGram",
+    "ram_disk": "RDISk",
+    "limits": "LIMits",
+}
+MASS_MEMORY_STORE_PROGRAM_FORMAT_VALUES = {
+    "ascii": "ASC",
+    "binary": "BIN",
+}
+MASS_MEMORY_STORE_TRACE_FORMAT_VALUES = ("SDF", "ASCII")
+PROGRAM_STATE_VALUES = {
+    "stop": "STOP",
+    "pause": "PAUSe",
+    "run": "RUN",
+    "continue": "CONTinue",
+}
+
+
+def _parse_ascii_floats(reply: str) -> list[float]:
+    """Parse a comma-separated ASCII response into a list of floats."""
+    if reply.strip() == "":
+        return []
+    values = []
+    for token in reply.split(","):
+        stripped = token.strip()
+        if stripped == "":
+            continue
+        values.append(float(stripped))
+    return values
+
+
+def _parse_ascii_ints(reply: str) -> list[int]:
+    """Parse a comma-separated ASCII response into a list of ints."""
+    if reply.strip() == "":
+        return []
+    values = []
+    for token in reply.split(","):
+        stripped = token.strip()
+        if stripped == "":
+            continue
+        values.append(int(stripped))
+    return values
+
+
+def _parse_csv_strings(reply: str) -> list[str]:
+    """Parse a CSV response into a list of unquoted strings."""
+    if reply.strip() == "":
+        return []
+    row = next(reader(StringIO(reply), skipinitialspace=True))
+    return [_strip_quotes(item.strip()) for item in row]
+
+
+def _strip_quotes(reply: str) -> str:
+    """Strip matching single or double quotes from string boundaries."""
+    value = reply.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _quote_string(value: str) -> str:
+    """Quote a string for SCPI arguments unless already quoted."""
+    if not isinstance(value, str):
+        raise TypeError("SCPI string arguments must be of type str.")
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped
+    escaped = value.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _require_confirmation(action: str, confirmed: bool):
+    """Require explicit confirmation for risky actions."""
+    if confirmed is not True:
+        raise ValueError(
+            f"Action '{action}' requires explicit confirmation. "
+            "Pass confirmed=True to execute."
+        )
+
+
+def _trace_selector(trace):
+    """Return a valid TRACe selector token."""
+    if isinstance(trace, int):
+        if trace not in (1, 2, 3, 4):
+            raise ValueError("Trace index must be in the range 1..4.")
+        return f"TRACe{trace}"
+    return str(trace)
+
+
+def _tcap_selector(capture_channel):
+    """Return a valid TCAP selector token."""
+    if isinstance(capture_channel, int):
+        if capture_channel not in (1, 2, 3, 4):
+            raise ValueError("Capture channel index must be in the range 1..4.")
+        return f"TCAP{capture_channel}"
+
+    token = str(capture_channel).strip().upper()
+    if token in {"TCAP1", "TCAP2", "TCAP3", "TCAP4"}:
+        return token
+    raise ValueError("Capture channel must be 1..4 or one of TCAP1..TCAP4.")
+
+
+def _data_register_selector(register):
+    """Return a valid data-register selector token."""
+    if isinstance(register, int):
+        index = int(strict_range(int(register), [1, 8]))
+        return SOURCE_USER_REGISTERS[index]
+
+    token = _strip_quotes(str(register)).strip().upper()
+    if token in SOURCE_USER_REGISTERS.values():
+        return token
+    raise ValueError("Data register must be 1..8 or one of D1..D8.")
+
+
+def _math_register_selector(register):
+    """Return a valid math register index."""
+    return int(strict_range(int(register), [1, 5]))
+
+
+def _strict_nonzero_range(value, values):
+    """Validate an inclusive range while excluding zero."""
+    validated = strict_range(value, values)
+    if float(validated) == 0.0:
+        raise ValueError("Value must not be 0.")
+    return validated
+
+
+def _normalize_on_off_once(value: str) -> str:
+    """Normalize ON/OFF/ONCE tokens returned as symbolic or numeric values."""
+    token = _strip_quotes(str(value)).strip().upper()
+    return {"0": "OFF", "1": "ON"}.get(token, token)
+
+
+def _normalize_data_format_token(reply: str) -> str:
+    """Normalize FORMat:DATA reply to the first mode token."""
+    token = _strip_quotes(str(reply)).strip()
+    if "," in token:
+        token = token.split(",", 1)[0]
+    return token.strip().upper()
+
+
+def _trace_data_register_selector(register):
+    """Return a valid TRACe data-register selector token."""
+    if isinstance(register, int):
+        index = int(strict_range(int(register), [1, 8]))
+        return f"D{index}"
+
+    token = _strip_quotes(str(register)).strip().upper()
+    if token in {f"D{i}" for i in range(1, 9)}:
+        return token
+    raise ValueError("Trace register must be 1..8 or one of D1..D8.")
+
+
+def _trace_waterfall_register_selector(register):
+    """Return a valid TRACe waterfall-register selector token."""
+    if isinstance(register, int):
+        index = int(strict_range(int(register), [1, 8]))
+        return f"W{index}"
+
+    token = _strip_quotes(str(register)).strip().upper()
+    if token in {f"W{i}" for i in range(1, 9)}:
+        return token
+    raise ValueError("Waterfall register must be 1..8 or one of W1..W8.")
+
+
+def _validate_int_triplet(value, values):
+    """Validate a triplet of integers against three inclusive [min, max] ranges."""
+    if isinstance(value, str):
+        tokens = _parse_ascii_ints(value)
+    elif isinstance(value, (list, tuple)):
+        tokens = [int(item) for item in value]
+    else:
+        raise ValueError("Value must be a 3-item tuple/list or CSV string.")
+
+    if len(tokens) != 3:
+        raise ValueError("Value must contain exactly 3 integers.")
+
+    validated = []
+    for item, limits in zip(tokens, values):
+        validated.append(int(strict_range(item, limits)))
+    return tuple(validated)
+
+
+def _validate_int_pair(value, values):
+    """Validate a pair of integers against two inclusive [min, max] ranges."""
+    if isinstance(value, str):
+        tokens = _parse_ascii_ints(value)
+    elif isinstance(value, (list, tuple)):
+        tokens = [int(item) for item in value]
+    else:
+        raise ValueError("Value must be a 2-item tuple/list or CSV string.")
+
+    if len(tokens) != 2:
+        raise ValueError("Value must contain exactly 2 integers.")
+
+    validated = []
+    for item, limits in zip(tokens, values):
+        validated.append(int(strict_range(item, limits)))
+    return tuple(validated)
+
+
+def _normalize_hardcopy_destination(value: str) -> str:
+    """Normalize hardcopy destination tokens to canonical short-form strings."""
+    token = _strip_quotes(str(value)).strip().upper().replace(" ", "")
+    if token in {"MMEM", "MMEMORY"}:
+        return "MMEM"
+    if "GPIB" in token and "RDEV" in token:
+        return "SYST:COMM:GPIB:RDEV"
+    if "CENT" in token:
+        return "SYST:COMM:CENT"
+    if "SER" in token:
+        return "SYST:COMM:SER"
+    raise ValueError(f"Invalid hardcopy destination '{value}'.")
+
+
+def _validate_hardcopy_destination(value, values):
+    """Validate hardcopy destination token."""
+    del values
+    return _normalize_hardcopy_destination(value)
+
+
+def _normalize_hardcopy_timestamp_format(value: str) -> str:
+    """Normalize hardcopy timestamp format tokens to FORM1..FORM5."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token.startswith("FORMAT"):
+        suffix = token[6:]
+    elif token.startswith("FORM"):
+        suffix = token[4:]
+    else:
+        raise ValueError(f"Invalid hardcopy timestamp format '{value}'.")
+
+    if suffix not in {"1", "2", "3", "4", "5"}:
+        raise ValueError(f"Invalid hardcopy timestamp format '{value}'.")
+    return f"FORM{suffix}"
+
+
+def _validate_hardcopy_timestamp_format(value, values):
+    """Validate hardcopy timestamp format token."""
+    del values
+    return _normalize_hardcopy_timestamp_format(value)
+
+
+def _normalize_hardcopy_source(value: str) -> str:
+    """Normalize hardcopy source token to canonical short-form strings."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token.startswith("ALL"):
+        return "ALL"
+    if token.startswith("TRAC"):
+        return "TRAC"
+    if token.startswith("MARK"):
+        return "MARK"
+    if token.startswith("REF"):
+        return "REF"
+    if token.startswith("GRID"):
+        return "GRID"
+    raise ValueError(f"Invalid hardcopy source '{value}'.")
+
+
+def _validate_hardcopy_source(value, values):
+    """Validate hardcopy source token."""
+    del values
+    return _normalize_hardcopy_source(value)
+
+
+def _normalize_hardcopy_line_type(value: str) -> str:
+    """Normalize hardcopy line-type token to SOL, DASH, DOTT, or STYL<n>."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token in {"SOL", "SOLID"}:
+        return "SOL"
+    if token in {"DASH", "DASHED"}:
+        return "DASH"
+    if token in {"DOTT", "DOTTED", "DOT"}:
+        return "DOTT"
+
+    if token.startswith("STYLE"):
+        suffix = token[5:]
+    elif token.startswith("STYL"):
+        suffix = token[4:]
+    else:
+        raise ValueError(f"Invalid hardcopy line type '{value}'.")
+
+    try:
+        style_index = int(suffix)
+    except ValueError as exc:
+        raise ValueError(f"Invalid hardcopy line type '{value}'.") from exc
+
+    strict_range(style_index, HARDCOPY_LINE_TYPE_STYLE_RANGE)
+    if style_index not in {0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}:
+        raise ValueError("Hardcopy style line type must be STYL0 or STYL3..STYL12.")
+    return f"STYL{style_index}"
+
+
+def _validate_hardcopy_line_type(value, values):
+    """Validate hardcopy line-type token."""
+    del values
+    return _normalize_hardcopy_line_type(value)
+
+
+def _normalize_memory_catalog_item(value: str) -> str:
+    """Normalize memory catalog/delete item selector token."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token.startswith("TCAP"):
+        return "TCAPture"
+    if token.startswith("WATERFALL") or token == "WAT":
+        return "WATerfall"
+    if token.startswith("WREG"):
+        return "WREGister"
+    if token.startswith("PROG"):
+        return "PROGram"
+    if token.startswith("RDIS"):
+        return "RDISk"
+    if token.startswith("LIM"):
+        return "LIMits"
+    raise ValueError(f"Invalid memory item selector '{value}'.")
+
+
+def _validate_memory_catalog_item(value, values):
+    """Validate memory catalog/delete item selector token."""
+    del values
+    return _normalize_memory_catalog_item(value)
+
+
+def _normalize_mass_memory_disk(value: str) -> str:
+    """Normalize mass-memory disk selector token."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token in {"RAM", "RAM:"}:
+        return "RAM:"
+    if token in {"NVRAM", "NVRAM:"}:
+        return "NVRAM:"
+    if token in {"INT", "INT:"}:
+        return "INT:"
+    if token in {"EXT", "EXT:"}:
+        return "EXT:"
+    if token.startswith("EXT,"):
+        return token if token.endswith(":") else token + ":"
+    raise ValueError(f"Invalid mass-memory disk selector '{value}'.")
+
+
+def _normalize_mass_memory_trace_selector(trace) -> str:
+    """Normalize trace selector for MMEMory trace-specific operations."""
+    index = int(strict_range(int(trace), [1, 4]))
+    return f"TRACe{index}"
+
+
+def _normalize_mass_memory_program_format(value: str) -> str:
+    """Normalize MMEMory:STORe:PROGram:FORMat token."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token.startswith("ASC"):
+        return "ASC"
+    if token.startswith("BIN"):
+        return "BIN"
+    raise ValueError(f"Invalid mass-memory program format '{value}'.")
+
+
+def _normalize_program_name(value: str) -> str:
+    """Normalize Instrument BASIC program-buffer selector token."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token in {"1", "PROG1", "PROGRAM1"}:
+        return "PROGram1"
+    if token in {"2", "PROG2", "PROGRAM2"}:
+        return "PROGram2"
+    if token in {"3", "PROG3", "PROGRAM3"}:
+        return "PROGram3"
+    if token in {"4", "PROG4", "PROGRAM4"}:
+        return "PROGram4"
+    if token in {"5", "PROG5", "PROGRAM5"}:
+        return "PROGram5"
+    raise ValueError(f"Invalid program selector '{value}'.")
+
+
+def _normalize_program_state(value: str) -> str:
+    """Normalize Instrument BASIC program state token."""
+    token = _strip_quotes(str(value)).strip().upper()
+    if token.startswith("STOP"):
+        return "STOP"
+    if token.startswith("PAUS"):
+        return "PAUSe"
+    if token.startswith("RUN"):
+        return "RUN"
+    if token.startswith("CONT"):
+        return "CONTinue"
+    raise ValueError(f"Invalid program state '{value}'.")
+
+
+def _normalize_program_variable_name(index, string_variable=False) -> str:
+    """Normalize Instrument BASIC variable identifier for SCPI program-variable commands."""
+    token = _strip_quotes(str(index)).strip()
+    if token == "":
+        raise ValueError("Program variable identifier must not be empty.")
+
+    if string_variable:
+        if token.endswith("$"):
+            return token
+        if token.isdigit():
+            return f"S{token}$"
+        return token + "$"
+
+    return token
+
+
+def _parse_ascii_or_definite_block_text(reply) -> str:
+    """Parse ASCII text or definite-block text reply into a Python string."""
+    if isinstance(reply, (bytes, bytearray)):
+        raw = bytes(reply)
+    else:
+        raw = str(reply).encode("latin1")
+
+    if raw == b"":
+        return ""
+
+    if raw.startswith(b"#"):
+        payload = _parse_definite_block(raw)
+        return payload.decode("latin1")
+
+    return raw.decode("latin1").strip()
+
+
+def _encode_program_block(text, raw=False) -> bytes:
+    """Encode Instrument BASIC program text for PROGram:*:DEFine commands."""
+    payload = _coerce_bytes(text)
+    if raw:
+        return payload
+    return _encode_definite_block(payload)
+
+
+def _encode_definite_block(payload: bytes) -> bytes:
+    """Encode payload bytes as an IEEE definite-length SCPI block."""
+    length = len(payload)
+    length_ascii = str(length).encode("ascii")
+    return b"#" + str(len(length_ascii)).encode("ascii") + length_ascii + payload
+
+
+def _parse_definite_block(block: bytes) -> bytes:
+    """Parse an IEEE definite-length SCPI block and return the payload bytes."""
+    if not block:
+        raise ValueError("Definite block is empty.")
+    if block[0:1] != b"#":
+        raise ValueError("Definite block must start with '#'.")
+
+    header_len_char = block[1:2]
+    if not header_len_char or not header_len_char.isdigit():
+        raise ValueError("Definite block header is malformed.")
+
+    header_len = int(header_len_char.decode("ascii"))
+    if header_len == 0:
+        return block[2:]
+
+    header_start = 2
+    header_end = header_start + header_len
+    if len(block) < header_end:
+        raise ValueError("Definite block length header is incomplete.")
+
+    length_ascii = block[header_start:header_end]
+    if not length_ascii.isdigit():
+        raise ValueError("Definite block byte count is malformed.")
+
+    payload_length = int(length_ascii.decode("ascii"))
+    payload_end = header_end + payload_length
+    if len(block) < payload_end:
+        raise ValueError("Definite block payload is incomplete.")
+
+    return block[header_end:payload_end]
+
+
+def _coerce_bytes(value) -> bytes:
+    """Convert supported system-state payload input to bytes."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("latin1")
+    raise TypeError("System state data must be bytes, bytearray, or str.")
+
+
+def _parse_ascii_or_definite_block_floats(reply) -> list[float]:
+    """Parse ASCII CSV float data or an ASCII definite block with CSV float payload."""
+    if isinstance(reply, (bytes, bytearray)):
+        raw = bytes(reply)
+    else:
+        raw = str(reply).strip().encode("latin1")
+
+    if raw == b"":
+        return []
+
+    if raw.startswith(b"#"):
+        payload = _parse_definite_block(raw)
+        try:
+            decoded = payload.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Binary definite blocks are not supported by this ASCII parser.") from exc
+        return _parse_ascii_floats(decoded)
+
+    return _parse_ascii_floats(raw.decode("ascii"))
+
+
+def _parse_limit_segment_data(reply) -> list[tuple[float, float, float, float]]:
+    """Parse limit-segment data into a list of 4-value (x0, y0, x1, y1) tuples."""
+    values = _parse_ascii_or_definite_block_floats(reply)
+    if len(values) % 4 != 0:
+        raise ValueError("Limit segment data must contain 4 values per segment.")
+    segments = []
+    for i in range(0, len(values), 4):
+        segments.append((values[i], values[i + 1], values[i + 2], values[i + 3]))
+    return segments
+
+
+def _format_limit_segment_data(value) -> str:
+    """Format limit-segment input as ASCII CSV for SCPI segment commands."""
+    if isinstance(value, str):
+        return value
+
+    if not isinstance(value, (list, tuple)):
+        raise ValueError("Limit segment data must be a sequence or CSV string.")
+
+    flat_values = []
+    if value and isinstance(value[0], (list, tuple)):
+        for segment in value:
+            if not isinstance(segment, (list, tuple)) or len(segment) != 4:
+                raise ValueError("Each limit segment must contain 4 values.")
+            for item in segment:
+                flat_values.append(float(strict_range(float(item), LIMIT_VALUE_RANGE)))
+    else:
+        for item in value:
+            flat_values.append(float(strict_range(float(item), LIMIT_VALUE_RANGE)))
+        if len(flat_values) % 4 != 0:
+            raise ValueError("Flat limit segment data must contain a multiple of 4 values.")
+
+    return ",".join(f"{item:g}" for item in flat_values)
+
+
+class Keysight35670AInputChannel(Channel):
+    """Represent an input channel of the Keysight 35670A."""
+
+    _state = Channel.control(
+        "INPut{ch}:STATe?",
+        "INPut{ch}:STATe %d",
+        """Control whether the input channel is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    @property
+    def state(self):
+        """Control whether the input channel is enabled."""
+        return type(self)._state.fget(self)
+
+    @state.setter
+    def state(self, value):
+        enabled = bool(strict_discrete_set(value, BOOL_VALUES))
+        if self.id == 1 and not enabled:
+            raise ValueError("Input channel 1 cannot be disabled.")
+        type(self)._state.fset(self, enabled)
+
+    enabled = state
+
+    bias_enabled = Channel.control(
+        "INPut{ch}:BIAS:STATe?",
+        "INPut{ch}:BIAS:STATe %d",
+        """Control whether the ICP bias supply is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    coupling = Channel.control(
+        "INPut{ch}:COUPling?",
+        "INPut{ch}:COUPling %s",
+        """Control the input coupling.""",
+        values=("AC", "DC"),
+        validator=strict_discrete_set,
+    )
+
+    a_weighting_enabled = Channel.control(
+        "INPut{ch}:FILTer:AWEighting:STATe?",
+        "INPut{ch}:FILTer:AWEighting:STATe %d",
+        """Control whether the A-weighting filter is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    anti_alias_filter_enabled = Channel.control(
+        "INPut{ch}:FILTer:LPASs:STATe?",
+        "INPut{ch}:FILTer:LPASs:STATe %d",
+        """Control whether the anti-alias low-pass filter is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    shield = Channel.control(
+        "INPut{ch}:LOW?",
+        "INPut{ch}:LOW %s",
+        """Control whether the input shield is grounded or floating.""",
+        values={"ground": "GRO", "float": "FLO"},
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    reference_direction = Channel.control(
+        "INPut{ch}:REFerence:DIRection?",
+        "INPut{ch}:REFerence:DIRection %d",
+        """Control the transducer reference direction code.""",
+        values=[0, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    reference_point = Channel.control(
+        "INPut{ch}:REFerence:POINt?",
+        "INPut{ch}:REFerence:POINt %d",
+        """Control the transducer reference point number.""",
+        values=[0, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    autorange_enabled = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:AUTO?",
+        "SENSe:VOLTage{ch}:RANGe:AUTO %d",
+        """Control whether input autoranging is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    autorange_direction = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:AUTO:DIRection?",
+        "SENSe:VOLTage{ch}:RANGe:AUTO:DIRection %s",
+        """Control whether autoranging moves upward only or in both directions.""",
+        values=AUTORANGE_DIRECTION_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    range_unit_user_label = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:LABel?",
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:LABel %s",
+        """Control custom transducer unit label (string up to 4 characters).""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    range_unit_user_scale_factor = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:SFACtor?",
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:SFACtor %g",
+        """Control custom transducer sensitivity scale factor.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    range_unit_user_enabled = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:STATe?",
+        "SENSe:VOLTage{ch}:RANGe:UNIT:USER:STATe %d",
+        """Control whether transducer units are enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    range_unit_transducer_label = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe:UNIT:XDCR:LABel?",
+        "SENSe:VOLTage{ch}:RANGe:UNIT:XDCR:LABel %s",
+        """Control transducer unit label selection.""",
+        values=INPUT_RANGE_TRANSDUCER_LABELS,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    range_dbvrms = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe?",
+        "SENSe:VOLTage{ch}:RANGe %g",
+        """Control the input range in dBVrms.""",
+        values=tuple(range(-51, 28, 2)),
+        validator=strict_discrete_set,
+        cast=float,
+    )
+
+    range_upper = Channel.control(
+        "SENSe:VOLTage{ch}:RANGe?",
+        "SENSe:VOLTage{ch}:RANGe %g",
+        """Control the upper input range value.""",
+        values=[-51.0, 31.66],
+        validator=strict_range,
+        cast=float,
+    )
+
+class Keysight35670ASenseWindow(Channel):
+    """Represent a measurement SENSE window of the Keysight 35670A."""
+
+    window_type = Channel.control(
+        "SENSe:WINDow{ch}:TYPE?",
+        "SENSe:WINDow{ch}:TYPE %s",
+        """Control the time-window type.""",
+        values=WINDOW_TYPES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    exponential_window_time_constant = Channel.control(
+        "SENSe:WINDow{ch}:EXPonential?",
+        "SENSe:WINDow{ch}:EXPonential %g",
+        """Control the exponential-window time constant in seconds.""",
+        values=[3.8147e-06, 9.9999e06],
+        validator=strict_range,
+        cast=float,
+    )
+
+    force_window_width = Channel.control(
+        "SENSe:WINDow{ch}:FORCe?",
+        "SENSe:WINDow{ch}:FORCe %g",
+        """Control the force-window width in seconds.""",
+        values=[3.8147e-06, 9.9999e06],
+        validator=strict_range,
+        cast=float,
+    )
+
+    force_window = force_window_width
+
+    order_dc_included = Channel.control(
+        "SENSe:WINDow{ch}:ORDer:DC?",
+        "SENSe:WINDow{ch}:ORDer:DC %d",
+        """Control whether the DC bin is included in order composite power.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+
+class Keysight35670ADisplayWindow(Keysight35670ASenseWindow):
+    """Represent a DISPlay window of the Keysight 35670A."""
+
+    data_table_marker_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:DTABle:MARKer:STATe?",
+        "DISPlay:WINDow{ch}:DTABle:MARKer:STATe %d",
+        """Control whether data-table markers are shown for the window.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    data_table_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:DTABle:STATe?",
+        "DISPlay:WINDow{ch}:DTABle:STATe %d",
+        """Control whether the data table is displayed for the window.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    limit_display_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:LIMit:STATe?",
+        "DISPlay:WINDow{ch}:LIMit:STATe %d",
+        """Control whether limit lines are displayed for the window.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    polar_clockwise = Channel.control(
+        "DISPlay:WINDow{ch}:POLar:CLOCkwise?",
+        "DISPlay:WINDow{ch}:POLar:CLOCkwise %d",
+        """Control clockwise direction for polar diagrams.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    polar_rotation = Channel.control(
+        "DISPlay:WINDow{ch}:POLar:ROTation?",
+        "DISPlay:WINDow{ch}:POLar:ROTation %g",
+        """Control polar rotation angle in degrees.""",
+        values=[-360.0, 360.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_a_power_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:APOWer:STATe?",
+        "DISPlay:WINDow{ch}:TRACe:APOWer:STATe %d",
+        """Control whether A-weighted overall power is displayed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    trace_b_power_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:BPOWer:STATe?",
+        "DISPlay:WINDow{ch}:TRACe:BPOWer:STATe %d",
+        """Control whether overall power is displayed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    trace_graticule_grid_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:GRATicule:GRID:STATe?",
+        "DISPlay:WINDow{ch}:TRACe:GRATicule:GRID:STATe %d",
+        """Control whether the trace graticule grid is displayed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    trace_label = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:LABel?",
+        "DISPlay:WINDow{ch}:TRACe:LABel %s",
+        """Control the custom trace label for the window.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    trace_label_default_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:LABel:DEFault:STATe?",
+        "DISPlay:WINDow{ch}:TRACe:LABel:DEFault:STATe %d",
+        """Control whether default trace labels are displayed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_trace_color = Channel.control(
+        "HCOPy:ITEM:WINDow{ch}:TRACe:COLor?",
+        "HCOPy:ITEM:WINDow{ch}:TRACe:COLor %d",
+        """Control the hardcopy pen number used for the window trace.""",
+        values=HARDCOPY_LABEL_COLOR_RANGE,
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_trace_graticule_color = Channel.control(
+        "HCOPy:ITEM:WINDow{ch}:TRACe:GRATicule:COLor?",
+        "HCOPy:ITEM:WINDow{ch}:TRACe:GRATicule:COLor %d",
+        """Control the hardcopy pen number used for the trace graticule.""",
+        values=HARDCOPY_LABEL_COLOR_RANGE,
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_trace_limit_line_type = Channel.control(
+        "HCOPy:ITEM:WINDow{ch}:TRACe:LIMit:LTYPe?",
+        "HCOPy:ITEM:WINDow{ch}:TRACe:LIMit:LTYPe %s",
+        """Control the hardcopy line type used for limit lines.""",
+        values=(),
+        validator=_validate_hardcopy_line_type,
+        get_process=_normalize_hardcopy_line_type,
+        set_process=_normalize_hardcopy_line_type,
+        cast=str,
+        maxsplit=0,
+    )
+
+    hardcopy_trace_line_type = Channel.control(
+        "HCOPy:ITEM:WINDow{ch}:TRACe:LTYPe?",
+        "HCOPy:ITEM:WINDow{ch}:TRACe:LTYPe %s",
+        """Control the hardcopy line type used for the window trace.""",
+        values=(),
+        validator=_validate_hardcopy_line_type,
+        get_process=_normalize_hardcopy_line_type,
+        set_process=_normalize_hardcopy_line_type,
+        cast=str,
+        maxsplit=0,
+    )
+
+    hardcopy_trace_marker_color = Channel.control(
+        "HCOPy:ITEM:WINDow{ch}:TRACe:MARKer:COLor?",
+        "HCOPy:ITEM:WINDow{ch}:TRACe:MARKer:COLor %d",
+        """Control the hardcopy pen number used for window markers.""",
+        values=HARDCOPY_LABEL_COLOR_RANGE,
+        validator=strict_range,
+        cast=int,
+    )
+
+    trace_x_autoscale = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:AUTO?",
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:AUTO %s",
+        """Control trace X autoscaling mode.""",
+        values=TRACE_X_AUTOSCALE,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trace_x_left = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:LEFT?",
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:LEFT %g",
+        """Control the left X-axis scale value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_x_right = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:RIGHt?",
+        "DISPlay:WINDow{ch}:TRACe:X:SCALe:RIGHt %g",
+        """Control the right X-axis scale value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_x_spacing = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:X:SPACing?",
+        "DISPlay:WINDow{ch}:TRACe:X:SPACing %s",
+        """Control the X-axis spacing mode.""",
+        values=DISPLAY_AXIS_SPACING_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trace_y_autoscale = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:AUTO?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:AUTO %s",
+        """Control trace Y autoscaling mode.""",
+        values=TRACE_Y_AUTOSCALE,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trace_y_bottom = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:BOTTom?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:BOTTom %g",
+        """Control the Y-axis bottom reference value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_y_center = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:CENTer?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:CENTer %g",
+        """Control the Y-axis center reference value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_y_per_division = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:PDIVision?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:PDIVision %g",
+        """Control the Y-axis height per vertical division.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_y_reference = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:REFerence?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:REFerence %s",
+        """Control the Y-axis reference anchor mode.""",
+        values=DISPLAY_TRACE_Y_REFERENCE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trace_y_top = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:TOP?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SCALe:TOP %g",
+        """Control the Y-axis top reference value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    trace_y_spacing = Channel.control(
+        "DISPlay:WINDow{ch}:TRACe:Y:SPACing?",
+        "DISPlay:WINDow{ch}:TRACe:Y:SPACing %s",
+        """Control the Y-axis spacing mode for linear magnitude traces.""",
+        values=DISPLAY_AXIS_SPACING_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    waterfall_baseline = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:BASeline?",
+        "DISPlay:WINDow{ch}:WATerfall:BASeline %g",
+        """Control the concealed baseline fraction in percent.""",
+        values=[0.0, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_bottom = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:BOTTom?",
+        "DISPlay:WINDow{ch}:WATerfall:BOTTom %g",
+        """Control the waterfall Z-axis bottom value.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_count = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:COUNt?",
+        "DISPlay:WINDow{ch}:WATerfall:COUNt %g",
+        """Control the displayed waterfall Z-axis span/count value.""",
+        values=[1e-6, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_height = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:HEIGht?",
+        "DISPlay:WINDow{ch}:WATerfall:HEIGht %g",
+        """Control the waterfall trace-box height in percent.""",
+        values=[1.0, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_hidden_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:HIDDen?",
+        "DISPlay:WINDow{ch}:WATerfall:HIDDen %d",
+        """Control whether hidden waterfall segments are removed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    waterfall_skew_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:SKEW?",
+        "DISPlay:WINDow{ch}:WATerfall:SKEW %d",
+        """Control whether waterfall skew is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    waterfall_skew_angle = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:SKEW:ANGLe?",
+        "DISPlay:WINDow{ch}:WATerfall:SKEW:ANGLe %g",
+        """Control the waterfall skew angle in degrees.""",
+        values=[-45.0, 45.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_enabled = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:STATe?",
+        "DISPlay:WINDow{ch}:WATerfall:STATe %d",
+        """Control whether waterfall display is enabled for the window.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    waterfall_top = Channel.control(
+        "DISPlay:WINDow{ch}:WATerfall:TOP?",
+        "DISPlay:WINDow{ch}:WATerfall:TOP %g",
+        """Control the waterfall Z-axis top value.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    def x_match(self, source_window) -> None:
+        """Match this window X-axis scaling to another display window."""
+        source = int(strict_range(int(source_window), [1, 4]))
+        self.write(f"DISPlay:WINDow{{ch}}:TRACe:X:MATCh{source}")
+
+    def y_match(self, source_window) -> None:
+        """Match this window Y-axis scaling to another display window."""
+        source = int(strict_range(int(source_window), [1, 4]))
+        self.write(f"DISPlay:WINDow{{ch}}:TRACe:Y:MATCh{source}")
+
+
+class Keysight35670AWindow(Keysight35670ADisplayWindow):
+    """Represent a measurement/display window of the Keysight 35670A."""
+
+
+class Keysight35670AOrderTrack(Channel):
+    """Represent an order-track configuration channel of the Keysight 35670A."""
+
+    order = Channel.control(
+        "SENSe:ORDer:TRACk{ch}?",
+        "SENSe:ORDer:TRACk{ch} %g",
+        """Control the order number assigned to this order track.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    enabled = Channel.control(
+        "SENSe:ORDer:TRACk{ch}:STATe?",
+        "SENSe:ORDer:TRACk{ch}:STATe %d",
+        """Control whether order-track mode is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+
+class Keysight35670ATrace(Channel):
+    """Represent a trace box of the Keysight 35670A."""
+
+    active = Channel.control(
+        "CALCulate{ch}:ACTive?",
+        "CALCulate{ch}:ACTive %s",
+        """Control which traces are active in the selected display group.""",
+        values=TRACE_ACTIVE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    feed = Channel.control(
+        "CALCulate{ch}:FEED?",
+        "CALCulate{ch}:FEED '%s'",
+        """Control the measurement data fed to the trace.""",
+        values=TRACE_FEEDS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+        maxsplit=0,
+    )
+
+    display_format = Channel.control(
+        "CALCulate{ch}:FORMat?",
+        "CALCulate{ch}:FORMat %s",
+        """Control the display coordinate format for the trace.""",
+        values=TRACE_DISPLAY_FORMATS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    group_delay_aperture = Channel.control(
+        "CALCulate{ch}:GDAPerture:APERture?",
+        "CALCulate{ch}:GDAPerture:APERture %g",
+        """Control the group-delay smoothing aperture in percent (float from 0 to 20).""",
+        values=[0.0, 20.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    amplitude_unit = Channel.control(
+        "CALCulate{ch}:UNIT:AMPLitude?",
+        "CALCulate{ch}:UNIT:AMPLitude %s",
+        """Control the trace amplitude unit.""",
+        values=TRACE_AMPLITUDE_UNITS,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    angle_unit = Channel.control(
+        "CALCulate{ch}:UNIT:ANGLe?",
+        "CALCulate{ch}:UNIT:ANGLe %s",
+        """Control the trace angle unit.""",
+        values=TRACE_ANGLE_UNITS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    x_unit = Channel.control(
+        "CALCulate{ch}:UNIT:X?",
+        "CALCulate{ch}:UNIT:X %s",
+        """Control the trace x-axis unit.""",
+        values=TRACE_X_UNITS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    db_reference = Channel.control(
+        "CALCulate{ch}:UNIT:DBReference?",
+        "CALCulate{ch}:UNIT:DBReference %s",
+        """Control the dB reference unit family.""",
+        values=DB_REFERENCE_UNITS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    db_reference_impedance = Channel.control(
+        "CALCulate{ch}:UNIT:DBReference:IMPedance?",
+        "CALCulate{ch}:UNIT:DBReference:IMPedance %g",
+        """Control the dBm reference impedance in ohms (float from 1e-15 to 1e15).""",
+        values=[1e-15, 1e15],
+        validator=strict_range,
+        cast=float,
+    )
+
+    db_reference_user_label = Channel.control(
+        "CALCulate{ch}:UNIT:DBReference:USER:LABel?",
+        "CALCulate{ch}:UNIT:DBReference:USER:LABel %s",
+        """Control the user label for dB reference units.""",
+        validator=lambda v, vs: v,
+        values=(),
+        cast=str,
+        set_process=_quote_string,
+        get_process=_strip_quotes,
+    )
+
+    db_reference_user_reference = Channel.control(
+        "CALCulate{ch}:UNIT:DBReference:USER:REFerence?",
+        "CALCulate{ch}:UNIT:DBReference:USER:REFerence %g",
+        """Control the reference level used for user dB units (float from 1e-15 to 1e15).""",
+        values=[1e-15, 1e15],
+        validator=strict_range,
+        cast=float,
+    )
+
+    mechanical_unit = Channel.control(
+        "CALCulate{ch}:UNIT:MECHanical?",
+        "CALCulate{ch}:UNIT:MECHanical %s",
+        """Control the mechanical engineering unit for the trace.""",
+        values=TRACE_MECHANICAL_UNITS,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    voltage_unit = Channel.control(
+        "CALCulate{ch}:UNIT:VOLTage?",
+        "CALCulate{ch}:UNIT:VOLTage %s",
+        """Control the voltage-derived vertical unit for the trace.""",
+        values=TRACE_VOLTAGE_UNITS,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    x_order_factor = Channel.control(
+        "CALCulate{ch}:UNIT:X:ORDer:FACTor?",
+        "CALCulate{ch}:UNIT:X:ORDer:FACTor %g",
+        """Control the X-axis order conversion factor (float from 1e-15 to 1e15).""",
+        values=[1e-15, 1e15],
+        validator=strict_range,
+        cast=float,
+    )
+
+    x_user_frequency_factor = Channel.control(
+        "CALCulate{ch}:UNIT:X:USER:FREQuency:FACTor?",
+        "CALCulate{ch}:UNIT:X:USER:FREQuency:FACTor %g",
+        """Control the user frequency-domain X-axis conversion factor (float from 1e-15 to 1e15).""",
+        values=[1e-15, 1e15],
+        validator=strict_range,
+        cast=float,
+    )
+
+    x_user_frequency_label = Channel.control(
+        "CALCulate{ch}:UNIT:X:USER:FREQuency:LABel?",
+        "CALCulate{ch}:UNIT:X:USER:FREQuency:LABel %s",
+        """Control the user frequency-domain X-axis unit label.""",
+        validator=lambda v, vs: v,
+        values=(),
+        cast=str,
+        set_process=_quote_string,
+        get_process=_strip_quotes,
+    )
+
+    x_user_time_factor = Channel.control(
+        "CALCulate{ch}:UNIT:X:USER:TIME:FACTor?",
+        "CALCulate{ch}:UNIT:X:USER:TIME:FACTor %g",
+        """Control the user time-domain X-axis conversion factor (float from 1e-15 to 1e15).""",
+        values=[1e-15, 1e15],
+        validator=strict_range,
+        cast=float,
+    )
+
+    x_user_time_label = Channel.control(
+        "CALCulate{ch}:UNIT:X:USER:TIME:LABel?",
+        "CALCulate{ch}:UNIT:X:USER:TIME:LABel %s",
+        """Control the user time-domain X-axis unit label.""",
+        validator=lambda v, vs: v,
+        values=(),
+        cast=str,
+        set_process=_quote_string,
+        get_process=_strip_quotes,
+    )
+
+    limit_beeper_enabled = Channel.control(
+        "CALCulate{ch}:LIMit:BEEP:STATe?",
+        "CALCulate{ch}:LIMit:BEEP:STATe %d",
+        """Control whether the limit-fail beeper is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    limit_failed = Channel.measurement(
+        "CALCulate{ch}:LIMit:FAIL?",
+        """Measure whether the last limit test failed.""",
+        cast=int,
+        get_process=bool,
+    )
+
+    lower_limit_segment = Channel.control(
+        "CALCulate{ch}:LIMit:LOWer:SEGMent?",
+        "CALCulate{ch}:LIMit:LOWer:SEGMent %s",
+        """Control lower limit line segments as (x0, y0, x1, y1) tuples.""",
+        validator=lambda v, vs: v,
+        values=(),
+        set_process=_format_limit_segment_data,
+        get_process=_parse_limit_segment_data,
+        cast=str,
+        maxsplit=0,
+    )
+
+    limit_enabled = Channel.control(
+        "CALCulate{ch}:LIMit:STATe?",
+        "CALCulate{ch}:LIMit:STATe %d",
+        """Control whether limit testing is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    upper_limit_segment = Channel.control(
+        "CALCulate{ch}:LIMit:UPPer:SEGMent?",
+        "CALCulate{ch}:LIMit:UPPer:SEGMent %s",
+        """Control upper limit line segments as (x0, y0, x1, y1) tuples.""",
+        validator=lambda v, vs: v,
+        values=(),
+        set_process=_format_limit_segment_data,
+        get_process=_parse_limit_segment_data,
+        cast=str,
+        maxsplit=0,
+    )
+
+    marker_band_start = Channel.control(
+        "CALCulate{ch}:MARKer:BAND:STARt?",
+        "CALCulate{ch}:MARKer:BAND:STARt %g",
+        """Control the start value of the marker band (float from -9.9e37 to 9.9e37).""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_band_stop = Channel.control(
+        "CALCulate{ch}:MARKer:BAND:STOP?",
+        "CALCulate{ch}:MARKer:BAND:STOP %g",
+        """Control the stop value of the marker band (float from -9.9e37 to 9.9e37).""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    markers_coupled = Channel.control(
+        "CALCulate{ch}:MARKer:COUpled:STATe?",
+        "CALCulate{ch}:MARKer:COUpled:STATe %d",
+        """Control whether markers are coupled across traces.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    marker_data_table_insert_x = Channel.control(
+        "CALCulate{ch}:MARKer:DTABle:X:INSert?",
+        "CALCulate{ch}:MARKer:DTABle:X:INSert %g",
+        """Control the inserted X-axis entry value in the marker data table.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_data_table_label = Channel.control(
+        "CALCulate{ch}:MARKer:DTABle:X:LABel?",
+        "CALCulate{ch}:MARKer:DTABle:X:LABel %s",
+        """Control the label of the selected marker data-table entry.""",
+        validator=lambda v, vs: v,
+        values=(),
+        cast=str,
+        set_process=_quote_string,
+        get_process=_strip_quotes,
+    )
+
+    marker_data_table_selected_point = Channel.control(
+        "CALCulate{ch}:MARKer:DTABle:X:SELect:POINt?",
+        "CALCulate{ch}:MARKer:DTABle:X:SELect:POINt %d",
+        """Control the selected marker data-table entry index (integer from 1 to 50).""",
+        values=[1, 50],
+        validator=strict_range,
+        cast=int,
+    )
+
+    marker_function = Channel.control(
+        "CALCulate{ch}:MARKer:FUNCtion?",
+        "CALCulate{ch}:MARKer:FUNCtion %s",
+        """Control the active marker function.""",
+        values=MARKER_FUNCTION_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    marker_function_result = Channel.measurement(
+        "CALCulate{ch}:MARKer:FUNCtion:RESult?",
+        """Measure the currently selected marker function result.""",
+        cast=float,
+    )
+
+    marker_harmonic_count = Channel.control(
+        "CALCulate{ch}:MARKer:HARMonic:COUNt?",
+        "CALCulate{ch}:MARKer:HARMonic:COUNt %d",
+        """Control the number of harmonic markers (integer from 0 to 400).""",
+        values=[0, 400],
+        validator=strict_range,
+        cast=int,
+    )
+
+    marker_harmonic_fundamental = Channel.control(
+        "CALCulate{ch}:MARKer:HARMonic:FUNDamental?",
+        "CALCulate{ch}:MARKer:HARMonic:FUNDamental %g",
+        """Control the fundamental frequency used for harmonic markers.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_global_maximum_tracking_enabled = Channel.control(
+        "CALCulate{ch}:MARKer:MAXimum:GLOBal:TRACk?",
+        "CALCulate{ch}:MARKer:MAXimum:GLOBal:TRACk %d",
+        """Control whether global-maximum marker tracking is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    marker_mode = Channel.control(
+        "CALCulate{ch}:MARKer:MODE?",
+        "CALCulate{ch}:MARKer:MODE %s",
+        """Control absolute or relative marker mode.""",
+        values=MARKER_MODE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    marker_position = Channel.control(
+        "CALCulate{ch}:MARKer:POSition?",
+        "CALCulate{ch}:MARKer:POSition %g",
+        """Control the main marker position along the independent axis.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_position_point = Channel.control(
+        "CALCulate{ch}:MARKer:POSition:POINt?",
+        "CALCulate{ch}:MARKer:POSition:POINt %d",
+        """Control the main marker position as an integer trace point index.""",
+        values=[0, 2047],
+        validator=strict_range,
+        cast=int,
+    )
+
+    marker_reference_x = Channel.control(
+        "CALCulate{ch}:MARKer:REFerence:X?",
+        "CALCulate{ch}:MARKer:REFerence:X %g",
+        """Control the marker reference X-axis position.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_reference_y = Channel.control(
+        "CALCulate{ch}:MARKer:REFerence:Y?",
+        "CALCulate{ch}:MARKer:REFerence:Y %g",
+        """Control the marker reference Y-axis position.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_sideband_carrier = Channel.control(
+        "CALCulate{ch}:MARKer:SIDeband:CARRier?",
+        "CALCulate{ch}:MARKer:SIDeband:CARRier %g",
+        """Control the carrier value used by sideband markers.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_sideband_count = Channel.control(
+        "CALCulate{ch}:MARKer:SIDeband:COUNt?",
+        "CALCulate{ch}:MARKer:SIDeband:COUNt %d",
+        """Control the number of sideband markers (integer from 0 to 200).""",
+        values=[0, 200],
+        validator=strict_range,
+        cast=int,
+    )
+
+    marker_sideband_increment = Channel.control(
+        "CALCulate{ch}:MARKer:SIDeband:INCRement?",
+        "CALCulate{ch}:MARKer:SIDeband:INCRement %g",
+        """Control the increment between sideband markers.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_enabled = Channel.control(
+        "CALCulate{ch}:MARKer:STATe?",
+        "CALCulate{ch}:MARKer:STATe %d",
+        """Control whether the trace marker is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    marker_x = Channel.control(
+        "CALCulate{ch}:MARKer:X?",
+        "CALCulate{ch}:MARKer:X %g",
+        """Control the marker x-axis position.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_x_relative = Channel.control(
+        "CALCulate{ch}:MARKer:X:RELative?",
+        "CALCulate{ch}:MARKer:X:RELative %g",
+        """Control the marker X-axis position relative to the reference.""",
+        values=[-102400.0, 102400.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    marker_y = Channel.measurement(
+        "CALCulate{ch}:MARKer:Y?",
+        """Measure the marker y-axis value.""",
+        cast=float,
+    )
+
+    marker_y_relative = Channel.control(
+        "CALCulate{ch}:MARKer:Y:RELative?",
+        "CALCulate{ch}:MARKer:Y:RELative %g",
+        """Control the marker Y-axis position relative to the reference.""",
+        values=[-150.0, 150.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    math_selected_function = Channel.control(
+        "CALCulate{ch}:MATH:SELect?",
+        "CALCulate{ch}:MATH:SELect %s",
+        """Control the selected math function register.""",
+        values=MATH_SELECTED_FUNCTION_VALUES,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    math_enabled = Channel.control(
+        "CALCulate{ch}:MATH:STATe?",
+        "CALCulate{ch}:MATH:STATe %d",
+        """Control whether the selected math function is evaluated.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    cfit_destination_register = Channel.control(
+        "CALCulate{ch}:CFIT:DESTination?",
+        "CALCulate{ch}:CFIT:DESTination %s",
+        """Control the destination data register for curve-fit results.""",
+        values=SOURCE_USER_REGISTERS,
+        map_values=True,
+        cast=str,
+        validator=strict_discrete_set,
+    )
+
+    cfit_frequency_auto_enabled = Channel.control(
+        "CALCulate{ch}:CFIT:FREQuency:AUTO?",
+        "CALCulate{ch}:CFIT:FREQuency:AUTO %d",
+        """Control whether curve fit uses the full-span frequency region.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    cfit_frequency_start = Channel.control(
+        "CALCulate{ch}:CFIT:FREQuency:STARt?",
+        "CALCulate{ch}:CFIT:FREQuency:STARt %g",
+        """Control the curve-fit start frequency in hertz.""",
+        values=[0.0, 114999.9023],
+        validator=strict_range,
+        cast=float,
+    )
+
+    cfit_frequency_stop = Channel.control(
+        "CALCulate{ch}:CFIT:FREQuency:STOP?",
+        "CALCulate{ch}:CFIT:FREQuency:STOP %g",
+        """Control the curve-fit stop frequency in hertz.""",
+        values=[0.390625, 115000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    cfit_frequency_scale = Channel.control(
+        "CALCulate{ch}:CFIT:FSCale?",
+        "CALCulate{ch}:CFIT:FSCale %g",
+        """Control the curve-fit frequency scaling factor.""",
+        values=[1e-6, 1e6],
+        validator=strict_range,
+        cast=float,
+    )
+
+    cfit_order_auto_enabled = Channel.control(
+        "CALCulate{ch}:CFIT:ORDer:AUTO?",
+        "CALCulate{ch}:CFIT:ORDer:AUTO %d",
+        """Control whether curve fit uses automatic model-order selection.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    cfit_order_poles = Channel.control(
+        "CALCulate{ch}:CFIT:ORDer:POLes?",
+        "CALCulate{ch}:CFIT:ORDer:POLes %d",
+        """Control the curve-fit pole-count upper bound.""",
+        values=[0, 20],
+        validator=strict_range,
+        cast=int,
+    )
+
+    cfit_order_zeros = Channel.control(
+        "CALCulate{ch}:CFIT:ORDer:ZERos?",
+        "CALCulate{ch}:CFIT:ORDer:ZERos %d",
+        """Control the curve-fit zero-count upper bound.""",
+        values=[0, 20],
+        validator=strict_range,
+        cast=int,
+    )
+
+    cfit_time_delay = Channel.control(
+        "CALCulate{ch}:CFIT:TDELay?",
+        "CALCulate{ch}:CFIT:TDELay %g",
+        """Control the curve-fit time-delay value in seconds.""",
+        values=[-100.0, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    cfit_weight_auto_enabled = Channel.control(
+        "CALCulate{ch}:CFIT:WEIGht:AUTO?",
+        "CALCulate{ch}:CFIT:WEIGht:AUTO %d",
+        """Control whether curve-fit weighting is generated automatically.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    cfit_weight_register = Channel.control(
+        "CALCulate{ch}:CFIT:WEIGht:REGister?",
+        "CALCulate{ch}:CFIT:WEIGht:REGister %s",
+        """Control the data register used as curve-fit weighting input.""",
+        values=SOURCE_USER_REGISTERS,
+        map_values=True,
+        cast=str,
+        validator=strict_discrete_set,
+    )
+
+    synthesis_destination_register = Channel.control(
+        "CALCulate{ch}:SYNThesis:DESTination?",
+        "CALCulate{ch}:SYNThesis:DESTination %s",
+        """Control the destination data register for synthesis results.""",
+        values=SOURCE_USER_REGISTERS,
+        map_values=True,
+        cast=str,
+        validator=strict_discrete_set,
+    )
+
+    synthesis_frequency_scale = Channel.control(
+        "CALCulate{ch}:SYNThesis:FSCale?",
+        "CALCulate{ch}:SYNThesis:FSCale %g",
+        """Control the synthesis frequency scaling factor.""",
+        values=[1e-6, 1e6],
+        validator=strict_range,
+        cast=float,
+    )
+
+    synthesis_gain = Channel.control(
+        "CALCulate{ch}:SYNThesis:GAIN?",
+        "CALCulate{ch}:SYNThesis:GAIN %g",
+        """Control the synthesis gain constant (float from -9.9e37 to 9.9e37, excluding 0).""",
+        values=LIMIT_VALUE_RANGE,
+        validator=_strict_nonzero_range,
+        cast=float,
+    )
+
+    synthesis_spacing = Channel.control(
+        "CALCulate{ch}:SYNThesis:SPACing?",
+        "CALCulate{ch}:SYNThesis:SPACing %s",
+        """Control the synthesis X-axis spacing mode.""",
+        values=SYNTHESIS_SPACING_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    synthesis_time_delay = Channel.control(
+        "CALCulate{ch}:SYNThesis:TDELay?",
+        "CALCulate{ch}:SYNThesis:TDELay %g",
+        """Control the synthesis time-delay value in seconds.""",
+        values=[-100.0, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    synthesis_table_type = Channel.control(
+        "CALCulate{ch}:SYNThesis:TTYPe?",
+        "CALCulate{ch}:SYNThesis:TTYPe %s",
+        """Control the synthesis table representation type.""",
+        values=SYNTHESIS_TABLE_TYPE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    waterfall_count = Channel.control(
+        "CALCulate{ch}:WATerfall:COUNt?",
+        "CALCulate{ch}:WATerfall:COUNt %d",
+        """Control the stored waterfall trace count.""",
+        values=[1, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    waterfall_slice_select = Channel.control(
+        "CALCulate{ch}:WATerfall:SLICe:SELect?",
+        "CALCulate{ch}:WATerfall:SLICe:SELect %g",
+        """Control the waterfall slice X-axis selection value.""",
+        values=[-16382.0, 1e6],
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_slice_select_point = Channel.control(
+        "CALCulate{ch}:WATerfall:SLICe:SELect:POINt?",
+        "CALCulate{ch}:WATerfall:SLICe:SELect:POINt %d",
+        """Control the waterfall slice selection by display point index.""",
+        values=[0, 2048],
+        validator=strict_range,
+        cast=int,
+    )
+
+    waterfall_trace_select = Channel.control(
+        "CALCulate{ch}:WATerfall:TRACe:SELect?",
+        "CALCulate{ch}:WATerfall:TRACe:SELect %g",
+        """Control the waterfall trace selection by Z-axis value.""",
+        values=LIMIT_VALUE_RANGE,
+        validator=strict_range,
+        cast=float,
+    )
+
+    waterfall_trace_select_point = Channel.control(
+        "CALCulate{ch}:WATerfall:TRACe:SELect:POINt?",
+        "CALCulate{ch}:WATerfall:TRACe:SELect:POINt %d",
+        """Control the waterfall trace selection by step index.""",
+        values=[0, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    def set_math_constant(
+            self, constant_register: int, real_part: float, imaginary_part: Optional[float] = None) -> None:
+        """Set a math constant register value."""
+        index = _math_register_selector(constant_register)
+        real_value = float(strict_range(float(real_part), LIMIT_VALUE_RANGE))
+        if imaginary_part is None:
+            self.write(f"CALCulate{{ch}}:MATH:CONStant{index} {real_value:g}")
+            return
+
+        imaginary_value = float(strict_range(float(imaginary_part), LIMIT_VALUE_RANGE))
+        self.write(
+            f"CALCulate{{ch}}:MATH:CONStant{index} {real_value:g},{imaginary_value:g}"
+        )
+
+    def math_constant(self, constant_register: int) -> tuple[float, float]:
+        """Read a math constant register as (real, imaginary)."""
+        index = _math_register_selector(constant_register)
+        values = _parse_ascii_floats(self.ask(f"CALCulate{{ch}}:MATH:CONStant{index}?"))
+        if not values:
+            raise ValueError("Math constant query returned no values.")
+        if len(values) == 1:
+            return values[0], 0.0
+        return values[0], values[1]
+
+    def set_math_expression(self, expression: str, function_register: int = 1) -> None:
+        """Set a math expression in the selected function register."""
+        index = _math_register_selector(function_register)
+        self.write(
+            f"CALCulate{{ch}}:MATH:EXPRession{index} {_quote_string(str(expression))}"
+        )
+
+    def math_expression(self, function_register: int = 1) -> str:
+        """Read the math expression in the selected function register."""
+        index = _math_register_selector(function_register)
+        return _strip_quotes(self.ask(f"CALCulate{{ch}}:MATH:EXPRession{index}?"))
+
+    def math_data(self, raw=False):
+        """Read the complete math table block data."""
+        self.write("CALCulate{ch}:MATH:DATA?")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        if block.startswith(b"#"):
+            return _parse_definite_block(block)
+        return block.decode("latin1")
+
+    def load_math_data(self, data, raw=False) -> None:
+        """Load complete math table block data."""
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        prefix = self.insert_id("CALCulate{ch}:MATH:DATA ").encode("ascii")
+        self.write_bytes(prefix + block)
+
+    def abort_curve_fit(self) -> None:
+        """Abort the curve-fit operation."""
+        self.write("CALCulate{ch}:CFIT:ABORt")
+
+    def copy_synthesis_to_curve_fit(self) -> None:
+        """Copy the synthesis table into the curve-fit table."""
+        self.write("CALCulate{ch}:CFIT:COPY SYNThesis")
+
+    def cfit_data(self, raw=False):
+        """Read the complete curve-fit table block data."""
+        self.write("CALCulate{ch}:CFIT:DATA?")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        if block.startswith(b"#"):
+            return _parse_definite_block(block)
+        return block.decode("latin1")
+
+    def load_cfit_data(self, data, raw=False) -> None:
+        """Load complete curve-fit table block data."""
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        prefix = self.insert_id("CALCulate{ch}:CFIT:DATA ").encode("ascii")
+        self.write_bytes(prefix + block)
+
+    def run_curve_fit(self) -> None:
+        """Start a curve-fit operation and use wait_for_completion() to synchronize."""
+        self.write("CALCulate{ch}:CFIT:IMMediate")
+
+    def copy_curve_fit_to_synthesis(self) -> None:
+        """Copy the curve-fit table into the synthesis table."""
+        self.write("CALCulate{ch}:SYNThesis:COPY CFIT")
+
+    def synthesis_data(self, raw=False):
+        """Read the complete synthesis table block data."""
+        self.write("CALCulate{ch}:SYNThesis:DATA?")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        if block.startswith(b"#"):
+            return _parse_definite_block(block)
+        return block.decode("latin1")
+
+    def load_synthesis_data(self, data, raw=False) -> None:
+        """Load complete synthesis table block data."""
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        prefix = self.insert_id("CALCulate{ch}:SYNThesis:DATA ").encode("ascii")
+        self.write_bytes(prefix + block)
+
+    def run_synthesis(self) -> None:
+        """Start synthesis and use wait_for_completion() to synchronize."""
+        self.write("CALCulate{ch}:SYNThesis:IMMediate")
+
+    def waterfall_data(self, raw=False):
+        """Read transformed waterfall data for the selected trace box."""
+        if raw:
+            self.write("CALCulate{ch}:WATerfall:DATA?")
+            return self.read_bytes(-1)
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:WATerfall:DATA?")
+        )
+
+    def copy_waterfall_slice_to_register(self, register) -> None:
+        """Copy the selected waterfall slice to a data register."""
+        selector = _data_register_selector(register)
+        self.write(f"CALCulate{{ch}}:WATerfall:SLICe:COPY {selector}")
+
+    def copy_waterfall_trace_to_register(self, register) -> None:
+        """Copy the selected waterfall trace to a data register."""
+        selector = _data_register_selector(register)
+        self.write(f"CALCulate{{ch}}:WATerfall:TRACe:COPY {selector}")
+
+    def data_points(self) -> int:
+        """Get the number of data points in the trace data block."""
+        return int(self.ask("CALCulate{ch}:DATA:HEADer:POINts?"))
+
+    def read_data(self) -> list[float]:
+        """Read the trace data values."""
+        return _parse_ascii_floats(self.ask("CALCulate{ch}:DATA?"))
+
+    def read_x_data(self) -> list[float]:
+        """Read the trace x-axis data values."""
+        return _parse_ascii_floats(self.ask("CALCulate{ch}:X:DATA?"))
+
+    def clear_marker_data_table(self, confirmed=False) -> None:
+        """Clear the marker data table after explicit confirmation."""
+        _require_confirmation("clear marker data table", confirmed)
+        self.write("CALCulate{ch}:MARKer:DTABle:CLEar:IMMediate")
+
+    def copy_marker_data_table_from(self, source_trace) -> None:
+        """Copy marker data-table entries from another trace index."""
+        source = int(strict_range(int(source_trace), [1, 4]))
+        self.write(f"CALCulate{{ch}}:MARKer:DTABle:COPY{source}")
+
+    def read_marker_data_table_y(self) -> list[float]:
+        """Read dependent-axis values from the marker data table."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:MARKer:DTABle:DATA?")
+        )
+
+    def read_marker_data_table_x(self) -> list[float]:
+        """Read independent-axis values from the marker data table."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:MARKer:DTABle:X:DATA?")
+        )
+
+    def delete_marker_data_table_entry(self, confirmed=False) -> None:
+        """Delete the selected marker data-table entry after explicit confirmation."""
+        _require_confirmation("delete marker data-table entry", confirmed)
+        self.write("CALCulate{ch}:MARKer:DTABle:X:DELete")
+
+    def clear_lower_limit(self, confirmed=False) -> None:
+        """Clear the complete lower limit line after explicit confirmation."""
+        _require_confirmation("clear lower limit line", confirmed)
+        self.write("CALCulate{ch}:LIMit:LOWer:CLEar:IMMediate")
+
+    def move_lower_limit_y(self, delta) -> None:
+        """Move the lower limit line by the specified Y-axis delta."""
+        value = float(strict_range(float(delta), LIMIT_VALUE_RANGE))
+        self.write(f"CALCulate{{ch}}:LIMit:LOWer:MOVE:Y {value:g}")
+
+    def read_lower_limit_report_x(self) -> list[float]:
+        """Read X-axis values of failed lower-limit points."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:LIMit:LOWer:REPort:DATA?")
+        )
+
+    def read_lower_limit_report_y(self) -> list[float]:
+        """Read Y-axis values of failed lower-limit points."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:LIMit:LOWer:REPort:YDATa?")
+        )
+
+    def clear_lower_limit_segment(self, segment, confirmed=False) -> None:
+        """Clear the lower-limit segment containing the selected X-axis value."""
+        _require_confirmation("clear lower limit segment", confirmed)
+        value = float(strict_range(float(segment), LIMIT_VALUE_RANGE))
+        self.write(f"CALCulate{{ch}}:LIMit:LOWer:SEGMent:CLEar {value:g}")
+
+    def make_lower_limit_from_trace(self, confirmed=False) -> None:
+        """Convert the current trace into a lower limit line after explicit confirmation."""
+        _require_confirmation("convert trace to lower limit line", confirmed)
+        self.write("CALCulate{ch}:LIMit:LOWer:TRACe:IMMediate")
+
+    def clear_upper_limit(self, confirmed=False) -> None:
+        """Clear the complete upper limit line after explicit confirmation."""
+        _require_confirmation("clear upper limit line", confirmed)
+        self.write("CALCulate{ch}:LIMit:UPPer:CLEar:IMMediate")
+
+    def move_upper_limit_y(self, delta) -> None:
+        """Move the upper limit line by the specified Y-axis delta."""
+        value = float(strict_range(float(delta), LIMIT_VALUE_RANGE))
+        self.write(f"CALCulate{{ch}}:LIMit:UPPer:MOVE:Y {value:g}")
+
+    def read_upper_limit_report_x(self) -> list[float]:
+        """Read X-axis values of failed upper-limit points."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:LIMit:UPPer:REPort:DATA?")
+        )
+
+    def read_upper_limit_report_y(self) -> list[float]:
+        """Read Y-axis values of failed upper-limit points."""
+        return _parse_ascii_or_definite_block_floats(
+            self.ask("CALCulate{ch}:LIMit:UPPer:REPort:YDATa?")
+        )
+
+    def clear_upper_limit_segment(self, segment, confirmed=False) -> None:
+        """Clear the upper-limit segment containing the selected X-axis value."""
+        _require_confirmation("clear upper limit segment", confirmed)
+        value = float(strict_range(float(segment), LIMIT_VALUE_RANGE))
+        self.write(f"CALCulate{{ch}}:LIMit:UPPer:SEGMent:CLEar {value:g}")
+
+    def make_upper_limit_from_trace(self, confirmed=False) -> None:
+        """Convert the current trace into an upper limit line after explicit confirmation."""
+        _require_confirmation("convert trace to upper limit line", confirmed)
+        self.write("CALCulate{ch}:LIMit:UPPer:TRACe:IMMediate")
+
+    def marker_to_left_maximum(self) -> None:
+        """Move the marker to the next peak on the left."""
+        self.write("CALCulate{ch}:MARKer:MAXimum:LEFT")
+
+    def marker_to_right_maximum(self) -> None:
+        """Move the marker to the next peak on the right."""
+        self.write("CALCulate{ch}:MARKer:MAXimum:RIGHt")
+
+    def marker_to_global_maximum(self) -> None:
+        """Move the marker to the global maximum."""
+        self.write("CALCulate{ch}:MARKer:MAXimum:GLOBAL")
+
+
+class Keysight35670A(SCPIMixin, Instrument):
+    """Represent the Keysight 35670A Dynamic Signal Analyzer."""
+
+    ch1 = Instrument.ChannelCreator(Keysight35670AInputChannel, 1)
+    ch2 = Instrument.ChannelCreator(Keysight35670AInputChannel, 2)
+    ch3 = Instrument.ChannelCreator(Keysight35670AInputChannel, 3)
+    ch4 = Instrument.ChannelCreator(Keysight35670AInputChannel, 4)
+
+    trace1 = Instrument.ChannelCreator(Keysight35670ATrace, 1)
+    trace2 = Instrument.ChannelCreator(Keysight35670ATrace, 2)
+    trace3 = Instrument.ChannelCreator(Keysight35670ATrace, 3)
+    trace4 = Instrument.ChannelCreator(Keysight35670ATrace, 4)
+
+    order_track1 = Instrument.ChannelCreator(Keysight35670AOrderTrack, 1)
+    order_track2 = Instrument.ChannelCreator(Keysight35670AOrderTrack, 2)
+    order_track3 = Instrument.ChannelCreator(Keysight35670AOrderTrack, 3)
+    order_track4 = Instrument.ChannelCreator(Keysight35670AOrderTrack, 4)
+    order_track5 = Instrument.ChannelCreator(Keysight35670AOrderTrack, 5)
+
+    sense_window1 = Instrument.ChannelCreator(Keysight35670ASenseWindow, 1)
+    sense_window2 = Instrument.ChannelCreator(Keysight35670ASenseWindow, 2)
+    sense_window3 = Instrument.ChannelCreator(Keysight35670ASenseWindow, 3)
+    sense_window4 = Instrument.ChannelCreator(Keysight35670ASenseWindow, 4)
+
+    display1 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 1)
+    display2 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 2)
+    display3 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 3)
+    display4 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 4)
+
+    window1 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 1)
+    window2 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 2)
+    window3 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 3)
+    window4 = Instrument.ChannelCreator(Keysight35670ADisplayWindow, 4)
+
+    def __init__(self, adapter, name="Keysight 35670A Dynamic Signal Analyzer", **kwargs):
+        kwargs.setdefault("timeout", 10000)
+        kwargs.setdefault("read_termination", "\n")
+        kwargs.setdefault("write_termination", "\n")
+        super().__init__(adapter, name, **kwargs)
+
+    instrument_mode = Instrument.control(
+        "INSTrument:SELect?",
+        "INSTrument:SELect %s",
+        """Control the instrument mode.""",
+        values=INSTRUMENT_MODES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    selected_instrument_number = Instrument.control(
+        "INSTrument:NSELect?",
+        "INSTrument:NSELect %d",
+        """Control the selected instrument mode by number.""",
+        values=[0, 5],
+        validator=strict_range,
+        cast=int,
+    )
+
+    _selected_instrument_number_setting = Instrument.setting(
+        "INSTrument:NSELect %d",
+        """Set the selected instrument mode by number.""",
+        values=[0, 5],
+        validator=strict_range,
+    )
+
+    continuous_initiation_enabled = Instrument.control(
+        "INITiate:CONTinuous?",
+        "INITiate:CONTinuous %d",
+        """Control whether measurements are continuously initiated.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    averaging_enabled = Instrument.control(
+        "SENSe:AVERage:STATe?",
+        "SENSe:AVERage:STATe %d",
+        """Control whether averaging is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    average_confidence = Instrument.control(
+        "SENSe:AVERage:CONFidence?",
+        "SENSe:AVERage:CONFidence %g",
+        """Control equal-confidence averaging level in dB.""",
+        values=[0.25, 2.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    average_count = Instrument.control(
+        "SENSe:AVERage:COUNt?",
+        "SENSe:AVERage:COUNt %d",
+        """Control the averaging count.""",
+        values=[1, 9999999],
+        validator=strict_range,
+        cast=int,
+    )
+
+    average_hold = Instrument.control(
+        "SENSe:AVERage:HOLD?",
+        "SENSe:AVERage:HOLD %s",
+        """Control the averaging hold mode for octave measurements.""",
+        values=AVERAGE_HOLD_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    average_impulse_enabled = Instrument.control(
+        "SENSe:AVERage:IMPulse?",
+        "SENSe:AVERage:IMPulse %d",
+        """Control whether octave impulse detection is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    average_iresult_rate = Instrument.control(
+        "SENSe:AVERage:IRESult:RATE?",
+        "SENSe:AVERage:IRESult:RATE %d",
+        """Control fast-average display update rate in averages.""",
+        values=[1, 9999999],
+        validator=strict_range,
+        cast=int,
+    )
+
+    average_iresult_enabled = Instrument.control(
+        "SENSe:AVERage:IRESult:STATe?",
+        "SENSe:AVERage:IRESult:STATe %d",
+        """Control whether fast-average display mode is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    average_preview = Instrument.control(
+        "SENSe:AVERage:PREView?",
+        "SENSe:AVERage:PREView %s",
+        """Control preview averaging mode.""",
+        values=AVERAGE_PREVIEW_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    average_preview_time = Instrument.control(
+        "SENSe:AVERage:PREView:TIME?",
+        "SENSe:AVERage:PREView:TIME %g",
+        """Control timed-preview wait duration in seconds.""",
+        values=[0.1, 3600.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    average_type = Instrument.control(
+        "SENSe:AVERage:TYPE?",
+        "SENSe:AVERage:TYPE %s",
+        """Control the averaging type.""",
+        values=AVERAGE_TYPES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    average_time = Instrument.control(
+        "SENSe:AVERage:TIME?",
+        "SENSe:AVERage:TIME %g",
+        """Control averaging time in seconds.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    average_tcontrol = Instrument.control(
+        "SENSe:AVERage:TCONtrol?",
+        "SENSe:AVERage:TCONtrol %s",
+        """Control averaging time-control behavior.""",
+        values=AVERAGE_TCONTROLS,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    source_output_enabled = Instrument.control(
+        "OUTPut:STATe?",
+        "OUTPut:STATe %d",
+        """Control whether the source output is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    output_low_pass_filter_enabled = Instrument.control(
+        "OUTPut:FILTer:LPASs:STATe?",
+        "OUTPut:FILTer:LPASs:STATe %d",
+        """Control whether the source output low-pass filter is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    source_function = Instrument.control(
+        "SOURce:FUNCtion:SHAPe?",
+        "SOURce:FUNCtion:SHAPe %s",
+        """Control the source waveform shape.""",
+        values=SOURCE_FUNCTIONS,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    source_frequency_cw = Instrument.control(
+        "SOURce:FREQuency?",
+        "SOURce:FREQuency %g",
+        """Control the sine source frequency in Hz using SOURce:FREQuency[:CW].""",
+        values=[0.0, 115000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_frequency_fixed = Instrument.control(
+        "SOURce:FREQuency:FIXed?",
+        "SOURce:FREQuency:FIXed %g",
+        """Control the sine source frequency in Hz using SOURce:FREQuency:FIXed.""",
+        values=[0.0, 115000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_frequency = source_frequency_fixed
+
+    source_burst_percent = Instrument.control(
+        "SOURce:BURSt?",
+        "SOURce:BURSt %g",
+        """Control the burst length as a percentage of the time record.""",
+        values=[0.0, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_user_capture_channel = Instrument.control(
+        "SOURce:USER:CAPTure?",
+        "SOURce:USER:CAPTure %d",
+        """Control the time-capture channel used by the CAPTure source waveform.""",
+        values=[1, 4],
+        validator=strict_range,
+        cast=int,
+    )
+
+    source_user_register = Instrument.control(
+        "SOURce:USER:REGister?",
+        "SOURce:USER:REGister %s",
+        """Control which data register index is used by the USER source waveform.""",
+        values=SOURCE_USER_REGISTERS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    source_user_repeat_enabled = Instrument.control(
+        "SOURce:USER:REPeat?",
+        "SOURce:USER:REPeat %d",
+        """Control whether USER/CAPTure source playback repeats.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    source_voltage_autolevel_enabled = Instrument.control(
+        "SOURce:VOLTage:LEVel:AUTO?",
+        "SOURce:VOLTage:LEVel:AUTO %d",
+        """Control whether swept-sine source autolevel is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    source_voltage_amplitude = Instrument.control(
+        "SOURce:VOLTage:LEVel:IMMediate:AMPLitude?",
+        "SOURce:VOLTage:LEVel:IMMediate:AMPLitude %g",
+        """Control source amplitude in the active level unit (range -9.9e37 to 13.9794).""",
+        values=[-9.9e37, 13.9794],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_offset = Instrument.control(
+        "SOURce:VOLTage:LEVel:IMMediate:OFFSet?",
+        "SOURce:VOLTage:LEVel:IMMediate:OFFSet %g",
+        """Control the source DC offset in volts.""",
+        values=[-10.0, 10.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_reference = Instrument.control(
+        "SOURce:VOLTage:LEVel:REFerence?",
+        "SOURce:VOLTage:LEVel:REFerence %g",
+        """Control the source autolevel reference amplitude in dB.""",
+        values=[-69.276, 31.66],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_reference_channel = Instrument.control(
+        "SOURce:VOLTage:LEVel:REFerence:CHANnel?",
+        "SOURce:VOLTage:LEVel:REFerence:CHANnel %s",
+        """Control the autolevel reference input channel index.""",
+        values=SOURCE_REFERENCE_CHANNELS,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+    )
+
+    source_voltage_reference_tolerance = Instrument.control(
+        "SOURce:VOLTage:LEVel:REFerence:TOLerance?",
+        "SOURce:VOLTage:LEVel:REFerence:TOLerance %g",
+        """Control the source autolevel sensitivity in dB.""",
+        values=[0.1, 20.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_limit_amplitude = Instrument.control(
+        "SOURce:VOLTage:LIMit:AMPLitude?",
+        "SOURce:VOLTage:LIMit:AMPLitude %g",
+        """Control the source autolevel maximum source amplitude limit.""",
+        values=[-9.9e37, 13.9794],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_limit_input = Instrument.control(
+        "SOURce:VOLTage:LIMit:INPut?",
+        "SOURce:VOLTage:LIMit:INPut %g",
+        """Control the autolevel maximum non-reference input amplitude limit in dB.""",
+        values=[-69.276, 31.66],
+        validator=strict_range,
+        cast=float,
+    )
+
+    source_voltage_slew = Instrument.control(
+        "SOURce:VOLTage:SLEW?",
+        "SOURce:VOLTage:SLEW %g",
+        """Control the source amplitude ramp rate in V/s.""",
+        values=[0.0, 10000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trigger_source = Instrument.control(
+        "TRIGger:SOURce?",
+        "TRIGger:SOURce %s",
+        """Control the trigger source.""",
+        values=TRIGGER_SOURCES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trigger_slope = Instrument.control(
+        "TRIGger:SLOPe?",
+        "TRIGger:SLOPe %s",
+        """Control the trigger slope.""",
+        values=TRIGGER_SLOPES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trigger_level = Instrument.control(
+        "TRIGger:LEVel?",
+        "TRIGger:LEVel %g",
+        """Control the trigger level.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    external_trigger_filter_enabled = Instrument.control(
+        "TRIGger:EXTernal:FILTer:LPAS:STATe?",
+        "TRIGger:EXTernal:FILTer:LPAS:STATe %d",
+        """Control whether external-trigger low-pass filtering is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    external_trigger_level = Instrument.control(
+        "TRIGger:EXTernal:LEVel?",
+        "TRIGger:EXTernal:LEVel %g",
+        """Control the external trigger level.""",
+        values=[-10.0, 10.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    external_trigger_range = Instrument.control(
+        "TRIGger:EXTernal:RANGe?",
+        "TRIGger:EXTernal:RANGe %s",
+        """Control external trigger input range.""",
+        values=EXTERNAL_TRIGGER_RANGES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    trigger_start1 = Instrument.control(
+        "TRIGger:STARt1?",
+        "TRIGger:STARt1 %g",
+        """Control channel 1 trigger start delay in seconds.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trigger_start2 = Instrument.control(
+        "TRIGger:STARt2?",
+        "TRIGger:STARt2 %g",
+        """Control channel 2 trigger start delay in seconds.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trigger_start3 = Instrument.control(
+        "TRIGger:STARt3?",
+        "TRIGger:STARt3 %g",
+        """Control channel 3 trigger start delay in seconds.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    trigger_start4 = Instrument.control(
+        "TRIGger:STARt4?",
+        "TRIGger:STARt4 %g",
+        """Control channel 4 trigger start delay in seconds.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    tachometer_holdoff = Instrument.control(
+        "TRIGger:TACHometer:HOLDoff?",
+        "TRIGger:TACHometer:HOLDoff %g",
+        """Control the tachometer trigger holdoff interval in seconds.""",
+        values=[0.0, 0.052224],
+        validator=strict_range,
+        cast=float,
+    )
+
+    tachometer_level = Instrument.control(
+        "TRIGger:TACHometer:LEVel?",
+        "TRIGger:TACHometer:LEVel %g",
+        """Control the tachometer trigger level in Volts."""
+        """ The valid range depends on tachometer_range.""",
+        values=[-20.0, 20.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    tachometer_pulse_count = Instrument.control(
+        "TRIGger:TACHometer:PCOunt?",
+        "TRIGger:TACHometer:PCOunt %g",
+        """Control tachometer pulses per revolution.""",
+        values=[0.5, 2048.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    tachometer_range = Instrument.control(
+        "TRIGger:TACHometer:RANGe?",
+        "TRIGger:TACHometer:RANGe %s",
+        """Control the tachometer input range.""",
+        values=TACHOMETER_TRIGGER_RANGES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    tachometer_slope = Instrument.control(
+        "TRIGger:TACHometer:SLOPe?",
+        "TRIGger:TACHometer:SLOPe %s",
+        """Control the tachometer trigger slope.""",
+        values=TACHOMETER_SLOPES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    tachometer_rpm = Instrument.measurement(
+        "TRIGger:TACHometer:RPM?",
+        """Measure the tachometer speed in RPM.""",
+        cast=float,
+    )
+
+    display_annotation_enabled = Instrument.control(
+        "DISPlay:ANNotation:ALL?",
+        "DISPlay:ANNotation:ALL %d",
+        """Control whether display annotations are shown.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_brightness = Instrument.control(
+        "DISPlay:BRIGhtness?",
+        "DISPlay:BRIGhtness %g",
+        """Control display brightness (float from 0.5 to 1).""",
+        values=[0.5, 1.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    display_external_enabled = Instrument.control(
+        "DISPlay:EXTernal:STATe?",
+        "DISPlay:EXTernal:STATe %d",
+        """Control whether the external monitor output is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_enabled = Instrument.control(
+        "DISPlay:STATe?",
+        "DISPlay:STATe %d",
+        """Control display enabled state.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_format = Instrument.control(
+        "DISPlay:FORMat?",
+        "DISPlay:FORMat %s",
+        """Control display format layout.""",
+        values=DISPLAY_FORMATS,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    display_gpib_echo_enabled = Instrument.control(
+        "DISPlay:GPIB:ECHO?",
+        "DISPlay:GPIB:ECHO %d",
+        """Control whether front-panel GPIB mnemonic echo is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_program_mode = Instrument.control(
+        "DISPlay:PROGram:MODE?",
+        "DISPlay:PROGram:MODE %s",
+        """Control which display region is allocated to Instrument BASIC output.""",
+        values=DISPLAY_PROGRAM_MODES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    display_program_vector_buffer_enabled = Instrument.control(
+        "DISPlay:PROGram:VECTor:BUFFer:STATe?",
+        "DISPlay:PROGram:VECTor:BUFFer:STATe %d",
+        """Control buffering of vectors drawn by Instrument BASIC graphics.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    program_edit_enabled = Instrument.control(
+        "PROGram:EDIT:ENABle?",
+        "PROGram:EDIT:ENABle %d",
+        """Control whether the Instrument BASIC editor is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    program_name = Instrument.control(
+        "PROGram:NAME?",
+        "PROGram:NAME %s",
+        """Control the active Instrument BASIC program buffer.""",
+        values=(),
+        validator=lambda value, values: _normalize_program_name(value),
+        set_process=lambda value: _normalize_program_name(value),
+        get_process=lambda value: _normalize_program_name(value),
+        cast=str,
+        maxsplit=0,
+    )
+
+    program_label = Instrument.control(
+        "PROGram:LABel?",
+        "PROGram:LABel %s",
+        """Control the softkey label of the active Instrument BASIC program.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    program_state = Instrument.control(
+        "PROGram:STATe?",
+        "PROGram:STATe %s",
+        """Control the run state of the active Instrument BASIC program.""",
+        values=PROGRAM_STATE_VALUES,
+        validator=lambda value, values: _normalize_program_state(value),
+        set_process=lambda value: _normalize_program_state(value),
+        get_process=lambda value: _normalize_program_state(value),
+        cast=str,
+        maxsplit=0,
+    )
+
+    program_allocated_memory = Instrument.measurement(
+        "PROGram:MALLocate?",
+        """Measure the allocated Instrument BASIC program memory in bytes.""",
+        cast=int,
+    )
+
+    display_rpm_enabled = Instrument.control(
+        "DISPlay:RPM:STATe?",
+        "DISPlay:RPM:STATe %d",
+        """Control whether the RPM indicator is shown.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_show_all_enabled = Instrument.control(
+        "DISPlay:SHOWall:STATe?",
+        "DISPlay:SHOWall:STATe %d",
+        """Control whether all FFT lines are shown when available.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_time_capture_envelope_enabled = Instrument.control(
+        "DISPlay:TCAPture:ENVelope:STATe?",
+        "DISPlay:TCAPture:ENVelope:STATe %d",
+        """Control whether time-capture envelope is displayed.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    display_view = Instrument.control(
+        "DISPlay:VIEW?",
+        "DISPlay:VIEW %s",
+        """Control display view selection.""",
+        values=DISPLAY_VIEWS,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_destination = Instrument.control(
+        "HCOPy:DESTination?",
+        "HCOPy:DESTination %s",
+        """Control the hardcopy destination handler.""",
+        values=HARDCOPY_DESTINATION_VALUES,
+        validator=_validate_hardcopy_destination,
+        get_process=_normalize_hardcopy_destination,
+        set_process=_quote_string,
+        cast=str,
+        maxsplit=0,
+    )
+
+    hardcopy_device_language = Instrument.control(
+        "HCOPy:DEVice:LANGuage?",
+        "HCOPy:DEVice:LANGuage %s",
+        """Control the hardcopy output language.""",
+        values=HARDCOPY_DEVICE_LANGUAGE_VALUES,
+        validator=strict_discrete_set,
+        cast=str,
+        get_process=lambda value: _strip_quotes(str(value)).upper(),
+        set_process=lambda value: _strip_quotes(str(value)).upper(),
+        maxsplit=0,
+    )
+
+    hardcopy_device_resolution = Instrument.control(
+        "HCOPy:DEVice:RESolution?",
+        "HCOPy:DEVice:RESolution %d",
+        """Control the hardcopy output resolution in dots per inch.""",
+        values=[0, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_device_speed = Instrument.control(
+        "HCOPy:DEVice:SPEed?",
+        "HCOPy:DEVice:SPEed %d",
+        """Control the hardcopy plotting speed in centimeters per second.""",
+        values=[0, 100],
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_form_feed_enabled = Instrument.control(
+        "HCOPy:ITEM:FFEed:STATe?",
+        "HCOPy:ITEM:FFEed:STATe %d",
+        """Control whether hardcopy page-eject is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_label_color = Instrument.control(
+        "HCOPy:ITEM:LABel:COLor?",
+        "HCOPy:ITEM:LABel:COLor %d",
+        """Control the hardcopy pen number used for labels and annotations.""",
+        values=HARDCOPY_LABEL_COLOR_RANGE,
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_label_enabled = Instrument.control(
+        "HCOPy:ITEM:LABel:STATe?",
+        "HCOPy:ITEM:LABel:STATe %d",
+        """Control whether the hardcopy label text is shown.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_label_text = Instrument.control(
+        "HCOPy:ITEM:LABel:TEXT?",
+        "HCOPy:ITEM:LABel:TEXT %s",
+        """Control the hardcopy label text.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    hardcopy_timestamp_format = Instrument.control(
+        "HCOPy:ITEM:TDSTamp:FORMat?",
+        "HCOPy:ITEM:TDSTamp:FORMat %s",
+        """Control the hardcopy date/time stamp format.""",
+        values=HARDCOPY_TIMESTAMP_FORMAT_VALUES,
+        validator=_validate_hardcopy_timestamp_format,
+        get_process=_normalize_hardcopy_timestamp_format,
+        set_process=_normalize_hardcopy_timestamp_format,
+        cast=str,
+        maxsplit=0,
+    )
+
+    hardcopy_timestamp_enabled = Instrument.control(
+        "HCOPy:ITEM:TDSTamp:STATe?",
+        "HCOPy:ITEM:TDSTamp:STATe %d",
+        """Control whether hardcopy time stamp output is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_page_dimensions_auto_enabled = Instrument.control(
+        "HCOPy:PAGE:DIMensions:AUTO?",
+        "HCOPy:PAGE:DIMensions:AUTO %d",
+        """Control whether hardcopy page dimensions are auto-configured.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    hardcopy_page_user_lower_left = Instrument.control(
+        "HCOPy:PAGE:DIMensions:USER:LLEFt?",
+        "HCOPy:PAGE:DIMensions:USER:LLEFt %d,%d",
+        """Control the hardcopy P1 page point as (x, y).""",
+        values=HARDCOPY_PAGE_POINT_VALUES,
+        validator=_validate_int_pair,
+        cast=int,
+        get_process_list=tuple,
+    )
+
+    hardcopy_page_user_upper_right = Instrument.control(
+        "HCOPy:PAGE:DIMensions:USER:URIGht?",
+        "HCOPy:PAGE:DIMensions:USER:URIGht %d,%d",
+        """Control the hardcopy P2 page point as (x, y).""",
+        values=HARDCOPY_PAGE_POINT_VALUES,
+        validator=_validate_int_pair,
+        cast=int,
+        get_process_list=tuple,
+    )
+
+    hardcopy_plot_address = Instrument.control(
+        "HCOPy:PLOT:ADDRess?",
+        "HCOPy:PLOT:ADDRess %d",
+        """Control the GPIB address used for plotter output.""",
+        values=[0, 30],
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_print_address = Instrument.control(
+        "HCOPy:PRINt:ADDRess?",
+        "HCOPy:PRINt:ADDRess %d",
+        """Control the GPIB address used for printer output.""",
+        values=[0, 30],
+        validator=strict_range,
+        cast=int,
+    )
+
+    hardcopy_title1 = Instrument.control(
+        "HCOPy:TITLe1?",
+        "HCOPy:TITLe1 %s",
+        """Control the first hardcopy title line.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    hardcopy_title2 = Instrument.control(
+        "HCOPy:TITLe2?",
+        "HCOPy:TITLe2 %s",
+        """Control the second hardcopy title line.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    hardcopy_source = Instrument.control(
+        "HCOPy:SOURce?",
+        "HCOPy:SOURce %s",
+        """Control which screen content is selected for hardcopy output.""",
+        values=HARDCOPY_SOURCE_VALUES,
+        validator=_validate_hardcopy_source,
+        get_process=_normalize_hardcopy_source,
+        set_process=_normalize_hardcopy_source,
+        cast=str,
+        maxsplit=0,
+    )
+
+    mass_memory_disk_address = Instrument.control(
+        "MMEMory:DISK:ADDRess?",
+        "MMEMory:DISK:ADDRess %d",
+        """Control the GPIB address assigned to the external mass-memory device.""",
+        values=[0, 30],
+        validator=strict_range,
+        cast=int,
+    )
+
+    mass_memory_disk_unit = Instrument.control(
+        "MMEMory:DISK:UNIT?",
+        "MMEMory:DISK:UNIT %d",
+        """Control the unit number assigned to the external mass-memory device.""",
+        values=[0, 10],
+        validator=strict_range,
+        cast=int,
+    )
+
+    mass_memory_filesystem = Instrument.measurement(
+        "MMEMory:FSYStem?",
+        """Measure the file-system type of the default mass-memory disk.""",
+        cast=str,
+        get_process=lambda value: _strip_quotes(str(value)).strip().upper(),
+        maxsplit=0,
+    )
+
+    mass_memory_default_disk = Instrument.control(
+        "MMEMory:MSIS?",
+        "MMEMory:MSIS %s",
+        """Control the default mass-memory disk selector.""",
+        values=(),
+        validator=lambda value, values: _normalize_mass_memory_disk(value),
+        set_process=_quote_string,
+        get_process=lambda value: _normalize_mass_memory_disk(value),
+        cast=str,
+        maxsplit=0,
+    )
+
+    mass_memory_name = Instrument.control(
+        "MMEMory:NAME?",
+        "MMEMory:NAME %s",
+        """Control the default mass-memory file name used by print/plot operations.""",
+        cast=str,
+        get_process=_strip_quotes,
+        set_process=_quote_string,
+        maxsplit=0,
+    )
+
+    mass_memory_load_continue_status = Instrument.measurement(
+        "MMEMory:LOAD:CONTinue?",
+        """Measure whether multi-disk mass-memory load continuation is requested.""",
+        cast=int,
+    )
+
+    mass_memory_store_continue_status = Instrument.measurement(
+        "MMEMory:STORe:CONTinue?",
+        """Measure whether multi-disk mass-memory store continuation is requested.""",
+        cast=int,
+    )
+
+    mass_memory_store_program_format = Instrument.control(
+        "MMEMory:STORe:PROGram:FORMat?",
+        "MMEMory:STORe:PROGram:FORMat %s",
+        """Control the file format used for storing Instrument BASIC programs.""",
+        values=MASS_MEMORY_STORE_PROGRAM_FORMAT_VALUES,
+        validator=lambda value, values: _normalize_mass_memory_program_format(value),
+        set_process=lambda value: _normalize_mass_memory_program_format(value),
+        get_process=lambda value: _normalize_mass_memory_program_format(value),
+        cast=str,
+        maxsplit=0,
+    )
+
+    mass_memory_store_trace_format = Instrument.control(
+        "MMEM:STORe:TRACe:FORMat?",
+        "MMEM:STORe:TRACe:FORMat %s",
+        """Control the file format used for storing trace files.""",
+        values=MASS_MEMORY_STORE_TRACE_FORMAT_VALUES,
+        validator=strict_discrete_set,
+        cast=str,
+        get_process=lambda value: _strip_quotes(str(value)).strip().upper(),
+        set_process=lambda value: _strip_quotes(str(value)).strip().upper(),
+        maxsplit=0,
+    )
+
+    data_format = Instrument.control(
+        "FORMat:DATA?",
+        "FORMat:DATA %s",
+        """Control numeric transfer format for block-data queries and uploads.""",
+        values=DATA_FORMAT_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+        preprocess_reply=_normalize_data_format_token,
+        maxsplit=0,
+    )
+
+    sense_feed = Instrument.control(
+        "SENSe:FEED?",
+        "SENSe:FEED %s",
+        """Control whether measurements use input channels or time-capture data.""",
+        values=SENSE_FEED_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    sense_data_frequency_start = Instrument.measurement(
+        "SENSe:DATA:HEADer:FREQuency:STARt?",
+        """Measure the start frequency metadata for the active time-capture buffer.""",
+        cast=float,
+    )
+
+    sense_data_frequency_stop = Instrument.measurement(
+        "SENSe:DATA:HEADer:FREQuency:STOP?",
+        """Measure the stop frequency metadata for the active time-capture buffer.""",
+        cast=float,
+    )
+
+    frequency_block_size = Instrument.control(
+        "SENSe:FREQuency:BLOCksize?",
+        "SENSe:FREQuency:BLOCksize %d",
+        """Control the real-time data block size in points.""",
+        values=[256, 2048],
+        validator=strict_range,
+        cast=int,
+    )
+
+    frequency_center = Instrument.control(
+        "SENSe:FREQuency:CENTer?",
+        "SENSe:FREQuency:CENTer %g",
+        """Control the center frequency in Hz.""",
+        values=[0.0234375, 115000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_manual = Instrument.control(
+        "SENSe:FREQuency:MANual?",
+        "SENSe:FREQuency:MANual %g",
+        """Control manual swept-sine frequency in Hz.""",
+        values=[0.015625, 51200.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_resolution = Instrument.control(
+        "SENSe:FREQuency:RESolution?",
+        "SENSe:FREQuency:RESolution %g",
+        """Control frequency resolution value for active measurement mode.""",
+        values=[0.015625, 51200.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_resolution_auto_enabled = Instrument.control(
+        "SENSe:FREQuency:RESolution:AUTO?",
+        "SENSe:FREQuency:RESolution:AUTO %d",
+        """Control whether swept-sine automatic resolution is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    frequency_resolution_auto_max_change = Instrument.control(
+        "SENSe:FREQuency:RESolution:AUTO:MCHange?",
+        "SENSe:FREQuency:RESolution:AUTO:MCHange %g",
+        """Control swept-sine maximum auto-resolution response change in percent.""",
+        values=[0.00391, 100.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_resolution_auto_minimum = Instrument.control(
+        "SENSe:FREQuency:RESolution:AUTO:MINimum?",
+        "SENSe:FREQuency:RESolution:AUTO:MINimum %g",
+        """Control swept-sine minimum automatic resolution value.""",
+        values=[0.015625, 51200.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_resolution_octave = Instrument.control(
+        "SENSe:FREQuency:RESolution:OCTave?",
+        "SENSe:FREQuency:RESolution:OCTave %s",
+        """Control the octave resolution family.""",
+        values=FREQUENCY_RESOLUTION_OCTAVE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    frequency_span = Instrument.control(
+        "SENSe:FREQuency:SPAN?",
+        "SENSe:FREQuency:SPAN %g",
+        """Control the frequency span in Hz.""",
+        values=[0.015625, 102400.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_span_link = Instrument.control(
+        "SENSe:FREQuency:SPAN:LINK?",
+        "SENSe:FREQuency:SPAN:LINK %s",
+        """Control which frequency reference remains fixed when span changes.""",
+        values=FREQUENCY_SPAN_LINK_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    frequency_start = Instrument.control(
+        "SENSe:FREQuency:STARt?",
+        "SENSe:FREQuency:STARt %g",
+        """Control the start frequency in Hz.""",
+        values=[0.0, 114999.9023],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_step_increment = Instrument.control(
+        "SENSe:FREQuency:STEP:INCRement?",
+        "SENSe:FREQuency:STEP:INCRement %g",
+        """Control the frequency increment used for manual stepping.""",
+        values=[0.015625, 102400.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    frequency_stop = Instrument.control(
+        "SENSe:FREQuency:STOP?",
+        "SENSe:FREQuency:STOP %g",
+        """Control the stop frequency in Hz.""",
+        values=[0.03125, 115000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    sweep_direction = Instrument.control(
+        "SENSe:SWEep:DIRection?",
+        "SENSe:SWEep:DIRection %s",
+        """Control swept-sine sweep direction.""",
+        values=SWEEP_DIRECTION_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    sweep_dwell = Instrument.control(
+        "SENSe:SWEep:DWELl?",
+        "SENSe:SWEep:DWELl %g",
+        """Control swept-sine integration dwell time.""",
+        values=[250e-6, 32768.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    sweep_mode = Instrument.control(
+        "SENSe:SWEep:MODE?",
+        "SENSe:SWEep:MODE %s",
+        """Control swept-sine sweep mode.""",
+        values=SWEEP_MODE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    sweep_overlap = Instrument.control(
+        "SENSe:SWEep:OVERlap?",
+        "SENSe:SWEep:OVERlap %d",
+        """Control maximum overlap percentage between time records.""",
+        values=[0, 99],
+        validator=strict_range,
+        cast=int,
+    )
+
+    sweep_spacing = Instrument.control(
+        "SENSe:SWEep:SPACing?",
+        "SENSe:SWEep:SPACing %s",
+        """Control swept-sine point spacing.""",
+        values=SWEEP_SPACING_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    sweep_settling_time = Instrument.control(
+        "SENSe:SWEep:STIMe?",
+        "SENSe:SWEep:STIMe %g",
+        """Control swept-sine settling time before integration.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    sweep_time = Instrument.control(
+        "SENSe:SWEep:TIME?",
+        "SENSe:SWEep:TIME %g",
+        """Control time-record length in seconds.""",
+        values=[976.5625e-6, 8192.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    histogram_bins = Instrument.control(
+        "SENSe:HISTogram:BINS?",
+        "SENSe:HISTogram:BINS %d",
+        """Control the number of bins in histogram measurements.""",
+        values=[4, 1024],
+        validator=strict_range,
+        cast=int,
+    )
+
+    order_maximum = Instrument.control(
+        "SENSe:ORDer:MAXimum?",
+        "SENSe:ORDer:MAXimum %g",
+        """Control the maximum analyzed order.""",
+        values=[3.125, 200.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    order_resolution = Instrument.control(
+        "SENSe:ORDer:RESolution?",
+        "SENSe:ORDer:RESolution %g",
+        """Control order-spectrum resolution in orders.""",
+        values=[0.0078125, 1.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    order_track_resolution = Instrument.control(
+        "SENSe:ORDer:RESolution:TRACk?",
+        "SENSe:ORDer:RESolution:TRACk %d",
+        """Control points per order track.""",
+        values=[1, 2048],
+        validator=strict_range,
+        cast=int,
+    )
+
+    order_rpm_maximum = Instrument.control(
+        "SENSe:ORDer:RPM:MAXimum?",
+        "SENSe:ORDer:RPM:MAXimum %g",
+        """Control maximum RPM for order measurements.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    order_rpm_minimum = Instrument.control(
+        "SENSe:ORDer:RPM:MINimum?",
+        "SENSe:ORDer:RPM:MINimum %g",
+        """Control minimum RPM for order measurements.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    reference_channels = Instrument.control(
+        "SENSe:REFerence?",
+        "SENSe:REFerence %s",
+        """Control reference-channel pairing mode.""",
+        values=REFERENCE_CHANNEL_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    overload_rejection_enabled = Instrument.control(
+        "SENSe:REJect:STATe?",
+        "SENSe:REJect:STATe %d",
+        """Control whether overloaded time records are rejected.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    time_capture_length = Instrument.control(
+        "SENSe:TCAPture:LENGth?",
+        "SENSe:TCAPture:LENGth %g",
+        """Control the time-capture buffer length.""",
+        values=[0.0, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_start1 = Instrument.control(
+        "SENSe:TCAPture:STARt1?",
+        "SENSe:TCAPture:STARt1 %g",
+        """Control time-capture start position for channel 1.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_start2 = Instrument.control(
+        "SENSe:TCAPture:STARt2?",
+        "SENSe:TCAPture:STARt2 %g",
+        """Control time-capture start position for channel 2.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_start3 = Instrument.control(
+        "SENSe:TCAPture:STARt3?",
+        "SENSe:TCAPture:STARt3 %g",
+        """Control time-capture start position for channel 3.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_start4 = Instrument.control(
+        "SENSe:TCAPture:STARt4?",
+        "SENSe:TCAPture:STARt4 %g",
+        """Control time-capture start position for channel 4.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_stop1 = Instrument.control(
+        "SENSe:TCAPture:STOP1?",
+        "SENSe:TCAPture:STOP1 %g",
+        """Control time-capture stop position for channel 1.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_stop2 = Instrument.control(
+        "SENSe:TCAPture:STOP2?",
+        "SENSe:TCAPture:STOP2 %g",
+        """Control time-capture stop position for channel 2.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_stop3 = Instrument.control(
+        "SENSe:TCAPture:STOP3?",
+        "SENSe:TCAPture:STOP3 %g",
+        """Control time-capture stop position for channel 3.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_stop4 = Instrument.control(
+        "SENSe:TCAPture:STOP4?",
+        "SENSe:TCAPture:STOP4 %g",
+        """Control time-capture stop position for channel 4.""",
+        values=[-9.9e37, 9.9e37],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_tachometer_rpm_maximum = Instrument.control(
+        "SENSe:TCAPture:TACHometer:RPM:MAXimum?",
+        "SENSe:TCAPture:TACHometer:RPM:MAXimum %g",
+        """Control maximum tachometer RPM for time-capture buffering.""",
+        values=[5.0, 491519.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    time_capture_tachometer_enabled = Instrument.control(
+        "SENSe:TCAPture:TACHometer:STATe?",
+        "SENSe:TCAPture:TACHometer:STATe %d",
+        """Control whether tachometer data is included in time capture.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    _installed_options = Instrument.measurement(
+        "*OPT?",
+        """Get the installed option configuration.""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    _next_system_error = Instrument.measurement(
+        "SYSTem:ERRor?",
+        """Get the next system error.""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    self_test_result = Instrument.measurement(
+        "*TST?",
+        """Measure the self-test result.""",
+        cast=int,
+    )
+
+    long_test_result = Instrument.measurement(
+        "TEST:LONG:RESult?",
+        """Measure the overall result of the long confidence test.""",
+        cast=int,
+    )
+
+    event_status_enable = Instrument.control(
+        "*ESE?",
+        "*ESE %d",
+        """Control the Standard Event enable register.""",
+        values=[0, 255],
+        validator=strict_range,
+        cast=int,
+    )
+
+    standard_event_status = Instrument.measurement(
+        "*ESR?",
+        """Measure the Standard Event status register.""",
+        cast=int,
+    )
+
+    power_on_status_clear = Instrument.control(
+        "*PSC?",
+        "*PSC %d",
+        """Control the Power-on Status Clear flag.""",
+        values=[-32767, 32767],
+        validator=strict_range,
+        cast=int,
+    )
+
+    service_request_enable = Instrument.control(
+        "*SRE?",
+        "*SRE %d",
+        """Control the Service Request enable register.""",
+        values=[0, 255],
+        validator=strict_range,
+        cast=int,
+    )
+
+    status_byte = Instrument.measurement(
+        "*STB?",
+        """Measure the status byte register.""",
+        cast=int,
+    )
+
+    arm_rpm_increment = Instrument.control(
+        "ARM:RPM:INCRement?",
+        "ARM:RPM:INCRement %g",
+        """Control the RPM step increment for RPM-step arming.""",
+        values=[1.0, 500000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    arm_rpm_mode = Instrument.control(
+        "ARM:RPM:MODE?",
+        "ARM:RPM:MODE %s",
+        """Control the Start RPM arming qualifier mode.""",
+        values=ARM_RPM_MODES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    arm_rpm_threshold = Instrument.control(
+        "ARM:RPM:THReshold?",
+        "ARM:RPM:THReshold %g",
+        """Control the starting RPM threshold for RPM-step arming.""",
+        values=[5.0, 491520.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    arm_source = Instrument.control(
+        "ARM:SOURce?",
+        "ARM:SOURce %s",
+        """Control the arming source.""",
+        values=ARM_SOURCES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    arm_timer = Instrument.control(
+        "ARM:TIMer?",
+        "ARM:TIMer %g",
+        """Control the time-step arming interval in seconds.""",
+        values=[0.0, 500000.0],
+        validator=strict_range,
+        cast=float,
+    )
+
+    calibration_auto = Instrument.control(
+        "CALibration:AUTO?",
+        "CALibration:AUTO %s",
+        """Control the autocalibration mode.""",
+        values={"off": "OFF", "on": "ON", "once": "ONCE"},
+        map_values=True,
+        validator=strict_discrete_set,
+        cast=str,
+        get_process=_normalize_on_off_once,
+    )
+
+    operation_condition = Instrument.measurement(
+        "STATus:OPERation:CONDition?",
+        """Measure the operation status condition register.""",
+        cast=int,
+    )
+
+    questionable_condition = Instrument.measurement(
+        "STATus:QUEStionable:CONDition?",
+        """Measure the questionable status condition register.""",
+        cast=int,
+    )
+
+    device_condition = Instrument.measurement(
+        "STATus:DEVice:CONDition?",
+        """Measure the device status condition register.""",
+        cast=int,
+    )
+
+    device_enable = Instrument.control(
+        "STATus:DEVice:ENABle?",
+        "STATus:DEVice:ENABle %d",
+        """Control the device status enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    device_event = Instrument.measurement(
+        "STATus:DEVice:EVENt?",
+        """Measure the device status event register.""",
+        cast=int,
+    )
+
+    device_negative_transition = Instrument.control(
+        "STATus:DEVice:NTRansition?",
+        "STATus:DEVice:NTRansition %d",
+        """Control the device status negative transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    device_positive_transition = Instrument.control(
+        "STATus:DEVice:PTRansition?",
+        "STATus:DEVice:PTRansition %d",
+        """Control the device status positive transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    operation_enable = Instrument.control(
+        "STATus:OPERation:ENABle?",
+        "STATus:OPERation:ENABle %d",
+        """Control the operation status enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    operation_event = Instrument.measurement(
+        "STATus:OPERation:EVENt?",
+        """Measure the operation status event register.""",
+        cast=int,
+    )
+
+    operation_negative_transition = Instrument.control(
+        "STATus:OPERation:NTRansition?",
+        "STATus:OPERation:NTRansition %d",
+        """Control the operation status negative transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    operation_positive_transition = Instrument.control(
+        "STATus:OPERation:PTRansition?",
+        "STATus:OPERation:PTRansition %d",
+        """Control the operation status positive transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_enable = Instrument.control(
+        "STATus:QUEStionable:ENABle?",
+        "STATus:QUEStionable:ENABle %d",
+        """Control the questionable status enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_event = Instrument.measurement(
+        "STATus:QUEStionable:EVENt?",
+        """Measure the questionable status event register.""",
+        cast=int,
+    )
+
+    questionable_limit_condition = Instrument.measurement(
+        "STATus:QUEStionable:LIMit:CONDition?",
+        """Measure the questionable limit condition register.""",
+        cast=int,
+    )
+
+    questionable_limit_enable = Instrument.control(
+        "STATus:QUEStionable:LIMit:ENABle?",
+        "STATus:QUEStionable:LIMit:ENABle %d",
+        """Control the questionable limit enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_limit_event = Instrument.measurement(
+        "STATus:QUEStionable:LIMit:EVENt?",
+        """Measure the questionable limit event register.""",
+        cast=int,
+    )
+
+    questionable_limit_negative_transition = Instrument.control(
+        "STATus:QUEStionable:LIMit:NTRansition?",
+        "STATus:QUEStionable:LIMit:NTRansition %d",
+        """Control the questionable limit negative transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_limit_positive_transition = Instrument.control(
+        "STATus:QUEStionable:LIMit:PTRansition?",
+        "STATus:QUEStionable:LIMit:PTRansition %d",
+        """Control the questionable limit positive transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_negative_transition = Instrument.control(
+        "STATus:QUEStionable:NTRansition?",
+        "STATus:QUEStionable:NTRansition %d",
+        """Control the questionable status negative transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_positive_transition = Instrument.control(
+        "STATus:QUEStionable:PTRansition?",
+        "STATus:QUEStionable:PTRansition %d",
+        """Control the questionable status positive transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_voltage_condition = Instrument.measurement(
+        "STATus:QUEStionable:VOLTage:CONDition?",
+        """Measure the questionable voltage condition register.""",
+        cast=int,
+    )
+
+    questionable_voltage_enable = Instrument.control(
+        "STATus:QUEStionable:VOLTage:ENABle?",
+        "STATus:QUEStionable:VOLTage:ENABle %d",
+        """Control the questionable voltage enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_voltage_event = Instrument.measurement(
+        "STATus:QUEStionable:VOLTage:EVENt?",
+        """Measure the questionable voltage event register.""",
+        cast=int,
+    )
+
+    questionable_voltage_negative_transition = Instrument.control(
+        "STATus:QUEStionable:VOLTage:NTRansition?",
+        "STATus:QUEStionable:VOLTage:NTRansition %d",
+        """Control the questionable voltage negative transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    questionable_voltage_positive_transition = Instrument.control(
+        "STATus:QUEStionable:VOLTage:PTRansition?",
+        "STATus:QUEStionable:VOLTage:PTRansition %d",
+        """Control the questionable voltage positive transition mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    user_status_enable = Instrument.control(
+        "STATus:USER:ENABle?",
+        "STATus:USER:ENABle %d",
+        """Control the user status enable register mask.""",
+        values=STATUS_MASK_VALUES,
+        validator=strict_range,
+        cast=int,
+    )
+
+    user_status_event = Instrument.measurement(
+        "STATus:USER:EVENt?",
+        """Measure the user status event register.""",
+        cast=int,
+    )
+
+    beeper_enabled = Instrument.control(
+        "SYSTem:BEEPer:STATe?",
+        "SYSTem:BEEPer:STATe %d",
+        """Control whether the beeper is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    gpib_address = Instrument.control(
+        "SYSTem:COMMunicate:GPIB:ADDRess?",
+        "SYSTem:COMMunicate:GPIB:ADDRess %d",
+        """Control the GPIB address.""",
+        values=[0, 30],
+        validator=strict_range,
+        cast=int,
+    )
+
+    serial_receive_baud = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:BAUD?",
+        "SYSTem:COMMunicate:SERial:RECeive:BAUD %d",
+        """Control the RS-232 receive baud rate.""",
+        values=SERIAL_BAUD_RATES,
+        validator=strict_discrete_set,
+        cast=int,
+    )
+
+    serial_receive_bits = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:BITS?",
+        "SYSTem:COMMunicate:SERial:RECeive:BITS %d",
+        """Control the RS-232 receive bits per character.""",
+        values=SERIAL_BITS,
+        validator=strict_discrete_set,
+        cast=int,
+    )
+
+    serial_receive_pace = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:PACE?",
+        "SYSTem:COMMunicate:SERial:RECeive:PACE %s",
+        """Control the RS-232 receive pacing mode.""",
+        values=SERIAL_RECEIVE_PACE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    serial_receive_parity_check_enabled = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:PARity:CHECk?",
+        "SYSTem:COMMunicate:SERial:RECeive:PARity:CHECk %d",
+        """Control whether RS-232 receive parity checking is enabled.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    serial_receive_parity = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:PARity?",
+        "SYSTem:COMMunicate:SERial:RECeive:PARity %s",
+        """Control the RS-232 receive parity type.""",
+        values=SERIAL_PARITY_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    serial_receive_stop_bits = Instrument.control(
+        "SYSTem:COMMunicate:SERial:RECeive:SBITs?",
+        "SYSTem:COMMunicate:SERial:RECeive:SBITs %d",
+        """Control the RS-232 receive stop bits.""",
+        values=SERIAL_STOP_BITS,
+        validator=strict_discrete_set,
+        cast=int,
+    )
+
+    serial_transmit_pace = Instrument.control(
+        "SYSTem:COMMunicate:SERial:TRANsmit:PACE?",
+        "SYSTem:COMMunicate:SERial:TRANsmit:PACE %s",
+        """Control the RS-232 transmit pacing mode.""",
+        values=SERIAL_TRANSMIT_PACE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    system_date = Instrument.control(
+        "SYSTem:DATE?",
+        "SYSTem:DATE %d,%d,%d",
+        """Control the system date as (year, month, day).""",
+        validator=_validate_int_triplet,
+        values=SYSTEM_DATE_VALUES,
+        cast=int,
+        get_process_list=tuple,
+    )
+
+    system_time = Instrument.control(
+        "SYSTem:TIME?",
+        "SYSTem:TIME %d,%d,%d",
+        """Control the system time as (hour, minute, second).""",
+        validator=_validate_int_triplet,
+        values=SYSTEM_TIME_VALUES,
+        cast=int,
+        get_process_list=tuple,
+    )
+
+    fan_state = Instrument.control(
+        "SYSTem:FAN:STATe?",
+        "SYSTem:FAN:STATe %s",
+        """Control the analyzer fan operating mode.""",
+        values=FAN_STATE_VALUES,
+        map_values=True,
+        validator=strict_discrete_set,
+    )
+
+    key_code = Instrument.control(
+        "SYSTem:KEY?",
+        "SYSTem:KEY %d",
+        """Control or query front-panel key codes.""",
+        cast=int,
+    )
+
+    keyboard_locked = Instrument.control(
+        "SYSTem:KLOCk?",
+        "SYSTem:KLOCk %d",
+        """Control whether the front-panel keyboard is locked.""",
+        values=BOOL_VALUES,
+        map_values=True,
+        cast=int,
+        validator=strict_discrete_set,
+    )
+
+    key_lock_enabled = keyboard_locked
+
+    power_source = Instrument.measurement(
+        "SYSTem:POWer:SOURce?",
+        """Measure the active power source.""",
+        cast=str,
+    )
+
+    power_state = Instrument.measurement(
+        "SYSTem:POWer:STATe?",
+        """Measure the analyzer power state.""",
+        cast=int,
+    )
+
+    system_version = Instrument.measurement(
+        "SYSTem:VERSion?",
+        """Measure the SCPI system version.""",
+        cast=str,
+    )
+
+    def abort(self) -> None:
+        """Abort the measurement in progress."""
+        self.write("ABORt")
+
+    def initiate(self) -> None:
+        """Initiate a measurement."""
+        self.write("INITiate:IMMediate")
+
+    def restart_measurement(self) -> None:
+        """Abort and restart a measurement."""
+        self.write("ABORt;:INITiate:IMMediate")
+
+    def wait_for_completion(self) -> int:
+        """Wait for pending operations to complete."""
+        return self.operation_complete()
+
+    def arm(self) -> None:
+        """Arm the trigger when manual arming is selected."""
+        self.write("ARM:IMMediate")
+
+    def pass_control_back_address(
+            self, primary_address: int, secondary_address: Optional[int] = None):
+        """Set the pass-control-back address."""
+        if secondary_address is None:
+            self.write(f"*PCB {int(primary_address)}")
+        else:
+            self.write(f"*PCB {int(primary_address)}, {int(secondary_address)}")
+
+    def wait(self) -> None:
+        """Wait until all preceding commands have been processed."""
+        self.write("*WAI")
+
+    def operation_complete(self) -> int:
+        """Get the operation-complete synchronization value."""
+        return int(self.ask("*OPC?"))
+
+    def trigger_immediate(self) -> None:
+        """Trigger immediately when trigger_source is BUS; otherwise this command is ignored."""
+        self.write("TRIGger:IMMediate")
+
+    def trigger(self) -> None:
+        """Trigger the analyzer."""
+        self.write("*TRG")
+
+    def bode(self) -> None:
+        """Display a Bode diagram layout."""
+        self.write("DISPlay:BODE")
+
+    def display_error(self, text: str) -> None:
+        """Display analyzer-style text in the message area."""
+        self.write(f"DISPlay:ERRor {_quote_string(str(text))}")
+
+    def hardcopy_color_default(self) -> None:
+        """Reset hardcopy color assignments to analyzer defaults."""
+        self.write("HCOPy:COLor:DEFault")
+
+    def hardcopy(self, confirmed=False) -> None:
+        """Start a hardcopy print or plot operation after explicit confirmation."""
+        _require_confirmation("start hardcopy output", confirmed)
+        self.write("HCOPy:IMMediate")
+
+    def print_or_plot(self, confirmed=False) -> None:
+        """Start a hardcopy print or plot operation after explicit confirmation."""
+        self.hardcopy(confirmed=confirmed)
+
+    def define_program(self, text, raw=False) -> None:
+        """Define the active Instrument BASIC program from controller-provided block data."""
+        block = _encode_program_block(text, raw=raw)
+        self.write_bytes(b"PROGram:DEFine " + block)
+
+    def read_program_definition(self, raw=False):
+        """Read the active Instrument BASIC program definition as text or raw block bytes."""
+        self.write("PROGram:DEFine?")
+        reply = self.read_bytes(-1)
+        if raw:
+            return reply
+        return _parse_ascii_or_definite_block_text(reply)
+
+    def define_explicit_program(self, text, program="program1", raw=False) -> None:
+        """Define a selected Instrument BASIC program buffer from controller-provided block data."""
+        program_selector = _normalize_program_name(program)
+        block = _encode_program_block(text, raw=raw)
+        prefix = f"PROGram:EXPLicit:DEFine {program_selector},".encode("ascii")
+        self.write_bytes(prefix + block)
+
+    def read_explicit_program_definition(self, raw=False):
+        """Read an Instrument BASIC program definition via PROGram:EXPLicit:DEFine?."""
+        self.write("PROGram:EXPLicit:DEFine?")
+        reply = self.read_bytes(-1)
+        if raw:
+            return reply
+        return _parse_ascii_or_definite_block_text(reply)
+
+    def set_explicit_program_label(self, label: str, program="program1") -> None:
+        """Set the softkey label for a specific Instrument BASIC program buffer."""
+        program_selector = _normalize_program_name(program)
+        self.write(f"PROGram:EXPLicit:LABel {program_selector}, {_quote_string(str(label))}")
+
+    def read_explicit_program_label(self):
+        """Read the softkey label via PROGram:EXPLicit:LABel?."""
+        return _strip_quotes(str(self.ask("PROGram:EXPLicit:LABel?")))
+
+    def delete_all_programs(self, confirmed=False) -> None:
+        """Delete all Instrument BASIC programs and variables after explicit confirmation."""
+        _require_confirmation("delete all Instrument BASIC programs", confirmed)
+        self.write("PROGram:DELete:ALL")
+
+    def delete_selected_program(self, confirmed=False) -> None:
+        """Delete the active Instrument BASIC program and variables after explicit confirmation."""
+        _require_confirmation("delete selected Instrument BASIC program", confirmed)
+        self.write("PROGram:DELete")
+
+    def allocate_program_memory(self, size) -> None:
+        """Allocate Instrument BASIC program memory in bytes."""
+        token = _strip_quotes(str(size)).strip().upper()
+        if token == "DEFAULT":
+            self.write("PROGram:MALLocate DEFault")
+            return
+        if token in {"MAX", "MIN"}:
+            self.write(f"PROGram:MALLocate {token}")
+            return
+        validated = int(strict_range(int(size), [1200, 500000]))
+        self.write(f"PROGram:MALLocate {validated}")
+
+    def set_program_number_variable(self, index, value) -> None:
+        """Set a numeric Instrument BASIC variable in the active program."""
+        variable = _normalize_program_variable_name(index, string_variable=False)
+        if isinstance(value, (list, tuple)):
+            payload = ",".join(f"{float(item):g}" for item in value)
+        else:
+            payload = f"{float(value):g}"
+        self.write(f"PROGram:NUMBer {_quote_string(variable)}, {payload}")
+
+    def read_program_number_variable(self, index, raw=False):
+        """Read a numeric Instrument BASIC variable from the active program."""
+        variable = _normalize_program_variable_name(index, string_variable=False)
+        self.write(f"PROGram:NUMBer? {_quote_string(variable)}")
+        reply = self.read_bytes(-1)
+        if raw:
+            return reply
+        return _parse_ascii_or_definite_block_floats(reply)
+
+    def set_program_string_variable(self, index, value: str) -> None:
+        """Set a string Instrument BASIC variable in the active program."""
+        variable = _normalize_program_variable_name(index, string_variable=True)
+        self.write(
+            f"PROGram:STRing {_quote_string(variable)}, {_quote_string(str(value))}"
+        )
+
+    def read_program_string_variable(self, index) -> str:
+        """Read a string Instrument BASIC variable from the active program."""
+        variable = _normalize_program_variable_name(index, string_variable=True)
+        return _strip_quotes(str(self.ask(f"PROGram:STRing? {_quote_string(variable)}")))
+
+    def memory_catalog(self, all_entries=False) -> str:
+        """Get volatile memory catalog information."""
+        command = "MEMory:CATalog:ALL?" if all_entries else "MEMory:CATalog?"
+        return str(self.ask(command))
+
+    def memory_catalog_name(self, item) -> str:
+        """Get volatile memory allocation information for one item class."""
+        selector = _validate_memory_catalog_item(item, MEMORY_CATALOG_ITEM_VALUES)
+        return str(self.ask(f"MEMory:CATalog:NAME? {selector}"))
+
+    def memory_free(self, all_entries=False) -> str:
+        """Get available and allocated volatile memory information."""
+        command = "MEMory:FREE:ALL?" if all_entries else "MEMory:FREE?"
+        return str(self.ask(command))
+
+    def memory_delete_all(self, confirmed=False) -> None:
+        """Delete all volatile memory allocations after explicit confirmation."""
+        _require_confirmation("delete all volatile memory allocations", confirmed)
+        self.write("MEMory:DELete:ALL")
+
+    def memory_delete(self, item, confirmed=False) -> None:
+        """Delete a volatile memory allocation item after explicit confirmation."""
+        _require_confirmation("delete volatile memory allocation item", confirmed)
+        selector = _validate_memory_catalog_item(item, MEMORY_CATALOG_ITEM_VALUES)
+        self.write(f"MEMory:DELete {selector}")
+
+    def mass_memory_copy(self, source: str, destination: str, confirmed=False) -> None:
+        """Copy one mass-memory file or disk target after explicit confirmation."""
+        _require_confirmation("copy mass-memory file or disk target", confirmed)
+        self.write(f"MMEMory:COPY {_quote_string(source)}, {_quote_string(destination)}")
+
+    def mass_memory_delete(self, path: str, confirmed=False) -> None:
+        """Delete a mass-memory file or directory target after explicit confirmation."""
+        _require_confirmation("delete mass-memory file or directory target", confirmed)
+        self.write(f"MMEMory:DELete {_quote_string(path)}")
+
+    def mass_memory_initialize(
+            self, disk: Optional[str] = None, filesystem: Optional[str] = None,
+            format_option: Optional[int] = None, interleave_factor: Optional[int] = None,
+            confirmed=False) -> None:
+        """Initialize a mass-memory disk after explicit confirmation."""
+        _require_confirmation("initialize mass-memory disk", confirmed)
+        parts = ["MMEMory:INITialize"]
+        if disk is not None:
+            parts.append(_quote_string(disk))
+        if filesystem is not None:
+            parts.append(_strip_quotes(str(filesystem)).strip().upper())
+        if format_option is not None:
+            parts.append(str(int(format_option)))
+        if interleave_factor is not None:
+            parts.append(str(int(interleave_factor)))
+        self.write(" ".join(parts))
+
+    def mass_memory_make_directory(self, directory: str, confirmed=False) -> None:
+        """Create a DOS directory on mass memory after explicit confirmation."""
+        _require_confirmation("create mass-memory directory", confirmed)
+        self.write(f"MMEMory:MDIRectory {_quote_string(directory)}")
+
+    def mass_memory_move(self, source: str, destination: str, confirmed=False) -> None:
+        """Rename or move a mass-memory file after explicit confirmation."""
+        _require_confirmation("move or rename mass-memory file", confirmed)
+        self.write(f"MMEMory:MOVE {_quote_string(source)}, {_quote_string(destination)}")
+
+    def mass_memory_load_continue(self, confirmed=False) -> None:
+        """Continue a multi-disk mass-memory load operation after explicit confirmation."""
+        _require_confirmation("continue mass-memory load operation", confirmed)
+        self.write("MMEMory:LOAD:CONTinue")
+
+    def mass_memory_store_continue(self, confirmed=False) -> None:
+        """Continue a multi-disk mass-memory store operation after explicit confirmation."""
+        _require_confirmation("continue mass-memory store operation", confirmed)
+        self.write("MMEMory:STORe:CONTinue")
+
+    def mass_memory_load_cfit(self, filename: str, confirmed=False) -> None:
+        """Load a curve-fit table file after explicit confirmation."""
+        _require_confirmation("load curve-fit table from mass memory", confirmed)
+        self.write(f"MMEMory:LOAD:CFIT {_quote_string(filename)}")
+
+    def mass_memory_load_data_table_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Load a data-table trace file after explicit confirmation."""
+        _require_confirmation("load data-table trace from mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:LOAD:DTABle:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_load_lower_limit_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Load a lower limit-line trace file after explicit confirmation."""
+        _require_confirmation("load lower limit trace from mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:LOAD:LIMit:LOWer:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_load_upper_limit_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Load an upper limit-line trace file after explicit confirmation."""
+        _require_confirmation("load upper limit trace from mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:LOAD:LIMit:UPPer:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_load_math(self, filename: str, confirmed=False) -> None:
+        """Load a math-definition file after explicit confirmation."""
+        _require_confirmation("load math definitions from mass memory", confirmed)
+        self.write(f"MMEMory:LOAD:MATH {_quote_string(filename)}")
+
+    def mass_memory_load_program(self, filename: str, confirmed=False) -> None:
+        """Load an Instrument BASIC program file after explicit confirmation."""
+        _require_confirmation("load Instrument BASIC program from mass memory", confirmed)
+        self.write(f"MMEMory:LOAD:PROGram {_quote_string(filename)}")
+
+    def mass_memory_load_state(self, filename: str, slot=1, confirmed=False) -> None:
+        """Load an instrument state file after explicit confirmation."""
+        _require_confirmation("load instrument state from mass memory", confirmed)
+        slot_number = int(strict_range(int(slot), [1, 1]))
+        self.write(f"MMEMory:LOAD:STATe {slot_number}, {_quote_string(filename)}")
+
+    def mass_memory_load_synthesis(self, filename: str, confirmed=False) -> None:
+        """Load a synthesis-table file after explicit confirmation."""
+        _require_confirmation("load synthesis table from mass memory", confirmed)
+        self.write(f"MMEMory:LOAD:SYNThesis {_quote_string(filename)}")
+
+    def mass_memory_load_time_capture(self, filename: str, confirmed=False) -> None:
+        """Load a time-capture file after explicit confirmation."""
+        _require_confirmation("load time-capture file from mass memory", confirmed)
+        self.write(f"MMEMory:LOAD:TCAPture {_quote_string(filename)}")
+
+    def mass_memory_load_trace(
+            self, register, filename: str, no_scale: Optional[bool] = None,
+            confirmed=False) -> None:
+        """Load a trace register file after explicit confirmation."""
+        _require_confirmation("load trace register from mass memory", confirmed)
+        register_token = _data_register_selector(register)
+        command = f"MMEMory:LOAD:TRACe {register_token}, {_quote_string(filename)}"
+        if no_scale is not None:
+            command += f", {1 if bool(no_scale) else 0}"
+        self.write(command)
+
+    def mass_memory_load_waterfall(self, register, filename: str, confirmed=False) -> None:
+        """Load a waterfall register file after explicit confirmation."""
+        _require_confirmation("load waterfall register from mass memory", confirmed)
+        register_token = _trace_waterfall_register_selector(register)
+        self.write(f"MMEMory:LOAD:WATerfall {register_token}, {_quote_string(filename)}")
+
+    def mass_memory_store_cfit(self, filename: str, confirmed=False) -> None:
+        """Store a curve-fit table file after explicit confirmation."""
+        _require_confirmation("store curve-fit table to mass memory", confirmed)
+        self.write(f"MMEMory:STORe:CFIT {_quote_string(filename)}")
+
+    def mass_memory_store_data_table_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Store a data-table trace file after explicit confirmation."""
+        _require_confirmation("store data-table trace to mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:STORe:DTABle:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_store_lower_limit_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Store a lower limit-line trace file after explicit confirmation."""
+        _require_confirmation("store lower limit trace to mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:STORe:LIMit:LOWer:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_store_upper_limit_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Store an upper limit-line trace file after explicit confirmation."""
+        _require_confirmation("store upper limit trace to mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:STORe:LIMit:UPPer:{trace_selector} {_quote_string(filename)}")
+
+    def mass_memory_store_math(self, filename: str, confirmed=False) -> None:
+        """Store a math-definition file after explicit confirmation."""
+        _require_confirmation("store math definitions to mass memory", confirmed)
+        self.write(f"MMEMory:STORe:MATH {_quote_string(filename)}")
+
+    def mass_memory_store_program(self, filename: str, confirmed=False) -> None:
+        """Store an Instrument BASIC program file after explicit confirmation."""
+        _require_confirmation("store Instrument BASIC program to mass memory", confirmed)
+        self.write(f"MMEMory:STORe:PROGram {_quote_string(filename)}")
+
+    def mass_memory_store_state(self, filename: str, slot=1, confirmed=False) -> None:
+        """Store an instrument state file after explicit confirmation."""
+        _require_confirmation("store instrument state to mass memory", confirmed)
+        slot_number = int(strict_range(int(slot), [1, 1]))
+        self.write(f"MMEMory:STORe:STATe {slot_number}, {_quote_string(filename)}")
+
+    def mass_memory_store_synthesis(self, filename: str, confirmed=False) -> None:
+        """Store a synthesis-table file after explicit confirmation."""
+        _require_confirmation("store synthesis table to mass memory", confirmed)
+        self.write(f"MMEMory:STORe:SYNThesis {_quote_string(filename)}")
+
+    def mass_memory_store_time_capture(self, filename: str, confirmed=False) -> None:
+        """Store a time-capture file after explicit confirmation."""
+        _require_confirmation("store time-capture file to mass memory", confirmed)
+        self.write(f"MMEMory:STORe:TCAPture {_quote_string(filename)}")
+
+    def mass_memory_store_trace(self, trace, filename: str, confirmed=False) -> None:
+        """Store a trace file after explicit confirmation."""
+        _require_confirmation("store trace file to mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:STORe:TRACe {trace_selector}, {_quote_string(filename)}")
+
+    def mass_memory_store_waterfall(self, trace, filename: str, confirmed=False) -> None:
+        """Store a waterfall display file after explicit confirmation."""
+        _require_confirmation("store waterfall file to mass memory", confirmed)
+        trace_selector = _normalize_mass_memory_trace_selector(trace)
+        self.write(f"MMEMory:STORe:WATerfall {trace_selector}, {_quote_string(filename)}")
+
+    def program_key_box(self, key_number: int, enabled: Optional[bool] = None) -> Optional[bool]:
+        """Control or query a boxed softkey indicator for Instrument BASIC output."""
+        key = int(strict_range(int(key_number), [0, 8]))
+        if enabled is None:
+            values = _parse_ascii_ints(self.ask(f"DISPlay:PROGram:KEY:BOX? {key}"))
+            if not values:
+                raise ValueError("Program key box query returned no values.")
+            return bool(values[-1])
+
+        state = int(strict_discrete_set(bool(enabled), BOOL_VALUES))
+        self.write(f"DISPlay:PROGram:KEY:BOX {key},{state}")
+        return None
+
+    def program_key_bracket(
+            self, first_key_number: int, last_key_number: int,
+            enabled: Optional[bool] = None) -> Optional[bool]:
+        """Control or query a bracket indicator spanning a softkey range."""
+        first = int(strict_range(int(first_key_number), [0, 8]))
+        last = int(strict_range(int(last_key_number), [0, 8]))
+        if enabled is None:
+            values = _parse_ascii_ints(
+                self.ask(f"DISPlay:PROGram:KEY:BRACket? {first},{last}")
+            )
+            if not values:
+                raise ValueError("Program key bracket query returned no values.")
+            return bool(values[-1])
+
+        state = int(strict_discrete_set(bool(enabled), BOOL_VALUES))
+        self.write(f"DISPlay:PROGram:KEY:BRACket {first},{last},{state}")
+        return None
+
+    def status_preset(self) -> None:
+        """Preset the status register masks."""
+        self.write("STATus:PRESet")
+
+    def pulse_user_status(self, mask: int) -> None:
+        """Pulse selected bits in the user status condition register."""
+        validated_mask = strict_range(mask, STATUS_MASK_VALUES)
+        self.write(f"STATus:USER:PULSe {int(validated_mask)}")
+
+    def user_status_pulse(self, mask: int) -> None:
+        """Pulse selected bits in the user status condition register."""
+        self.pulse_user_status(mask)
+
+    def beep(self) -> None:
+        """Sound the beeper."""
+        self.write("SYSTem:BEEPer:IMMediate")
+
+    def clear_fault_log(self, confirmed=False) -> None:
+        """Clear the analyzer fault log after explicit confirmation."""
+        _require_confirmation("clear fault log", confirmed)
+        self.write("SYSTem:FLOG:CLEar")
+
+    def clear_test_log(self, confirmed=False) -> None:
+        """Clear the long confidence test log after explicit confirmation."""
+        _require_confirmation("clear test log", confirmed)
+        self.write("TEST:LOG:CLEar")
+
+    def run_long_test(self, confirmed=False) -> None:
+        """Run the long confidence test after explicit confirmation."""
+        _require_confirmation("run long confidence test", confirmed)
+        self.write("TEST:LONG")
+
+    def power_off(self, confirmed=False) -> None:
+        """Turn off analyzer power after explicit confirmation."""
+        _require_confirmation("power off", confirmed)
+        self.write("SYSTem:POWer:STATe OFF")
+
+    def system_preset(self, confirmed=False) -> None:
+        """Preset the analyzer system state after explicit confirmation."""
+        _require_confirmation("system preset", confirmed)
+        self.write("SYSTem:PRESet")
+
+    def system_state_data(self, raw=False) -> bytes:
+        """Read system state block data."""
+        self.write("SYSTem:SET?")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        return _parse_definite_block(block)
+
+    def load_system_state(self, data, raw=False) -> None:
+        """Load system state block data."""
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        self.write_bytes(b"SYSTem:SET " + block)
+
+    def run_self_calibration(self, confirmed=False) -> int:
+        """Run full self-calibration and return the result code."""
+        _require_confirmation("run self calibration", confirmed)
+        return int(self.ask("*CAL?"))
+
+    def run_calibration(self, confirmed=False) -> int:
+        """Run CALibration:ALL and return the result code."""
+        _require_confirmation("run full calibration", confirmed)
+        return int(self.ask("CALibration:ALL?"))
+
+    def accept_average_preview(self) -> None:
+        """Accept the current time record during preview averaging."""
+        self.write("SENSe:AVERage:PREView:ACCept")
+
+    def reject_average_preview(self) -> None:
+        """Reject the current time record during preview averaging."""
+        self.write("SENSe:AVERage:PREView:REJect")
+
+    def abort_time_capture(self) -> None:
+        """Abort the time-capture acquisition process."""
+        self.write("SENSe:TCAPture:ABORt")
+
+    def delete_time_capture(self, confirmed=False) -> None:
+        """Delete the time-capture buffer after explicit confirmation."""
+        _require_confirmation("delete time capture buffer", confirmed)
+        self.write("SENSe:TCAPture:DELete")
+
+    def time_capture_file(self, raw=False) -> bytes:
+        """Read the time-capture SDF file transfer block."""
+        self.write("SENSe:TCAPture:FILE?")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        return _parse_definite_block(block)
+
+    def load_time_capture_file(self, data, raw=False) -> None:
+        """Load a time-capture SDF file transfer block."""
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        self.write_bytes(b"SENSe:TCAPture:FILE " + block)
+
+    def start_time_capture(self) -> None:
+        """Start time-capture data acquisition."""
+        self.write("SENSe:TCAPture:IMMediate")
+
+    def allocate_time_capture_memory(self) -> None:
+        """Allocate memory for the time-capture buffer."""
+        self.write("SENSe:TCAPture:MALLocate")
+
+    def sense_data(self, capture_channel=1, raw=False) -> bytes:
+        """Read time-capture data block from the selected capture channel."""
+        selector = _tcap_selector(capture_channel)
+        self.write(f"SENSe:DATA? {selector}")
+        block = self.read_bytes(-1)
+        if raw:
+            return block
+        return _parse_definite_block(block)
+
+    def set_sense_data(self, data, capture_channel=1, raw=False) -> None:
+        """Write time-capture data block to the selected capture channel."""
+        selector = _tcap_selector(capture_channel)
+        payload = _coerce_bytes(data)
+        block = payload if raw else _encode_definite_block(payload)
+        prefix = f"SENSe:DATA {selector},".encode("ascii")
+        self.write_bytes(prefix + block)
+
+    def sense_data_points(self, capture_channel=1) -> int:
+        """Measure the number of points available in a time-capture buffer."""
+        selector = _tcap_selector(capture_channel)
+        return int(self.ask(f"SENSe:DATA:HEADer:POINts? {selector}"))
+
+    def sense_data_range(self, capture_channel=1) -> float:
+        """Measure the configured range metadata for a time-capture buffer."""
+        selector = _tcap_selector(capture_channel)
+        return float(self.ask(f"SENSe:DATA:RANGe? {selector}"))
+
+    def set_sense_data_range(self, capture_channel, value) -> None:
+        """Set range metadata for a time-capture buffer before data upload."""
+        selector = _tcap_selector(capture_channel)
+        validated = strict_range(float(value), DATA_RANGE_VALUES)
+        self.write(f"SENSe:DATA:RANGe {selector}, {validated:g}")
+
+    def set_full_frequency_span(self) -> None:
+        """Set frequency span to full range for the active mode."""
+        self.write("SENSe:FREQuency:SPAN:FULL")
+
+    def read_trace_raw_data(self, register=None, raw=False):
+        """Read data from a TRACe data register as parsed values or raw bytes."""
+        selector = _trace_data_register_selector(1 if register is None else register)
+        command = f"TRACe:DATA? {selector}"
+        if raw:
+            self.write(command)
+            return self.read_bytes(-1)
+        return _parse_ascii_or_definite_block_floats(self.ask(command))
+
+    def write_trace_raw_data(self, data, register=None, raw=False) -> None:
+        """Write data to a TRACe data register using ASCII or block payloads."""
+        selector = _trace_data_register_selector(1 if register is None else register)
+        prefix = f"TRACe:DATA {selector},"
+
+        if raw:
+            payload = _coerce_bytes(data)
+            self.write_bytes(prefix.encode("ascii") + payload)
+            return
+
+        if isinstance(data, (bytes, bytearray)):
+            block = _encode_definite_block(bytes(data))
+            self.write_bytes(prefix.encode("ascii") + block)
+            return
+
+        if isinstance(data, str):
+            self.write(f"{prefix} {data}")
+            return
+
+        if isinstance(data, (list, tuple)):
+            values = ",".join(f"{float(item):g}" for item in data)
+            self.write(f"{prefix} {values}")
+            return
+
+        if isinstance(data, (int, float)):
+            self.write(f"{prefix} {data:g}")
+            return
+
+        raise TypeError("Trace data must be bytes, str, sequence, int, or float.")
+
+    def read_trace_x_data(self, raw=False):
+        """Read X-axis values for trace displays."""
+        if raw:
+            self.write("TRACe:X:DATA?")
+            return self.read_bytes(-1)
+        return _parse_ascii_or_definite_block_floats(self.ask("TRACe:X:DATA?"))
+
+    def read_trace_x_unit(self) -> str:
+        """Read the X-axis unit token for trace displays."""
+        return _strip_quotes(str(self.ask("TRACe:X:UNIT?")).strip())
+
+    def read_trace_z_data(self, raw=False):
+        """Read Z-axis values for waterfall displays."""
+        if raw:
+            self.write("TRACe:Z:DATA?")
+            return self.read_bytes(-1)
+        return _parse_ascii_or_definite_block_floats(self.ask("TRACe:Z:DATA?"))
+
+    def read_trace_z_unit(self) -> str:
+        """Read the Z-axis unit token for waterfall displays."""
+        return _strip_quotes(str(self.ask("TRACe:Z:UNIT?")).strip())
+
+    def read_trace_waterfall_data(self, raw=False):
+        """Read data from the active waterfall register set."""
+        if raw:
+            self.write("TRACe:WATerfall:DATA?")
+            return self.read_bytes(-1)
+        return _parse_ascii_or_definite_block_floats(self.ask("TRACe:WATerfall:DATA?"))
+
+    def write_trace_waterfall_data(self, data, register=None, raw=False) -> None:
+        """Write data to a TRACe waterfall register using ASCII or block payloads."""
+        selector = _trace_waterfall_register_selector(1 if register is None else register)
+        prefix = f"TRACe:WATerfall:DATA {selector},"
+
+        if raw:
+            payload = _coerce_bytes(data)
+            self.write_bytes(prefix.encode("ascii") + payload)
+            return
+
+        if isinstance(data, (bytes, bytearray)):
+            block = _encode_definite_block(bytes(data))
+            self.write_bytes(prefix.encode("ascii") + block)
+            return
+
+        if isinstance(data, str):
+            self.write(f"{prefix} {data}")
+            return
+
+        if isinstance(data, (list, tuple)):
+            values = ",".join(f"{float(item):g}" for item in data)
+            self.write(f"{prefix} {values}")
+            return
+
+        if isinstance(data, (int, float)):
+            self.write(f"{prefix} {data:g}")
+            return
+
+        raise TypeError("Waterfall data must be bytes, str, sequence, int, or float.")
+
+    def trace_data(self, trace=1) -> list[float]:
+        """Read trace data from a data register (compatibility wrapper)."""
+        return self.read_trace_raw_data(register=trace, raw=False)
+
+    def trace_x_data(self, trace=1) -> list[float]:
+        """Read trace X-axis data (compatibility wrapper)."""
+        del trace
+        return self.read_trace_x_data(raw=False)
+
+    def trace_z_data(self, trace=1) -> list[float]:
+        """Read trace Z-axis data (compatibility wrapper)."""
+        del trace
+        return self.read_trace_z_data(raw=False)
+
+    def trace_x_unit(self, trace=1) -> str:
+        """Read trace X-axis unit (compatibility wrapper)."""
+        del trace
+        return self.read_trace_x_unit()
+
+    def trace_z_unit(self, trace=1) -> str:
+        """Read trace Z-axis unit (compatibility wrapper)."""
+        del trace
+        return self.read_trace_z_unit()
+
+    def options(self) -> str:
+        """Get the installed option configuration."""
+        return self._installed_options
+
+    def system_error(self) -> str:
+        """Get the next system error."""
+        return self._next_system_error
+
+    def _raise_if_errors(self, max_errors=10) -> None:
+        """Raise runtime errors if the system error queue contains failures."""
+        if max_errors < 1:
+            raise ValueError("max_errors must be >= 1.")
+
+        errors = []
+        for _ in range(max_errors):
+            reply = self.ask("SYSTem:ERRor?")
+            tokens = _parse_csv_strings(reply)
+            if not tokens:
+                break
+            code_token = tokens[0]
+            try:
+                code = int(code_token)
+            except ValueError:
+                try:
+                    code = int(float(code_token))
+                except ValueError:
+                    code = None
+
+            message = ",".join(tokens[1:]).strip() if len(tokens) > 1 else ""
+            if code == 0 and "NO ERROR" in message.upper():
+                break
+
+            errors.append(reply)
+
+        if errors:
+            raise RuntimeError(f"Instrument error queue is not empty: {errors}")
+
+    def drain_errors(self, max_errors=10) -> None:
+        """Drain the error queue and raise if any error is reported."""
+        self._raise_if_errors(max_errors=max_errors)
+
+    def check_id(self) -> None:
+        """Check that the connected instrument is a 35670A."""
+        idn = self.id
+        parts = [part.strip() for part in idn.split(",")]
+        if len(parts) < 2:
+            raise ValueError(f"Unexpected instrument IDN response: '{idn}'.")
+
+        manufacturer = parts[0].upper()
+        model = parts[1].upper()
+
+        accepted_manufacturers = ("HEWLETT-PACKARD", "HP", "AGILENT", "KEYSIGHT")
+        is_supported_manufacturer = any(
+            token in manufacturer for token in accepted_manufacturers
+        )
+        is_supported_model = model == "35670A"
+
+        if not (is_supported_manufacturer and is_supported_model):
+            raise ValueError(
+                f"Instrument ID '{idn}' is not a supported 35670A "
+                "from Hewlett-Packard, HP, Agilent, or Keysight."
+            )

--- a/pymeasure/instruments/keysight/keysight35670A.py
+++ b/pymeasure/instruments/keysight/keysight35670A.py
@@ -909,7 +909,9 @@ def _parse_ascii_or_definite_block_floats(reply) -> list[float]:
         try:
             decoded = payload.decode("ascii")
         except UnicodeDecodeError as exc:
-            raise ValueError("Binary definite blocks are not supported by this ASCII parser.") from exc
+            raise ValueError(
+                "Binary definite blocks are not supported by this ASCII parser."
+            ) from exc
         return _parse_ascii_floats(decoded)
 
     return _parse_ascii_floats(raw.decode("ascii"))
@@ -1116,6 +1118,7 @@ class Keysight35670AInputChannel(Channel):
         validator=strict_range,
         cast=float,
     )
+
 
 class Keysight35670ASenseWindow(Channel):
     """Represent a measurement SENSE window of the Keysight 35670A."""
@@ -1675,7 +1678,10 @@ class Keysight35670ATrace(Channel):
     x_user_frequency_factor = Channel.control(
         "CALCulate{ch}:UNIT:X:USER:FREQuency:FACTor?",
         "CALCulate{ch}:UNIT:X:USER:FREQuency:FACTor %g",
-        """Control the user frequency-domain X-axis conversion factor (float from 1e-15 to 1e15).""",
+        (
+            """Control the user frequency-domain X-axis conversion factor """
+            """(float from 1e-15 to 1e15)."""
+        ),
         values=[1e-15, 1e15],
         validator=strict_range,
         cast=float,
@@ -2204,7 +2210,11 @@ class Keysight35670ATrace(Channel):
     )
 
     def set_math_constant(
-            self, constant_register: int, real_part: float, imaginary_part: Optional[float] = None) -> None:
+        self,
+        constant_register: int,
+        real_part: float,
+        imaginary_part: Optional[float] = None,
+    ) -> None:
         """Set a math constant register value."""
         index = _math_register_selector(constant_register)
         real_value = float(strict_range(float(real_part), LIMIT_VALUE_RANGE))

--- a/tests/instruments/keysight/test_keysight35670A.py
+++ b/tests/instruments/keysight/test_keysight35670A.py
@@ -1,0 +1,6025 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.instruments.keysight import Keysight35670A
+from pymeasure.instruments.keysight.keysight35670A import (
+    _coerce_bytes,
+    _encode_definite_block,
+    _format_limit_segment_data,
+    _math_register_selector,
+    _normalize_hardcopy_destination,
+    _normalize_hardcopy_line_type,
+    _normalize_hardcopy_source,
+    _normalize_hardcopy_timestamp_format,
+    _normalize_mass_memory_disk,
+    _normalize_memory_catalog_item,
+    _normalize_program_name,
+    _normalize_program_state,
+    _normalize_program_variable_name,
+    _parse_ascii_floats,
+    _parse_ascii_or_definite_block_floats,
+    _parse_ascii_ints,
+    _parse_csv_strings,
+    _parse_definite_block,
+    _parse_limit_segment_data,
+    _quote_string,
+    _require_confirmation,
+    _strip_quotes,
+    _tcap_selector,
+    _trace_selector,
+    _data_register_selector,
+    _validate_int_pair,
+    _validate_int_triplet,
+)
+from pymeasure.test import expected_protocol
+
+
+# --- helper tests ---
+
+def test_parse_ascii_floats_empty():
+    """Verify empty replies return empty list."""
+    assert _parse_ascii_floats("") == []
+    assert _parse_ascii_floats("   ") == []
+
+
+def test_parse_ascii_floats_values():
+    """Verify values are parsed as floats."""
+    assert _parse_ascii_floats("1, 2.5, -3E-1") == [1.0, 2.5, -0.3]
+
+
+def test_parse_ascii_floats_skips_empty_tokens():
+    """Verify empty CSV tokens are ignored by float parser."""
+    assert _parse_ascii_floats("1,,2") == [1.0, 2.0]
+
+
+def test_parse_ascii_floats_bad_token_raises():
+    """Verify non-float tokens raise ValueError."""
+    with pytest.raises(ValueError):
+        _parse_ascii_floats("bad")
+
+
+def test_parse_ascii_ints_empty():
+    """Verify empty int replies return empty list."""
+    assert _parse_ascii_ints("") == []
+    assert _parse_ascii_ints("   ") == []
+
+
+def test_parse_ascii_ints_values():
+    """Verify integer values are parsed correctly."""
+    assert _parse_ascii_ints("1, -2, +3") == [1, -2, 3]
+
+
+def test_parse_ascii_ints_bad_token_raises():
+    """Verify non-integer tokens raise ValueError."""
+    with pytest.raises(ValueError):
+        _parse_ascii_ints("bad")
+
+
+def test_parse_csv_strings():
+    """Verify CSV strings are parsed and unquoted."""
+    assert _parse_csv_strings('"A","B,C", D ') == ["A", "B,C", "D"]
+
+
+def test_parse_csv_strings_quoted_values():
+    """Verify CSV parser keeps quoted commas and strips quotes."""
+    assert _parse_csv_strings('"A","B,C","D"') == ["A", "B,C", "D"]
+
+
+def test_strip_quotes():
+    """Verify matching boundary quotes are removed."""
+    assert _strip_quotes('"ABC"') == "ABC"
+    assert _strip_quotes("'ABC'") == "ABC"
+    assert _strip_quotes("ABC") == "ABC"
+
+
+def test_quote_string():
+    """Verify SCPI strings are safely quoted."""
+    assert _quote_string("ABC") == '"ABC"'
+    assert _quote_string('"ABC"') == '"ABC"'
+    assert _quote_string('A"B') == '"A""B"'
+
+
+def test_quote_string_rejects_non_string():
+    """Verify quoting rejects non-string arguments."""
+    with pytest.raises(TypeError):
+        _quote_string(123)  # type: ignore[arg-type]
+
+
+def test_require_confirmation_requires_true():
+    """Verify risky actions require explicit confirmation."""
+    with pytest.raises(ValueError, match="requires explicit confirmation"):
+        _require_confirmation("delete state", confirmed=False)
+
+
+def test_require_confirmation_accepts_true():
+    """Verify confirmed=True does not raise."""
+    _require_confirmation("delete state", confirmed=True)
+
+
+def test_trace_selector_with_int_indices():
+    """Verify trace selector helper for integer indices."""
+    assert _trace_selector(1) == "TRACe1"
+    assert _trace_selector(4) == "TRACe4"
+
+
+def test_trace_selector_rejects_out_of_range_index():
+    """Verify trace selector rejects invalid index."""
+    with pytest.raises(ValueError):
+        _trace_selector(0)
+
+
+def test_trace_selector_accepts_direct_selector():
+    """Verify trace selector accepts preformatted selector tokens."""
+    assert _trace_selector("D1") == "D1"
+
+
+def test_tcap_selector_with_int_indices():
+    """Verify time-capture selector helper for integer indices."""
+    assert _tcap_selector(1) == "TCAP1"
+    assert _tcap_selector(4) == "TCAP4"
+
+
+def test_tcap_selector_accepts_direct_selector():
+    """Verify time-capture selector accepts preformatted selector."""
+    assert _tcap_selector("TCAP4") == "TCAP4"
+
+
+def test_tcap_selector_rejects_out_of_range_index():
+    """Verify time-capture selector rejects invalid index."""
+    with pytest.raises(ValueError):
+        _tcap_selector(5)
+
+
+def test_data_register_selector_valid_values():
+    """Verify data-register selector accepts numeric and token forms."""
+    assert _data_register_selector(1) == "D1"
+    assert _data_register_selector("D8") == "D8"
+
+
+def test_data_register_selector_rejects_out_of_range_index():
+    """Verify data-register selector rejects invalid index."""
+    with pytest.raises(ValueError):
+        _data_register_selector(9)
+
+
+def test_math_register_selector_valid_values():
+    """Verify math-register selector accepts valid indexes."""
+    assert _math_register_selector(1) == 1
+    assert _math_register_selector(5) == 5
+
+
+def test_math_register_selector_rejects_out_of_range_index():
+    """Verify math-register selector rejects invalid index."""
+    with pytest.raises(ValueError):
+        _math_register_selector(6)
+
+
+def test_validate_int_pair_valid():
+    """Verify integer pair validator accepts valid tuples."""
+    assert _validate_int_pair((1, 2), [(0, 4), (0, 4)]) == (1, 2)
+
+
+def test_validate_int_pair_invalid_length_raises():
+    """Verify integer pair validator rejects wrong tuple length."""
+    with pytest.raises(ValueError):
+        _validate_int_pair((1,), [(0, 4), (0, 4)])
+
+
+def test_validate_int_pair_invalid_type_raises():
+    """Verify integer pair validator rejects unsupported types."""
+    with pytest.raises(ValueError):
+        _validate_int_pair(3.14, [(0, 4), (0, 4)])
+
+
+def test_validate_int_triplet_valid():
+    """Verify integer triplet validator accepts valid tuples."""
+    assert _validate_int_triplet((1, 2, 3), [(0, 4), (0, 4), (0, 4)]) == (1, 2, 3)
+
+
+def test_validate_int_triplet_invalid_length_raises():
+    """Verify integer triplet validator rejects wrong tuple length."""
+    with pytest.raises(ValueError):
+        _validate_int_triplet((1, 2), [(0, 4), (0, 4), (0, 4)])
+
+
+def test_validate_int_triplet_invalid_type_raises():
+    """Verify integer triplet validator rejects unsupported types."""
+    with pytest.raises(ValueError):
+        _validate_int_triplet(object(), [(0, 4), (0, 4), (0, 4)])
+
+
+def test_encode_definite_block():
+    """Verify definite-block encoding helper."""
+    assert _encode_definite_block(b"ABC") == b"#13ABC"
+
+
+def test_parse_definite_block():
+    """Verify definite-block parsing helper."""
+    assert _parse_definite_block(b"#14ABCD") == b"ABCD"
+
+
+def test_parse_definite_block_empty_raises():
+    """Verify empty definite block raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"")
+
+
+def test_parse_definite_block_missing_hash_raises():
+    """Verify non-block payload raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"ABC")
+
+
+def test_parse_definite_block_malformed_header_raises():
+    """Verify malformed header raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"#x3ABC")
+
+
+def test_parse_definite_block_incomplete_header_raises():
+    """Verify incomplete byte-count header raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"#23A")
+
+
+def test_parse_definite_block_bad_byte_count_raises():
+    """Verify non-numeric byte count raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"#1AABC")
+
+
+def test_parse_definite_block_short_payload_raises():
+    """Verify short payload raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_definite_block(b"#14ABC")
+
+
+def test_parse_definite_block_indefinite_length_path():
+    """Verify #0 block path returns trailing payload bytes."""
+    assert _parse_definite_block(b"#0ABC") == b"ABC"
+
+
+def test_parse_ascii_or_definite_block_floats_ascii():
+    """Verify mixed parser accepts ASCII CSV float payload."""
+    assert _parse_ascii_or_definite_block_floats("1,2,3") == [1.0, 2.0, 3.0]
+
+
+def test_parse_ascii_or_definite_block_floats_definite_block_ascii():
+    """Verify mixed parser accepts ASCII definite block payload."""
+    assert _parse_ascii_or_definite_block_floats(b"#151,2,3") == [1.0, 2.0, 3.0]
+
+
+def test_parse_ascii_or_definite_block_floats_definite_block_not_float_raises():
+    """Verify non-float ASCII block payload raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_ascii_or_definite_block_floats(b"#13ABC")
+
+
+def test_parse_ascii_or_definite_block_floats_binary_block_raises():
+    """Verify non-ASCII block payload raises ValueError."""
+    with pytest.raises(ValueError):
+        _parse_ascii_or_definite_block_floats(b"#13\xff\x00\x01")
+
+
+def test_format_limit_segment_data_nested():
+    """Verify limit segment formatter accepts nested tuples."""
+    assert _format_limit_segment_data([(1, 2, 3, 4)]) == "1,2,3,4"
+
+
+def test_format_limit_segment_data_flat():
+    """Verify limit segment formatter accepts flat lists."""
+    assert _format_limit_segment_data([1, 2, 3, 4]) == "1,2,3,4"
+
+
+def test_format_limit_segment_data_invalid_segment_length_raises():
+    """Verify limit segment formatter rejects malformed tuples."""
+    with pytest.raises(ValueError):
+        _format_limit_segment_data([(1, 2, 3)])
+
+
+def test_format_limit_segment_data_flat_invalid_multiple_raises():
+    """Verify limit segment formatter rejects non-multiple-of-4 flat lists."""
+    with pytest.raises(ValueError):
+        _format_limit_segment_data([1, 2, 3])
+
+
+def test_format_limit_segment_data_non_sequence_raises():
+    """Verify limit segment formatter rejects unsupported types."""
+    with pytest.raises(ValueError):
+        _format_limit_segment_data(123)
+
+
+def test_parse_limit_segment_data_valid():
+    """Verify limit segment parser returns 4-value tuples."""
+    assert _parse_limit_segment_data("1,2,3,4") == [(1.0, 2.0, 3.0, 4.0)]
+
+
+def test_parse_limit_segment_data_invalid_length_raises():
+    """Verify limit segment parser rejects malformed payloads."""
+    with pytest.raises(ValueError):
+        _parse_limit_segment_data("1,2,3")
+
+
+def test_normalize_hardcopy_destination_valid_and_invalid():
+    """Verify hardcopy destination normalizer valid and invalid paths."""
+    assert _normalize_hardcopy_destination("MMEMORY") == "MMEM"
+    with pytest.raises(ValueError):
+        _normalize_hardcopy_destination("INVALID")
+
+
+def test_normalize_hardcopy_timestamp_format_variants():
+    """Verify hardcopy timestamp format normalizer variants."""
+    assert _normalize_hardcopy_timestamp_format("FORM1") == "FORM1"
+    assert _normalize_hardcopy_timestamp_format("FORMAT1") == "FORM1"
+    with pytest.raises(ValueError):
+        _normalize_hardcopy_timestamp_format("FORM9")
+
+
+def test_normalize_hardcopy_source_valid_and_invalid():
+    """Verify hardcopy source normalizer valid and invalid paths."""
+    assert _normalize_hardcopy_source("MARK") == "MARK"
+    with pytest.raises(ValueError):
+        _normalize_hardcopy_source("INVALID")
+
+
+def test_normalize_hardcopy_line_type_variants_and_invalid():
+    """Verify hardcopy line-type normalizer variants and invalid values."""
+    assert _normalize_hardcopy_line_type("SOL") == "SOL"
+    assert _normalize_hardcopy_line_type("DASH") == "DASH"
+    assert _normalize_hardcopy_line_type("DOTT") == "DOTT"
+    assert _normalize_hardcopy_line_type("STYL3") == "STYL3"
+    with pytest.raises(ValueError):
+        _normalize_hardcopy_line_type("STYL2")
+    with pytest.raises(ValueError):
+        _normalize_hardcopy_line_type("INVALID")
+
+
+def test_normalize_memory_catalog_item_valid_and_invalid():
+    """Verify memory-catalog item normalizer valid and invalid paths."""
+    assert _normalize_memory_catalog_item("program") == "PROGram"
+    with pytest.raises(ValueError):
+        _normalize_memory_catalog_item("invalid")
+
+
+def test_normalize_mass_memory_disk_variants_and_invalid():
+    """Verify mass-memory disk normalizer variants and invalid values."""
+    assert _normalize_mass_memory_disk("RAM") == "RAM:"
+    assert _normalize_mass_memory_disk("NVRAM") == "NVRAM:"
+    assert _normalize_mass_memory_disk("EXT") == "EXT:"
+    with pytest.raises(ValueError):
+        _normalize_mass_memory_disk("INVALID")
+
+
+def test_normalize_program_name_variants_and_invalid():
+    """Verify program name normalizer variants and invalid values."""
+    assert _normalize_program_name("1") == "PROGram1"
+    assert _normalize_program_name("PROG1") == "PROGram1"
+    with pytest.raises(ValueError):
+        _normalize_program_name("PROG9")
+
+
+def test_normalize_program_state_variants_and_invalid():
+    """Verify program state normalizer variants and invalid values."""
+    assert _normalize_program_state("STOP") == "STOP"
+    assert _normalize_program_state("PAUSE") == "PAUSe"
+    assert _normalize_program_state("RUN") == "RUN"
+    assert _normalize_program_state("CONTINUE") == "CONTinue"
+    with pytest.raises(ValueError):
+        _normalize_program_state("INVALID")
+
+
+def test_normalize_program_variable_name_variants():
+    """Verify program variable normalizer for numeric and string variants."""
+    assert _normalize_program_variable_name(5) == "5"
+    assert _normalize_program_variable_name(5, string_variable=True) == "S5$"
+    assert _normalize_program_variable_name("A$", string_variable=True) == "A$"
+
+
+def test_coerce_bytes_variants_and_invalid():
+    """Verify bytes coercion accepts supported inputs and rejects invalid types."""
+    assert _coerce_bytes(b"AB") == b"AB"
+    assert _coerce_bytes(bytearray(b"AB")) == b"AB"
+    assert _coerce_bytes("AB") == b"AB"
+    with pytest.raises(TypeError):
+        _coerce_bytes(123)
+
+
+def test_input_channel_bias_enabled_bool_mapping():
+    """Verify the channel bias enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut2:BIAS:STATe 1", None)],
+    ) as inst:
+        inst.ch2.bias_enabled = True
+
+
+def test_input_channel_state_bool_mapping():
+    """Verify the channel state bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut2:STATe 1", None)],
+    ) as inst:
+        inst.ch2.state = True
+
+
+def test_input_channel_enabled_alias():
+    """Verify the channel enabled alias."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut4:STATe 1", None),
+         ("INPut4:STATe?", "0")],
+    ) as inst:
+        inst.ch4.enabled = True
+        assert inst.ch4.enabled is False
+
+
+def test_input_channel_1_cannot_be_disabled():
+    """Verify channel 1 enable state cannot be set to off."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="cannot be disabled"):
+            inst.ch1.enabled = False
+
+
+def test_input_channel_1_enable_command():
+    """Verify channel 1 can be explicitly enabled."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut1:STATe 1", None)],
+    ) as inst:
+        inst.ch1.enabled = True
+
+
+def test_input_channel_2_disable_command():
+    """Verify channels other than 1 can be disabled."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut2:STATe 0", None)],
+    ) as inst:
+        inst.ch2.enabled = False
+
+
+def test_input_channel_coupling():
+    """Verify the channel coupling setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut1:COUPling AC", None)],
+    ) as inst:
+        inst.ch1.coupling = "AC"
+
+
+def test_input_channel_a_weighting_enabled_bool_mapping():
+    """Verify A-weighting bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut1:FILTer:AWEighting:STATe 1", None)],
+    ) as inst:
+        inst.ch1.a_weighting_enabled = True
+
+
+def test_input_channel_anti_alias_filter_enabled_bool_mapping():
+    """Verify anti-alias filter bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut1:FILTer:LPASs:STATe 0", None)],
+    ) as inst:
+        inst.ch1.anti_alias_filter_enabled = False
+
+
+def test_input_channel_shield():
+    """Verify the channel shield setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut3:LOW GRO", None),
+         ("INPut3:LOW?", "FLO")],
+    ) as inst:
+        inst.ch3.shield = "ground"
+        assert inst.ch3.shield == "float"
+
+
+def test_input_channel_reference_direction_setter_and_getter():
+    """Verify channel reference direction roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut2:REFerence:DIRection 3", None),
+         ("INPut2:REFerence:DIRection?", "9")],
+    ) as inst:
+        inst.ch2.reference_direction = 3
+        assert inst.ch2.reference_direction == 9
+
+
+def test_input_channel_reference_point_setter_and_getter():
+    """Verify channel reference point roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INPut2:REFerence:POINt 12720", None),
+         ("INPut2:REFerence:POINt?", "11081")],
+    ) as inst:
+        inst.ch2.reference_point = 12720
+        assert inst.ch2.reference_point == 11081
+
+
+def test_input_channel_range_dbvrms_valid_discrete_values():
+    """Verify the channel range accepts valid discrete values."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage1:RANGe -51", None)],
+    ) as inst:
+        inst.ch1.range_dbvrms = -51
+
+
+def test_input_channel_autorange_direction_mapping():
+    """Verify input autorange direction mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage2:RANGe:AUTO:DIRection UP", None),
+         ("SENSe:VOLTage2:RANGe:AUTO:DIRection?", "EITH")],
+    ) as inst:
+        inst.ch2.autorange_direction = "up"
+        assert inst.ch2.autorange_direction == "either"
+
+
+def test_input_channel_range_unit_user_label_setter_and_getter():
+    """Verify input user unit label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('SENSe:VOLTage1:RANGe:UNIT:USER:LABel "Cdeg"', None),
+         ("SENSe:VOLTage1:RANGe:UNIT:USER:LABel?", '"Pa"')],
+    ) as inst:
+        inst.ch1.range_unit_user_label = "Cdeg"
+        assert inst.ch1.range_unit_user_label == "Pa"
+
+
+def test_input_channel_range_unit_user_scale_factor_setter_and_getter():
+    """Verify input user unit scale-factor roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage3:RANGe:UNIT:USER:SFACtor 1.8e-06", None),
+         ("SENSe:VOLTage3:RANGe:UNIT:USER:SFACtor?", "0.1")],
+    ) as inst:
+        inst.ch3.range_unit_user_scale_factor = 1.8e-06
+        assert inst.ch3.range_unit_user_scale_factor == 0.1
+
+
+def test_input_channel_range_unit_user_enabled_bool_mapping():
+    """Verify input user unit enable bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage2:RANGe:UNIT:USER:STATe 1", None),
+         ("SENSe:VOLTage2:RANGe:UNIT:USER:STATe?", "0")],
+    ) as inst:
+        inst.ch2.range_unit_user_enabled = True
+        assert inst.ch2.range_unit_user_enabled is False
+
+
+def test_input_channel_range_unit_transducer_label_setter_and_getter():
+    """Verify input transducer unit label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage4:RANGe:UNIT:XDCR:LABel PA", None),
+         ("SENSe:VOLTage4:RANGe:UNIT:XDCR:LABel?", "USER")],
+    ) as inst:
+        inst.ch4.range_unit_transducer_label = "PA"
+        assert inst.ch4.range_unit_transducer_label == "USER"
+
+
+def test_input_channel_range_upper_setter():
+    """Verify input upper range setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:VOLTage1:RANGe -20", None)],
+    ) as inst:
+        inst.ch1.range_upper = -20
+
+
+def test_trace_feed_mapping():
+    """Verify trace feed mapping for power_spectrum_ch1."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:FEED 'XFR:POW 1'", None)],
+    ) as inst:
+        inst.trace1.feed = "power_spectrum_ch1"
+
+
+def test_trace_active_mapping():
+    """Verify active trace-group mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:ACTive ABCD", None),
+         ("CALCulate2:ACTive?", "CD")],
+    ) as inst:
+        inst.trace2.active = "abcd"
+        assert inst.trace2.active == "cd"
+
+
+def test_trace_display_format_mapping():
+    """Verify trace display-format mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:FORMat GDEL", None),
+         ("CALCulate3:FORMat?", "UPH")],
+    ) as inst:
+        inst.trace3.display_format = "group_delay"
+        assert inst.trace3.display_format == "unwrapped_phase"
+
+
+def test_trace_group_delay_aperture_setter_and_getter():
+    """Verify trace group-delay aperture roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:GDAPerture:APERture 5", None),
+         ("CALCulate1:GDAPerture:APERture?", "2.5")],
+    ) as inst:
+        inst.trace1.group_delay_aperture = 5
+        assert inst.trace1.group_delay_aperture == 2.5
+
+
+def test_trace_data_points():
+    """Verify the trace data points method."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:DATA:HEADer:POINts?", "401")],
+    ) as inst:
+        assert inst.trace1.data_points() == 401
+
+
+def test_trace_read_data_ascii():
+    """Verify the trace data read method for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:DATA?", "1.0,2.0,3.5")],
+    ) as inst:
+        assert inst.trace1.read_data() == [1.0, 2.0, 3.5]
+
+
+def test_trace_read_x_data_ascii():
+    """Verify the trace x data read method for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:X:DATA?", "0.0,1.0,2.0")],
+    ) as inst:
+        assert inst.trace1.read_x_data() == [0.0, 1.0, 2.0]
+
+
+def test_instrument_mode():
+    """Verify the instrument mode setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INSTrument:SELect FFT", None),
+         ("INSTrument:SELect?", "SINE")],
+    ) as inst:
+        inst.instrument_mode = "fft"
+        assert inst.instrument_mode == "swept_sine"
+
+
+def test_selected_instrument_number():
+    """Verify the selected instrument number setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INSTrument:NSELect 3", None),
+         ("INSTrument:NSELect?", 4)],
+    ) as inst:
+        inst.selected_instrument_number = 3
+        assert inst.selected_instrument_number == 4
+
+
+def test_selected_instrument_number_accepts_fft_code_zero():
+    """Verify selected instrument number accepts FFT code 0."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INSTrument:NSELect 0", None)],
+    ) as inst:
+        inst.selected_instrument_number = 0
+
+
+def test_source_function_setter_maps_periodic_chirp_to_pch():
+    """Verify source function setter maps periodic chirp to PCH."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:FUNCtion:SHAPe PCH", None)],
+    ) as inst:
+        inst.source_function = "periodic_chirp"
+
+
+def test_source_frequency_setter():
+    """Verify source frequency setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:FREQuency:FIXed 1000", None)],
+    ) as inst:
+        inst.source_frequency = 1000
+
+
+def test_source_frequency_cw_setter():
+    """Verify source CW frequency setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:FREQuency 2000", None)],
+    ) as inst:
+        inst.source_frequency_cw = 2000
+
+
+def test_source_frequency_fixed_setter():
+    """Verify source fixed frequency setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:FREQuency:FIXed 3000", None)],
+    ) as inst:
+        inst.source_frequency_fixed = 3000
+
+
+def test_source_burst_percent_setter():
+    """Verify source burst percent setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:BURSt 25", None)],
+    ) as inst:
+        inst.source_burst_percent = 25
+
+
+def test_source_user_capture_channel_setter():
+    """Verify source user capture channel setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:USER:CAPTure 2", None)],
+    ) as inst:
+        inst.source_user_capture_channel = 2
+
+
+def test_source_user_register_setter_and_getter():
+    """Verify source user register mapping roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:USER:REGister D3", None),
+         ("SOURce:USER:REGister?", "D7")],
+    ) as inst:
+        inst.source_user_register = 3
+        assert inst.source_user_register == 7
+
+
+def test_source_user_repeat_enabled_bool_mapping():
+    """Verify source user repeat bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:USER:REPeat 1", None),
+         ("SOURce:USER:REPeat?", "0")],
+    ) as inst:
+        inst.source_user_repeat_enabled = True
+        assert inst.source_user_repeat_enabled is False
+
+
+def test_source_voltage_autolevel_enabled_bool_mapping():
+    """Verify source autolevel bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:AUTO 1", None),
+         ("SOURce:VOLTage:LEVel:AUTO?", "0")],
+    ) as inst:
+        inst.source_voltage_autolevel_enabled = True
+        assert inst.source_voltage_autolevel_enabled is False
+
+
+def test_source_voltage_amplitude_setter():
+    """Verify source voltage amplitude setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:IMMediate:AMPLitude 0.25", None)],
+    ) as inst:
+        inst.source_voltage_amplitude = 0.25
+
+
+def test_source_voltage_reference_setter():
+    """Verify source voltage reference setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:REFerence -20", None)],
+    ) as inst:
+        inst.source_voltage_reference = -20.0
+
+
+def test_source_voltage_reference_channel_setter_and_getter():
+    """Verify source voltage reference channel mapping roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:REFerence:CHANnel INP2", None),
+         ("SOURce:VOLTage:LEVel:REFerence:CHANnel?", "INP4")],
+    ) as inst:
+        inst.source_voltage_reference_channel = 2
+        assert inst.source_voltage_reference_channel == 4
+
+
+def test_source_voltage_reference_tolerance_setter():
+    """Verify source voltage reference tolerance setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:REFerence:TOLerance 3", None)],
+    ) as inst:
+        inst.source_voltage_reference_tolerance = 3.0
+
+
+def test_source_voltage_limit_amplitude_setter():
+    """Verify source voltage limit amplitude setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LIMit:AMPLitude 2", None)],
+    ) as inst:
+        inst.source_voltage_limit_amplitude = 2.0
+
+
+def test_source_voltage_limit_input_setter():
+    """Verify source voltage limit input setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LIMit:INPut -10", None)],
+    ) as inst:
+        inst.source_voltage_limit_input = -10.0
+
+
+def test_source_voltage_slew_setter():
+    """Verify source voltage slew setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:SLEW 100", None)],
+    ) as inst:
+        inst.source_voltage_slew = 100.0
+
+
+def test_source_voltage_offset_setter_and_getter():
+    """Verify source voltage offset roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SOURce:VOLTage:LEVel:IMMediate:OFFSet 1.5", None),
+         ("SOURce:VOLTage:LEVel:IMMediate:OFFSet?", "-0.25")],
+    ) as inst:
+        inst.source_voltage_offset = 1.5
+        assert inst.source_voltage_offset == -0.25
+
+
+def test_source_output_enabled_bool_mapping():
+    """Verify source output enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("OUTPut:STATe 1", None),
+         ("OUTPut:STATe?", "0")],
+    ) as inst:
+        inst.source_output_enabled = True
+        assert inst.source_output_enabled is False
+
+
+def test_output_low_pass_filter_enabled_bool_mapping():
+    """Verify output low-pass filter bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("OUTPut:FILTer:LPASs:STATe 1", None),
+         ("OUTPut:FILTer:LPASs:STATe?", "0")],
+    ) as inst:
+        inst.output_low_pass_filter_enabled = True
+        assert inst.output_low_pass_filter_enabled is False
+
+
+def test_source_voltage_offset_range_validation():
+    """Verify source voltage offset range validation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.source_voltage_offset = 10.1
+
+
+def test_averaging_enabled_bool_mapping():
+    """Verify averaging enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:STATe 1", None)],
+    ) as inst:
+        inst.averaging_enabled = True
+
+
+def test_average_count_setter():
+    """Verify average count setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:COUNt 16", None)],
+    ) as inst:
+        inst.average_count = 16
+
+
+def test_average_confidence_setter():
+    """Verify average confidence setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:CONFidence 0.5", None)],
+    ) as inst:
+        inst.average_confidence = 0.5
+
+
+def test_average_hold_mapping():
+    """Verify average hold mode mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:HOLD MIN", None),
+         ("SENSe:AVERage:HOLD?", "MAX")],
+    ) as inst:
+        inst.average_hold = "minimum"
+        assert inst.average_hold == "maximum"
+
+
+def test_average_impulse_enabled_bool_mapping():
+    """Verify average impulse bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:IMPulse 1", None),
+         ("SENSe:AVERage:IMPulse?", "0")],
+    ) as inst:
+        inst.average_impulse_enabled = True
+        assert inst.average_impulse_enabled is False
+
+
+def test_average_iresult_rate_setter():
+    """Verify average iresult update-rate setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:IRESult:RATE 5", None)],
+    ) as inst:
+        inst.average_iresult_rate = 5
+
+
+def test_average_iresult_enabled_bool_mapping():
+    """Verify average iresult bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:IRESult:STATe 1", None),
+         ("SENSe:AVERage:IRESult:STATe?", "0")],
+    ) as inst:
+        inst.average_iresult_enabled = True
+        assert inst.average_iresult_enabled is False
+
+
+def test_average_preview_mapping():
+    """Verify average preview mode mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:PREView TIM", None),
+         ("SENSe:AVERage:PREView?", "MAN")],
+    ) as inst:
+        inst.average_preview = "timed"
+        assert inst.average_preview == "manual"
+
+
+def test_average_preview_time_setter():
+    """Verify average preview time setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:PREView:TIME 10", None)],
+    ) as inst:
+        inst.average_preview_time = 10.0
+
+
+def test_average_type_mapping():
+    """Verify average type mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:TYPE ECON", None)],
+    ) as inst:
+        inst.average_type = "equal_confidence"
+
+
+def test_average_time_setter():
+    """Verify average time setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:TIME 0.5", None)],
+    ) as inst:
+        inst.average_time = 0.5
+
+
+def test_average_tcontrol_mapping():
+    """Verify average time-control mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:TCONtrol EXP", None)],
+    ) as inst:
+        inst.average_tcontrol = "exponential"
+
+
+def test_accept_average_preview_command():
+    """Verify average preview accept command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:PREView:ACCept", None)],
+    ) as inst:
+        inst.accept_average_preview()
+
+
+def test_reject_average_preview_command():
+    """Verify average preview reject command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:AVERage:PREView:REJect", None)],
+    ) as inst:
+        inst.reject_average_preview()
+
+
+def test_window_type_mapping():
+    """Verify measurement window type mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow2:TYPE HANN", None)],
+    ) as inst:
+        inst.window2.window_type = "hanning"
+
+
+def test_force_window_setter():
+    """Verify force window setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow4:FORCe 0.01", None)],
+    ) as inst:
+        inst.window4.force_window = 0.01
+
+
+def test_sense_window_exponential_time_constant_setter():
+    """Verify sense-window exponential time constant setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow2:EXPonential 0.1", None)],
+    ) as inst:
+        inst.sense_window2.exponential_window_time_constant = 0.1
+
+
+def test_sense_window_force_window_width_setter():
+    """Verify sense-window force width setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow3:FORCe 0.05", None)],
+    ) as inst:
+        inst.sense_window3.force_window_width = 0.05
+
+
+def test_sense_window_type_mapping():
+    """Verify sense-window type mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow4:TYPE LLAG", None),
+         ("SENSe:WINDow4:TYPE?", "HANN")],
+    ) as inst:
+        inst.sense_window4.window_type = "llag"
+        assert inst.sense_window4.window_type == "hanning"
+
+
+def test_sense_window_order_dc_included_bool_mapping():
+    """Verify sense-window order DC bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:WINDow1:ORDer:DC 0", None),
+         ("SENSe:WINDow1:ORDer:DC?", "1")],
+    ) as inst:
+        inst.sense_window1.order_dc_included = False
+        assert inst.sense_window1.order_dc_included is True
+
+
+def test_order_track_order_mapping():
+    """Verify order-track order setting for all tracks."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:TRACk1 1", None),
+         ("SENSe:ORDer:TRACk2 2", None),
+         ("SENSe:ORDer:TRACk3 3", None),
+         ("SENSe:ORDer:TRACk4 4", None),
+         ("SENSe:ORDer:TRACk5 5", None)],
+    ) as inst:
+        inst.order_track1.order = 1
+        inst.order_track2.order = 2
+        inst.order_track3.order = 3
+        inst.order_track4.order = 4
+        inst.order_track5.order = 5
+
+
+def test_order_track_enabled_bool_mapping():
+    """Verify order-track state bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:TRACk1:STATe 1", None),
+         ("SENSe:ORDer:TRACk2:STATe 0", None),
+         ("SENSe:ORDer:TRACk3:STATe 1", None),
+         ("SENSe:ORDer:TRACk4:STATe 0", None),
+         ("SENSe:ORDer:TRACk5:STATe 1", None),
+         ("SENSe:ORDer:TRACk3:STATe?", "0")],
+    ) as inst:
+        inst.order_track1.enabled = True
+        inst.order_track2.enabled = False
+        inst.order_track3.enabled = True
+        inst.order_track4.enabled = False
+        inst.order_track5.enabled = True
+        assert inst.order_track3.enabled is False
+
+
+def test_trigger_source_mapping():
+    """Verify trigger source mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:SOURce EXT", None),
+         ("TRIGger:SOURce INT2", None),
+         ("TRIGger:SOURce OUTP", None)],
+    ) as inst:
+        inst.trigger_source = "external"
+        inst.trigger_source = "internal2"
+        inst.trigger_source = "output"
+
+
+def test_trigger_slope_mapping():
+    """Verify trigger slope mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:SLOPe POS", None)],
+    ) as inst:
+        inst.trigger_slope = "positive"
+
+
+def test_trigger_level_setter():
+    """Verify trigger level setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:LEVel 0.125", None)],
+    ) as inst:
+        inst.trigger_level = 0.125
+
+
+def test_external_trigger_level_setter():
+    """Verify external trigger level setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:EXTernal:LEVel 0.5", None)],
+    ) as inst:
+        inst.external_trigger_level = 0.5
+
+
+def test_external_trigger_filter_enabled_bool_mapping():
+    """Verify external trigger filter bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:EXTernal:FILTer:LPAS:STATe 1", None),
+         ("TRIGger:EXTernal:FILTer:LPAS:STATe?", "0")],
+    ) as inst:
+        inst.external_trigger_filter_enabled = True
+        assert inst.external_trigger_filter_enabled is False
+
+
+def test_external_trigger_range_mapping():
+    """Verify external trigger range mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:EXTernal:RANGe LOW", None)],
+    ) as inst:
+        inst.external_trigger_range = "low"
+
+
+def test_trigger_start_per_channel_setters():
+    """Verify per-channel trigger start delay mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:STARt1 -0.001", None),
+         ("TRIGger:STARt2 0.002", None),
+         ("TRIGger:STARt3 0.003", None),
+         ("TRIGger:STARt4 0.004", None)],
+    ) as inst:
+        inst.trigger_start1 = -0.001
+        inst.trigger_start2 = 0.002
+        inst.trigger_start3 = 0.003
+        inst.trigger_start4 = 0.004
+
+
+def test_tachometer_holdoff_setter():
+    """Verify tachometer holdoff setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:HOLDoff 0.01", None)],
+    ) as inst:
+        inst.tachometer_holdoff = 0.01
+
+
+def test_tachometer_level_setter():
+    """Verify tachometer trigger level setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:LEVel 1.5", None)],
+    ) as inst:
+        inst.tachometer_level = 1.5
+
+
+def test_tachometer_pulse_count_setter():
+    """Verify tachometer pulse-count setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:PCOunt 60", None)],
+    ) as inst:
+        inst.tachometer_pulse_count = 60
+
+
+def test_tachometer_range_mapping():
+    """Verify tachometer range mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:RANGe HIGH", None)],
+    ) as inst:
+        inst.tachometer_range = "high"
+
+
+def test_tachometer_slope_mapping():
+    """Verify tachometer slope mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:SLOPe NEG", None)],
+    ) as inst:
+        inst.tachometer_slope = "negative"
+
+
+def test_tachometer_rpm_measurement():
+    """Verify tachometer RPM query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:TACHometer:RPM?", "1234.5")],
+    ) as inst:
+        assert inst.tachometer_rpm == 1234.5
+
+
+def test_trigger_immediate_command():
+    """Verify immediate trigger command mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRIGger:IMMediate", None)],
+    ) as inst:
+        inst.trigger_immediate()
+
+
+def test_display_enabled_bool_mapping():
+    """Verify display enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:STATe 0", None)],
+    ) as inst:
+        inst.display_enabled = False
+
+
+def test_display_format_mapping():
+    """Verify display format mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:FORMat QUAD", None)],
+    ) as inst:
+        inst.display_format = "quad"
+
+
+def test_display_view_mapping():
+    """Verify display view mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:VIEW CTAB", None)],
+    ) as inst:
+        inst.display_view = "calc_table"
+
+
+def test_trace_y_autoscale_window_mapping():
+    """Verify trace y autoscale command mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:Y:SCALe:AUTO ONCE", None)],
+    ) as inst:
+        inst.window3.trace_y_autoscale = "once"
+
+
+def test_trace_x_autoscale_window_mapping():
+    """Verify trace x autoscale command mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow1:TRACe:X:SCALe:AUTO OFF", None)],
+    ) as inst:
+        inst.window1.trace_x_autoscale = "off"
+
+
+def test_display_annotation_enabled_bool_mapping():
+    """Verify display annotation bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:ANNotation:ALL 1", None),
+         ("DISPlay:ANNotation:ALL?", "0")],
+    ) as inst:
+        inst.display_annotation_enabled = True
+        assert inst.display_annotation_enabled is False
+
+
+def test_display_bode_command():
+    """Verify BODE display command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:BODE", None)],
+    ) as inst:
+        inst.bode()
+
+
+def test_display_brightness_setter_and_getter():
+    """Verify display brightness roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:BRIGhtness 0.759", None),
+         ("DISPlay:BRIGhtness?", "1")],
+    ) as inst:
+        inst.display_brightness = 0.759
+        assert inst.display_brightness == 1
+
+
+def test_display_error_command():
+    """Verify display error text command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('DISPlay:ERRor "Please try again."', None)],
+    ) as inst:
+        inst.display_error("Please try again.")
+
+
+def test_display_external_enabled_bool_mapping():
+    """Verify external display bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:EXTernal:STATe 0", None),
+         ("DISPlay:EXTernal:STATe?", "1")],
+    ) as inst:
+        inst.display_external_enabled = False
+        assert inst.display_external_enabled is True
+
+
+def test_display_gpib_echo_enabled_bool_mapping():
+    """Verify display GPIB echo bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:GPIB:ECHO 1", None),
+         ("DISPlay:GPIB:ECHO?", "0")],
+    ) as inst:
+        inst.display_gpib_echo_enabled = True
+        assert inst.display_gpib_echo_enabled is False
+
+
+def test_display_program_mode_mapping():
+    """Verify display program mode mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:MODE LOW", None),
+         ("DISPlay:PROGram:MODE?", "UPP")],
+    ) as inst:
+        inst.display_program_mode = "lower"
+        assert inst.display_program_mode == "upper"
+
+
+def test_display_program_vector_buffer_enabled_bool_mapping():
+    """Verify display program vector buffer bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:VECTor:BUFFer:STATe 0", None),
+         ("DISPlay:PROGram:VECTor:BUFFer:STATe?", "1")],
+    ) as inst:
+        inst.display_program_vector_buffer_enabled = False
+        assert inst.display_program_vector_buffer_enabled is True
+
+
+def test_display_rpm_enabled_bool_mapping():
+    """Verify display RPM indicator bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:RPM:STATe 1", None),
+         ("DISPlay:RPM:STATe?", "0")],
+    ) as inst:
+        inst.display_rpm_enabled = True
+        assert inst.display_rpm_enabled is False
+
+
+def test_display_show_all_enabled_bool_mapping():
+    """Verify display show-all-lines bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:SHOWall:STATe 1", None),
+         ("DISPlay:SHOWall:STATe?", "0")],
+    ) as inst:
+        inst.display_show_all_enabled = True
+        assert inst.display_show_all_enabled is False
+
+
+def test_display_time_capture_envelope_enabled_bool_mapping():
+    """Verify display time-capture envelope bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:TCAPture:ENVelope:STATe 0", None),
+         ("DISPlay:TCAPture:ENVelope:STATe?", "1")],
+    ) as inst:
+        inst.display_time_capture_envelope_enabled = False
+        assert inst.display_time_capture_envelope_enabled is True
+
+
+def test_display_program_key_box_command():
+    """Verify display program key-box command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:KEY:BOX 3,1", None)],
+    ) as inst:
+        inst.program_key_box(3, True)
+
+
+def test_display_program_key_box_query():
+    """Verify display program key-box query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:KEY:BOX? 3", "3,0")],
+    ) as inst:
+        assert inst.program_key_box(3) is False
+
+
+def test_display_program_key_bracket_command():
+    """Verify display program key-bracket command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:KEY:BRACket 0,4,1", None)],
+    ) as inst:
+        inst.program_key_bracket(0, 4, True)
+
+
+def test_display_program_key_bracket_query():
+    """Verify display program key-bracket query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:PROGram:KEY:BRACket? 0,4", "0,4,1")],
+    ) as inst:
+        assert inst.program_key_bracket(0, 4) is True
+
+
+def test_program_edit_enabled_bool_mapping():
+    """Verify Instrument BASIC editor enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:EDIT:ENABle 0", None),
+         ("PROGram:EDIT:ENABle?", "1")],
+    ) as inst:
+        inst.program_edit_enabled = False
+        assert inst.program_edit_enabled is True
+
+
+def test_program_name_mapping():
+    """Verify active Instrument BASIC program selection mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:NAME PROGram4", None),
+         ("PROGram:NAME?", "PROG2")],
+    ) as inst:
+        inst.program_name = "program4"
+        assert inst.program_name == "PROGram2"
+
+
+def test_program_label_setter_and_getter():
+    """Verify active Instrument BASIC program label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:LABel "START TEST"', None),
+         ("PROGram:LABel?", '"PRINT REPORT"')],
+    ) as inst:
+        inst.program_label = "START TEST"
+        assert inst.program_label == "PRINT REPORT"
+
+
+def test_program_state_mapping():
+    """Verify active Instrument BASIC program state mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:STATe CONTinue", None),
+         ("PROGram:STATe?", "PAUS")],
+    ) as inst:
+        inst.program_state = "continue"
+        assert inst.program_state == "PAUSe"
+
+
+def test_program_allocated_memory_query():
+    """Verify Instrument BASIC allocated memory query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:MALLocate?", "187046")],
+    ) as inst:
+        assert inst.program_allocated_memory == 187046
+
+
+def test_allocate_program_memory_numeric():
+    """Verify Instrument BASIC memory allocation command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:MALLocate 416211", None)],
+    ) as inst:
+        inst.allocate_program_memory(416211)
+
+
+def test_allocate_program_memory_default():
+    """Verify Instrument BASIC memory allocation default command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:MALLocate DEFault", None)],
+    ) as inst:
+        inst.allocate_program_memory("DEFAULT")
+
+
+def test_allocate_program_memory_max():
+    """Verify Instrument BASIC memory allocation MAX command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:MALLocate MAX", None)],
+    ) as inst:
+        inst.allocate_program_memory("MAX")
+
+
+def test_allocate_program_memory_min():
+    """Verify Instrument BASIC memory allocation MIN command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:MALLocate MIN", None)],
+    ) as inst:
+        inst.allocate_program_memory("MIN")
+
+
+def test_define_program_command_definite_block():
+    """Verify selected Instrument BASIC definition upload command."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"PROGram:DEFine #11A", None)],
+    ) as inst:
+        inst.define_program("A")
+
+
+def test_define_program_command_raw_block():
+    """Verify selected Instrument BASIC definition upload in raw mode."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"PROGram:DEFine #11A", None)],
+    ) as inst:
+        inst.define_program(b"#11A", raw=True)
+
+
+def test_read_program_definition_query_block():
+    """Verify selected Instrument BASIC definition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:DEFine?", b"#11A")],
+    ) as inst:
+        assert inst.read_program_definition() == "A"
+
+
+def test_read_program_definition_query_block_raw():
+    """Verify selected Instrument BASIC definition query in raw mode."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:DEFine?", b"#11A")],
+    ) as inst:
+        assert inst.read_program_definition(raw=True) == b"#11A"
+
+
+def test_define_explicit_program_command_definite_block():
+    """Verify explicit Instrument BASIC definition upload command."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"PROGram:EXPLicit:DEFine PROGram3,#12AB", None)],
+    ) as inst:
+        inst.define_explicit_program("AB", program=3)
+
+
+def test_read_explicit_program_definition_query_block():
+    """Verify explicit Instrument BASIC definition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:EXPLicit:DEFine?", b"#12AB")],
+    ) as inst:
+        assert inst.read_explicit_program_definition() == "AB"
+
+
+def test_set_explicit_program_label_command():
+    """Verify explicit Instrument BASIC label command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:EXPLicit:LABel PROGram5, "PRINT REPORT"', None)],
+    ) as inst:
+        inst.set_explicit_program_label("PRINT REPORT", program=5)
+
+
+def test_read_explicit_program_label_query():
+    """Verify explicit Instrument BASIC label query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:EXPLicit:LABel?", '"START TEST"')],
+    ) as inst:
+        assert inst.read_explicit_program_label() == "START TEST"
+
+
+def test_delete_all_programs_requires_confirmation():
+    """Verify deleting all programs requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.delete_all_programs()
+
+
+def test_delete_all_programs_command():
+    """Verify deleting all programs command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:DELete:ALL", None)],
+    ) as inst:
+        inst.delete_all_programs(confirmed=True)
+
+
+def test_delete_selected_program_requires_confirmation():
+    """Verify deleting selected program requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.delete_selected_program()
+
+
+def test_delete_selected_program_command():
+    """Verify deleting selected program command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("PROGram:DELete", None)],
+    ) as inst:
+        inst.delete_selected_program(confirmed=True)
+
+
+def test_set_program_number_variable_command():
+    """Verify program numeric variable set command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:NUMBer "Address", 11', None)],
+    ) as inst:
+        inst.set_program_number_variable("Address", 11)
+
+
+def test_set_program_number_variable_sequence_command():
+    """Verify program numeric variable set command with sequence payload."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:NUMBer "3", 1,2,3.5', None)],
+    ) as inst:
+        inst.set_program_number_variable(3, (1, 2.0, 3.5))
+
+
+def test_read_program_number_variable_query():
+    """Verify program numeric variable query."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:NUMBer? "Address"', "11,7")],
+    ) as inst:
+        assert inst.read_program_number_variable("Address") == [11.0, 7.0]
+
+
+def test_set_program_string_variable_command():
+    """Verify program string variable set command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:STRing "Message$", "Measuring"', None)],
+    ) as inst:
+        inst.set_program_string_variable("Message", "Measuring")
+
+
+def test_read_program_string_variable_query():
+    """Verify program string variable query."""
+    with expected_protocol(
+        Keysight35670A,
+        [('PROGram:STRing? "Message$"', '"Done"')],
+    ) as inst:
+        assert inst.read_program_string_variable("Message") == "Done"
+
+
+def test_display_window_data_table_marker_enabled_bool_mapping():
+    """Verify display window data-table marker bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:DTABle:MARKer:STATe 1", None),
+         ("DISPlay:WINDow4:DTABle:MARKer:STATe?", "0")],
+    ) as inst:
+        inst.display4.data_table_marker_enabled = True
+        assert inst.display4.data_table_marker_enabled is False
+
+
+def test_display_window_data_table_enabled_bool_mapping():
+    """Verify display window data-table bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:DTABle:STATe 0", None),
+         ("DISPlay:WINDow4:DTABle:STATe?", "1")],
+    ) as inst:
+        inst.display4.data_table_enabled = False
+        assert inst.display4.data_table_enabled is True
+
+
+def test_display_window_limit_display_enabled_bool_mapping():
+    """Verify display window limit-line bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:LIMit:STATe 1", None),
+         ("DISPlay:WINDow2:LIMit:STATe?", "0")],
+    ) as inst:
+        inst.display2.limit_display_enabled = True
+        assert inst.display2.limit_display_enabled is False
+
+
+def test_display_window_polar_clockwise_bool_mapping():
+    """Verify display window polar clockwise bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:POLar:CLOCkwise 1", None),
+         ("DISPlay:WINDow3:POLar:CLOCkwise?", "0")],
+    ) as inst:
+        inst.display3.polar_clockwise = True
+        assert inst.display3.polar_clockwise is False
+
+
+def test_display_window_polar_rotation_setter_and_getter():
+    """Verify display window polar rotation roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:POLar:ROTation -311", None),
+         ("DISPlay:WINDow3:POLar:ROTation?", "-76")],
+    ) as inst:
+        inst.display3.polar_rotation = -311
+        assert inst.display3.polar_rotation == -76
+
+
+def test_display_window_trace_a_power_enabled_bool_mapping():
+    """Verify display window trace A power bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow1:TRACe:APOWer:STATe 0", None),
+         ("DISPlay:WINDow1:TRACe:APOWer:STATe?", "1")],
+    ) as inst:
+        inst.display1.trace_a_power_enabled = False
+        assert inst.display1.trace_a_power_enabled is True
+
+
+def test_display_window_trace_b_power_enabled_bool_mapping():
+    """Verify display window trace B power bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow1:TRACe:BPOWer:STATe 1", None),
+         ("DISPlay:WINDow1:TRACe:BPOWer:STATe?", "0")],
+    ) as inst:
+        inst.display1.trace_b_power_enabled = True
+        assert inst.display1.trace_b_power_enabled is False
+
+
+def test_display_window_trace_graticule_grid_enabled_bool_mapping():
+    """Verify display window graticule-grid bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:GRATicule:GRID:STATe 0", None),
+         ("DISPlay:WINDow3:TRACe:GRATicule:GRID:STATe?", "1")],
+    ) as inst:
+        inst.display3.trace_graticule_grid_enabled = False
+        assert inst.display3.trace_graticule_grid_enabled is True
+
+
+def test_display_window_trace_label_setter_and_getter():
+    """Verify display window trace label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('DISPlay:WINDow2:TRACe:LABel "CEPSTRUM"', None),
+         ("DISPlay:WINDow2:TRACe:LABel?", '"SPL"')],
+    ) as inst:
+        inst.display2.trace_label = "CEPSTRUM"
+        assert inst.display2.trace_label == "SPL"
+
+
+def test_display_window_trace_label_default_enabled_bool_mapping():
+    """Verify display window default-label bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:TRACe:LABel:DEFault:STATe 0", None),
+         ("DISPlay:WINDow2:TRACe:LABel:DEFault:STATe?", "1")],
+    ) as inst:
+        inst.display2.trace_label_default_enabled = False
+        assert inst.display2.trace_label_default_enabled is True
+
+
+def test_display_window_x_match_command():
+    """Verify display window X-axis match command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:TRACe:X:MATCh3", None)],
+    ) as inst:
+        inst.display4.x_match(3)
+
+
+def test_display_window_x_match_command_window2():
+    """Verify display2 X-axis match command keeps channel substitution."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:TRACe:X:MATCh1", None)],
+    ) as inst:
+        inst.display2.x_match(1)
+
+
+def test_display_window_trace_x_left_setter_and_getter():
+    """Verify display window X-left roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:TRACe:X:SCALe:LEFT 5.61155e+37", None),
+         ("DISPlay:WINDow2:TRACe:X:SCALe:LEFT?", "-8.83941e+37")],
+    ) as inst:
+        inst.display2.trace_x_left = 5.61155e37
+        assert inst.display2.trace_x_left == -8.83941e37
+
+
+def test_display_window_trace_x_right_setter_and_getter():
+    """Verify display window X-right roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:TRACe:X:SCALe:RIGHt -1.10689e+37", None),
+         ("DISPlay:WINDow2:TRACe:X:SCALe:RIGHt?", "-9.29266e+37")],
+    ) as inst:
+        inst.display2.trace_x_right = -1.10689e37
+        assert inst.display2.trace_x_right == -9.29266e37
+
+
+def test_display_window_trace_x_spacing_mapping():
+    """Verify display window X-spacing mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:TRACe:X:SPACing LOG", None),
+         ("DISPlay:WINDow4:TRACe:X:SPACing?", "LIN")],
+    ) as inst:
+        inst.display4.trace_x_spacing = "logarithmic"
+        assert inst.display4.trace_x_spacing == "linear"
+
+
+def test_display_window_y_match_command():
+    """Verify display window Y-axis match command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:TRACe:Y:MATCh3", None)],
+    ) as inst:
+        inst.display4.y_match(3)
+
+
+def test_display_window_y_match_command_window3():
+    """Verify display3 Y-axis match command keeps channel substitution."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:Y:MATCh2", None)],
+    ) as inst:
+        inst.display3.y_match(2)
+
+
+def test_display_window_trace_y_bottom_setter_and_getter():
+    """Verify display window Y-bottom roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:Y:SCALe:BOTTom 3.87223e+37", None),
+         ("DISPlay:WINDow3:TRACe:Y:SCALe:BOTTom?", "7.35957e+37")],
+    ) as inst:
+        inst.display3.trace_y_bottom = 3.87223e37
+        assert inst.display3.trace_y_bottom == 7.35957e37
+
+
+def test_display_window_trace_y_center_setter_and_getter():
+    """Verify display window Y-center roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:Y:SCALe:CENTer 0", None),
+         ("DISPlay:WINDow3:TRACe:Y:SCALe:CENTer?", "-40")],
+    ) as inst:
+        inst.display3.trace_y_center = 0
+        assert inst.display3.trace_y_center == -40
+
+
+def test_display_window_trace_y_per_division_setter_and_getter():
+    """Verify display window Y-per-division roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow1:TRACe:Y:SCALe:PDIVision 4.5054e+37", None),
+         ("DISPlay:WINDow1:TRACe:Y:SCALe:PDIVision?", "9.20888e+37")],
+    ) as inst:
+        inst.display1.trace_y_per_division = 4.5054e37
+        assert inst.display1.trace_y_per_division == 9.20888e37
+
+
+def test_display_window_trace_y_reference_mapping():
+    """Verify display window Y-reference mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:TRACe:Y:SCALe:REFerence CENT", None),
+         ("DISPlay:WINDow3:TRACe:Y:SCALe:REFerence?", "RANG")],
+    ) as inst:
+        inst.display3.trace_y_reference = "center"
+        assert inst.display3.trace_y_reference == "range"
+
+
+def test_display_window_trace_y_top_setter_and_getter():
+    """Verify display window Y-top roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:TRACe:Y:SCALe:TOP 5", None),
+         ("DISPlay:WINDow4:TRACe:Y:SCALe:TOP?", "0")],
+    ) as inst:
+        inst.display4.trace_y_top = 5
+        assert inst.display4.trace_y_top == 0
+
+
+def test_display_window_trace_y_spacing_mapping():
+    """Verify display window Y-spacing mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:TRACe:Y:SPACing LOG", None),
+         ("DISPlay:WINDow2:TRACe:Y:SPACing?", "LIN")],
+    ) as inst:
+        inst.display2.trace_y_spacing = "logarithmic"
+        assert inst.display2.trace_y_spacing == "linear"
+
+
+def test_display_window_waterfall_baseline_setter_and_getter():
+    """Verify display window waterfall baseline roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:WATerfall:BASeline 33", None),
+         ("DISPlay:WINDow3:WATerfall:BASeline?", "30")],
+    ) as inst:
+        inst.display3.waterfall_baseline = 33
+        assert inst.display3.waterfall_baseline == 30
+
+
+def test_display_window_waterfall_bottom_setter_and_getter():
+    """Verify display window waterfall bottom roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:WATerfall:BOTTom 8.84371e+37", None),
+         ("DISPlay:WINDow2:WATerfall:BOTTom?", "3.94581e+37")],
+    ) as inst:
+        inst.display2.waterfall_bottom = 8.84371e37
+        assert inst.display2.waterfall_bottom == 3.94581e37
+
+
+def test_display_window_waterfall_count_setter_and_getter():
+    """Verify display window waterfall count-value roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow2:WATerfall:COUNt 100", None),
+         ("DISPlay:WINDow2:WATerfall:COUNt?", "5")],
+    ) as inst:
+        inst.display2.waterfall_count = 100
+        assert inst.display2.waterfall_count == 5
+
+
+def test_display_window_waterfall_height_setter_and_getter():
+    """Verify display window waterfall height roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:WATerfall:HEIGht 69", None),
+         ("DISPlay:WINDow4:WATerfall:HEIGht?", "84")],
+    ) as inst:
+        inst.display4.waterfall_height = 69
+        assert inst.display4.waterfall_height == 84
+
+
+def test_display_window_waterfall_hidden_enabled_bool_mapping():
+    """Verify display window waterfall hidden-line bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow4:WATerfall:HIDDen 1", None),
+         ("DISPlay:WINDow4:WATerfall:HIDDen?", "0")],
+    ) as inst:
+        inst.display4.waterfall_hidden_enabled = True
+        assert inst.display4.waterfall_hidden_enabled is False
+
+
+def test_display_window_waterfall_skew_enabled_bool_mapping():
+    """Verify display window waterfall skew bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:WATerfall:SKEW 1", None),
+         ("DISPlay:WINDow3:WATerfall:SKEW?", "0")],
+    ) as inst:
+        inst.display3.waterfall_skew_enabled = True
+        assert inst.display3.waterfall_skew_enabled is False
+
+
+def test_display_window_waterfall_skew_angle_setter_and_getter():
+    """Verify display window waterfall skew-angle roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:WATerfall:SKEW:ANGLe 20", None),
+         ("DISPlay:WINDow3:WATerfall:SKEW:ANGLe?", "30")],
+    ) as inst:
+        inst.display3.waterfall_skew_angle = 20
+        assert inst.display3.waterfall_skew_angle == 30
+
+
+def test_display_window_waterfall_enabled_bool_mapping():
+    """Verify display window waterfall enable bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow1:WATerfall:STATe 1", None),
+         ("DISPlay:WINDow1:WATerfall:STATe?", "0")],
+    ) as inst:
+        inst.display1.waterfall_enabled = True
+        assert inst.display1.waterfall_enabled is False
+
+
+def test_display_window_waterfall_top_setter_and_getter():
+    """Verify display window waterfall top roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("DISPlay:WINDow3:WATerfall:TOP 9.26034e+37", None),
+         ("DISPlay:WINDow3:WATerfall:TOP?", "2.70387e+37")],
+    ) as inst:
+        inst.display3.waterfall_top = 9.26034e37
+        assert inst.display3.waterfall_top == 2.70387e37
+
+
+def test_hardcopy_color_default_command():
+    """Verify hardcopy color defaults command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:COLor:DEFault", None)],
+    ) as inst:
+        inst.hardcopy_color_default()
+
+
+def test_hardcopy_destination_setter_and_getter():
+    """Verify hardcopy destination roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('HCOPy:DESTination "MMEM"', None),
+         ("HCOPy:DESTination?", '"SYST:COMM:CENT"')],
+    ) as inst:
+        inst.hardcopy_destination = "MMEM"
+        assert inst.hardcopy_destination == "SYST:COMM:CENT"
+
+
+def test_hardcopy_device_language_setter_and_getter():
+    """Verify hardcopy device language roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:DEVice:LANGuage PCL", None),
+         ("HCOPy:DEVice:LANGuage?", "HPGL")],
+    ) as inst:
+        inst.hardcopy_device_language = "PCL"
+        assert inst.hardcopy_device_language == "HPGL"
+
+
+def test_hardcopy_device_resolution_setter_and_getter():
+    """Verify hardcopy device resolution roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:DEVice:RESolution 75", None),
+         ("HCOPy:DEVice:RESolution?", "0")],
+    ) as inst:
+        inst.hardcopy_device_resolution = 75
+        assert inst.hardcopy_device_resolution == 0
+
+
+def test_hardcopy_device_speed_setter_and_getter():
+    """Verify hardcopy device speed roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:DEVice:SPEed 53", None),
+         ("HCOPy:DEVice:SPEed?", "10")],
+    ) as inst:
+        inst.hardcopy_device_speed = 53
+        assert inst.hardcopy_device_speed == 10
+
+
+def test_hardcopy_requires_confirmation():
+    """Verify hardcopy execution requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.hardcopy()
+
+
+def test_hardcopy_command():
+    """Verify hardcopy immediate command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:IMMediate", None)],
+    ) as inst:
+        inst.hardcopy(confirmed=True)
+
+
+def test_print_or_plot_command():
+    """Verify print_or_plot alias command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:IMMediate", None)],
+    ) as inst:
+        inst.print_or_plot(confirmed=True)
+
+
+def test_hardcopy_form_feed_enabled_bool_mapping():
+    """Verify hardcopy form-feed bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:FFEed:STATe 1", None),
+         ("HCOPy:ITEM:FFEed:STATe?", "0")],
+    ) as inst:
+        inst.hardcopy_form_feed_enabled = True
+        assert inst.hardcopy_form_feed_enabled is False
+
+
+def test_hardcopy_label_color_setter_and_getter():
+    """Verify hardcopy label color roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:LABel:COLor 4", None),
+         ("HCOPy:ITEM:LABel:COLor?", "5")],
+    ) as inst:
+        inst.hardcopy_label_color = 4
+        assert inst.hardcopy_label_color == 5
+
+
+def test_hardcopy_label_enabled_bool_mapping():
+    """Verify hardcopy label enable bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:LABel:STATe 1", None),
+         ("HCOPy:ITEM:LABel:STATe?", "0")],
+    ) as inst:
+        inst.hardcopy_label_enabled = True
+        assert inst.hardcopy_label_enabled is False
+
+
+def test_hardcopy_label_text_setter_and_getter():
+    """Verify hardcopy label text roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('HCOPy:ITEM:LABel:TEXT "TEST 1 RESULTS"', None),
+         ("HCOPy:ITEM:LABel:TEXT?", '"TEST LABEL"')],
+    ) as inst:
+        inst.hardcopy_label_text = "TEST 1 RESULTS"
+        assert inst.hardcopy_label_text == "TEST LABEL"
+
+
+def test_hardcopy_timestamp_format_setter_and_getter():
+    """Verify hardcopy timestamp format roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:TDSTamp:FORMat FORM2", None),
+         ("HCOPy:ITEM:TDSTamp:FORMat?", "FORM5")],
+    ) as inst:
+        inst.hardcopy_timestamp_format = "format2"
+        assert inst.hardcopy_timestamp_format == "FORM5"
+
+
+def test_hardcopy_timestamp_enabled_bool_mapping():
+    """Verify hardcopy timestamp enable bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:TDSTamp:STATe 1", None),
+         ("HCOPy:ITEM:TDSTamp:STATe?", "0")],
+    ) as inst:
+        inst.hardcopy_timestamp_enabled = True
+        assert inst.hardcopy_timestamp_enabled is False
+
+
+def test_hardcopy_page_dimensions_auto_enabled_bool_mapping():
+    """Verify hardcopy page auto-dimensions bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:PAGE:DIMensions:AUTO 0", None),
+         ("HCOPy:PAGE:DIMensions:AUTO?", "1")],
+    ) as inst:
+        inst.hardcopy_page_dimensions_auto_enabled = False
+        assert inst.hardcopy_page_dimensions_auto_enabled is True
+
+
+def test_hardcopy_page_user_lower_left_setter_and_getter():
+    """Verify hardcopy lower-left page point roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:PAGE:DIMensions:USER:LLEFt 332,1195", None),
+         ("HCOPy:PAGE:DIMensions:USER:LLEFt?", "4743,4286")],
+    ) as inst:
+        inst.hardcopy_page_user_lower_left = (332, 1195)
+        assert inst.hardcopy_page_user_lower_left == (4743, 4286)
+
+
+def test_hardcopy_page_user_upper_right_setter_and_getter():
+    """Verify hardcopy upper-right page point roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:PAGE:DIMensions:USER:URIGht 9155,7377", None),
+         ("HCOPy:PAGE:DIMensions:USER:URIGht?", "9155,4286")],
+    ) as inst:
+        inst.hardcopy_page_user_upper_right = (9155, 7377)
+        assert inst.hardcopy_page_user_upper_right == (9155, 4286)
+
+
+def test_hardcopy_plot_address_setter_and_getter():
+    """Verify hardcopy plotter address roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:PLOT:ADDRess 5", None),
+         ("HCOPy:PLOT:ADDRess?", "9")],
+    ) as inst:
+        inst.hardcopy_plot_address = 5
+        assert inst.hardcopy_plot_address == 9
+
+
+def test_hardcopy_print_address_setter_and_getter():
+    """Verify hardcopy printer address roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:PRINt:ADDRess 3", None),
+         ("HCOPy:PRINt:ADDRess?", "1")],
+    ) as inst:
+        inst.hardcopy_print_address = 3
+        assert inst.hardcopy_print_address == 1
+
+
+def test_hardcopy_title1_setter_and_getter():
+    """Verify hardcopy title line 1 roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('HCOPy:TITLe1 "BEARING CHARACTERISTICS"', None),
+         ("HCOPy:TITLe1?", '"LINE 1"')],
+    ) as inst:
+        inst.hardcopy_title1 = "BEARING CHARACTERISTICS"
+        assert inst.hardcopy_title1 == "LINE 1"
+
+
+def test_hardcopy_title2_setter_and_getter():
+    """Verify hardcopy title line 2 roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('HCOPy:TITLe2 "RMS SUMMARY"', None),
+         ("HCOPy:TITLe2?", '"LINE 2"')],
+    ) as inst:
+        inst.hardcopy_title2 = "RMS SUMMARY"
+        assert inst.hardcopy_title2 == "LINE 2"
+
+
+def test_hardcopy_source_setter_and_getter():
+    """Verify hardcopy source roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:SOURce MARK", None),
+         ("HCOPy:SOURce?", "REF")],
+    ) as inst:
+        inst.hardcopy_source = "marker"
+        assert inst.hardcopy_source == "REF"
+
+
+def test_display_window_hardcopy_trace_color_setter_and_getter():
+    """Verify display-window hardcopy trace color roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:WINDow2:TRACe:COLor 6", None),
+         ("HCOPy:ITEM:WINDow2:TRACe:COLor?", "2")],
+    ) as inst:
+        inst.display2.hardcopy_trace_color = 6
+        assert inst.display2.hardcopy_trace_color == 2
+
+
+def test_display_window_hardcopy_trace_graticule_color_setter_and_getter():
+    """Verify display-window hardcopy graticule color roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:WINDow1:TRACe:GRATicule:COLor 8", None),
+         ("HCOPy:ITEM:WINDow1:TRACe:GRATicule:COLor?", "1")],
+    ) as inst:
+        inst.display1.hardcopy_trace_graticule_color = 8
+        assert inst.display1.hardcopy_trace_graticule_color == 1
+
+
+def test_display_window_hardcopy_trace_limit_line_type_setter_and_getter():
+    """Verify display-window hardcopy limit line type roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:WINDow3:TRACe:LIMit:LTYPe STYL3", None),
+         ("HCOPy:ITEM:WINDow3:TRACe:LIMit:LTYPe?", "DOTT")],
+    ) as inst:
+        inst.display3.hardcopy_trace_limit_line_type = "style3"
+        assert inst.display3.hardcopy_trace_limit_line_type == "DOTT"
+
+
+def test_display_window_hardcopy_trace_line_type_setter_and_getter():
+    """Verify display-window hardcopy trace line type roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:WINDow4:TRACe:LTYPe DASH", None),
+         ("HCOPy:ITEM:WINDow4:TRACe:LTYPe?", "STYL4")],
+    ) as inst:
+        inst.display4.hardcopy_trace_line_type = "dashed"
+        assert inst.display4.hardcopy_trace_line_type == "STYL4"
+
+
+def test_display_window_hardcopy_trace_marker_color_setter_and_getter():
+    """Verify display-window hardcopy marker color roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("HCOPy:ITEM:WINDow4:TRACe:MARKer:COLor 9", None),
+         ("HCOPy:ITEM:WINDow4:TRACe:MARKer:COLor?", "6")],
+    ) as inst:
+        inst.display4.hardcopy_trace_marker_color = 9
+        assert inst.display4.hardcopy_trace_marker_color == 6
+
+
+def test_memory_catalog_query():
+    """Verify volatile memory catalog query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:CATalog?", "1,2,TCAP,TCAP,10")],
+    ) as inst:
+        assert inst.memory_catalog() == "1,2,TCAP,TCAP,10"
+
+
+def test_memory_catalog_all_query():
+    """Verify volatile memory full catalog query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:CATalog:ALL?", "1,2,TCAP,TCAP,10")],
+    ) as inst:
+        assert inst.memory_catalog(all_entries=True) == "1,2,TCAP,TCAP,10"
+
+
+def test_memory_catalog_name_query():
+    """Verify volatile memory named-item catalog query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:CATalog:NAME? PROGram", "PROG,1024,2048")],
+    ) as inst:
+        assert inst.memory_catalog_name("program") == "PROG,1024,2048"
+
+
+def test_memory_free_query():
+    """Verify volatile memory free query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:FREE?", "4096,2048")],
+    ) as inst:
+        assert inst.memory_free() == "4096,2048"
+
+
+def test_memory_free_all_query():
+    """Verify volatile memory free-all query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:FREE:ALL?", "4096,2048")],
+    ) as inst:
+        assert inst.memory_free(all_entries=True) == "4096,2048"
+
+
+def test_memory_delete_all_requires_confirmation():
+    """Verify volatile memory delete-all requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.memory_delete_all()
+
+
+def test_memory_delete_all_command():
+    """Verify volatile memory delete-all command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:DELete:ALL", None)],
+    ) as inst:
+        inst.memory_delete_all(confirmed=True)
+
+
+def test_memory_delete_requires_confirmation():
+    """Verify volatile memory item delete requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.memory_delete("program")
+
+
+def test_memory_delete_command():
+    """Verify volatile memory item delete command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MEMory:DELete PROGram", None)],
+    ) as inst:
+        inst.memory_delete("program", confirmed=True)
+
+
+def test_mass_memory_disk_address_setter_and_getter():
+    """Verify mass-memory disk address roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:DISK:ADDRess 21", None),
+         ("MMEMory:DISK:ADDRess?", "6")],
+    ) as inst:
+        inst.mass_memory_disk_address = 21
+        assert inst.mass_memory_disk_address == 6
+
+
+def test_mass_memory_disk_unit_setter_and_getter():
+    """Verify mass-memory disk unit roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:DISK:UNIT 1", None),
+         ("MMEMory:DISK:UNIT?", "0")],
+    ) as inst:
+        inst.mass_memory_disk_unit = 1
+        assert inst.mass_memory_disk_unit == 0
+
+
+def test_mass_memory_filesystem_query():
+    """Verify mass-memory filesystem query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:FSYStem?", "DOS")],
+    ) as inst:
+        assert inst.mass_memory_filesystem == "DOS"
+
+
+def test_mass_memory_default_disk_setter_and_getter():
+    """Verify mass-memory default disk roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:MSIS "RAM:"', None),
+         ("MMEMory:MSIS?", '"INT:"')],
+    ) as inst:
+        inst.mass_memory_default_disk = "RAM:"
+        assert inst.mass_memory_default_disk == "INT:"
+
+
+def test_mass_memory_name_setter_and_getter():
+    """Verify mass-memory name roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:NAME "INT:PLOT.HPG"', None),
+         ("MMEMory:NAME?", '"INT:PRINT1.HPG"')],
+    ) as inst:
+        inst.mass_memory_name = "INT:PLOT.HPG"
+        assert inst.mass_memory_name == "INT:PRINT1.HPG"
+
+
+def test_mass_memory_load_continue_status_query():
+    """Verify mass-memory load-continue status query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:LOAD:CONTinue?", "1")],
+    ) as inst:
+        assert inst.mass_memory_load_continue_status == 1
+
+
+def test_mass_memory_store_continue_status_query():
+    """Verify mass-memory store-continue status query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:STORe:CONTinue?", "0")],
+    ) as inst:
+        assert inst.mass_memory_store_continue_status == 0
+
+
+def test_mass_memory_store_program_format_setter_and_getter():
+    """Verify mass-memory program store format roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:STORe:PROGram:FORMat BIN", None),
+         ("MMEMory:STORe:PROGram:FORMat?", "ASC")],
+    ) as inst:
+        inst.mass_memory_store_program_format = "binary"
+        assert inst.mass_memory_store_program_format == "ASC"
+
+
+def test_mass_memory_store_trace_format_setter_and_getter():
+    """Verify mass-memory trace store format roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEM:STORe:TRACe:FORMat ASCII", None),
+         ("MMEM:STORe:TRACe:FORMat?", "SDF")],
+    ) as inst:
+        inst.mass_memory_store_trace_format = "ASCII"
+        assert inst.mass_memory_store_trace_format == "SDF"
+
+
+def test_mass_memory_copy_requires_confirmation():
+    """Verify mass-memory copy requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.mass_memory_copy("INT:FILE1", "INT:FILE2")
+
+
+def test_mass_memory_copy_command():
+    """Verify mass-memory copy command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:COPY "INT:FILE1", "INT:FILE2"', None)],
+    ) as inst:
+        inst.mass_memory_copy("INT:FILE1", "INT:FILE2", confirmed=True)
+
+
+def test_mass_memory_delete_requires_confirmation():
+    """Verify mass-memory delete requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.mass_memory_delete("INT:FILE1")
+
+
+def test_mass_memory_delete_command():
+    """Verify mass-memory delete command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:DELete "INT:FILE1"', None)],
+    ) as inst:
+        inst.mass_memory_delete("INT:FILE1", confirmed=True)
+
+
+def test_mass_memory_initialize_requires_confirmation():
+    """Verify mass-memory initialize requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.mass_memory_initialize("INT:", "DOS", 0, 1)
+
+
+def test_mass_memory_initialize_command():
+    """Verify mass-memory initialize command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:INITialize "INT:" DOS 0 1', None)],
+    ) as inst:
+        inst.mass_memory_initialize("INT:", "DOS", 0, 1, confirmed=True)
+
+
+def test_mass_memory_initialize_disk_only_command():
+    """Verify mass-memory initialize command with disk-only argument."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:INITialize "RAM"', None)],
+    ) as inst:
+        inst.mass_memory_initialize("RAM", confirmed=True)
+
+
+def test_mass_memory_initialize_full_optional_arguments_command():
+    """Verify mass-memory initialize command with all optional arguments."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:INITialize "RAM" LIF 1 2', None)],
+    ) as inst:
+        inst.mass_memory_initialize("RAM", "LIF", 1, 2, confirmed=True)
+
+
+def test_mass_memory_load_continue_requires_confirmation():
+    """Verify mass-memory load-continue command requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.mass_memory_load_continue()
+
+
+def test_mass_memory_load_continue_command():
+    """Verify mass-memory load-continue command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:LOAD:CONTinue", None)],
+    ) as inst:
+        inst.mass_memory_load_continue(confirmed=True)
+
+
+def test_mass_memory_load_cfit_command():
+    """Verify mass-memory load curve-fit command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:CFIT "INT:CURVE1.FIT"', None)],
+    ) as inst:
+        inst.mass_memory_load_cfit("INT:CURVE1.FIT", confirmed=True)
+
+
+def test_mass_memory_load_data_table_trace_command():
+    """Verify mass-memory load data-table trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:DTABle:TRACe2 "INT:DTAB2.DAT"', None)],
+    ) as inst:
+        inst.mass_memory_load_data_table_trace(2, "INT:DTAB2.DAT", confirmed=True)
+
+
+def test_mass_memory_load_data_table_trace_command_short_filename():
+    """Verify mass-memory load data-table trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:DTABle:TRACe2 "A"', None)],
+    ) as inst:
+        inst.mass_memory_load_data_table_trace(2, "A", confirmed=True)
+
+
+def test_mass_memory_load_lower_limit_trace_command():
+    """Verify mass-memory load lower-limit trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:LIMit:LOWer:TRACe3 "INT:LOW3.LIM"', None)],
+    ) as inst:
+        inst.mass_memory_load_lower_limit_trace(3, "INT:LOW3.LIM", confirmed=True)
+
+
+def test_mass_memory_load_lower_limit_trace_command_short_filename():
+    """Verify mass-memory load lower-limit trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:LIMit:LOWer:TRACe2 "A"', None)],
+    ) as inst:
+        inst.mass_memory_load_lower_limit_trace(2, "A", confirmed=True)
+
+
+def test_mass_memory_load_upper_limit_trace_command():
+    """Verify mass-memory load upper-limit trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:LIMit:UPPer:TRACe4 "INT:UP4.LIM"', None)],
+    ) as inst:
+        inst.mass_memory_load_upper_limit_trace(4, "INT:UP4.LIM", confirmed=True)
+
+
+def test_mass_memory_load_upper_limit_trace_command_short_filename():
+    """Verify mass-memory load upper-limit trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:LIMit:UPPer:TRACe2 "A"', None)],
+    ) as inst:
+        inst.mass_memory_load_upper_limit_trace(2, "A", confirmed=True)
+
+
+def test_mass_memory_load_math_command():
+    """Verify mass-memory load math command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:MATH "INT:MATH.DEF"', None)],
+    ) as inst:
+        inst.mass_memory_load_math("INT:MATH.DEF", confirmed=True)
+
+
+def test_mass_memory_load_program_command():
+    """Verify mass-memory load program command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:PROGram "INT:MYPROG.BAS"', None)],
+    ) as inst:
+        inst.mass_memory_load_program("INT:MYPROG.BAS", confirmed=True)
+
+
+def test_mass_memory_load_state_command():
+    """Verify mass-memory load state command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:STATe 1, "INT:AUTO_ST.STA"', None)],
+    ) as inst:
+        inst.mass_memory_load_state("INT:AUTO_ST.STA", slot=1, confirmed=True)
+
+
+def test_mass_memory_load_synthesis_command():
+    """Verify mass-memory load synthesis command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:SYNThesis "INT:SYNTH.SYN"', None)],
+    ) as inst:
+        inst.mass_memory_load_synthesis("INT:SYNTH.SYN", confirmed=True)
+
+
+def test_mass_memory_load_time_capture_command():
+    """Verify mass-memory load time-capture command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:TCAPture "INT:TCAP1.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_load_time_capture("INT:TCAP1.SDF", confirmed=True)
+
+
+def test_mass_memory_load_trace_command():
+    """Verify mass-memory load trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:TRACe D4, "INT:TRACE4.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_load_trace(4, "INT:TRACE4.SDF", confirmed=True)
+
+
+def test_mass_memory_load_trace_with_no_scale_command():
+    """Verify mass-memory load trace command with no-scale argument."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:TRACe D1, "INT:TRACE1.SDF", 1', None)],
+    ) as inst:
+        inst.mass_memory_load_trace(1, "INT:TRACE1.SDF", no_scale=True, confirmed=True)
+
+
+def test_mass_memory_load_trace_with_no_scale_false_command():
+    """Verify mass-memory load trace command with explicit no-scale false value."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:TRACe D2, "INT:TRACE2.SDF", 0', None)],
+    ) as inst:
+        inst.mass_memory_load_trace(2, "INT:TRACE2.SDF", no_scale=False, confirmed=True)
+
+
+def test_mass_memory_load_waterfall_command():
+    """Verify mass-memory load waterfall command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:LOAD:WATerfall W3, "INT:WAT3.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_load_waterfall(3, "INT:WAT3.SDF", confirmed=True)
+
+
+def test_mass_memory_make_directory_command():
+    """Verify mass-memory make-directory command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:MDIRectory "INT:\\RESULTS"', None)],
+    ) as inst:
+        inst.mass_memory_make_directory("INT:\\RESULTS", confirmed=True)
+
+
+def test_mass_memory_move_command():
+    """Verify mass-memory move command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:MOVE "INT:OLD.DAT", "INT:NEW.DAT"', None)],
+    ) as inst:
+        inst.mass_memory_move("INT:OLD.DAT", "INT:NEW.DAT", confirmed=True)
+
+
+def test_mass_memory_store_continue_requires_confirmation():
+    """Verify mass-memory store-continue command requires confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.mass_memory_store_continue()
+
+
+def test_mass_memory_store_continue_command():
+    """Verify mass-memory store-continue command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("MMEMory:STORe:CONTinue", None)],
+    ) as inst:
+        inst.mass_memory_store_continue(confirmed=True)
+
+
+def test_mass_memory_store_cfit_command():
+    """Verify mass-memory store curve-fit command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:CFIT "INT:CURVE1.FIT"', None)],
+    ) as inst:
+        inst.mass_memory_store_cfit("INT:CURVE1.FIT", confirmed=True)
+
+
+def test_mass_memory_store_data_table_trace_command():
+    """Verify mass-memory store data-table trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:DTABle:TRACe1 "INT:DTAB1.DAT"', None)],
+    ) as inst:
+        inst.mass_memory_store_data_table_trace(1, "INT:DTAB1.DAT", confirmed=True)
+
+
+def test_mass_memory_store_data_table_trace_command_short_filename():
+    """Verify mass-memory store data-table trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:DTABle:TRACe3 "A"', None)],
+    ) as inst:
+        inst.mass_memory_store_data_table_trace(3, "A", confirmed=True)
+
+
+def test_mass_memory_store_lower_limit_trace_command():
+    """Verify mass-memory store lower-limit trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:LIMit:LOWer:TRACe2 "INT:LOW2.LIM"', None)],
+    ) as inst:
+        inst.mass_memory_store_lower_limit_trace(2, "INT:LOW2.LIM", confirmed=True)
+
+
+def test_mass_memory_store_lower_limit_trace_command_short_filename():
+    """Verify mass-memory store lower-limit trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:LIMit:LOWer:TRACe2 "A"', None)],
+    ) as inst:
+        inst.mass_memory_store_lower_limit_trace(2, "A", confirmed=True)
+
+
+def test_mass_memory_store_upper_limit_trace_command():
+    """Verify mass-memory store upper-limit trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:LIMit:UPPer:TRACe4 "INT:UP4.LIM"', None)],
+    ) as inst:
+        inst.mass_memory_store_upper_limit_trace(4, "INT:UP4.LIM", confirmed=True)
+
+
+def test_mass_memory_store_upper_limit_trace_command_short_filename():
+    """Verify mass-memory store upper-limit trace command trace-index rendering."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:LIMit:UPPer:TRACe2 "A"', None)],
+    ) as inst:
+        inst.mass_memory_store_upper_limit_trace(2, "A", confirmed=True)
+
+
+def test_mass_memory_store_math_command():
+    """Verify mass-memory store math command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:MATH "INT:MATH.DEF"', None)],
+    ) as inst:
+        inst.mass_memory_store_math("INT:MATH.DEF", confirmed=True)
+
+
+def test_mass_memory_store_program_command():
+    """Verify mass-memory store program command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:PROGram "INT:MYPROG.BAS"', None)],
+    ) as inst:
+        inst.mass_memory_store_program("INT:MYPROG.BAS", confirmed=True)
+
+
+def test_mass_memory_store_state_command():
+    """Verify mass-memory store state command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:STATe 1, "INT:AUTO_ST.STA"', None)],
+    ) as inst:
+        inst.mass_memory_store_state("INT:AUTO_ST.STA", slot=1, confirmed=True)
+
+
+def test_mass_memory_store_synthesis_command():
+    """Verify mass-memory store synthesis command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:SYNThesis "INT:SYNTH.SYN"', None)],
+    ) as inst:
+        inst.mass_memory_store_synthesis("INT:SYNTH.SYN", confirmed=True)
+
+
+def test_mass_memory_store_time_capture_command():
+    """Verify mass-memory store time-capture command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:TCAPture "INT:TCAP1.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_store_time_capture("INT:TCAP1.SDF", confirmed=True)
+
+
+def test_mass_memory_store_trace_command():
+    """Verify mass-memory store trace command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:TRACe TRACe3, "INT:TRACE3.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_store_trace(3, "INT:TRACE3.SDF", confirmed=True)
+
+
+def test_mass_memory_store_waterfall_command():
+    """Verify mass-memory store waterfall command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('MMEMory:STORe:WATerfall TRACe2, "INT:WAT2.SDF"', None)],
+    ) as inst:
+        inst.mass_memory_store_waterfall(2, "INT:WAT2.SDF", confirmed=True)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    [
+        ("mass_memory_load_cfit", ("INT:CURVE1.FIT",), {}),
+        ("mass_memory_load_data_table_trace", (2, "INT:DTAB2.DAT"), {}),
+        ("mass_memory_load_lower_limit_trace", (2, "INT:LOW2.LIM"), {}),
+        ("mass_memory_load_upper_limit_trace", (2, "INT:UP2.LIM"), {}),
+        ("mass_memory_load_math", ("INT:MATH.DEF",), {}),
+        ("mass_memory_load_program", ("INT:MYPROG.BAS",), {}),
+        ("mass_memory_load_state", ("INT:STATE.STA",), {"slot": 1}),
+        ("mass_memory_load_synthesis", ("INT:SYNTH.SYN",), {}),
+        ("mass_memory_load_time_capture", ("INT:TCAP1.SDF",), {}),
+        ("mass_memory_load_trace", (2, "INT:TRACE2.SDF"), {}),
+        ("mass_memory_load_waterfall", (2, "INT:WAT2.SDF"), {}),
+        ("mass_memory_make_directory", ("INT:\\RESULTS",), {}),
+        ("mass_memory_move", ("INT:OLD.DAT", "INT:NEW.DAT"), {}),
+        ("mass_memory_store_cfit", ("INT:CURVE1.FIT",), {}),
+        ("mass_memory_store_data_table_trace", (3, "INT:DTAB3.DAT"), {}),
+        ("mass_memory_store_lower_limit_trace", (2, "INT:LOW2.LIM"), {}),
+        ("mass_memory_store_upper_limit_trace", (2, "INT:UP2.LIM"), {}),
+        ("mass_memory_store_math", ("INT:MATH.DEF",), {}),
+        ("mass_memory_store_program", ("INT:MYPROG.BAS",), {}),
+        ("mass_memory_store_state", ("INT:STATE.STA",), {"slot": 1}),
+        ("mass_memory_store_synthesis", ("INT:SYNTH.SYN",), {}),
+        ("mass_memory_store_time_capture", ("INT:TCAP1.SDF",), {}),
+        ("mass_memory_store_trace", (2, "INT:TRACE2.SDF"), {}),
+        ("mass_memory_store_waterfall", (2, "INT:WAT2.SDF"), {}),
+    ],
+)
+def test_mass_memory_methods_require_confirmation(method_name, args, kwargs):
+    """Verify destructive mass-memory methods require explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        method = getattr(inst, method_name)
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            method(*args, **kwargs)
+
+
+def test_trace_amplitude_unit_mapping():
+    """Verify trace amplitude unit mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:UNIT:AMPLitude PP", None),
+         ("CALCulate1:UNIT:AMPLitude?", "RMS")],
+    ) as inst:
+        inst.trace1.amplitude_unit = "PP"
+        assert inst.trace1.amplitude_unit == "RMS"
+
+
+def test_trace_angle_unit_mapping():
+    """Verify trace angle unit mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:UNIT:ANGLe RAD", None)],
+    ) as inst:
+        inst.trace2.angle_unit = "radian"
+
+
+def test_trace_x_unit_mapping():
+    """Verify trace x unit mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:UNIT:X ORD", None),
+         ("CALCulate4:UNIT:X?", "CPM")],
+    ) as inst:
+        inst.trace4.x_unit = "orders"
+        assert inst.trace4.x_unit == "cycles_per_minute"
+
+
+def test_trace_db_reference_impedance_setter_and_getter():
+    """Verify trace dB reference impedance roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:UNIT:DBReference:IMPedance 600", None),
+         ("CALCulate3:UNIT:DBReference:IMPedance?", "50")],
+    ) as inst:
+        inst.trace3.db_reference_impedance = 600
+        assert inst.trace3.db_reference_impedance == 50
+
+
+def test_trace_db_reference_user_label_setter_and_getter():
+    """Verify trace dB user label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate2:UNIT:DBReference:USER:LABel "m/s2"', None),
+         ("CALCulate2:UNIT:DBReference:USER:LABel?", '"Pa"')],
+    ) as inst:
+        inst.trace2.db_reference_user_label = "m/s2"
+        assert inst.trace2.db_reference_user_label == "Pa"
+
+
+def test_trace_db_reference_user_reference_setter_and_getter():
+    """Verify trace dB user reference roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:UNIT:DBReference:USER:REFerence 20", None),
+         ("CALCulate4:UNIT:DBReference:USER:REFerence?", "1e3")],
+    ) as inst:
+        inst.trace4.db_reference_user_reference = 20
+        assert inst.trace4.db_reference_user_reference == 1e3
+
+
+def test_trace_mechanical_unit_setter_and_getter():
+    """Verify trace mechanical unit roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:UNIT:MECHanical M/S", None),
+         ("CALCulate1:UNIT:MECHanical?", "MILS")],
+    ) as inst:
+        inst.trace1.mechanical_unit = "M/S"
+        assert inst.trace1.mechanical_unit == "MILS"
+
+
+def test_trace_voltage_unit_setter_and_getter():
+    """Verify trace voltage unit roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:UNIT:VOLTage V2/HZ", None),
+         ("CALCulate2:UNIT:VOLTage?", "V/RTHZ")],
+    ) as inst:
+        inst.trace2.voltage_unit = "V2/HZ"
+        assert inst.trace2.voltage_unit == "V/RTHZ"
+
+
+def test_trace_x_order_factor_setter_and_getter():
+    """Verify trace x-axis order-factor roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:UNIT:X:ORDer:FACTor 600", None),
+         ("CALCulate3:UNIT:X:ORDer:FACTor?", "10")],
+    ) as inst:
+        inst.trace3.x_order_factor = 600
+        assert inst.trace3.x_order_factor == 10
+
+
+def test_trace_x_user_frequency_factor_setter_and_getter():
+    """Verify trace user frequency-factor roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:UNIT:X:USER:FREQuency:FACTor 0.159", None),
+         ("CALCulate3:UNIT:X:USER:FREQuency:FACTor?", "1.667e-2")],
+    ) as inst:
+        inst.trace3.x_user_frequency_factor = 0.159
+        assert inst.trace3.x_user_frequency_factor == 1.667e-2
+
+
+def test_trace_x_user_frequency_label_setter_and_getter():
+    """Verify trace user frequency-label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate2:UNIT:X:USER:FREQuency:LABel "rad/s"', None),
+         ("CALCulate2:UNIT:X:USER:FREQuency:LABel?", '"cpm"')],
+    ) as inst:
+        inst.trace2.x_user_frequency_label = "rad/s"
+        assert inst.trace2.x_user_frequency_label == "cpm"
+
+
+def test_trace_x_user_time_factor_setter_and_getter():
+    """Verify trace user time-factor roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:UNIT:X:USER:TIME:FACTor 331.45", None),
+         ("CALCulate4:UNIT:X:USER:TIME:FACTor?", "1.0789e3")],
+    ) as inst:
+        inst.trace4.x_user_time_factor = 331.45
+        assert inst.trace4.x_user_time_factor == 1.0789e3
+
+
+def test_trace_x_user_time_label_setter_and_getter():
+    """Verify trace user time-label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate1:UNIT:X:USER:TIME:LABel "ft"', None),
+         ("CALCulate1:UNIT:X:USER:TIME:LABel?", '"m"')],
+    ) as inst:
+        inst.trace1.x_user_time_label = "ft"
+        assert inst.trace1.x_user_time_label == "m"
+
+
+def test_trace_limit_beeper_enabled_bool_mapping():
+    """Verify trace limit beeper bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:LIMit:BEEP:STATe 1", None),
+         ("CALCulate2:LIMit:BEEP:STATe?", "0")],
+    ) as inst:
+        inst.trace2.limit_beeper_enabled = True
+        assert inst.trace2.limit_beeper_enabled is False
+
+
+def test_trace_limit_failed_measurement_false():
+    """Verify trace limit failed query maps 0 to False."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:FAIL?", "0")],
+    ) as inst:
+        assert inst.trace1.limit_failed is False
+
+
+def test_trace_limit_failed_measurement_true():
+    """Verify trace limit failed query maps 1 to True."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:LIMit:FAIL?", "1")],
+    ) as inst:
+        assert inst.trace3.limit_failed is True
+
+
+def test_trace_clear_lower_limit_requires_confirmation():
+    """Verify lower-limit clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace1.clear_lower_limit()
+
+
+def test_trace_clear_lower_limit_command():
+    """Verify lower-limit clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:LOWer:CLEar:IMMediate", None)],
+    ) as inst:
+        inst.trace1.clear_lower_limit(confirmed=True)
+
+
+def test_trace_move_lower_limit_y_command():
+    """Verify lower-limit move command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:LOWer:MOVE:Y -2.5", None)],
+    ) as inst:
+        inst.trace1.move_lower_limit_y(-2.5)
+
+
+def test_trace_read_lower_limit_report_x_ascii():
+    """Verify lower-limit report X parser for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:LIMit:LOWer:REPort:DATA?", "1.0,2.0,3.5")],
+    ) as inst:
+        assert inst.trace4.read_lower_limit_report_x() == [1.0, 2.0, 3.5]
+
+
+def test_trace_read_lower_limit_report_y_definite_block_ascii():
+    """Verify lower-limit report Y parser for ASCII definite-block data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:LIMit:LOWer:REPort:YDATa?", "#170.5,1.5")],
+    ) as inst:
+        assert inst.trace4.read_lower_limit_report_y() == [0.5, 1.5]
+
+
+def test_trace_lower_limit_segment_setter_and_getter():
+    """Verify lower-limit segment setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:LIMit:LOWer:SEGMent 10,2,100,3,200,-5,300,-5", None),
+         ("CALCulate2:LIMit:LOWer:SEGMent?", "#21010,2,100,3")],
+    ) as inst:
+        inst.trace2.lower_limit_segment = [(10, 2, 100, 3), (200, -5, 300, -5)]
+        assert inst.trace2.lower_limit_segment == [(10.0, 2.0, 100.0, 3.0)]
+
+
+def test_trace_clear_lower_limit_segment_requires_confirmation():
+    """Verify lower-limit segment clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace3.clear_lower_limit_segment(100)
+
+
+def test_trace_clear_lower_limit_segment_command():
+    """Verify lower-limit segment clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:LIMit:LOWer:SEGMent:CLEar 100", None)],
+    ) as inst:
+        inst.trace3.clear_lower_limit_segment(100, confirmed=True)
+
+
+def test_trace_make_lower_limit_from_trace_requires_confirmation():
+    """Verify lower-limit trace conversion requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace1.make_lower_limit_from_trace()
+
+
+def test_trace_make_lower_limit_from_trace_command():
+    """Verify lower-limit trace conversion command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:LOWer:TRACe:IMMediate", None)],
+    ) as inst:
+        inst.trace1.make_lower_limit_from_trace(confirmed=True)
+
+
+def test_trace_limit_enabled_bool_mapping():
+    """Verify trace limit enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:LIMit:STATe 1", None),
+         ("CALCulate2:LIMit:STATe?", "0")],
+    ) as inst:
+        inst.trace2.limit_enabled = True
+        assert inst.trace2.limit_enabled is False
+
+
+def test_trace_clear_upper_limit_requires_confirmation():
+    """Verify upper-limit clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace1.clear_upper_limit()
+
+
+def test_trace_clear_upper_limit_command():
+    """Verify upper-limit clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:UPPer:CLEar:IMMediate", None)],
+    ) as inst:
+        inst.trace1.clear_upper_limit(confirmed=True)
+
+
+def test_trace_move_upper_limit_y_command():
+    """Verify upper-limit move command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:UPPer:MOVE:Y 4", None)],
+    ) as inst:
+        inst.trace1.move_upper_limit_y(4)
+
+
+def test_trace_move_upper_limit_y_command_trace2():
+    """Verify upper-limit move command keeps channel substitution."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:LIMit:UPPer:MOVE:Y 1.5", None)],
+    ) as inst:
+        inst.trace2.move_upper_limit_y(1.5)
+
+
+def test_trace_read_upper_limit_report_x_ascii():
+    """Verify upper-limit report X parser for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:LIMit:UPPer:REPort:DATA?", "4.0,5.0")],
+    ) as inst:
+        assert inst.trace4.read_upper_limit_report_x() == [4.0, 5.0]
+
+
+def test_trace_read_upper_limit_report_y_definite_block_ascii():
+    """Verify upper-limit report Y parser for ASCII definite-block data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:LIMit:UPPer:REPort:YDATa?", "#171.0,2.0")],
+    ) as inst:
+        assert inst.trace4.read_upper_limit_report_y() == [1.0, 2.0]
+
+
+def test_trace_upper_limit_segment_setter_and_getter():
+    """Verify upper-limit segment setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:LIMit:UPPer:SEGMent 10,5,100,6", None),
+         ("CALCulate2:LIMit:UPPer:SEGMent?", "10,5,100,6,200,7,300,8")],
+    ) as inst:
+        inst.trace2.upper_limit_segment = [(10, 5, 100, 6)]
+        assert inst.trace2.upper_limit_segment == [
+            (10.0, 5.0, 100.0, 6.0),
+            (200.0, 7.0, 300.0, 8.0),
+        ]
+
+
+def test_trace_clear_upper_limit_segment_requires_confirmation():
+    """Verify upper-limit segment clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace3.clear_upper_limit_segment(100)
+
+
+def test_trace_clear_upper_limit_segment_command():
+    """Verify upper-limit segment clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:LIMit:UPPer:SEGMent:CLEar 100", None)],
+    ) as inst:
+        inst.trace3.clear_upper_limit_segment(100, confirmed=True)
+
+
+def test_trace_make_upper_limit_from_trace_requires_confirmation():
+    """Verify upper-limit trace conversion requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace1.make_upper_limit_from_trace()
+
+
+def test_trace_make_upper_limit_from_trace_command():
+    """Verify upper-limit trace conversion command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:LIMit:UPPer:TRACe:IMMediate", None)],
+    ) as inst:
+        inst.trace1.make_upper_limit_from_trace(confirmed=True)
+
+
+def test_trace_marker_band_start_setter_and_getter():
+    """Verify marker band start roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:BAND:STARt 1000", None),
+         ("CALCulate1:MARKer:BAND:STARt?", "2000")],
+    ) as inst:
+        inst.trace1.marker_band_start = 1000
+        assert inst.trace1.marker_band_start == 2000
+
+
+def test_trace_marker_band_stop_setter_and_getter():
+    """Verify marker band stop roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:BAND:STOP 10000", None),
+         ("CALCulate1:MARKer:BAND:STOP?", "20000")],
+    ) as inst:
+        inst.trace1.marker_band_stop = 10000
+        assert inst.trace1.marker_band_stop == 20000
+
+
+def test_trace_markers_coupled_bool_mapping():
+    """Verify coupled markers bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:COUpled:STATe 1", None),
+         ("CALCulate2:MARKer:COUpled:STATe?", "0")],
+    ) as inst:
+        inst.trace2.markers_coupled = True
+        assert inst.trace2.markers_coupled is False
+
+
+def test_trace_clear_marker_data_table_requires_confirmation():
+    """Verify marker data-table clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace1.clear_marker_data_table()
+
+
+def test_trace_clear_marker_data_table_command():
+    """Verify marker data-table clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:DTABle:CLEar:IMMediate", None)],
+    ) as inst:
+        inst.trace1.clear_marker_data_table(confirmed=True)
+
+
+def test_trace_copy_marker_data_table_from_command():
+    """Verify marker data-table copy command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MARKer:DTABle:COPY1", None)],
+    ) as inst:
+        inst.trace4.copy_marker_data_table_from(1)
+
+
+def test_trace_read_marker_data_table_y_ascii():
+    """Verify marker data-table Y read parser for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:DTABle:DATA?", "1.0,2.5,3.75")],
+    ) as inst:
+        assert inst.trace2.read_marker_data_table_y() == [1.0, 2.5, 3.75]
+
+
+def test_trace_read_marker_data_table_x_definite_block_ascii():
+    """Verify marker data-table X read parser for ASCII definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:DTABle:X:DATA?", "#1810,20,30")],
+    ) as inst:
+        assert inst.trace2.read_marker_data_table_x() == [10.0, 20.0, 30.0]
+
+
+def test_trace_delete_marker_data_table_entry_requires_confirmation():
+    """Verify marker data-table entry delete requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.trace2.delete_marker_data_table_entry()
+
+
+def test_trace_delete_marker_data_table_entry_command():
+    """Verify marker data-table entry delete command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:DTABle:X:DELete", None)],
+    ) as inst:
+        inst.trace2.delete_marker_data_table_entry(confirmed=True)
+
+
+def test_trace_marker_data_table_insert_x_setter_and_getter():
+    """Verify marker data-table insert X roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:DTABle:X:INSert 123.4", None),
+         ("CALCulate3:MARKer:DTABle:X:INSert?", "567.8")],
+    ) as inst:
+        inst.trace3.marker_data_table_insert_x = 123.4
+        assert inst.trace3.marker_data_table_insert_x == 567.8
+
+
+def test_trace_marker_data_table_label_setter_and_getter():
+    """Verify marker data-table label roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate1:MARKer:DTABle:X:LABel "Fundamental"', None),
+         ("CALCulate1:MARKer:DTABle:X:LABel?", '"Carrier"')],
+    ) as inst:
+        inst.trace1.marker_data_table_label = "Fundamental"
+        assert inst.trace1.marker_data_table_label == "Carrier"
+
+
+def test_trace_marker_data_table_selected_point_setter_and_getter():
+    """Verify marker data-table selected point roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MARKer:DTABle:X:SELect:POINt 23", None),
+         ("CALCulate4:MARKer:DTABle:X:SELect:POINt?", "32")],
+    ) as inst:
+        inst.trace4.marker_data_table_selected_point = 23
+        assert inst.trace4.marker_data_table_selected_point == 32
+
+
+def test_trace_marker_function_setter_and_getter():
+    """Verify marker function mapping roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:FUNCtion OVER", None),
+         ("CALCulate2:MARKer:FUNCtion?", "FREQ")],
+    ) as inst:
+        inst.trace2.marker_function = "overshoot"
+        assert inst.trace2.marker_function == "frequency"
+
+
+def test_trace_marker_function_result_measurement():
+    """Verify marker function result query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:FUNCtion:RESult?", "12.34")],
+    ) as inst:
+        assert inst.trace3.marker_function_result == 12.34
+
+
+def test_trace_marker_harmonic_count_setter_and_getter():
+    """Verify harmonic marker count roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:HARMonic:COUNt 5", None),
+         ("CALCulate1:MARKer:HARMonic:COUNt?", "3")],
+    ) as inst:
+        inst.trace1.marker_harmonic_count = 5
+        assert inst.trace1.marker_harmonic_count == 3
+
+
+def test_trace_marker_harmonic_fundamental_setter_and_getter():
+    """Verify harmonic fundamental roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:HARMonic:FUNDamental 440", None),
+         ("CALCulate1:MARKer:HARMonic:FUNDamental?", "1750")],
+    ) as inst:
+        inst.trace1.marker_harmonic_fundamental = 440
+        assert inst.trace1.marker_harmonic_fundamental == 1750
+
+
+def test_trace_marker_to_global_maximum_command():
+    """Verify trace marker global maximum command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MARKer:MAXimum:GLOBAL", None)],
+    ) as inst:
+        inst.trace4.marker_to_global_maximum()
+
+
+def test_trace_marker_global_maximum_tracking_enabled_roundtrip():
+    """Verify global-maximum marker tracking bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:MAXimum:GLOBal:TRACk 1", None),
+         ("CALCulate3:MARKer:MAXimum:GLOBal:TRACk?", "0")],
+    ) as inst:
+        inst.trace3.marker_global_maximum_tracking_enabled = True
+        assert inst.trace3.marker_global_maximum_tracking_enabled is False
+
+
+def test_trace_marker_to_left_maximum_command():
+    """Verify marker left-maximum command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:MAXimum:LEFT", None)],
+    ) as inst:
+        inst.trace2.marker_to_left_maximum()
+
+
+def test_trace_marker_to_right_maximum_command():
+    """Verify marker right-maximum command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:MAXimum:RIGHt", None)],
+    ) as inst:
+        inst.trace2.marker_to_right_maximum()
+
+
+def test_trace_marker_mode_mapping():
+    """Verify marker mode mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:MODE REL", None),
+         ("CALCulate1:MARKer:MODE?", "ABS")],
+    ) as inst:
+        inst.trace1.marker_mode = "relative"
+        assert inst.trace1.marker_mode == "absolute"
+
+
+def test_trace_marker_position_setter_and_getter():
+    """Verify marker position roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MARKer:POSition 102400", None),
+         ("CALCulate4:MARKer:POSition?", "0.013")],
+    ) as inst:
+        inst.trace4.marker_position = 102400
+        assert inst.trace4.marker_position == 0.013
+
+
+def test_trace_marker_position_point_setter_and_getter():
+    """Verify marker position point roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MARKer:POSition:POINt 558", None),
+         ("CALCulate4:MARKer:POSition:POINt?", "49")],
+    ) as inst:
+        inst.trace4.marker_position_point = 558
+        assert inst.trace4.marker_position_point == 49
+
+
+def test_trace_marker_reference_x_setter_and_getter():
+    """Verify marker reference X roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:REFerence:X 10", None),
+         ("CALCulate1:MARKer:REFerence:X?", "20")],
+    ) as inst:
+        inst.trace1.marker_reference_x = 10
+        assert inst.trace1.marker_reference_x == 20
+
+
+def test_trace_marker_reference_y_setter_and_getter():
+    """Verify marker reference Y roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:REFerence:Y -3", None),
+         ("CALCulate1:MARKer:REFerence:Y?", "4")],
+    ) as inst:
+        inst.trace1.marker_reference_y = -3
+        assert inst.trace1.marker_reference_y == 4
+
+
+def test_trace_marker_sideband_carrier_setter_and_getter():
+    """Verify marker sideband carrier roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:SIDeband:CARRier 2200", None),
+         ("CALCulate2:MARKer:SIDeband:CARRier?", "19800")],
+    ) as inst:
+        inst.trace2.marker_sideband_carrier = 2200
+        assert inst.trace2.marker_sideband_carrier == 19800
+
+
+def test_trace_marker_sideband_count_setter_and_getter():
+    """Verify marker sideband count roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:SIDeband:COUNt 2", None),
+         ("CALCulate2:MARKer:SIDeband:COUNt?", "6")],
+    ) as inst:
+        inst.trace2.marker_sideband_count = 2
+        assert inst.trace2.marker_sideband_count == 6
+
+
+def test_trace_marker_sideband_increment_setter_and_getter():
+    """Verify marker sideband increment roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:SIDeband:INCRement 600", None),
+         ("CALCulate2:MARKer:SIDeband:INCRement?", "1800")],
+    ) as inst:
+        inst.trace2.marker_sideband_increment = 600
+        assert inst.trace2.marker_sideband_increment == 1800
+
+
+def test_trace_marker_enabled_mapping():
+    """Verify trace marker enabled mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MARKer:STATe 1", None),
+         ("CALCulate2:MARKer:STATe?", "0")],
+    ) as inst:
+        inst.trace2.marker_enabled = True
+        assert inst.trace2.marker_enabled is False
+
+
+def test_trace_marker_x_setter_and_getter():
+    """Verify trace marker x roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MARKer:X 123.4", None),
+         ("CALCulate1:MARKer:X?", "567.8")],
+    ) as inst:
+        inst.trace1.marker_x = 123.4
+        assert inst.trace1.marker_x == 567.8
+
+
+def test_trace_marker_x_relative_setter_and_getter():
+    """Verify trace marker x-relative roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:X:RELative 10.5", None),
+         ("CALCulate3:MARKer:X:RELative?", "-2.25")],
+    ) as inst:
+        inst.trace3.marker_x_relative = 10.5
+        assert inst.trace3.marker_x_relative == -2.25
+
+
+def test_trace_marker_y_measurement():
+    """Verify trace marker y measurement."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:Y?", "2.5")],
+    ) as inst:
+        assert inst.trace3.marker_y == 2.5
+
+
+def test_trace_marker_y_relative_setter_and_getter():
+    """Verify trace marker y-relative roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MARKer:Y:RELative 12.5", None),
+         ("CALCulate3:MARKer:Y:RELative?", "-7.5")],
+    ) as inst:
+        inst.trace3.marker_y_relative = 12.5
+        assert inst.trace3.marker_y_relative == -7.5
+
+
+def test_trace_set_math_constant_real_command():
+    """Verify math constant command with real value only."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MATH:CONStant5 0.1151", None)],
+    ) as inst:
+        inst.trace2.set_math_constant(5, 0.1151)
+
+
+def test_trace_set_math_constant_complex_command():
+    """Verify math constant command with real and imaginary values."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MATH:CONStant1 -1,1", None)],
+    ) as inst:
+        inst.trace1.set_math_constant(1, -1, 1)
+
+
+def test_trace_set_math_constant_command_trace2():
+    """Verify math constant command keeps channel substitution for trace 2."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MATH:CONStant1 2", None)],
+    ) as inst:
+        inst.trace2.set_math_constant(1, 2.0)
+
+
+def test_trace_math_constant_query():
+    """Verify math constant query parser."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:MATH:CONStant4?", "2.5,-0.25")],
+    ) as inst:
+        assert inst.trace3.math_constant(4) == (2.5, -0.25)
+
+
+def test_trace_set_math_expression_command():
+    """Verify math expression set command."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate4:MATH:EXPRession2 "(K1*FRES)"', None)],
+    ) as inst:
+        inst.trace4.set_math_expression("(K1*FRES)", function_register=2)
+
+
+def test_trace_set_math_expression_command_trace2():
+    """Verify math expression command keeps channel substitution for trace 2."""
+    with expected_protocol(
+        Keysight35670A,
+        [('CALCulate2:MATH:EXPRession3 "A+B"', None)],
+    ) as inst:
+        inst.trace2.set_math_expression("A+B", 3)
+
+
+def test_trace_math_expression_query():
+    """Verify math expression query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:MATH:EXPRession2?", '"(F1+K2)"')],
+    ) as inst:
+        assert inst.trace4.math_expression(function_register=2) == "(F1+K2)"
+
+
+def test_trace_math_data_query_parses_definite_block():
+    """Verify math table query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MATH:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace2.math_data() == b"ABCD"
+
+
+def test_trace_math_data_query_raw():
+    """Verify raw math table query returns unparsed block bytes."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:MATH:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace2.math_data(raw=True) == b"#14ABCD"
+
+
+def test_trace_load_math_data_encodes_definite_block():
+    """Verify math table upload encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate2:MATH:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace2.load_math_data(b"ABCD")
+
+
+def test_trace_load_math_data_raw():
+    """Verify raw math table upload keeps caller-provided block framing."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate2:MATH:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace2.load_math_data(b"#14ABCD", raw=True)
+
+
+def test_trace_math_selected_function_setter_and_getter():
+    """Verify math selected-function roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MATH:SELect F3", None),
+         ("CALCulate1:MATH:SELect?", "F5")],
+    ) as inst:
+        inst.trace1.math_selected_function = "F3"
+        assert inst.trace1.math_selected_function == "F5"
+
+
+def test_trace_math_enabled_bool_mapping():
+    """Verify math state bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:MATH:STATe 1", None),
+         ("CALCulate1:MATH:STATe?", "0")],
+    ) as inst:
+        inst.trace1.math_enabled = True
+        assert inst.trace1.math_enabled is False
+
+
+def test_trace_abort_curve_fit_command():
+    """Verify curve-fit abort command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:CFIT:ABORt", None)],
+    ) as inst:
+        inst.trace2.abort_curve_fit()
+
+
+def test_trace_copy_synthesis_to_curve_fit_command():
+    """Verify curve-fit copy-from-synthesis command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:CFIT:COPY SYNThesis", None)],
+    ) as inst:
+        inst.trace2.copy_synthesis_to_curve_fit()
+
+
+def test_trace_cfit_data_query_parses_definite_block():
+    """Verify curve-fit table query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:CFIT:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace3.cfit_data() == b"ABCD"
+
+
+def test_trace_cfit_data_query_raw():
+    """Verify raw curve-fit table query returns unparsed block bytes."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:CFIT:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace3.cfit_data(raw=True) == b"#14ABCD"
+
+
+def test_trace_load_cfit_data_encodes_definite_block():
+    """Verify curve-fit table upload encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate3:CFIT:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace3.load_cfit_data(b"ABCD")
+
+
+def test_trace_load_cfit_data_raw():
+    """Verify raw curve-fit table upload keeps caller-provided block framing."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate3:CFIT:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace3.load_cfit_data(b"#14ABCD", raw=True)
+
+
+def test_trace_cfit_destination_register_setter_and_getter():
+    """Verify curve-fit destination register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:CFIT:DESTination D5", None),
+         ("CALCulate1:CFIT:DESTination?", "D8")],
+    ) as inst:
+        inst.trace1.cfit_destination_register = 5
+        assert inst.trace1.cfit_destination_register == 8
+
+
+def test_trace_cfit_frequency_auto_enabled_bool_mapping():
+    """Verify curve-fit frequency AUTO bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:CFIT:FREQuency:AUTO 0", None),
+         ("CALCulate2:CFIT:FREQuency:AUTO?", "1")],
+    ) as inst:
+        inst.trace2.cfit_frequency_auto_enabled = False
+        assert inst.trace2.cfit_frequency_auto_enabled is True
+
+
+def test_trace_cfit_frequency_start_setter_and_getter():
+    """Verify curve-fit start frequency roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:CFIT:FREQuency:STARt 10.2", None),
+         ("CALCulate2:CFIT:FREQuency:STARt?", "600")],
+    ) as inst:
+        inst.trace2.cfit_frequency_start = 10.2
+        assert inst.trace2.cfit_frequency_start == 600
+
+
+def test_trace_cfit_frequency_stop_setter_and_getter():
+    """Verify curve-fit stop frequency roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:CFIT:FREQuency:STOP 800", None),
+         ("CALCulate2:CFIT:FREQuency:STOP?", "1.2e3")],
+    ) as inst:
+        inst.trace2.cfit_frequency_stop = 800
+        assert inst.trace2.cfit_frequency_stop == 1.2e3
+
+
+def test_trace_cfit_frequency_scale_setter_and_getter():
+    """Verify curve-fit frequency scale roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:CFIT:FSCale 582699", None),
+         ("CALCulate4:CFIT:FSCale?", "604144")],
+    ) as inst:
+        inst.trace4.cfit_frequency_scale = 582699
+        assert inst.trace4.cfit_frequency_scale == 604144
+
+
+def test_trace_run_curve_fit_command():
+    """Verify curve-fit immediate command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:CFIT:IMMediate", None)],
+    ) as inst:
+        inst.trace1.run_curve_fit()
+
+
+def test_trace_cfit_order_auto_enabled_bool_mapping():
+    """Verify curve-fit order AUTO bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:CFIT:ORDer:AUTO 0", None),
+         ("CALCulate1:CFIT:ORDer:AUTO?", "1")],
+    ) as inst:
+        inst.trace1.cfit_order_auto_enabled = False
+        assert inst.trace1.cfit_order_auto_enabled is True
+
+
+def test_trace_cfit_order_poles_setter_and_getter():
+    """Verify curve-fit pole-count roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:CFIT:ORDer:POLes 14", None),
+         ("CALCulate3:CFIT:ORDer:POLes?", "5")],
+    ) as inst:
+        inst.trace3.cfit_order_poles = 14
+        assert inst.trace3.cfit_order_poles == 5
+
+
+def test_trace_cfit_order_zeros_setter_and_getter():
+    """Verify curve-fit zero-count roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:CFIT:ORDer:ZERos 1", None),
+         ("CALCulate3:CFIT:ORDer:ZERos?", "5")],
+    ) as inst:
+        inst.trace3.cfit_order_zeros = 1
+        assert inst.trace3.cfit_order_zeros == 5
+
+
+def test_trace_cfit_time_delay_setter_and_getter():
+    """Verify curve-fit time-delay roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:CFIT:TDELay -19.0035", None),
+         ("CALCulate4:CFIT:TDELay?", "71.4756")],
+    ) as inst:
+        inst.trace4.cfit_time_delay = -19.0035
+        assert inst.trace4.cfit_time_delay == 71.4756
+
+
+def test_trace_cfit_weight_auto_enabled_bool_mapping():
+    """Verify curve-fit weight AUTO bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:CFIT:WEIGht:AUTO 1", None),
+         ("CALCulate4:CFIT:WEIGht:AUTO?", "0")],
+    ) as inst:
+        inst.trace4.cfit_weight_auto_enabled = True
+        assert inst.trace4.cfit_weight_auto_enabled is False
+
+
+def test_trace_cfit_weight_register_setter_and_getter():
+    """Verify curve-fit weight register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:CFIT:WEIGht:REGister D1", None),
+         ("CALCulate4:CFIT:WEIGht:REGister?", "D7")],
+    ) as inst:
+        inst.trace4.cfit_weight_register = 1
+        assert inst.trace4.cfit_weight_register == 7
+
+
+def test_trace_copy_curve_fit_to_synthesis_command():
+    """Verify synthesis copy-from-curve-fit command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:SYNThesis:COPY CFIT", None)],
+    ) as inst:
+        inst.trace2.copy_curve_fit_to_synthesis()
+
+
+def test_trace_synthesis_data_query_parses_definite_block():
+    """Verify synthesis table query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:SYNThesis:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace2.synthesis_data() == b"ABCD"
+
+
+def test_trace_synthesis_data_query_raw():
+    """Verify raw synthesis table query returns unparsed block bytes."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:SYNThesis:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.trace2.synthesis_data(raw=True) == b"#14ABCD"
+
+
+def test_trace_load_synthesis_data_encodes_definite_block():
+    """Verify synthesis table upload encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate2:SYNThesis:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace2.load_synthesis_data(b"ABCD")
+
+
+def test_trace_load_synthesis_data_raw():
+    """Verify raw synthesis table upload keeps caller-provided block framing."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"CALCulate2:SYNThesis:DATA #14ABCD", None)],
+    ) as inst:
+        inst.trace2.load_synthesis_data(b"#14ABCD", raw=True)
+
+
+def test_trace_synthesis_destination_register_setter_and_getter():
+    """Verify synthesis destination register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:SYNThesis:DESTination D3", None),
+         ("CALCulate3:SYNThesis:DESTination?", "D8")],
+    ) as inst:
+        inst.trace3.synthesis_destination_register = 3
+        assert inst.trace3.synthesis_destination_register == 8
+
+
+def test_trace_synthesis_frequency_scale_setter_and_getter():
+    """Verify synthesis frequency scale roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:SYNThesis:FSCale 669766", None),
+         ("CALCulate3:SYNThesis:FSCale?", "300318")],
+    ) as inst:
+        inst.trace3.synthesis_frequency_scale = 669766
+        assert inst.trace3.synthesis_frequency_scale == 300318
+
+
+def test_trace_synthesis_gain_setter_and_getter():
+    """Verify synthesis gain roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:SYNThesis:GAIN 4.33554e+37", None),
+         ("CALCulate3:SYNThesis:GAIN?", "1.3059e+37")],
+    ) as inst:
+        inst.trace3.synthesis_gain = 4.33554e37
+        assert inst.trace3.synthesis_gain == 1.3059e37
+
+
+def test_trace_synthesis_gain_rejects_zero():
+    """Verify synthesis gain rejects zero as invalid value."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError):
+            inst.trace1.synthesis_gain = 0
+
+
+def test_trace_run_synthesis_command():
+    """Verify synthesis immediate command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:SYNThesis:IMMediate", None)],
+    ) as inst:
+        inst.trace1.run_synthesis()
+
+
+def test_trace_synthesis_spacing_setter_and_getter():
+    """Verify synthesis spacing roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:SYNThesis:SPACing LOG", None),
+         ("CALCulate3:SYNThesis:SPACing?", "LIN")],
+    ) as inst:
+        inst.trace3.synthesis_spacing = "logarithmic"
+        assert inst.trace3.synthesis_spacing == "linear"
+
+
+def test_trace_synthesis_time_delay_setter_and_getter():
+    """Verify synthesis time-delay roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:SYNThesis:TDELay 63.7533", None),
+         ("CALCulate4:SYNThesis:TDELay?", "68.8017")],
+    ) as inst:
+        inst.trace4.synthesis_time_delay = 63.7533
+        assert inst.trace4.synthesis_time_delay == 68.8017
+
+
+def test_trace_synthesis_table_type_setter_and_getter():
+    """Verify synthesis table-type mapping roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:SYNThesis:TTYPe PFR", None),
+         ("CALCulate2:SYNThesis:TTYPe?", "POLY")],
+    ) as inst:
+        inst.trace2.synthesis_table_type = "pole_fraction"
+        assert inst.trace2.synthesis_table_type == "polynomial"
+
+
+def test_trace_waterfall_count_setter_and_getter():
+    """Verify waterfall count roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:WATerfall:COUNt 50", None),
+         ("CALCulate1:WATerfall:COUNt?", "32")],
+    ) as inst:
+        inst.trace1.waterfall_count = 50
+        assert inst.trace1.waterfall_count == 32
+
+
+def test_trace_waterfall_data_query_ascii():
+    """Verify waterfall data parser for ASCII data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:WATerfall:DATA?", "1.0,2.0,3.5")],
+    ) as inst:
+        assert inst.trace2.waterfall_data() == [1.0, 2.0, 3.5]
+
+
+def test_trace_waterfall_data_query_definite_block_ascii():
+    """Verify waterfall data parser for ASCII definite-block data."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:WATerfall:DATA?", "#151,2,3")],
+    ) as inst:
+        assert inst.trace2.waterfall_data() == [1.0, 2.0, 3.0]
+
+
+def test_trace_waterfall_data_query_raw():
+    """Verify raw waterfall query returns unparsed bytes."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:WATerfall:DATA?", b"#171,2,3")],
+    ) as inst:
+        assert inst.trace2.waterfall_data(raw=True) == b"#171,2,3"
+
+
+def test_trace_copy_waterfall_slice_to_register_command():
+    """Verify waterfall slice copy command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:WATerfall:SLICe:COPY D8", None)],
+    ) as inst:
+        inst.trace4.copy_waterfall_slice_to_register(8)
+
+
+def test_trace_copy_waterfall_slice_to_register_command_trace2():
+    """Verify waterfall slice copy command keeps channel substitution for trace 2."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:WATerfall:SLICe:COPY D4", None)],
+    ) as inst:
+        inst.trace2.copy_waterfall_slice_to_register(4)
+
+
+def test_trace_waterfall_slice_select_setter_and_getter():
+    """Verify waterfall slice select roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:WATerfall:SLICe:SELect 757455", None),
+         ("CALCulate1:WATerfall:SLICe:SELect?", "880661")],
+    ) as inst:
+        inst.trace1.waterfall_slice_select = 757455
+        assert inst.trace1.waterfall_slice_select == 880661
+
+
+def test_trace_waterfall_slice_select_point_setter_and_getter():
+    """Verify waterfall slice point-selection roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:WATerfall:SLICe:SELect:POINt 816", None),
+         ("CALCulate3:WATerfall:SLICe:SELect:POINt?", "1409")],
+    ) as inst:
+        inst.trace3.waterfall_slice_select_point = 816
+        assert inst.trace3.waterfall_slice_select_point == 1409
+
+
+def test_trace_copy_waterfall_trace_to_register_command():
+    """Verify waterfall trace copy command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:WATerfall:TRACe:COPY D7", None)],
+    ) as inst:
+        inst.trace3.copy_waterfall_trace_to_register(7)
+
+
+def test_trace_copy_waterfall_trace_to_register_command_trace2():
+    """Verify waterfall trace copy command keeps channel substitution for trace 2."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate2:WATerfall:TRACe:COPY D5", None)],
+    ) as inst:
+        inst.trace2.copy_waterfall_trace_to_register(5)
+
+
+def test_trace_waterfall_trace_select_setter_and_getter():
+    """Verify waterfall trace selection by Z-axis value roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate1:WATerfall:TRACe:SELect 3.5", None),
+         ("CALCulate1:WATerfall:TRACe:SELect?", "10")],
+    ) as inst:
+        inst.trace1.waterfall_trace_select = 3.5
+        assert inst.trace1.waterfall_trace_select == 10
+
+
+def test_trace_waterfall_trace_select_point_setter_and_getter():
+    """Verify waterfall trace selection by point index roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate4:WATerfall:TRACe:SELect:POINt 15879", None),
+         ("CALCulate4:WATerfall:TRACe:SELect:POINt?", "4104")],
+    ) as inst:
+        inst.trace4.waterfall_trace_select_point = 15879
+        assert inst.trace4.waterfall_trace_select_point == 4104
+
+
+def test_trace_db_reference_mapping():
+    """Verify dB reference mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALCulate3:UNIT:DBReference DBV", None)],
+    ) as inst:
+        inst.trace3.db_reference = "dbv"
+
+
+def test_operation_condition_query():
+    """Verify operation condition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:OPERation:CONDition?", "42")],
+    ) as inst:
+        assert inst.operation_condition == 42
+
+
+def test_questionable_condition_query():
+    """Verify questionable condition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:CONDition?", "5")],
+    ) as inst:
+        assert inst.questionable_condition == 5
+
+
+def test_device_condition_query():
+    """Verify device condition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:DEVice:CONDition?", "3")],
+    ) as inst:
+        assert inst.device_condition == 3
+
+
+def test_status_preset_command():
+    """Verify status preset command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:PRESet", None)],
+    ) as inst:
+        inst.status_preset()
+
+
+def test_device_enable_setter_and_getter():
+    """Verify device enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:DEVice:ENABle 3", None),
+         ("STATus:DEVice:ENABle?", "5")],
+    ) as inst:
+        inst.device_enable = 3
+        assert inst.device_enable == 5
+
+
+def test_device_event_query():
+    """Verify device event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:DEVice:EVENt?", "1")],
+    ) as inst:
+        assert inst.device_event == 1
+
+
+def test_device_negative_transition_setter_and_getter():
+    """Verify device negative transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:DEVice:NTRansition 2", None),
+         ("STATus:DEVice:NTRansition?", "6")],
+    ) as inst:
+        inst.device_negative_transition = 2
+        assert inst.device_negative_transition == 6
+
+
+def test_device_positive_transition_setter_and_getter():
+    """Verify device positive transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:DEVice:PTRansition 9", None),
+         ("STATus:DEVice:PTRansition?", "10")],
+    ) as inst:
+        inst.device_positive_transition = 9
+        assert inst.device_positive_transition == 10
+
+
+def test_operation_enable_setter_and_getter():
+    """Verify operation enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:OPERation:ENABle 4", None),
+         ("STATus:OPERation:ENABle?", "7")],
+    ) as inst:
+        inst.operation_enable = 4
+        assert inst.operation_enable == 7
+
+
+def test_operation_event_query():
+    """Verify operation event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:OPERation:EVENt?", "8")],
+    ) as inst:
+        assert inst.operation_event == 8
+
+
+def test_operation_negative_transition_setter_and_getter():
+    """Verify operation negative transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:OPERation:NTRansition 1", None),
+         ("STATus:OPERation:NTRansition?", "11")],
+    ) as inst:
+        inst.operation_negative_transition = 1
+        assert inst.operation_negative_transition == 11
+
+
+def test_operation_positive_transition_setter_and_getter():
+    """Verify operation positive transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:OPERation:PTRansition 12", None),
+         ("STATus:OPERation:PTRansition?", "13")],
+    ) as inst:
+        inst.operation_positive_transition = 12
+        assert inst.operation_positive_transition == 13
+
+
+def test_questionable_enable_setter_and_getter():
+    """Verify questionable enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:ENABle 14", None),
+         ("STATus:QUEStionable:ENABle?", "15")],
+    ) as inst:
+        inst.questionable_enable = 14
+        assert inst.questionable_enable == 15
+
+
+def test_questionable_event_query():
+    """Verify questionable event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:EVENt?", "16")],
+    ) as inst:
+        assert inst.questionable_event == 16
+
+
+def test_questionable_negative_transition_setter_and_getter():
+    """Verify questionable negative transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:NTRansition 17", None),
+         ("STATus:QUEStionable:NTRansition?", "18")],
+    ) as inst:
+        inst.questionable_negative_transition = 17
+        assert inst.questionable_negative_transition == 18
+
+
+def test_questionable_positive_transition_setter_and_getter():
+    """Verify questionable positive transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:PTRansition 19", None),
+         ("STATus:QUEStionable:PTRansition?", "20")],
+    ) as inst:
+        inst.questionable_positive_transition = 19
+        assert inst.questionable_positive_transition == 20
+
+
+def test_questionable_limit_condition_query():
+    """Verify questionable limit condition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:LIMit:CONDition?", "21")],
+    ) as inst:
+        assert inst.questionable_limit_condition == 21
+
+
+def test_questionable_limit_enable_setter_and_getter():
+    """Verify questionable limit enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:LIMit:ENABle 22", None),
+         ("STATus:QUEStionable:LIMit:ENABle?", "23")],
+    ) as inst:
+        inst.questionable_limit_enable = 22
+        assert inst.questionable_limit_enable == 23
+
+
+def test_questionable_limit_event_query():
+    """Verify questionable limit event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:LIMit:EVENt?", "24")],
+    ) as inst:
+        assert inst.questionable_limit_event == 24
+
+
+def test_questionable_limit_negative_transition_setter_and_getter():
+    """Verify questionable limit negative transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:LIMit:NTRansition 25", None),
+         ("STATus:QUEStionable:LIMit:NTRansition?", "26")],
+    ) as inst:
+        inst.questionable_limit_negative_transition = 25
+        assert inst.questionable_limit_negative_transition == 26
+
+
+def test_questionable_limit_positive_transition_setter_and_getter():
+    """Verify questionable limit positive transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:LIMit:PTRansition 27", None),
+         ("STATus:QUEStionable:LIMit:PTRansition?", "28")],
+    ) as inst:
+        inst.questionable_limit_positive_transition = 27
+        assert inst.questionable_limit_positive_transition == 28
+
+
+def test_questionable_voltage_condition_query():
+    """Verify questionable voltage condition query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:VOLTage:CONDition?", "29")],
+    ) as inst:
+        assert inst.questionable_voltage_condition == 29
+
+
+def test_questionable_voltage_enable_setter_and_getter():
+    """Verify questionable voltage enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:VOLTage:ENABle 30", None),
+         ("STATus:QUEStionable:VOLTage:ENABle?", "31")],
+    ) as inst:
+        inst.questionable_voltage_enable = 30
+        assert inst.questionable_voltage_enable == 31
+
+
+def test_questionable_voltage_event_query():
+    """Verify questionable voltage event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:VOLTage:EVENt?", "32")],
+    ) as inst:
+        assert inst.questionable_voltage_event == 32
+
+
+def test_questionable_voltage_negative_transition_setter_and_getter():
+    """Verify questionable voltage negative transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:VOLTage:NTRansition 33", None),
+         ("STATus:QUEStionable:VOLTage:NTRansition?", "34")],
+    ) as inst:
+        inst.questionable_voltage_negative_transition = 33
+        assert inst.questionable_voltage_negative_transition == 34
+
+
+def test_questionable_voltage_positive_transition_setter_and_getter():
+    """Verify questionable voltage positive transition mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:QUEStionable:VOLTage:PTRansition 35", None),
+         ("STATus:QUEStionable:VOLTage:PTRansition?", "36")],
+    ) as inst:
+        inst.questionable_voltage_positive_transition = 35
+        assert inst.questionable_voltage_positive_transition == 36
+
+
+def test_user_status_enable_setter_and_getter():
+    """Verify user status enable mask roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:USER:ENABle 37", None),
+         ("STATus:USER:ENABle?", "38")],
+    ) as inst:
+        inst.user_status_enable = 37
+        assert inst.user_status_enable == 38
+
+
+def test_user_status_event_query():
+    """Verify user status event query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:USER:EVENt?", "39")],
+    ) as inst:
+        assert inst.user_status_event == 39
+
+
+def test_pulse_user_status_command():
+    """Verify user status pulse command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:USER:PULSe 32", None)],
+    ) as inst:
+        inst.pulse_user_status(32)
+
+
+def test_user_status_pulse_alias_command():
+    """Verify user status pulse alias command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("STATus:USER:PULSe 8", None)],
+    ) as inst:
+        inst.user_status_pulse(8)
+
+
+def test_data_format_mapping():
+    """Verify FORMat:DATA mapping helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("FORMat:DATA REAL", None),
+         ("FORMat:DATA?", "ASC,12")],
+    ) as inst:
+        inst.data_format = "real"
+        assert inst.data_format == "ascii"
+
+
+def test_read_trace_raw_data_ascii():
+    """Verify reading trace data register values in ASCII format."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA? D2", "1.0,2.0")],
+    ) as inst:
+        assert inst.read_trace_raw_data(register=2) == [1.0, 2.0]
+
+
+def test_read_trace_raw_data_raw_bytes():
+    """Verify reading raw trace register bytes."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA? D4", b"#14ABCD")],
+    ) as inst:
+        assert inst.read_trace_raw_data(register="D4", raw=True) == b"#14ABCD"
+
+
+def test_write_trace_raw_data_from_source_token():
+    """Verify writing trace register from another trace source token."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA D1, TRACe2", None)],
+    ) as inst:
+        inst.write_trace_raw_data("TRACe2", register=1)
+
+
+def test_write_trace_raw_data_ascii_values():
+    """Verify writing ASCII numeric values to a trace data register."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA D3, 1,2.5,-3", None)],
+    ) as inst:
+        inst.write_trace_raw_data([1, 2.5, -3], register="D3")
+
+
+def test_write_trace_raw_data_float_value():
+    """Verify writing scalar float values to a trace data register."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA D1, 1.5", None)],
+    ) as inst:
+        inst.write_trace_raw_data(1.5, register=1)
+
+
+def test_write_trace_raw_data_encodes_definite_block():
+    """Verify writing bytes auto-encodes to definite block for TRACe:DATA."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"TRACe:DATA D4,#14ABCD", None)],
+    ) as inst:
+        inst.write_trace_raw_data(b"ABCD", register=4)
+
+
+def test_write_trace_raw_data_raw_block_passthrough():
+    """Verify writing raw pre-framed block for TRACe:DATA."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"TRACe:DATA D4,#14ABCD", None)],
+    ) as inst:
+        inst.write_trace_raw_data(b"#14ABCD", register=4, raw=True)
+
+
+def test_write_trace_raw_data_invalid_type_raises():
+    """Verify writing unsupported TRACe:DATA payload type raises TypeError."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(TypeError):
+            inst.write_trace_raw_data(object(), register=1)
+
+
+def test_read_trace_x_data_ascii():
+    """Verify trace X-axis data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:X:DATA?", "10,20,30")],
+    ) as inst:
+        assert inst.read_trace_x_data() == [10.0, 20.0, 30.0]
+
+
+def test_read_trace_x_data_raw_bytes():
+    """Verify raw trace X-axis data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:X:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.read_trace_x_data(raw=True) == b"#14ABCD"
+
+
+def test_read_trace_x_unit():
+    """Verify trace X-axis unit read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:X:UNIT?", "HZ")],
+    ) as inst:
+        assert inst.read_trace_x_unit() == "HZ"
+
+
+def test_read_trace_z_data_ascii():
+    """Verify trace Z-axis data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:Z:DATA?", "0.25,0.5")],
+    ) as inst:
+        assert inst.read_trace_z_data() == [0.25, 0.5]
+
+
+def test_read_trace_z_data_raw_bytes():
+    """Verify raw trace Z-axis data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:Z:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.read_trace_z_data(raw=True) == b"#14ABCD"
+
+
+def test_read_trace_z_unit():
+    """Verify trace Z-axis unit read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:Z:UNIT?", "VOLT")],
+    ) as inst:
+        assert inst.read_trace_z_unit() == "VOLT"
+
+
+def test_read_trace_waterfall_data_ascii():
+    """Verify trace waterfall data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:WATerfall:DATA?", "1.0,2.0,3.0")],
+    ) as inst:
+        assert inst.read_trace_waterfall_data() == [1.0, 2.0, 3.0]
+
+
+def test_read_trace_waterfall_data_raw_bytes():
+    """Verify raw trace waterfall data read helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:WATerfall:DATA?", b"#14ABCD")],
+    ) as inst:
+        assert inst.read_trace_waterfall_data(raw=True) == b"#14ABCD"
+
+
+def test_write_trace_waterfall_data_from_source_token():
+    """Verify writing waterfall register from a trace source token."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:WATerfall:DATA W2, TRACe3", None)],
+    ) as inst:
+        inst.write_trace_waterfall_data("TRACe3", register=2)
+
+
+def test_write_trace_waterfall_data_ascii_values():
+    """Verify writing ASCII numeric values to waterfall register."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:WATerfall:DATA W3, 1,2.5,-3", None)],
+    ) as inst:
+        inst.write_trace_waterfall_data([1, 2.5, -3], register="W3")
+
+
+def test_write_trace_waterfall_data_float_value():
+    """Verify writing scalar float values to a waterfall register."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:WATerfall:DATA W1, 1.5", None)],
+    ) as inst:
+        inst.write_trace_waterfall_data(1.5, register=1)
+
+
+def test_write_trace_waterfall_data_encodes_definite_block():
+    """Verify writing bytes auto-encodes to definite block for TRACe:WATerfall:DATA."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"TRACe:WATerfall:DATA W4,#14ABCD", None)],
+    ) as inst:
+        inst.write_trace_waterfall_data(b"ABCD", register=4)
+
+
+def test_write_trace_waterfall_data_raw_block_passthrough():
+    """Verify writing raw pre-framed block for TRACe:WATerfall:DATA."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"TRACe:WATerfall:DATA W4,#14ABCD", None)],
+    ) as inst:
+        inst.write_trace_waterfall_data(b"#14ABCD", register=4, raw=True)
+
+
+def test_write_trace_waterfall_data_invalid_type_raises():
+    """Verify writing unsupported waterfall payload type raises TypeError."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(TypeError):
+            inst.write_trace_waterfall_data(object(), register=1)
+
+
+def test_trace_data_transfer_wrapper():
+    """Verify backward-compatible trace_data wrapper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:DATA? D2", "1.0,2.0")],
+    ) as inst:
+        assert inst.trace_data(2) == [1.0, 2.0]
+
+
+def test_trace_x_data_transfer_wrapper():
+    """Verify backward-compatible trace_x_data wrapper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:X:DATA?", "10,20,30")],
+    ) as inst:
+        assert inst.trace_x_data(3) == [10.0, 20.0, 30.0]
+
+
+def test_trace_z_data_transfer_wrapper():
+    """Verify backward-compatible trace_z_data wrapper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:Z:DATA?", "0.25,0.5")],
+    ) as inst:
+        assert inst.trace_z_data() == [0.25, 0.5]
+
+
+def test_trace_x_unit_transfer_wrapper():
+    """Verify backward-compatible trace_x_unit wrapper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:X:UNIT?", "HZ")],
+    ) as inst:
+        assert inst.trace_x_unit("D1") == "HZ"
+
+
+def test_trace_z_unit_transfer_wrapper():
+    """Verify backward-compatible trace_z_unit wrapper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TRACe:Z:UNIT?", "VOLT")],
+    ) as inst:
+        assert inst.trace_z_unit(4) == "VOLT"
+
+
+def test_beep_command():
+    """Verify beeper command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:BEEPer:IMMediate", None)],
+    ) as inst:
+        inst.beep()
+
+
+def test_beeper_enabled_bool_mapping():
+    """Verify beeper enabled bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:BEEPer:STATe 1", None)],
+    ) as inst:
+        inst.beeper_enabled = True
+
+
+def test_gpib_address_setter():
+    """Verify GPIB address setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:GPIB:ADDRess 14", None)],
+    ) as inst:
+        inst.gpib_address = 14
+
+
+def test_gpib_address_query():
+    """Verify GPIB address query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:GPIB:ADDRess?", "14")],
+    ) as inst:
+        assert inst.gpib_address == 14
+
+
+def test_serial_receive_baud_setter_and_getter():
+    """Verify serial receive baud roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:BAUD 9600", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:BAUD?", "1200")],
+    ) as inst:
+        inst.serial_receive_baud = 9600
+        assert inst.serial_receive_baud == 1200
+
+
+def test_serial_receive_bits_setter_and_getter():
+    """Verify serial receive bits roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:BITS 8", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:BITS?", "7")],
+    ) as inst:
+        inst.serial_receive_bits = 8
+        assert inst.serial_receive_bits == 7
+
+
+def test_serial_receive_pace_setter_and_getter():
+    """Verify serial receive pacing roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:PACE XON", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:PACE?", "NONE")],
+    ) as inst:
+        inst.serial_receive_pace = "xon"
+        assert inst.serial_receive_pace == "none"
+
+
+def test_serial_receive_parity_check_setter_and_getter():
+    """Verify serial receive parity-check bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:PARity:CHECk 1", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:PARity:CHECk?", "0")],
+    ) as inst:
+        inst.serial_receive_parity_check_enabled = True
+        assert inst.serial_receive_parity_check_enabled is False
+
+
+def test_serial_receive_parity_setter_and_getter():
+    """Verify serial receive parity roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:PARity ODD", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:PARity?", "EVEN")],
+    ) as inst:
+        inst.serial_receive_parity = "odd"
+        assert inst.serial_receive_parity == "even"
+
+
+def test_serial_receive_stop_bits_setter_and_getter():
+    """Verify serial receive stop bits roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:RECeive:SBITs 2", None),
+         ("SYSTem:COMMunicate:SERial:RECeive:SBITs?", "1")],
+    ) as inst:
+        inst.serial_receive_stop_bits = 2
+        assert inst.serial_receive_stop_bits == 1
+
+
+def test_serial_transmit_pace_setter_and_getter():
+    """Verify serial transmit pacing roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:COMMunicate:SERial:TRANsmit:PACE DSR", None),
+         ("SYSTem:COMMunicate:SERial:TRANsmit:PACE?", "XON")],
+    ) as inst:
+        inst.serial_transmit_pace = "dsr"
+        assert inst.serial_transmit_pace == "xon"
+
+
+def test_system_date_setter_and_getter():
+    """Verify system date roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:DATE 1993,9,27", None),
+         ("SYSTem:DATE?", "1994,12,25")],
+    ) as inst:
+        inst.system_date = (1993, 9, 27)
+        assert inst.system_date == (1994, 12, 25)
+
+
+def test_system_time_setter_and_getter():
+    """Verify system time roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:TIME 15,5,0", None),
+         ("SYSTem:TIME?", "9,30,45")],
+    ) as inst:
+        inst.system_time = (15, 5, 0)
+        assert inst.system_time == (9, 30, 45)
+
+
+def test_fan_state_setter_and_getter():
+    """Verify fan-state roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:FAN:STATe FULL", None),
+         ("SYSTem:FAN:STATe?", "AUTO")],
+    ) as inst:
+        inst.fan_state = "full"
+        assert inst.fan_state == "auto"
+
+
+def test_key_code_setter_and_getter():
+    """Verify key-code command/query roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:KEY 21", None),
+         ("SYSTem:KEY?", "53")],
+    ) as inst:
+        inst.key_code = 21
+        assert inst.key_code == 53
+
+
+def test_key_lock_enabled_bool_mapping():
+    """Verify key lock bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:KLOCk 1", None)],
+    ) as inst:
+        inst.key_lock_enabled = True
+
+
+def test_keyboard_locked_setter_and_getter():
+    """Verify keyboard lock roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:KLOCk 1", None),
+         ("SYSTem:KLOCk?", "0")],
+    ) as inst:
+        inst.keyboard_locked = True
+        assert inst.keyboard_locked is False
+
+
+def test_power_source_query():
+    """Verify power source query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:POWer:SOURce?", "AC")],
+    ) as inst:
+        assert inst.power_source == "AC"
+
+
+def test_power_state_query():
+    """Verify power state query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:POWer:STATe?", "1")],
+    ) as inst:
+        assert inst.power_state == 1
+
+
+def test_system_version_query():
+    """Verify system version query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:VERSion?", "A.01.11")],
+    ) as inst:
+        assert inst.system_version == "A.01.11"
+
+
+def test_long_test_result_query():
+    """Verify long confidence test-result query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TEST:LONG:RESult?", "1")],
+    ) as inst:
+        assert inst.long_test_result == 1
+
+
+def test_clear_test_log_requires_confirmation():
+    """Verify test-log clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.clear_test_log()
+
+
+def test_clear_test_log_command():
+    """Verify test-log clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TEST:LOG:CLEar", None)],
+    ) as inst:
+        inst.clear_test_log(confirmed=True)
+
+
+def test_run_long_test_requires_confirmation():
+    """Verify long test requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.run_long_test()
+
+
+def test_run_long_test_command():
+    """Verify long confidence test command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("TEST:LONG", None)],
+    ) as inst:
+        inst.run_long_test(confirmed=True)
+
+
+def test_clear_fault_log_requires_confirmation():
+    """Verify fault-log clear requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.clear_fault_log()
+
+
+def test_clear_fault_log_command():
+    """Verify fault-log clear command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:FLOG:CLEar", None)],
+    ) as inst:
+        inst.clear_fault_log(confirmed=True)
+
+
+def test_power_off_requires_confirmation():
+    """Verify power-off requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.power_off()
+
+
+def test_power_off_command():
+    """Verify power-off command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:POWer:STATe OFF", None)],
+    ) as inst:
+        inst.power_off(confirmed=True)
+
+
+def test_system_preset_requires_confirmation():
+    """Verify system preset requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.system_preset()
+
+
+def test_system_preset_command():
+    """Verify system preset command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:PRESet", None)],
+    ) as inst:
+        inst.system_preset(confirmed=True)
+
+
+def test_system_state_data_query_parses_definite_block():
+    """Verify system-state query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:SET?", b"#14ABCD")],
+    ) as inst:
+        assert inst.system_state_data() == b"ABCD"
+
+
+def test_system_state_data_query_raw():
+    """Verify raw system-state query response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:SET?", b"#14ABCD")],
+    ) as inst:
+        assert inst.system_state_data(raw=True) == b"#14ABCD"
+
+
+def test_load_system_state_encodes_definite_block():
+    """Verify system-state load encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SYSTem:SET #14ABCD", None)],
+    ) as inst:
+        inst.load_system_state(b"ABCD")
+
+
+def test_load_system_state_raw_writes_block_as_is():
+    """Verify raw system-state load writes block bytes unchanged."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SYSTem:SET #14ABCD", None)],
+    ) as inst:
+        inst.load_system_state(b"#14ABCD", raw=True)
+
+
+def test_frequency_span():
+    """Verify the frequency span setter and getter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:SPAN 2000", None),
+         ("SENSe:FREQuency:SPAN?", 2500)],
+    ) as inst:
+        inst.frequency_span = 2000.0
+        assert inst.frequency_span == 2500.0
+
+
+def test_sense_feed_mapping():
+    """Verify sense feed mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FEED TCAP", None),
+         ("SENSe:FEED?", "INP")],
+    ) as inst:
+        inst.sense_feed = "time_capture"
+        assert inst.sense_feed == "input"
+
+
+def test_sense_data_frequency_start_query():
+    """Verify sense data frequency start query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA:HEADer:FREQuency:STARt?", "0.0")],
+    ) as inst:
+        assert inst.sense_data_frequency_start == 0.0
+
+
+def test_sense_data_frequency_stop_query():
+    """Verify sense data frequency stop query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA:HEADer:FREQuency:STOP?", "102400.0")],
+    ) as inst:
+        assert inst.sense_data_frequency_stop == 102400.0
+
+
+def test_sense_data_points_query():
+    """Verify sense data points query helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA:HEADer:POINts? TCAP3", "4096")],
+    ) as inst:
+        assert inst.sense_data_points(3) == 4096
+
+
+def test_sense_data_query_parses_definite_block():
+    """Verify sense data query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA? TCAP2", b"#14ABCD")],
+    ) as inst:
+        assert inst.sense_data(2) == b"ABCD"
+
+
+def test_sense_data_query_raw():
+    """Verify sense data query raw response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA? TCAP2", b"#14ABCD")],
+    ) as inst:
+        assert inst.sense_data(2, raw=True) == b"#14ABCD"
+
+
+def test_set_sense_data_encodes_definite_block():
+    """Verify sense data upload encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SENSe:DATA TCAP2,#14ABCD", None)],
+    ) as inst:
+        inst.set_sense_data(b"ABCD", 2)
+
+
+def test_set_sense_data_raw_writes_block_as_is():
+    """Verify raw sense data upload writes block bytes unchanged."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SENSe:DATA TCAP2,#14ABCD", None)],
+    ) as inst:
+        inst.set_sense_data(b"#14ABCD", 2, raw=True)
+
+
+def test_sense_data_range_query():
+    """Verify sense data range query helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA:RANGe? TCAP1", "1500")],
+    ) as inst:
+        assert inst.sense_data_range(1) == 1500.0
+
+
+def test_set_sense_data_range_command():
+    """Verify sense data range setter helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:DATA:RANGe TCAP1, 1500", None)],
+    ) as inst:
+        inst.set_sense_data_range(1, 1500.0)
+
+
+def test_frequency_block_size_setter_and_getter():
+    """Verify frequency block-size roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:BLOCksize 1024", None),
+         ("SENSe:FREQuency:BLOCksize?", "512")],
+    ) as inst:
+        inst.frequency_block_size = 1024
+        assert inst.frequency_block_size == 512
+
+
+def test_frequency_center_setter_and_getter():
+    """Verify frequency center roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:CENTer 1000", None),
+         ("SENSe:FREQuency:CENTer?", "2000")],
+    ) as inst:
+        inst.frequency_center = 1000.0
+        assert inst.frequency_center == 2000.0
+
+
+def test_frequency_manual_setter():
+    """Verify frequency manual setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:MANual 123.5", None)],
+    ) as inst:
+        inst.frequency_manual = 123.5
+
+
+def test_frequency_resolution_setter():
+    """Verify frequency resolution setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:RESolution 400", None)],
+    ) as inst:
+        inst.frequency_resolution = 400.0
+
+
+def test_frequency_resolution_auto_enabled_bool_mapping():
+    """Verify frequency resolution auto bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:RESolution:AUTO 1", None),
+         ("SENSe:FREQuency:RESolution:AUTO?", "0")],
+    ) as inst:
+        inst.frequency_resolution_auto_enabled = True
+        assert inst.frequency_resolution_auto_enabled is False
+
+
+def test_frequency_resolution_auto_max_change_setter():
+    """Verify frequency resolution auto max-change setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:RESolution:AUTO:MCHange 2", None)],
+    ) as inst:
+        inst.frequency_resolution_auto_max_change = 2.0
+
+
+def test_frequency_resolution_auto_minimum_setter():
+    """Verify frequency resolution auto minimum setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:RESolution:AUTO:MINimum 200", None)],
+    ) as inst:
+        inst.frequency_resolution_auto_minimum = 200.0
+
+
+def test_frequency_resolution_octave_mapping():
+    """Verify frequency resolution octave mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:RESolution:OCTave THIR", None),
+         ("SENSe:FREQuency:RESolution:OCTave?", "TWEL")],
+    ) as inst:
+        inst.frequency_resolution_octave = "third"
+        assert inst.frequency_resolution_octave == "twelfth"
+
+
+def test_set_full_frequency_span_command():
+    """Verify full frequency span command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:SPAN:FULL", None)],
+    ) as inst:
+        inst.set_full_frequency_span()
+
+
+def test_frequency_span_link_mapping():
+    """Verify frequency span link mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:SPAN:LINK CENT", None),
+         ("SENSe:FREQuency:SPAN:LINK?", "STAR")],
+    ) as inst:
+        inst.frequency_span_link = "center"
+        assert inst.frequency_span_link == "start"
+
+
+def test_frequency_start_setter():
+    """Verify frequency start setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:STARt 10", None)],
+    ) as inst:
+        inst.frequency_start = 10.0
+
+
+def test_frequency_step_increment_setter():
+    """Verify frequency step increment setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:STEP:INCRement 100", None)],
+    ) as inst:
+        inst.frequency_step_increment = 100.0
+
+
+def test_frequency_stop_setter():
+    """Verify frequency stop setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:FREQuency:STOP 10000", None)],
+    ) as inst:
+        inst.frequency_stop = 10000.0
+
+
+def test_sweep_direction_mapping():
+    """Verify sweep direction mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:DIRection DOWN", None),
+         ("SENSe:SWEep:DIRection?", "UP")],
+    ) as inst:
+        inst.sweep_direction = "down"
+        assert inst.sweep_direction == "up"
+
+
+def test_sweep_dwell_setter():
+    """Verify sweep dwell setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:DWELl 0.01", None)],
+    ) as inst:
+        inst.sweep_dwell = 0.01
+
+
+def test_sweep_mode_mapping():
+    """Verify sweep mode mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:MODE MAN", None),
+         ("SENSe:SWEep:MODE?", "AUTO")],
+    ) as inst:
+        inst.sweep_mode = "manual"
+        assert inst.sweep_mode == "auto"
+
+
+def test_sweep_overlap_setter():
+    """Verify sweep overlap setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:OVERlap 33", None)],
+    ) as inst:
+        inst.sweep_overlap = 33
+
+
+def test_sweep_spacing_mapping():
+    """Verify sweep spacing mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:SPACing LOG", None),
+         ("SENSe:SWEep:SPACing?", "LIN")],
+    ) as inst:
+        inst.sweep_spacing = "logarithmic"
+        assert inst.sweep_spacing == "linear"
+
+
+def test_sweep_settling_time_setter():
+    """Verify sweep settling time setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:STIMe 0.005", None)],
+    ) as inst:
+        inst.sweep_settling_time = 0.005
+
+
+def test_sweep_time_setter():
+    """Verify sweep time setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:SWEep:TIME 0.125", None)],
+    ) as inst:
+        inst.sweep_time = 0.125
+
+
+def test_histogram_bins_setter_and_getter():
+    """Verify histogram bins roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:HISTogram:BINS 400", None),
+         ("SENSe:HISTogram:BINS?", "512")],
+    ) as inst:
+        inst.histogram_bins = 400
+        assert inst.histogram_bins == 512
+
+
+def test_order_maximum_setter_and_getter():
+    """Verify order maximum roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:MAXimum 10", None),
+         ("SENSe:ORDer:MAXimum?", "20")],
+    ) as inst:
+        inst.order_maximum = 10.0
+        assert inst.order_maximum == 20.0
+
+
+def test_order_resolution_setter():
+    """Verify order resolution setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:RESolution 0.1", None)],
+    ) as inst:
+        inst.order_resolution = 0.1
+
+
+def test_order_track_resolution_setter():
+    """Verify order track resolution setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:RESolution:TRACk 15", None)],
+    ) as inst:
+        inst.order_track_resolution = 15
+
+
+def test_order_rpm_maximum_setter():
+    """Verify order RPM maximum setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:RPM:MAXimum 6000", None)],
+    ) as inst:
+        inst.order_rpm_maximum = 6000.0
+
+
+def test_order_rpm_minimum_setter():
+    """Verify order RPM minimum setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:ORDer:RPM:MINimum 600", None)],
+    ) as inst:
+        inst.order_rpm_minimum = 600.0
+
+
+def test_reference_channels_mapping():
+    """Verify reference channels mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:REFerence PAIR", None),
+         ("SENSe:REFerence?", "SING")],
+    ) as inst:
+        inst.reference_channels = "pair"
+        assert inst.reference_channels == "single"
+
+
+def test_overload_rejection_enabled_bool_mapping():
+    """Verify overload rejection bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:REJect:STATe 1", None),
+         ("SENSe:REJect:STATe?", "0")],
+    ) as inst:
+        inst.overload_rejection_enabled = True
+        assert inst.overload_rejection_enabled is False
+
+
+def test_time_capture_length_setter_and_getter():
+    """Verify time capture length roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:LENGth 1", None),
+         ("SENSe:TCAPture:LENGth?", "2")],
+    ) as inst:
+        inst.time_capture_length = 1.0
+        assert inst.time_capture_length == 2.0
+
+
+def test_time_capture_start_channels_setter():
+    """Verify all time capture start channel setters."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:STARt1 0.1", None),
+         ("SENSe:TCAPture:STARt2 0.2", None),
+         ("SENSe:TCAPture:STARt3 0.3", None),
+         ("SENSe:TCAPture:STARt4 0.4", None)],
+    ) as inst:
+        inst.time_capture_start1 = 0.1
+        inst.time_capture_start2 = 0.2
+        inst.time_capture_start3 = 0.3
+        inst.time_capture_start4 = 0.4
+
+
+def test_time_capture_stop_channels_setter():
+    """Verify all time capture stop channel setters."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:STOP1 1.1", None),
+         ("SENSe:TCAPture:STOP2 1.2", None),
+         ("SENSe:TCAPture:STOP3 1.3", None),
+         ("SENSe:TCAPture:STOP4 1.4", None)],
+    ) as inst:
+        inst.time_capture_stop1 = 1.1
+        inst.time_capture_stop2 = 1.2
+        inst.time_capture_stop3 = 1.3
+        inst.time_capture_stop4 = 1.4
+
+
+def test_time_capture_tachometer_rpm_maximum_setter():
+    """Verify time capture tachometer RPM maximum setter."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:TACHometer:RPM:MAXimum 6000", None)],
+    ) as inst:
+        inst.time_capture_tachometer_rpm_maximum = 6000.0
+
+
+def test_time_capture_tachometer_enabled_bool_mapping():
+    """Verify time capture tachometer bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:TACHometer:STATe 1", None),
+         ("SENSe:TCAPture:TACHometer:STATe?", "0")],
+    ) as inst:
+        inst.time_capture_tachometer_enabled = True
+        assert inst.time_capture_tachometer_enabled is False
+
+
+def test_abort_time_capture_command():
+    """Verify abort time capture command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:ABORt", None)],
+    ) as inst:
+        inst.abort_time_capture()
+
+
+def test_delete_time_capture_requires_confirmation():
+    """Verify delete time capture requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.delete_time_capture()
+
+
+def test_delete_time_capture_command():
+    """Verify delete time capture command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:DELete", None)],
+    ) as inst:
+        inst.delete_time_capture(confirmed=True)
+
+
+def test_start_time_capture_command():
+    """Verify start time capture command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:IMMediate", None)],
+    ) as inst:
+        inst.start_time_capture()
+
+
+def test_allocate_time_capture_memory_command():
+    """Verify allocate time capture memory command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:MALLocate", None)],
+    ) as inst:
+        inst.allocate_time_capture_memory()
+
+
+def test_time_capture_file_query_parses_definite_block():
+    """Verify time capture file query parses a definite block response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:FILE?", b"#14ABCD")],
+    ) as inst:
+        assert inst.time_capture_file() == b"ABCD"
+
+
+def test_time_capture_file_query_raw():
+    """Verify raw time capture file query response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SENSe:TCAPture:FILE?", b"#14ABCD")],
+    ) as inst:
+        assert inst.time_capture_file(raw=True) == b"#14ABCD"
+
+
+def test_load_time_capture_file_encodes_definite_block():
+    """Verify time capture file load encodes data as a definite block."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SENSe:TCAPture:FILE #14ABCD", None)],
+    ) as inst:
+        inst.load_time_capture_file(b"ABCD")
+
+
+def test_load_time_capture_file_raw_writes_block_as_is():
+    """Verify raw time capture file load writes block bytes unchanged."""
+    with expected_protocol(
+        Keysight35670A,
+        [(b"SENSe:TCAPture:FILE #14ABCD", None)],
+    ) as inst:
+        inst.load_time_capture_file(b"#14ABCD", raw=True)
+
+
+def test_abort():
+    """Verify abort command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ABORt", None)],
+    ) as inst:
+        inst.abort()
+
+
+def test_initiate():
+    """Verify initiate command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INITiate:IMMediate", None)],
+    ) as inst:
+        inst.initiate()
+
+
+def test_restart_measurement_sequence():
+    """Verify restart command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ABORt;:INITiate:IMMediate", None)],
+    ) as inst:
+        inst.restart_measurement()
+
+
+def test_wait_for_completion():
+    """Verify wait for completion command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*OPC?", "1")],
+    ) as inst:
+        assert inst.wait_for_completion() == 1
+
+
+def test_wait_for_completion_zero_response():
+    """Verify wait for completion keeps an explicit zero response as integer 0."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*OPC?", "0")],
+    ) as inst:
+        assert inst.wait_for_completion() == 0
+
+
+def test_wait_command():
+    """Verify wait command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*WAI", None)],
+    ) as inst:
+        inst.wait()
+
+
+def test_operation_complete():
+    """Verify operation complete query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*OPC?", "1")],
+    ) as inst:
+        assert inst.operation_complete() == 1
+
+
+def test_operation_complete_zero_response():
+    """Verify operation complete query does not treat '0' as truthy."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*OPC?", "0")],
+    ) as inst:
+        result = inst.operation_complete()
+        assert result == 0
+        assert bool(result) is False
+
+
+def test_self_test_result_query():
+    """Verify self-test query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*TST?", "0")],
+    ) as inst:
+        assert inst.self_test_result == 0
+
+
+def test_run_self_calibration_requires_confirmation():
+    """Verify self calibration requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.run_self_calibration()
+
+
+def test_run_self_calibration():
+    """Verify self calibration command helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*CAL?", "0")],
+    ) as inst:
+        assert inst.run_self_calibration(confirmed=True) == 0
+
+
+def test_event_status_enable_setter_and_getter():
+    """Verify event status enable register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*ESE 7", None),
+         ("*ESE?", "3")],
+    ) as inst:
+        inst.event_status_enable = 7
+        assert inst.event_status_enable == 3
+
+
+def test_standard_event_status_query():
+    """Verify standard event status query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*ESR?", "1")],
+    ) as inst:
+        assert inst.standard_event_status == 1
+
+
+def test_power_on_status_clear_setter_and_getter():
+    """Verify power-on status clear register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*PSC -1", None),
+         ("*PSC?", "1")],
+    ) as inst:
+        inst.power_on_status_clear = -1
+        assert inst.power_on_status_clear == 1
+
+
+def test_service_request_enable_setter_and_getter():
+    """Verify service request enable register roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*SRE 32", None),
+         ("*SRE?", "64")],
+    ) as inst:
+        inst.service_request_enable = 32
+        assert inst.service_request_enable == 64
+
+
+def test_status_byte_query():
+    """Verify status byte query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*STB?", "48")],
+    ) as inst:
+        assert inst.status_byte == 48
+
+
+def test_pass_control_back_address_primary_only():
+    """Verify setting pass-control-back primary address."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*PCB 14", None)],
+    ) as inst:
+        inst.pass_control_back_address(14)
+
+
+def test_pass_control_back_address_primary_and_secondary():
+    """Verify setting pass-control-back primary and secondary addresses."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*PCB 14, 2", None)],
+    ) as inst:
+        inst.pass_control_back_address(14, 2)
+
+
+def test_arm_command():
+    """Verify arm command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:IMMediate", None)],
+    ) as inst:
+        inst.arm()
+
+
+def test_arm_rpm_increment_setter_and_getter():
+    """Verify arm RPM increment roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:RPM:INCRement 123.4", None),
+         ("ARM:RPM:INCRement?", "50")],
+    ) as inst:
+        inst.arm_rpm_increment = 123.4
+        assert inst.arm_rpm_increment == 50.0
+
+
+def test_arm_rpm_mode_setter_and_getter():
+    """Verify arm RPM mode roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:RPM:MODE UP", None),
+         ("ARM:RPM:MODE?", "DOWN")],
+    ) as inst:
+        inst.arm_rpm_mode = "up"
+        assert inst.arm_rpm_mode == "down"
+
+
+def test_arm_rpm_threshold_setter_and_getter():
+    """Verify arm RPM threshold roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:RPM:THReshold 1000", None),
+         ("ARM:RPM:THReshold?", "250")],
+    ) as inst:
+        inst.arm_rpm_threshold = 1000.0
+        assert inst.arm_rpm_threshold == 250.0
+
+
+def test_arm_source_setter_and_getter():
+    """Verify arm source roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:SOURce TIM", None),
+         ("ARM:SOURce?", "MAN")],
+    ) as inst:
+        inst.arm_source = "timer"
+        assert inst.arm_source == "manual"
+
+
+def test_arm_timer_setter_and_getter():
+    """Verify arm timer roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("ARM:TIMer 0.125", None),
+         ("ARM:TIMer?", "1.5")],
+    ) as inst:
+        inst.arm_timer = 0.125
+        assert inst.arm_timer == 1.5
+
+
+def test_continuous_initiation_enabled_setter_and_getter():
+    """Verify continuous initiation bool mapping."""
+    with expected_protocol(
+        Keysight35670A,
+        [("INITiate:CONTinuous 1", None),
+         ("INITiate:CONTinuous?", "0")],
+    ) as inst:
+        inst.continuous_initiation_enabled = True
+        assert inst.continuous_initiation_enabled is False
+
+
+def test_calibration_auto_setter_and_getter():
+    """Verify calibration auto mode roundtrip."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALibration:AUTO ONCE", None),
+         ("CALibration:AUTO?", "ON")],
+    ) as inst:
+        inst.calibration_auto = "once"
+        assert inst.calibration_auto == "on"
+
+
+def test_run_calibration_requires_confirmation():
+    """Verify CALibration:ALL requires explicit confirmation."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="requires explicit confirmation"):
+            inst.run_calibration()
+
+
+def test_run_calibration():
+    """Verify CALibration:ALL query helper."""
+    with expected_protocol(
+        Keysight35670A,
+        [("CALibration:ALL?", "0")],
+    ) as inst:
+        assert inst.run_calibration(confirmed=True) == 0
+
+
+def test_drain_errors_no_error():
+    """Verify drain errors returns cleanly for no-error response."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", "0,No error")],
+    ) as inst:
+        inst.drain_errors()
+
+
+def test_drain_errors_no_error_plus_zero_with_quotes():
+    """Verify '+0,\"No error\"' is treated as queue-empty sentinel."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", '+0,"No error"')],
+    ) as inst:
+        inst.drain_errors()
+
+
+def test_drain_errors_raises_runtime_error():
+    """Verify drain errors raises when queue contains failures."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", "-200,Execution error"),
+         ("SYSTem:ERRor?", "0,No error")],
+    ) as inst:
+        with pytest.raises(RuntimeError, match="error queue is not empty"):
+            inst.drain_errors()
+
+
+def test_drain_errors_float_code_raises_runtime_error():
+    """Verify float-like error code token is parsed and treated as error."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", '-100.0,"Command error"'),
+         ("SYSTem:ERRor?", '+0,"No error"')],
+    ) as inst:
+        with pytest.raises(RuntimeError, match="error queue is not empty"):
+            inst.drain_errors()
+
+
+def test_drain_errors_unparseable_code_raises_runtime_error():
+    """Verify unparseable error token does not crash parser and still raises RuntimeError."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", '"BAD","Malformed response"'),
+         ("SYSTem:ERRor?", '+0,"No error"')],
+    ) as inst:
+        with pytest.raises(RuntimeError, match="error queue is not empty"):
+            inst.drain_errors()
+
+
+def test_drain_errors_respects_max_errors_limit():
+    """Verify drain errors stops after max_errors reads and raises with collected errors."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", '-100,"Command error"'),
+         ("SYSTem:ERRor?", '-200,"Execution error"'),
+         ("SYSTem:ERRor?", '-300,"Device-specific error"')],
+    ) as inst:
+        with pytest.raises(RuntimeError, match="error queue is not empty"):
+            inst.drain_errors(max_errors=3)
+
+
+def test_drain_errors_rejects_invalid_max_errors():
+    """Verify invalid max_errors rejects early without sending instrument commands."""
+    with expected_protocol(Keysight35670A, []) as inst:
+        with pytest.raises(ValueError, match="max_errors must be >= 1"):
+            inst.drain_errors(max_errors=0)
+
+
+def test_trigger():
+    """Verify trigger command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*TRG", None)],
+    ) as inst:
+        inst.trigger()
+
+
+def test_clear():
+    """Verify clear-status command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*CLS", None)],
+    ) as inst:
+        inst.clear()
+
+
+def test_reset():
+    """Verify reset command."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*RST", None)],
+    ) as inst:
+        inst.reset()
+
+
+def test_options():
+    """Verify options query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*OPT?", "A6J")],
+    ) as inst:
+        assert inst.options() == "A6J"
+
+
+def test_system_error():
+    """Verify system error query."""
+    with expected_protocol(
+        Keysight35670A,
+        [("SYSTem:ERRor?", "0,No error")],
+    ) as inst:
+        assert inst.system_error() == "0,No error"
+
+
+def test_id_query_accepts_hewlett_packard():
+    """Verify check_id accepts Hewlett-Packard manufacturer."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*IDN?", "HEWLETT-PACKARD,35670A,MY42509215,A.01.11")],
+    ) as inst:
+        inst.check_id()
+
+
+def test_id_query_accepts_keysight():
+    """Verify check_id accepts Keysight manufacturer."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*IDN?", "KEYSIGHT TECHNOLOGIES,35670A,MY42509215,A.01.11")],
+    ) as inst:
+        inst.check_id()
+
+
+def test_check_id_rejects_unsupported_model():
+    """Verify check_id rejects unsupported models."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*IDN?", "KEYSIGHT,35665A,0,1.0")],
+    ) as inst:
+        with pytest.raises(ValueError, match="supported 35670A"):
+            inst.check_id()
+
+
+def test_check_id_rejects_invalid_response():
+    """Verify check_id rejects malformed ID responses."""
+    with expected_protocol(
+        Keysight35670A,
+        [("*IDN?", "BAD_RESPONSE")],
+    ) as inst:
+        with pytest.raises(ValueError, match="Unexpected instrument IDN response"):
+            inst.check_id()

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -67,6 +67,23 @@ def _assert_no_system_error(analyzer, context, max_reads=32):
         )
 
 
+def _close_adapter(adapter, context):
+    """Close adapter best-effort and always clear adapter.connection when present."""
+    if adapter is None:
+        return
+    try:
+        adapter.close()
+    except Exception as exc:
+        warnings.warn(
+            f"Ignored error during {context} adapter cleanup: {exc!r}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    finally:
+        if hasattr(adapter, "connection"):
+            adapter.connection = None
+
+
 def _has_ay6_option(options_reply):
     """Return True if options indicate 4-channel capability."""
     tokens = {
@@ -81,15 +98,17 @@ def _has_ay6_option(options_reply):
 def analyzer(connected_device_address):
     """Create one instrument instance per module with safe teardown and queue drain."""
     instr = Keysight35670A(connected_device_address, timeout=20000)
+    adapter = getattr(instr, "adapter", None)
     try:
-        instr.source_output_enabled = False
-    except Exception as exc:
-        warnings.warn(
-            f"Ignored error during safe-state setup cleanup: {exc!r}",
-            RuntimeWarning,
-        )
-    _assert_no_system_error(instr, "ensure_safe_state", max_reads=32)
-    try:
+        try:
+            instr.source_output_enabled = False
+        except Exception as exc:
+            warnings.warn(
+                f"Ignored error during safe-state setup cleanup: {exc!r}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        _assert_no_system_error(instr, "setup", max_reads=32)
         yield instr
     finally:
         teardown_notes = []
@@ -97,21 +116,20 @@ def analyzer(connected_device_address):
             instr.source_output_enabled = False
         except Exception as exc:
             teardown_notes.append(f"failed to force source_output_enabled=False: {exc!r}")
+        try:
+            errors, last_reply = _drain_system_error_queue(instr, max_reads=32)
+            if errors:
+                teardown_notes.append(
+                    "teardown: error queue not empty; "
+                    f"errors={errors}; last_reply={last_reply!r}"
+                )
+        except Exception as exc:
+            teardown_notes.append(f"teardown drain failed: {exc!r}")
+
+        _close_adapter(adapter, "analyzer teardown")
+
         if teardown_notes:
             pytest.fail("; ".join(teardown_notes))
-        _assert_no_system_error(instr, "teardown", max_reads=32)
-        adapter = getattr(instr, "adapter", None)
-        if adapter is not None:
-            try:
-                adapter.close()
-            except Exception as exc:
-                warnings.warn(
-                    f"Ignored error during analyzer teardown cleanup: {exc!r}",
-                    RuntimeWarning,
-                )
-            finally:
-                if hasattr(adapter, "connection"):
-                    adapter.connection = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -1,0 +1,279 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# Call signature:
+# $ pytest test_keysight35670A_with_device.py --device-address "GPIB0::14::INSTR"
+
+import pytest
+
+from pymeasure.instruments.keysight import Keysight35670A
+
+
+def _system_error_code(reply):
+    """Extract the integer code from a SYSTem:ERRor? reply."""
+    token = str(reply).split(",", 1)[0].strip()
+    try:
+        return int(token)
+    except ValueError:
+        try:
+            return int(float(token))
+        except ValueError:
+            return None
+
+
+def _drain_system_error_queue(analyzer, max_reads=32):
+    """Drain and return non-zero system-error replies and the last observed reply."""
+    errors = []
+    last_reply = ""
+    for _ in range(max_reads):
+        reply = str(analyzer.system_error())
+        last_reply = reply
+        if _system_error_code(reply) == 0:
+            break
+        errors.append(reply)
+    return errors, last_reply
+
+
+def _assert_no_system_error(analyzer, context, max_reads=32):
+    """Fail with context when SYSTem:ERRor? reports non-zero entries."""
+    errors, last_reply = _drain_system_error_queue(analyzer, max_reads=max_reads)
+    if errors:
+        pytest.fail(
+            f"{context}: instrument error queue not empty after {max_reads} reads; "
+            f"errors={errors}; last_reply={last_reply!r}"
+        )
+
+
+def _has_ay6_option(options_reply):
+    """Return True if options indicate 4-channel capability."""
+    tokens = {
+        token.strip().strip('"')
+        for token in str(options_reply).upper().split(",")
+        if token.strip()
+    }
+    return "AY6" in tokens or "A6J" in tokens
+
+
+@pytest.fixture(scope="module")
+def analyzer(connected_device_address):
+    """Create one instrument instance per module with safe teardown and queue drain."""
+    instr = Keysight35670A(connected_device_address, timeout=20000)
+    try:
+        instr.source_output_enabled = False
+    except Exception:
+        pass
+    _drain_system_error_queue(instr)
+    try:
+        yield instr
+    finally:
+        teardown_notes = []
+        try:
+            instr.source_output_enabled = False
+        except Exception as exc:
+            teardown_notes.append(f"failed to force source_output_enabled=False: {exc!r}")
+        errors, last_reply = _drain_system_error_queue(instr)
+        if errors:
+            teardown_notes.append(
+                f"non-zero SYSTem:ERRor? during finalizer: errors={errors}; "
+                f"last_reply={last_reply!r}"
+            )
+        adapter = getattr(instr, "adapter", None)
+        if adapter is not None:
+            try:
+                adapter.close()
+            except Exception:
+                pass
+            finally:
+                if hasattr(adapter, "connection"):
+                    adapter.connection = None
+        if teardown_notes:
+            pytest.fail("; ".join(teardown_notes))
+
+
+@pytest.fixture(autouse=True)
+def ensure_safe_state(analyzer, request):
+    """Force output OFF and fail clearly when any post-test instrument error remains."""
+    analyzer.source_output_enabled = False
+    _drain_system_error_queue(analyzer)
+    yield
+    notes = []
+    try:
+        analyzer.source_output_enabled = False
+    except Exception as exc:
+        notes.append(f"could not force source_output_enabled=False: {exc!r}")
+    errors, last_reply = _drain_system_error_queue(analyzer)
+    if errors:
+        notes.append(
+            f"SYSTem:ERRor? after {request.node.name}: errors={errors}; last_reply={last_reply!r}"
+        )
+    if notes:
+        pytest.fail("; ".join(notes))
+
+
+def test_hardware_identity_and_options(analyzer):
+    """Use only *IDN? and *OPT? reads, which are safe and non-destructive."""
+    idn = analyzer.id
+    options = analyzer.options()
+    assert "35670A" in idn.upper()
+    analyzer.check_id()
+    assert isinstance(options, str)
+    print(f"*IDN? -> {idn}")
+    print(f"*OPT? -> {options}")
+
+
+def test_hardware_system_readonly_queries(analyzer):
+    """Use query-only system/status accessors that do not change instrument state."""
+    assert isinstance(analyzer.system_version, str)
+    assert isinstance(analyzer.power_source, str)
+    assert isinstance(analyzer.status_byte, int)
+    assert isinstance(analyzer.operation_condition, int)
+    assert isinstance(analyzer.questionable_condition, int)
+    assert isinstance(analyzer.device_condition, int)
+    system_error_reply = analyzer.system_error()
+    assert isinstance(system_error_reply, str)
+    print(f"SYSTem:ERRor? -> {system_error_reply}")
+
+
+def test_hardware_source_safe_roundtrip_restores_state(analyzer):
+    """Set only safe source fields with output OFF and restore state in finally."""
+    original_output_enabled = analyzer.source_output_enabled
+    original_function = analyzer.source_function
+    original_frequency = analyzer.source_frequency
+    original_offset = analyzer.source_voltage_offset
+
+    try:
+        analyzer.source_output_enabled = False
+        analyzer.source_function = "sine"
+        analyzer.source_frequency = 1000.0
+        assert analyzer.source_frequency == pytest.approx(1000.0, abs=1e-3, rel=1e-6)
+        analyzer.source_voltage_offset = 0.0
+        assert analyzer.source_voltage_offset == pytest.approx(0.0, abs=1e-3, rel=1e-6)
+    finally:
+        try:
+            analyzer.source_frequency = original_frequency
+        finally:
+            try:
+                analyzer.source_voltage_offset = original_offset
+            finally:
+                try:
+                    analyzer.source_function = original_function
+                finally:
+                    analyzer.source_output_enabled = False
+                    assert analyzer.source_output_enabled is False
+        if original_output_enabled is True:
+            analyzer.source_output_enabled = False
+
+
+def test_hardware_input_ch1_coupling_roundtrip_restores_state(analyzer):
+    """Toggle CH1 coupling AC/DC and restore original state in finally."""
+    original_coupling = analyzer.ch1.coupling
+    try:
+        analyzer.ch1.coupling = "AC"
+        assert str(analyzer.ch1.coupling).upper().startswith("AC")
+        analyzer.ch1.coupling = "DC"
+        assert str(analyzer.ch1.coupling).upper().startswith("DC")
+    finally:
+        analyzer.ch1.coupling = original_coupling
+
+
+def test_hardware_input_ch1_autorange_roundtrip_restores_state(analyzer):
+    """Toggle CH1 autorange and restore original state in finally."""
+    original_autorange_enabled = analyzer.ch1.autorange_enabled
+    try:
+        analyzer.ch1.autorange_enabled = True
+        assert isinstance(analyzer.ch1.autorange_enabled, bool)
+    finally:
+        analyzer.ch1.autorange_enabled = original_autorange_enabled
+
+
+def test_hardware_trace_ascii_data_smoke(analyzer):
+    """Read trace points/data in ASCII after safe FFT setup and restore state."""
+    original_mode = analyzer.instrument_mode
+    original_data_format = analyzer.data_format
+
+    try:
+        analyzer.source_output_enabled = False
+        analyzer.data_format = "ascii"
+        analyzer.instrument_mode = "fft"
+        analyzer.trace1.feed = "power_spectrum_ch1"
+        analyzer.initiate()
+        analyzer.wait_for_completion()
+
+        points = analyzer.trace1.data_points()
+        data = analyzer.trace1.read_data()
+        x_axis = analyzer.trace1.read_x_data()
+
+        assert isinstance(points, int)
+        assert points > 0
+        assert isinstance(data, list)
+        assert isinstance(x_axis, list)
+        assert len(data) > 0
+        assert len(x_axis) > 0
+    finally:
+        try:
+            analyzer.instrument_mode = original_mode
+        finally:
+            analyzer.data_format = original_data_format
+            analyzer.source_output_enabled = False
+
+
+def test_hardware_format_data_roundtrip_restores_state(analyzer):
+    """Roundtrip FORMat:DATA with ascii only and restore original state."""
+    original_data_format = analyzer.data_format
+    try:
+        analyzer.data_format = "ascii"
+        assert analyzer.data_format == "ascii"
+    finally:
+        analyzer.data_format = original_data_format
+
+
+def test_hardware_display_safe_roundtrip_restores_state(analyzer):
+    """Toggle display enable state and restore original state in finally."""
+    original_display_enabled = analyzer.display_enabled
+    try:
+        analyzer.display_enabled = True
+        assert isinstance(analyzer.display_enabled, bool)
+    finally:
+        analyzer.display_enabled = original_display_enabled
+
+
+def test_hardware_beeper_enabled_roundtrip_restores_state(analyzer):
+    """Toggle beeper state without immediate beep command, then restore original state."""
+    original_beeper_enabled = analyzer.beeper_enabled
+    try:
+        analyzer.beeper_enabled = False
+        assert analyzer.beeper_enabled is False
+        analyzer.beeper_enabled = True
+        assert analyzer.beeper_enabled is True
+    finally:
+        analyzer.beeper_enabled = original_beeper_enabled
+
+
+def test_hardware_ch3_ch4_skip_if_no_option(analyzer):
+    """Query CH3/CH4 only when AY6/A6J is installed; otherwise skip with clear reason."""
+    options = analyzer.options()
+    if not _has_ay6_option(options):
+        pytest.skip(f"4-channel option (AY6/A6J) not installed; *OPT?={options!r}")
+    assert isinstance(analyzer.ch3.coupling, str)
+    assert isinstance(analyzer.ch4.coupling, str)

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -25,6 +25,8 @@
 # Call signature:
 # $ pytest test_keysight35670A_with_device.py --device-address "GPIB0::14::INSTR"
 
+import warnings
+
 import pytest
 
 from pymeasure.instruments.keysight import Keysight35670A
@@ -81,9 +83,12 @@ def analyzer(connected_device_address):
     instr = Keysight35670A(connected_device_address, timeout=20000)
     try:
         instr.source_output_enabled = False
-    except Exception:
-        pass
-    _drain_system_error_queue(instr)
+    except Exception as exc:
+        warnings.warn(
+            f"Ignored error during safe-state setup cleanup: {exc!r}",
+            RuntimeWarning,
+        )
+    _assert_no_system_error(instr, "ensure_safe_state", max_reads=32)
     try:
         yield instr
     finally:
@@ -92,43 +97,41 @@ def analyzer(connected_device_address):
             instr.source_output_enabled = False
         except Exception as exc:
             teardown_notes.append(f"failed to force source_output_enabled=False: {exc!r}")
-        errors, last_reply = _drain_system_error_queue(instr)
-        if errors:
-            teardown_notes.append(
-                f"non-zero SYSTem:ERRor? during finalizer: errors={errors}; "
-                f"last_reply={last_reply!r}"
-            )
+        if teardown_notes:
+            pytest.fail("; ".join(teardown_notes))
+        _assert_no_system_error(instr, "teardown", max_reads=32)
         adapter = getattr(instr, "adapter", None)
         if adapter is not None:
             try:
                 adapter.close()
-            except Exception:
-                pass
+            except Exception as exc:
+                warnings.warn(
+                    f"Ignored error during analyzer teardown cleanup: {exc!r}",
+                    RuntimeWarning,
+                )
             finally:
                 if hasattr(adapter, "connection"):
                     adapter.connection = None
-        if teardown_notes:
-            pytest.fail("; ".join(teardown_notes))
 
 
 @pytest.fixture(autouse=True)
 def ensure_safe_state(analyzer, request):
     """Force output OFF and fail clearly when any post-test instrument error remains."""
     analyzer.source_output_enabled = False
-    _drain_system_error_queue(analyzer)
+    _assert_no_system_error(analyzer, "ensure_safe_state", max_reads=32)
     yield
     notes = []
     try:
         analyzer.source_output_enabled = False
     except Exception as exc:
         notes.append(f"could not force source_output_enabled=False: {exc!r}")
-    errors, last_reply = _drain_system_error_queue(analyzer)
-    if errors:
-        notes.append(
-            f"SYSTem:ERRor? after {request.node.name}: errors={errors}; last_reply={last_reply!r}"
-        )
     if notes:
         pytest.fail("; ".join(notes))
+    _assert_no_system_error(
+        analyzer,
+        f"ensure_safe_state after {request.node.name}",
+        max_reads=32,
+    )
 
 
 def test_hardware_identity_and_options(analyzer):
@@ -168,6 +171,8 @@ def test_hardware_source_safe_roundtrip_restores_state(analyzer):
         assert analyzer.source_frequency == pytest.approx(1000.0, abs=1e-3, rel=1e-6)
         analyzer.source_voltage_offset = 0.0
         assert analyzer.source_voltage_offset == pytest.approx(0.0, abs=1e-3, rel=1e-6)
+        analyzer.source_output_enabled = False
+        assert analyzer.source_output_enabled is False
     finally:
         try:
             analyzer.source_frequency = original_frequency
@@ -179,7 +184,6 @@ def test_hardware_source_safe_roundtrip_restores_state(analyzer):
                     analyzer.source_function = original_function
                 finally:
                     analyzer.source_output_enabled = False
-                    assert analyzer.source_output_enabled is False
 
 
 def test_hardware_input_ch1_coupling_roundtrip_restores_state(analyzer):

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -99,17 +99,27 @@ def analyzer(connected_device_address):
     """Create one instrument instance per module with safe teardown and queue drain."""
     instr = Keysight35670A(connected_device_address, timeout=20000)
     adapter = getattr(instr, "adapter", None)
+    setup_error = None
+    test_error = None
     try:
         try:
             instr.source_output_enabled = False
-        except Exception as exc:
-            warnings.warn(
-                f"Ignored error during safe-state setup cleanup: {exc!r}",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-        _assert_no_system_error(instr, "setup", max_reads=32)
-        yield instr
+            if instr.source_output_enabled is not False:
+                raise RuntimeError(
+                    "Failed to disable Keysight 35670A source output during setup."
+                )
+            _assert_no_system_error(instr, "setup", max_reads=32)
+        except BaseException as exc:
+            _close_adapter(adapter, "analyzer setup failure")
+            adapter = None
+            setup_error = exc
+
+        if setup_error is None:
+            try:
+                yield instr
+            except BaseException as exc:
+                test_error = exc
+                raise
     finally:
         teardown_notes = []
         try:
@@ -128,8 +138,26 @@ def analyzer(connected_device_address):
 
         _close_adapter(adapter, "analyzer teardown")
 
+        if setup_error is not None:
+            if teardown_notes:
+                warnings.warn(
+                    "Ignored teardown issues after setup failure: "
+                    + "; ".join(teardown_notes),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            raise setup_error
+
         if teardown_notes:
-            pytest.fail("; ".join(teardown_notes))
+            if test_error is not None:
+                warnings.warn(
+                    "Ignored teardown issues after test failure: "
+                    + "; ".join(teardown_notes),
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            else:
+                pytest.fail("; ".join(teardown_notes))
 
 
 @pytest.fixture(autouse=True)
@@ -221,7 +249,7 @@ def test_hardware_input_ch1_autorange_roundtrip_restores_state(analyzer):
     original_autorange_enabled = analyzer.ch1.autorange_enabled
     try:
         analyzer.ch1.autorange_enabled = True
-        assert isinstance(analyzer.ch1.autorange_enabled, bool)
+        assert analyzer.ch1.autorange_enabled is True
     finally:
         analyzer.ch1.autorange_enabled = original_autorange_enabled
 
@@ -287,7 +315,7 @@ def test_hardware_display_safe_roundtrip_restores_state(analyzer):
     original_display_enabled = analyzer.display_enabled
     try:
         analyzer.display_enabled = True
-        assert isinstance(analyzer.display_enabled, bool)
+        assert analyzer.display_enabled is True
     finally:
         analyzer.display_enabled = original_display_enabled
 

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -157,7 +157,6 @@ def test_hardware_system_readonly_queries(analyzer):
 
 def test_hardware_source_safe_roundtrip_restores_state(analyzer):
     """Set only safe source fields with output OFF and restore state in finally."""
-    original_output_enabled = analyzer.source_output_enabled
     original_function = analyzer.source_function
     original_frequency = analyzer.source_frequency
     original_offset = analyzer.source_voltage_offset
@@ -181,8 +180,6 @@ def test_hardware_source_safe_roundtrip_restores_state(analyzer):
                 finally:
                     analyzer.source_output_enabled = False
                     assert analyzer.source_output_enabled is False
-        if original_output_enabled is True:
-            analyzer.source_output_enabled = False
 
 
 def test_hardware_input_ch1_coupling_roundtrip_restores_state(analyzer):
@@ -211,6 +208,15 @@ def test_hardware_trace_ascii_data_smoke(analyzer):
     """Read trace points/data in ASCII after safe FFT setup and restore state."""
     original_mode = analyzer.instrument_mode
     original_data_format = analyzer.data_format
+    original_trace1_feed = None
+    original_trace1_feed_raw = None
+    try:
+        original_trace1_feed = analyzer.trace1.feed
+    except KeyError:
+        raw_feed = analyzer.ask("CALCulate1:FEED?").strip()
+        if raw_feed.startswith('"') and raw_feed.endswith('"'):
+            raw_feed = raw_feed[1:-1]
+        original_trace1_feed_raw = raw_feed
 
     try:
         analyzer.source_output_enabled = False
@@ -232,10 +238,16 @@ def test_hardware_trace_ascii_data_smoke(analyzer):
         assert len(x_axis) > 0
     finally:
         try:
-            analyzer.instrument_mode = original_mode
+            if original_trace1_feed is not None:
+                analyzer.trace1.feed = original_trace1_feed
+            elif original_trace1_feed_raw:
+                analyzer.write(f'CALCulate1:FEED "{original_trace1_feed_raw}"')
         finally:
-            analyzer.data_format = original_data_format
-            analyzer.source_output_enabled = False
+            try:
+                analyzer.instrument_mode = original_mode
+            finally:
+                analyzer.data_format = original_data_format
+                analyzer.source_output_enabled = False
 
 
 def test_hardware_format_data_roundtrip_restores_state(analyzer):

--- a/tests/instruments/keysight/test_keysight35670A_with_device.py
+++ b/tests/instruments/keysight/test_keysight35670A_with_device.py
@@ -164,11 +164,24 @@ def analyzer(connected_device_address):
 def ensure_safe_state(analyzer, request):
     """Force output OFF and fail clearly when any post-test instrument error remains."""
     analyzer.source_output_enabled = False
+    setup_readback = analyzer.source_output_enabled
+    if setup_readback is not False:
+        pytest.fail(
+            "ensure_safe_state setup: expected source_output_enabled=False "
+            f"after write, got {setup_readback!r}"
+        )
     _assert_no_system_error(analyzer, "ensure_safe_state", max_reads=32)
     yield
     notes = []
     try:
         analyzer.source_output_enabled = False
+        teardown_readback = analyzer.source_output_enabled
+        if teardown_readback is not False:
+            pytest.fail(
+                f"ensure_safe_state after {request.node.name}: expected "
+                "source_output_enabled=False after write, got "
+                f"{teardown_readback!r}"
+            )
     except Exception as exc:
         notes.append(f"could not force source_output_enabled=False: {exc!r}")
     if notes:


### PR DESCRIPTION
Summary
Add Keysight35670A driver for Keysight/Agilent/HP 35670A Dynamic Signal Analyzer.
Support input channels, trace boxes, display windows, source/output, trigger, sense, status/system, memory/MMEM/program helpers, and block-transfer helpers.
Add protocol tests and safe hardware tests.
Tests
.\.venv\Scripts\python.exe -m pytest tests/instruments/keysight/test_keysight35670A.py -q

Result: 655 passed

.\.venv\Scripts\python.exe -m pytest tests/instruments/keysight/test_keysight35670A_with_device.py -q

Result: 10 skipped

.\.venv\Scripts\python.exe -m pytest tests/instruments/keysight/test_keysight35670A_with_device.py --device-address "GPIB0::14::INSTR" -q -s

Result: 10 passed

Hardware
Instrument ID: HEWLETT-PACKARD,35670A,MY42509215,A.01.11
Options: "1D2,1D3,1D4,1C2,UFF,UFC,AY6"
Final SYSTem:ERRor?: +0,"No error"
Safety
Destructive or long-running operations require explicit confirmation in the API and are not executed in hardware tests.
Source output is forced off in safe hardware tests.
Hardware tests are skipped unless a device address is explicitly provided.
Notes
The driver accepts vendor IDs HEWLETT-PACKARD, HP, AGILENT, and KEYSIGHT.
Four-channel paths are option-dependent and were tested on hardware with option AY6.