### PR TITLE
Add plugin registry system for out-of-tree instrument drivers

### DIFF
--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -26,3 +26,4 @@ from .channel import Channel
 from .instrument import Instrument
 from .resources import find_serial_port, list_resources
 from .generic_types import SCPIMixin, SCPIUnknownMixin
+from .registry import clear, discover, get, list_plugins, register, unregister

--- a/pymeasure/instruments/registry.py
+++ b/pymeasure/instruments/registry.py
@@ -1,0 +1,118 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import importlib.metadata
+import warnings
+from typing import Dict, Optional, Tuple, Type
+
+from .instrument import Instrument
+
+_REGISTRY: Dict[Tuple[str, str], Type[Instrument]] = {}
+
+
+def register(cls: Type[Instrument], manufacturer: str, name: str) -> None:
+    """Register an instrument class in the plugin registry.
+
+    The class must be a subclass of
+    :py:class:`~pymeasure.instruments.instrument.Instrument`.
+
+    :param cls: Instrument class to register.
+    :param manufacturer: Manufacturer identifier (e.g. ``"ni"``).
+    :param name: Instrument name within the manufacturer namespace (e.g. ``"daqmx"``).
+    :raises TypeError: If *cls* is not an :py:class:`~pymeasure.instruments.Instrument` subclass.
+    """
+    if not isinstance(cls, type) or not issubclass(cls, Instrument):
+        raise TypeError(f"{cls!r} is not an Instrument subclass")
+    _REGISTRY[(manufacturer, name)] = cls
+
+
+def unregister(manufacturer: str, name: str) -> None:
+    """Remove a previously registered instrument from the registry.
+
+    :param manufacturer: Manufacturer identifier.
+    :param name: Instrument name.
+    :raises KeyError: If the (manufacturer, name) pair is not registered.
+    """
+    del _REGISTRY[(manufacturer, name)]
+
+
+def discover(group: str = "pymeasure.instruments") -> Dict[Tuple[str, str], Type[Instrument]]:
+    """Auto-discover and load plugin instruments via entry points.
+
+    Third-party packages declare instruments under the
+    ``pymeasure.instruments`` entry point group in their ``pyproject.toml``::
+
+        [project.entry-points."pymeasure.instruments"]
+        "ni.daqmx" = "pymeasure_ni.daqmx:DAQmxInstrument"
+
+    The entry point name uses the convention ``"<manufacturer>.<name>"``.
+    If the dot is absent, the entire name is used as the instrument name
+    and the manufacturer is set to ``"unknown"``.
+
+    This function may be called multiple times; already-registered entries
+    are silently overwritten.
+
+    :param group: The entry point group to scan.
+    :returns: Mapping of ``(manufacturer, name)`` to the loaded instrument classes.
+    """
+    eps = importlib.metadata.entry_points()
+    if isinstance(eps, dict):
+        entries = eps.get(group, [])
+    else:
+        entries = eps.select(group=group)
+    loaded: Dict[Tuple[str, str], Type[Instrument]] = {}
+    for ep in entries:
+        try:
+            cls = ep.load()
+            parts = ep.name.split(".", 1)
+            manufacturer = parts[0] if len(parts) > 1 else "unknown"
+            name = parts[-1]
+            register(cls, manufacturer, name)
+            loaded[(manufacturer, name)] = cls
+        except Exception as exc:
+            warnings.warn(f"Failed to load plugin {ep.name!r}: {exc}", RuntimeWarning)
+    return loaded
+
+
+def list_plugins() -> Dict[Tuple[str, str], Type[Instrument]]:
+    """Return a shallow copy of the current plugin registry.
+
+    :returns: Mapping of ``(manufacturer, name)`` to instrument classes.
+    """
+    return dict(_REGISTRY)
+
+
+def get(manufacturer: str, name: str) -> Optional[Type[Instrument]]:
+    """Look up a registered instrument class.
+
+    :param manufacturer: Manufacturer identifier.
+    :param name: Instrument name.
+    :returns: The instrument class, or ``None`` if not registered.
+    """
+    return _REGISTRY.get((manufacturer, name))
+
+
+def clear() -> None:
+    """Remove all entries from the plugin registry."""
+    _REGISTRY.clear()

--- a/tests/instruments/test_registry.py
+++ b/tests/instruments/test_registry.py
@@ -1,0 +1,187 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import warnings
+from importlib.metadata import EntryPoint
+from unittest import mock
+
+import pytest
+
+from pymeasure.instruments.fakes import FakeInstrument
+from pymeasure.instruments.registry import (
+    _REGISTRY,
+    clear,
+    discover,
+    get,
+    list_plugins,
+    register,
+    unregister,
+)
+
+
+class FakePlugin(FakeInstrument):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    _REGISTRY.clear()
+
+
+class TestRegister:
+    def test_registers_instrument_subclass(self):
+        register(FakePlugin, "acme", "widget")
+        assert _REGISTRY[("acme", "widget")] is FakePlugin
+
+    def test_rejects_non_instrument(self):
+        with pytest.raises(TypeError, match="not an Instrument subclass"):
+            register(int, "acme", "bad")
+
+    def test_rejects_non_type(self):
+        with pytest.raises(TypeError, match="not an Instrument subclass"):
+            register("not a class", "acme", "bad")
+
+    def test_overwrite_existing(self):
+        register(FakePlugin, "acme", "widget")
+
+        class AnotherPlugin(FakeInstrument):
+            pass
+
+        register(AnotherPlugin, "acme", "widget")
+        assert _REGISTRY[("acme", "widget")] is AnotherPlugin
+
+
+class TestUnregister:
+    def test_removes_entry(self):
+        register(FakePlugin, "acme", "widget")
+        unregister("acme", "widget")
+        assert ("acme", "widget") not in _REGISTRY
+
+    def test_raises_on_missing(self):
+        with pytest.raises(KeyError):
+            unregister("no", "such")
+
+
+class TestGet:
+    def test_returns_registered_class(self):
+        register(FakePlugin, "acme", "widget")
+        assert get("acme", "widget") is FakePlugin
+
+    def test_returns_none_for_missing(self):
+        assert get("no", "such") is None
+
+
+class TestListPlugins:
+    def test_returns_copy(self):
+        register(FakePlugin, "acme", "widget")
+        plugins = list_plugins()
+        assert plugins == {("acme", "widget"): FakePlugin}
+        plugins.clear()
+        assert ("acme", "widget") in _REGISTRY
+
+    def test_empty_when_nothing_registered(self):
+        assert list_plugins() == {}
+
+
+class TestClear:
+    def test_empties_registry(self):
+        register(FakePlugin, "acme", "widget")
+        clear()
+        assert len(_REGISTRY) == 0
+
+
+class TestDiscover:
+    def test_loads_entry_points(self):
+        ep = EntryPoint(
+            name="ni.daqmx",
+            value="pymeasure.instruments.fakes:FakeInstrument",
+            group="pymeasure.instruments",
+        )
+        with mock.patch(
+            "pymeasure.instruments.registry.importlib.metadata.entry_points",
+            return_value={"pymeasure.instruments": [ep]},
+        ):
+            loaded = discover()
+        assert loaded == {("ni", "daqmx"): FakeInstrument}
+        assert get("ni", "daqmx") is FakeInstrument
+
+    def test_entry_point_without_dot(self):
+        ep = EntryPoint(
+            name="daqmx",
+            value="pymeasure.instruments.fakes:FakeInstrument",
+            group="pymeasure.instruments",
+        )
+        with mock.patch(
+            "pymeasure.instruments.registry.importlib.metadata.entry_points",
+            return_value={"pymeasure.instruments": [ep]},
+        ):
+            loaded = discover()
+        assert ("unknown", "daqmx") in loaded
+
+    def test_warns_on_broken_plugin(self):
+        ep = EntryPoint(
+            name="ni.broken",
+            value="nonexistent_module:BrokenClass",
+            group="pymeasure.instruments",
+        )
+        with mock.patch(
+            "pymeasure.instruments.registry.importlib.metadata.entry_points",
+            return_value={"pymeasure.instruments": [ep]},
+        ):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                discover()
+        assert any("Failed to load plugin" in str(warning.message) for warning in w)
+
+    def test_select_api_for_python312(self):
+        ep = EntryPoint(
+            name="ni.scope",
+            value="pymeasure.instruments.fakes:FakeInstrument",
+            group="pymeasure.instruments",
+        )
+
+        class _Eps:
+            def select(self, *, group):
+                return [ep] if group == "pymeasure.instruments" else []
+
+        with mock.patch(
+            "pymeasure.instruments.registry.importlib.metadata.entry_points",
+            return_value=_Eps(),
+        ):
+            loaded = discover()
+        assert ("ni", "scope") in loaded
+
+    def test_custom_group(self):
+        ep = EntryPoint(
+            name="custom.inst",
+            value="pymeasure.instruments.fakes:FakeInstrument",
+            group="custom.group",
+        )
+        with mock.patch(
+            "pymeasure.instruments.registry.importlib.metadata.entry_points",
+            return_value={"custom.group": [ep]},
+        ):
+            loaded = discover(group="custom.group")
+        assert ("custom", "inst") in loaded


### PR DESCRIPTION
Related to #1114 #1058 

Implements a hybrid entry-point + registry plugin system:
- New pymeasure/instruments/registry.py with register, unregister, discover, get, list_plugins, and clear functions
- Entry-point auto-discovery via importlib.metadata for packages declaring instruments under the 'pymeasure.instruments' group
- Validates that registered classes are Instrument subclasses
- Updated __init__.py to export registry functions
- 16 tests covering all registry functionality


Implemented the **Hybrid entry-point + registry** plugin system (Option 5 from my earlier analysis). All 16 tests pass, lint is clean.

## Changes

### New: `pymeasure/instruments/registry.py`
Plugin registry with entry-point auto-discovery:
- **`register(cls, manufacturer, name)`** — manually register an Instrument subclass (validates type)
- **`unregister(manufacturer, name)`** — remove a registration
- **`discover(group="pymeasure.instruments")`** — auto-discover plugins via `importlib.metadata.entry_points()`, with warnings for broken plugins
- **`list_plugins()`** — returns a copy of the current registry
- **`get(manufacturer, name)`** — look up a registered instrument class
- **`clear()`** — empty the registry

Entry point naming convention: `"<manufacturer>.<name>"` (e.g. `"ni.daqmx"`).

### Modified: `pymeasure/instruments/__init__.py`
Exports all registry functions for convenient access:
```python
from pymeasure.instruments import register, discover, get, list_plugins, unregister, clear
```

### New: `tests/instruments/test_registry.py`
16 tests covering registration, unregistration, lookup, clearing, entry-point loading (dict + select APIs), broken plugin warnings, custom groups, and edge cases.

## How plugin authors use it

In their `pyproject.toml`:
```toml
[project.entry-points."pymeasure.instruments"]
"ni.daqmx" = "pymeasure_ni.daqmx:DAQmxInstrument"
```

In application code:
```python
from pymeasure.instruments import discover, get
discover()  # call once at startup
DAQmx = get("ni", "daqmx")
```

Or import directly:
```python
from pymeasure_ni.daqmx import DAQmxInstrument
```