### PR TITLE
Update PTW UNIDOS with interval_measurement, typing, and docstrings

### DIFF
--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -135,7 +135,8 @@ wrong format of the parameter",
 
         for n in range(len(err_txt)):
             if err_code & (2**n):
-                err_msg.append(err_txt[n])
+                if err_txt[n] is not None:
+                    err_msg.append(err_txt[n])
 
         return err_msg
 

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -25,6 +25,7 @@
 
 import logging
 import json
+import warnings
 from typing import Any, Union, Optional
 
 from pymeasure.adapters import Adapter
@@ -157,6 +158,18 @@ wrong format of the parameter",
         .. note:: Write permission is required.
         """
         self.ask("HLD")
+
+    def intervall(self, intervall: Optional[int] = None) -> None:
+        """Execute an interval measurement.
+
+        .. deprecated:: 0.16.0
+            Use :meth:`interval_measurement` instead.
+        """
+        warnings.warn(
+            "`intervall()` is deprecated, use 'interval_measurement()' instead",
+            FutureWarning
+            )
+        return self.interval_measurement(intervall)
 
     def interval_measurement(self, interval: Optional[int] = None) -> None:
         """Execute an interval measurement.

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -25,7 +25,7 @@
 
 import logging
 import json
-from typing import Any, Union
+from typing import Any, Union, Optional
 
 from pymeasure.adapters import Adapter
 from pymeasure.instruments import Instrument

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -25,7 +25,9 @@
 
 import logging
 import json
+from typing import Any, Union
 
+from pymeasure.adapters import Adapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import (strict_discrete_set,
                                               strict_range)
@@ -37,8 +39,10 @@ log.addHandler(logging.NullHandler())
 class ptwUNIDOS(Instrument):
     """A class representing the PTW UNIDOS Tango/Romeo dosemeters."""
 
-    def __init__(self, adapter, name="PTW UNIDOS dosemeter",
-                 **kwargs):
+    def __init__(self,
+                 adapter: Union[Adapter, int, str],
+                 name: str = "PTW UNIDOS dosemeter",
+                 **kwargs: Any) -> None:
         super().__init__(
             adapter,
             name,
@@ -49,7 +53,7 @@ class ptwUNIDOS(Instrument):
             **kwargs
         )
 
-    def read(self):
+    def read(self) -> str:
         """Read the device response and check for errors.
 
         :return: Read string with semicolons replaced by comma
@@ -96,7 +100,7 @@ wrong format of the parameter",
             command, sep, response = got.partition(";")  # command is removed from response
             return response.replace(";", ",")
 
-    def check_set_errors(self):
+    def check_set_errors(self) -> list[str]:
         """Check for errors after sending a command."""
 
         try:
@@ -107,7 +111,7 @@ wrong format of the parameter",
         else:
             return []
 
-    def errorflags_to_text(self, flags):
+    def errorflags_to_text(self, flags: str) -> str:
         """Convert the error flags to the error message(s).
 
         :param str flags:
@@ -139,21 +143,21 @@ wrong format of the parameter",
 # Methods #
 ###########
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear the complete measurement history.
 
         .. note:: Write permission is required.
         """
         self.ask("CHR")
 
-    def hold(self):
+    def hold(self) -> None:
         """Set the measurment to HOLD state.
 
         .. note:: Write permission is required.
         """
         self.ask("HLD")
 
-    def interval_measurement(self, interval=None):
+    def interval_measurement(self, interval=None) -> None:
         """Execute an interval measurement.
 
         :param int interval: optional, measurement interval in seconds
@@ -167,21 +171,21 @@ wrong format of the parameter",
             self.integration_time = interval
         self.ask("INT")
 
-    def measure(self):
+    def measure(self) -> None:
         """Start the dose or charge measurement.
 
         .. note:: Write permission is required.
         """
         self.ask("STA")
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the dose and charge measurement values.
 
         .. note:: Write permission is required.
         """
         self.ask("RES")
 
-    def selftest(self):
+    def selftest(self) -> None:
         """Execute the electrometer selftest.
 
         The function returns before the end of the selftest.
@@ -192,7 +196,7 @@ wrong format of the parameter",
         """
         self.ask("AST")
 
-    def zero(self):
+    def zero(self) -> None:
         """Execute a zero correction measurement.
 
         The function returns before the end of the zero correction
@@ -457,7 +461,7 @@ wrong format of the parameter",
 # only read access is implemented #
 ###################################
 
-    def read_detector(self, guid="ALL"):
+    def read_detector(self, guid: str = "ALL") -> Union[dict, list[dict]]:
         """Read the properties of the requested detector.
 
         :param str guid: optional, ID of the detector. A list of all

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -214,9 +214,7 @@ wrong format of the parameter",
     autostart_level = Instrument.control(
         "ASL", "ASL;%s",
         """Control the threshold level of autostart measurements
-        (str strictly in "LOW", "MEDIUM", "HIGH").
-
-        :type: str, strictly in ``LOW``, ``MEDIUM``, ``HIGH``
+        (str, strictly ``LOW``, ``MEDIUM`` or ``HIGH``).
         """,
         validator=strict_discrete_set,
         values=["LOW", "MEDIUM", "HIGH"],
@@ -225,9 +223,7 @@ wrong format of the parameter",
 
     id = Instrument.measurement(
         "PTW",
-        """Get the dosemeter ID.
-
-        :return: list of str
+        """Get the dosemeter ID (list[str]).
 
         .. [name, type number, firmware version, hardware revision]
         """
@@ -235,9 +231,8 @@ wrong format of the parameter",
 
     integration_time = Instrument.control(
         "IT", "IT;%d",
-        """Control the time of the interval measurement in seconds (strictly from 1 to 3599999).
-
-        :type: int, strictly from ``1`` to ``3599999``
+        """Control the time of the interval measurement in seconds
+        (int, strictly from ``1`` to ``3599999``).
         """,
         validator=strict_range,
         values=[1, 3599999],
@@ -247,17 +242,13 @@ wrong format of the parameter",
 
     mac_address = Instrument.measurement(
         "MAC",
-        """Get the dosemeter MAC address.
-
-        :return: str
-        """
+        """Get the dosemeter MAC address (str)."""
         )
 
     measurement_result = Instrument.measurement(
         "MV",
-        """Get the measurement results.
+        """Get the measurement results (dict).
 
-        :return: dict
         :dict keys: ``status``,
                     ``charge``,
                     ``dose``,
@@ -283,9 +274,8 @@ wrong format of the parameter",
 
     range = Instrument.control(
         "RGE", "RGE;%s",
-        """Control the measurement range (str strictly in "VERY_LOW", "LOW", "MEDIUM", "HIGH").
-
-        :type: str, strictly in ``VERY_LOW``, ``LOW``, ``MEDIUM``, ``HIGH``
+        """Control the measurement range
+        (str, strictly ``VERY_LOW``, ``LOW``, ``MEDIUM`` or ``HIGH``).
         """,
         validator=strict_discrete_set,
         values=["VERY_LOW", "LOW", "MEDIUM", "HIGH"],
@@ -294,9 +284,8 @@ wrong format of the parameter",
 
     range_max = Instrument.measurement(
         "MVM",
-        """Get the max value of the current measurement range.
+        """Get the max value of the current measurement range (dict).
 
-        :return: dict
         :dict keys: ``range``,
                     ``current``,
                     ``doserate``,
@@ -312,9 +301,8 @@ wrong format of the parameter",
 
     range_res = Instrument.measurement(
         "MVR",
-        """Get the resolution of the measurement range.
+        """Get the resolution of the measurement range (dict).
 
-        :return: dict
         :dict keys: ``range``,
                     ``charge``,
                     ``dose``,
@@ -334,9 +322,8 @@ wrong format of the parameter",
 
     selftest_result = Instrument.measurement(
         "ASS",
-        """Get the dosemeter selftest status and result.
+        """Get the dosemeter selftest status and result (dict).
 
-        :return: dict
         :dict keys: ``status``,
                     ``time_remaining``,
                     ``time_total``,
@@ -356,18 +343,13 @@ wrong format of the parameter",
 
     serial_number = Instrument.measurement(
         "SER",
-        """Get the dosemeter serial number.
-
-        :return: int
-        """,
+        """Get the dosemeter serial number (int).""",
         cast=int
         )
 
     status = Instrument.measurement(
         "S",
-        """Get the measurement status.
-
-        :return: str
+        """Get the measurement status (str).
 
         The status string has of one of the following values: ``RES``,
         ``MEAS``, ``HOLD``, ``INT``, ``INTHLD``, ``ZERO``, ``AUTO``,
@@ -378,9 +360,7 @@ wrong format of the parameter",
 
     tfi = Instrument.measurement(
         "TFI",
-        """Get the telegram failure information.
-
-        :return: str
+        """Get the telegram failure information (str).
 
         The property provides information about the last failed command with HTTP request.
         """
@@ -415,9 +395,7 @@ wrong format of the parameter",
 
     voltage = Instrument.control(
         "HV", "HV;%d",
-        """Control the detector voltage in Volts.
-
-        :type: int,  strictly from ``-400`` to ``400`` and within detector limits
+        """Control the detector voltage in Volts (int,  strictly from ``-400`` to ``400``)
 
         The Limits of the detector are applied.
         """,
@@ -446,9 +424,8 @@ wrong format of the parameter",
 
     zero_status = Instrument.measurement(
         "NUS",
-        """Get the status of the zero correction measurement.
+        """Get the status of the zero correction measurement (dict).
 
-        :return: dict
         :dict keys:  ``status``,
                      ``time_remaining``,
                      ``time_total``
@@ -467,7 +444,7 @@ wrong format of the parameter",
         :param str guid: optional, ID of the detector. A list of all
             detectors is returned if *guid* is not passed.
 
-        :type: dict or list of dict
+        :type: dict or list[dict]
         :dict keys: ``calibrationFactor``,
                     ``calibrationFactorUnit``,
                     ``calibrationLab``,
@@ -505,9 +482,8 @@ wrong format of the parameter",
 
     lan_config = Instrument.measurement(
         "REC",
-        """Get the ethernet configuration.
+        """Get the ethernet configuration (dict).
 
-        :return: dict
         :dict keys: ``dns``,
                     ``ipv4``,
                     ``ipv6``
@@ -517,9 +493,8 @@ wrong format of the parameter",
 
     measurement_history = Instrument.measurement(
         "RHR",
-        """Get the measurement history.
+        """Get the measurement history (list[dict]).
 
-        :return: list of dict
         :dict keys: ``date``,
                     ``detector``,
                     ``dose``,
@@ -534,9 +509,8 @@ wrong format of the parameter",
 
     measurement_parameters = Instrument.measurement(
         "RMR",
-        """Get the measurement parameters.
+        """Get the measurement parameters (dict).
 
-        :return: dict
         :dict keys: ``correction``,
                     ``detectorGuid``,
                     ``highResolution``,
@@ -557,9 +531,8 @@ wrong format of the parameter",
 
     system_info = Instrument.measurement(
         "RIR",
-        """Get the system information.
+        """Get the system information (dict).
 
-        :return: dict
         :dict keys: ``calibrationDate``,
                     ``debugBuild``,
                     ``features``,
@@ -578,9 +551,8 @@ wrong format of the parameter",
 
     system_settings = Instrument.measurement(
         "RSR",
-        """Get the system settings.
+        """Get the system settings (dict).
 
-        :return: dict
         :dict keys: ``brightness``,
                     ``date``,
                     ``keyboardSound``,
@@ -596,9 +568,8 @@ wrong format of the parameter",
 
     wlan_config = Instrument.measurement(
         "RAC",
-        """Get the WLAN access point configuration.
+        """Get the WLAN access point configuration (dict).
 
-        :return: dict
         :dict keys: ``enabled``,
                     ``ssid``
         """,

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -153,18 +153,18 @@ wrong format of the parameter",
         """
         self.ask("HLD")
 
-    def intervall(self, intervall=None):
-        """Execute an intervall measurement.
+    def interval_measurement(self, interval=None):
+        """Execute an interval measurement.
 
-        :param int intervall: optional, measurement intervall in seconds
+        :param int interval: optional, measurement interval in seconds
 
-        If *intervall* is not specified a measurement with the current setting of the
+        If *interval* is not specified a measurement with the current setting of the
         :attr:`integration_time` is executed.
 
         .. note:: Write permission is required.
         """
-        if intervall is not None:
-            self.integration_time = intervall
+        if interval is not None:
+            self.integration_time = interval
         self.ask("INT")
 
     def measure(self):

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -111,7 +111,7 @@ wrong format of the parameter",
         else:
             return []
 
-    def errorflags_to_text(self, flags: str) -> str:
+    def errorflags_to_text(self, flags: str) -> list[str]:
         """Convert the error flags to the error message(s).
 
         :param str flags:

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -160,7 +160,7 @@ wrong format of the parameter",
     def interval_measurement(self, interval: Optional[int] = None) -> None:
         """Execute an interval measurement.
 
-        :param int interval: optional, measurement interval in seconds
+        :param interval: optional, measurement interval in seconds
 
         If *interval* is not specified a measurement with the current setting of the
         :attr:`integration_time` is executed.

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -157,7 +157,7 @@ wrong format of the parameter",
         """
         self.ask("HLD")
 
-    def interval_measurement(self, interval=None) -> None:
+    def interval_measurement(self, interval: Optional[int] = None) -> None:
         """Execute an interval measurement.
 
         :param int interval: optional, measurement interval in seconds

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -34,7 +34,6 @@ LEVELS = ["LOW", "MEDIUM", "HIGH"]
 
 @pytest.mark.parametrize("level", LEVELS)
 def test_autostart_level(level):
-    """Verify the communication of the autostart_level getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [(f"ASL;{level}", f"ASL;{level}"),
@@ -45,7 +44,6 @@ def test_autostart_level(level):
 
 
 def test_id():
-    """Verify the communication of the ID getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("PTW", "PTW;UNIDOS Tango;TM10052;1.2.4;A16")],
@@ -55,7 +53,6 @@ def test_id():
 
 @pytest.mark.parametrize("it", (1, 600, 1E6))
 def test_integration_time(it):
-    """Verify the communication of the integration_time getter/setter."""
     it = int(it)
     with expected_protocol(
         ptwUNIDOS,
@@ -68,7 +65,6 @@ def test_integration_time(it):
 
 @pytest.mark.parametrize("it", (-3, 0, 1E12))
 def test_integration_time_limits(it):
-    """Verify the communication of the integration_time getter/setter when out of range."""
     try:
         ptwUNIDOS.integration_time = it
     except ValueError:
@@ -76,7 +72,6 @@ def test_integration_time_limits(it):
 
 
 def test_mac_address():
-    """Verify the communication of the mac address getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("MAC", "MAC;xx-xx-xx-xx-xx-xx")],
@@ -85,7 +80,6 @@ def test_mac_address():
 
 
 def test_measurement_result():
-    """Verify the communication of the measurement_result getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("MV", "MV;RES;0.0;E-12;p;C;0.0;E-12;p;A;;0.0;ms;200;V;0x0"),
@@ -113,7 +107,6 @@ def test_measurement_result():
 
 @pytest.mark.parametrize("range", RANGES)
 def test_range(range):
-    """Verify the communication of the range getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [(f"RGE;{range}", f"RGE;{range}"),
@@ -124,7 +117,6 @@ def test_range(range):
 
 
 def test_range_max():
-    """Verify the communication of the range_max getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("MVM", "MVM;MEDIUM;1.65;E-06;µ;Gy;min")]
@@ -136,7 +128,6 @@ def test_range_max():
 
 
 def test_range_res():
-    """Verify the communication of the range_res getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("MVR", "MVR;MEDIUM;0.5;E-12;p;Gy;0.003;E-09;n;Gy;min")]
@@ -150,7 +141,6 @@ def test_range_res():
 
 
 def test_selftest_result():
-    """Verify the communication of the selftest_result getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("ASS", "ASS;Passed;0;89000;Low; 136.6;E-12;p;C;Med; 1.500;E-09;n;C;High; 13.50;E-09;n;C")]
@@ -164,7 +154,6 @@ def test_selftest_result():
 
 
 def test_serial_number():
-    """Verify the communication of the serial_number getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("SER", "SER;123456")]
@@ -173,7 +162,6 @@ def test_serial_number():
 
 
 def test_status():
-    """Verify the communication of the status getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("S", "S;RES")]
@@ -182,7 +170,6 @@ def test_status():
 
 
 def test_tfi():
-    """Verify the communication of the tfi getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("TFI", "TFI;-")]
@@ -191,7 +178,6 @@ def test_tfi():
 
 
 def test_autostart_enabled():
-    """Verify the communication of the autostart_enabled getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [("ASE;true", "ASE;true"),
@@ -202,7 +188,6 @@ def test_autostart_enabled():
 
 
 def test_autoreset_enabled():
-    """Verify the communication of the autoreset_enabled getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [("ASR;true", "ASR;true"),
@@ -213,7 +198,6 @@ def test_autoreset_enabled():
 
 
 def test_electrical_units_enabled():
-    """Verify the communication of the electrical_units_enabled getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [("UEL;true", "UEL;true"),
@@ -225,7 +209,6 @@ def test_electrical_units_enabled():
 
 @pytest.mark.parametrize("voltage", (-400, -13, 0, 10, 400))
 def test_voltage(voltage):
-    """Verify the communication of the voltage getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [(f"HV;{voltage}", f"HV;{voltage}"),
@@ -237,7 +220,6 @@ def test_voltage(voltage):
 
 @pytest.mark.parametrize("voltage", (-401, 401, 1E3))
 def test_voltage_limits(voltage):
-    """Verify the communication of the voltage getter/setter when out of range."""
     try:
         ptwUNIDOS.voltage = voltage
     except ValueError:
@@ -245,7 +227,6 @@ def test_voltage_limits(voltage):
 
 
 def test_write_enabled():
-    """Verify the communication of the write_enabled getter/setter."""
     with expected_protocol(
         ptwUNIDOS,
         [("TOK", "TOK;true"),
@@ -260,7 +241,6 @@ def test_write_enabled():
 
 
 def test_zero_status():
-    """Verify the communication of the zero_status getter."""
     with expected_protocol(
         ptwUNIDOS,
         [("NUS", "NUS;Passed;0;82000")]

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -151,15 +151,15 @@ class TestProperties:
                                                "voltage": 300,
                                                "error": "0x0"}
 
-    @pytest.mark.parametrize("range", RANGES)
-    def test_range(self, range):
+    @pytest.mark.parametrize("measurement_range", RANGES)
+    def test_range(self, measurement_range):
         with expected_protocol(
             ptwUNIDOS,
-            [(f"RGE;{range}", f"RGE;{range}"),
-             ("RGE", f"RGE;{range}")],
+            [(f"RGE;{measurement_range}", f"RGE;{measurement_range}"),
+             ("RGE", f"RGE;{measurement_range}")],
         ) as inst:
-            inst.range = range
-            assert inst.range == range
+            inst.range = measurement_range
+            assert inst.range == measurement_range
 
     def test_range_max(self):
         with expected_protocol(

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -54,6 +54,14 @@ class TestMethods:
         ) as inst:
             inst.interval_measurement()
 
+    def test_intervall_deprecation_warning(self):
+        with pytest.warns(FutureWarning):
+            with expected_protocol(
+                ptwUNIDOS,
+                [("INT", "INT")]
+            ) as inst:
+                inst.intervall()
+
     def test_measure(self):
         with expected_protocol(
             ptwUNIDOS,

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -316,11 +316,11 @@ class TestJSON:
     def test_measurement_history(self):
         with expected_protocol(
             ptwUNIDOS,
-            [("RHR", 'RHR;{"key1":"value1";"key2":"value2"}')]
+            [("RHR", 'RHR;[{"key1":"value1"};{"key2":"value2"}]')]
         ) as inst:
-            assert inst.measurement_history == {"key1": "value1",
-                                                "key2": "value2",
-                                                }
+            assert inst.measurement_history == [{"key1": "value1"},
+                                                {"key2": "value2"},
+                                                ]
 
     def test_measurement_parameters(self):
         with expected_protocol(

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -114,7 +114,7 @@ class TestProperties:
 
     @pytest.mark.parametrize("it", [-3, 0, 1E12])
     def test_integration_time_limits(self, it):
-        with expected_protocol(ptwUNIDOS,[]) as inst:
+        with expected_protocol(ptwUNIDOS, []) as inst:
             with pytest.raises(ValueError):
                 inst.integration_time = it
 

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -32,219 +32,328 @@ RANGES = ["VERY_LOW", "LOW", "MEDIUM", "HIGH"]
 LEVELS = ["LOW", "MEDIUM", "HIGH"]
 
 
-@pytest.mark.parametrize("level", LEVELS)
-def test_autostart_level(level):
-    with expected_protocol(
-        ptwUNIDOS,
-        [(f"ASL;{level}", f"ASL;{level}"),
-         ("ASL", f"ASL;{level}")],
-    ) as inst:
-        inst.autostart_level = level
-        assert inst.autostart_level == level
+class TestMethods:
+    def test_clear(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("CHR", "CHR")]
+        ) as inst:
+            inst.clear()
+
+    def test_hold(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("HLD", "HLD")]
+        ) as inst:
+            inst.hold()
+
+    def test_interval_measurement(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("INT", "INT")]
+        ) as inst:
+            inst.interval_measurement()
+
+    def test_measure(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("STA", "STA")]
+        ) as inst:
+            inst.measure()
+
+    def test_reset(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RES", "RES")]
+        ) as inst:
+            inst.reset()
+
+    def test_selftest(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("AST", "AST")]
+        ) as inst:
+            inst.selftest()
+
+    def test_zero(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("NUL", "NUL")]
+        ) as inst:
+            inst.zero()
 
 
-def test_id():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("PTW", "PTW;UNIDOS Tango;TM10052;1.2.4;A16")],
-    ) as inst:
-        assert inst.id == ["UNIDOS Tango", "TM10052", "1.2.4", "A16"]
+class TestProperties:
+    @pytest.mark.parametrize("level", LEVELS)
+    def test_autostart_level(self, level):
+        with expected_protocol(
+            ptwUNIDOS,
+            [(f"ASL;{level}", f"ASL;{level}"),
+             ("ASL", f"ASL;{level}")],
+        ) as inst:
+            inst.autostart_level = level
+            assert inst.autostart_level == level
+
+    def test_id(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("PTW", "PTW;UNIDOS Tango;TM10052;1.2.4;A16")],
+        ) as inst:
+            assert inst.id == ["UNIDOS Tango", "TM10052", "1.2.4", "A16"]
+
+    @pytest.mark.parametrize("it", [1, 600, 1E6])
+    def test_integration_time(self, it):
+        it = int(it)
+        with expected_protocol(
+            ptwUNIDOS,
+            [(f"IT;{it}", f"IT;{it}"),
+             ("IT", f"IT;{it}")]
+        ) as inst:
+            inst.integration_time = it
+            assert inst.integration_time == it
+
+    @pytest.mark.parametrize("it", [-3, 0, 1E12])
+    def test_integration_time_limits(self, it):
+        try:
+            ptwUNIDOS.integration_time = it
+        except ValueError:
+            pass
+
+    def test_mac_address(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("MAC", "MAC;xx-xx-xx-xx-xx-xx")],
+        ) as inst:
+            assert inst.mac_address == "xx-xx-xx-xx-xx-xx"
+
+    def test_measurement_result(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("MV", "MV;RES;0.0;E-12;p;C;0.0;E-12;p;A;;0.0;ms;200;V;0x0"),
+             ("MV", "MV;RES;2.6;E-3;m;Gy;5.6;E-09;n;Gy;min;3000.0;ms;300.0;V;0x0")]
+        ) as inst:
+            assert inst.measurement_result == {"status": "RES",
+                                               "charge": 0,
+                                               "dose": 0,
+                                               "current": 0,
+                                               "doserate": 0,
+                                               "timebase": "",
+                                               "time": 0,
+                                               "voltage": 200,
+                                               "error": "0x0"}
+            assert inst.measurement_result == {"status": "RES",
+                                               "charge": 2.6E-3,
+                                               "dose": 2.6E-3,
+                                               "current": 5.6E-9,
+                                               "doserate": 5.6E-9,
+                                               "timebase": "min",
+                                               "time": 3000,
+                                               "voltage": 300,
+                                               "error": "0x0"}
+
+    @pytest.mark.parametrize("range", RANGES)
+    def test_range(self, range):
+        with expected_protocol(
+            ptwUNIDOS,
+            [(f"RGE;{range}", f"RGE;{range}"),
+             ("RGE", f"RGE;{range}")],
+        ) as inst:
+            inst.range = range
+            assert inst.range == range
+
+    def test_range_max(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("MVM", "MVM;MEDIUM;1.65;E-06;µ;Gy;min")]
+        ) as inst:
+            assert inst.range_max == {"range": "MEDIUM",
+                                      "current": 1.65e-06,
+                                      "doserate": 1.65e-06,
+                                      "timebase": "min"}
+
+    def test_range_res(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("MVR", "MVR;MEDIUM;0.5;E-12;p;Gy;0.003;E-09;n;Gy;min")]
+        ) as inst:
+            assert inst.range_res == {"range": "MEDIUM",
+                                      "charge": 5e-13,
+                                      "dose": 5e-13,
+                                      "current": 3e-12,
+                                      "doserate": 3e-12,
+                                      "timebase": "min"}
+
+    def test_selftest_result(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("ASS",
+              "ASS;Passed;0;89000;Low; 136.6;E-12;p;C;Med; 1.500;E-09;n;C;High; 13.50;E-09;n;C"
+              )]
+        ) as inst:
+            assert inst.selftest_result == {"status": "Passed",
+                                            "time_remaining": 0,
+                                            "time_total": 89000,
+                                            "low": 1.366e-10,
+                                            "medium": 1.5e-09,
+                                            "high": 1.35e-08}
+
+    def test_serial_number(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("SER", "SER;123456")]
+        ) as inst:
+            assert inst.serial_number == 123456
+
+    def test_status(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("S", "S;RES")]
+        ) as inst:
+            assert inst.status == "RES"
+
+    def test_tfi(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("TFI", "TFI;-")]
+        ) as inst:
+            assert inst.tfi == "-"
+
+    def test_autostart_enabled(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("ASE;true", "ASE;true"),
+             ("ASE", "ASE;false")]
+        ) as inst:
+            inst.autostart_enabled = True
+            assert inst.autostart_enabled is False
+
+    def test_autoreset_enabled(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("ASR;true", "ASR;true"),
+             ("ASR", "ASR;false")]
+        ) as inst:
+            inst.autoreset_enabled = True
+            assert inst.autoreset_enabled is False
+
+    def test_electrical_units_enabled(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("UEL;true", "UEL;true"),
+             ("UEL", "UEL;false")]
+        ) as inst:
+            inst.electrical_units_enabled = True
+            assert inst.electrical_units_enabled is False
+
+    @pytest.mark.parametrize("voltage", [-400, -13, 0, 10, 400])
+    def test_voltage(self, voltage):
+        with expected_protocol(
+            ptwUNIDOS,
+            [(f"HV;{voltage}", f"HV;{voltage}"),
+             ("HV", f"HV;{voltage}")]
+        ) as inst:
+            inst.voltage = voltage
+            assert inst.voltage == voltage
+
+    @pytest.mark.parametrize("voltage", [-401, 401, 1E3])
+    def test_voltage_limits(self, voltage):
+        try:
+            ptwUNIDOS.voltage = voltage
+        except ValueError:
+            pass
+
+    def test_write_enabled(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("TOK", "TOK;true"),
+             ("TOK;0", "TOK;0;true"),
+             ("TOK;1", "TOK;1;true"),
+             ("TOK;1", "TOK;1;false")]
+        ) as inst:
+            inst.write_enabled = True
+            inst.write_enabled = False
+            assert inst.write_enabled is True
+            assert inst.write_enabled is False
+
+    def test_zero_status(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("NUS", "NUS;Passed;0;82000")]
+        ) as inst:
+            assert inst.zero_status == {"status": "Passed",
+                                        "time_remaining": 0.0,
+                                        "time_total": 82000.0}
 
 
-@pytest.mark.parametrize("it", (1, 600, 1E6))
-def test_integration_time(it):
-    it = int(it)
-    with expected_protocol(
-        ptwUNIDOS,
-        [(f"IT;{it}", f"IT;{it}"),
-         ("IT", f"IT;{it}")]
-    ) as inst:
-        inst.integration_time = it
-        assert inst.integration_time == it
+class TestJSON:
+    def test_read_detector(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RDA", 'RDA;[{"key1":1,"key2":2};{"key3":3,"key4":"4"}]')]
+        ) as inst:
+            assert inst.read_detector() == [{"key1": 1, "key2": 2},
+                                            {"key3": 3, "key4": "4"},
+                                            ]
 
+    def test_read_detector_with_guid(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RDR;detector_guid", 'RDR;guid;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.read_detector("detector_guid") == {"key1": "value1",
+                                                           "key2": "value2",
+                                                           }
 
-@pytest.mark.parametrize("it", (-3, 0, 1E12))
-def test_integration_time_limits(it):
-    try:
-        ptwUNIDOS.integration_time = it
-    except ValueError:
-        pass
+    def test_lan_config(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("REC", 'REC;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.lan_config == {"key1": "value1",
+                                       "key2": "value2",
+                                       }
 
+    def test_measurement_history(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RHR", 'RHR;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.measurement_history == {"key1": "value1",
+                                                "key2": "value2",
+                                                }
 
-def test_mac_address():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("MAC", "MAC;xx-xx-xx-xx-xx-xx")],
-    ) as inst:
-        assert inst.mac_address == "xx-xx-xx-xx-xx-xx"
+    def test_measurement_parameters(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RMR", 'RMR;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.measurement_parameters == {"key1": "value1",
+                                                   "key2": "value2",
+                                                   }
 
+    def test_system_info(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RIR", 'RIR;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.system_info == {"key1": "value1",
+                                        "key2": "value2",
+                                        }
 
-def test_measurement_result():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("MV", "MV;RES;0.0;E-12;p;C;0.0;E-12;p;A;;0.0;ms;200;V;0x0"),
-         ("MV", "MV;RES;2.6;E-3;m;Gy;5.6;E-09;n;Gy;min;3000.0;ms;300.0;V;0x0")]
-    ) as inst:
-        assert inst.measurement_result == {"status": "RES",
-                                           "charge": 0,
-                                           "dose": 0,
-                                           "current": 0,
-                                           "doserate": 0,
-                                           "timebase": "",
-                                           "time": 0,
-                                           "voltage": 200,
-                                           "error": "0x0"}
-        assert inst.measurement_result == {"status": "RES",
-                                           "charge": 2.6E-3,
-                                           "dose": 2.6E-3,
-                                           "current": 5.6E-9,
-                                           "doserate": 5.6E-9,
-                                           "timebase": "min",
-                                           "time": 3000,
-                                           "voltage": 300,
-                                           "error": "0x0"}
+    def test_system_settings(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RSR", 'RSR;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.system_settings == {"key1": "value1",
+                                            "key2": "value2",
+                                            }
 
-
-@pytest.mark.parametrize("range", RANGES)
-def test_range(range):
-    with expected_protocol(
-        ptwUNIDOS,
-        [(f"RGE;{range}", f"RGE;{range}"),
-         ("RGE", f"RGE;{range}")],
-    ) as inst:
-        inst.range = range
-        assert inst.range == range
-
-
-def test_range_max():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("MVM", "MVM;MEDIUM;1.65;E-06;µ;Gy;min")]
-    ) as inst:
-        assert inst.range_max == {"range": "MEDIUM",
-                                  "current": 1.65e-06,
-                                  "doserate": 1.65e-06,
-                                  "timebase": "min"}
-
-
-def test_range_res():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("MVR", "MVR;MEDIUM;0.5;E-12;p;Gy;0.003;E-09;n;Gy;min")]
-    ) as inst:
-        assert inst.range_res == {"range": "MEDIUM",
-                                  "charge": 5e-13,
-                                  "dose": 5e-13,
-                                  "current": 3e-12,
-                                  "doserate": 3e-12,
-                                  "timebase": "min"}
-
-
-def test_selftest_result():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("ASS", "ASS;Passed;0;89000;Low; 136.6;E-12;p;C;Med; 1.500;E-09;n;C;High; 13.50;E-09;n;C")]
-    ) as inst:
-        assert inst.selftest_result == {"status": "Passed",
-                                        "time_remaining": 0,
-                                        "time_total": 89000,
-                                        "low": 1.366e-10,
-                                        "medium": 1.5e-09,
-                                        "high": 1.35e-08}
-
-
-def test_serial_number():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("SER", "SER;123456")]
-    ) as inst:
-        assert inst.serial_number == 123456
-
-
-def test_status():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("S", "S;RES")]
-    ) as inst:
-        assert inst.status == "RES"
-
-
-def test_tfi():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("TFI", "TFI;-")]
-    ) as inst:
-        assert inst.tfi == "-"
-
-
-def test_autostart_enabled():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("ASE;true", "ASE;true"),
-         ("ASE", "ASE;false")]
-    ) as inst:
-        inst.autostart_enabled = True
-        assert inst.autostart_enabled is False
-
-
-def test_autoreset_enabled():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("ASR;true", "ASR;true"),
-         ("ASR", "ASR;false")]
-    ) as inst:
-        inst.autoreset_enabled = True
-        assert inst.autoreset_enabled is False
-
-
-def test_electrical_units_enabled():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("UEL;true", "UEL;true"),
-         ("UEL", "UEL;false")]
-    ) as inst:
-        inst.electrical_units_enabled = True
-        assert inst.electrical_units_enabled is False
-
-
-@pytest.mark.parametrize("voltage", (-400, -13, 0, 10, 400))
-def test_voltage(voltage):
-    with expected_protocol(
-        ptwUNIDOS,
-        [(f"HV;{voltage}", f"HV;{voltage}"),
-         ("HV", f"HV;{voltage}")]
-    ) as inst:
-        inst.voltage = voltage
-        assert inst.voltage == voltage
-
-
-@pytest.mark.parametrize("voltage", (-401, 401, 1E3))
-def test_voltage_limits(voltage):
-    try:
-        ptwUNIDOS.voltage = voltage
-    except ValueError:
-        pass
-
-
-def test_write_enabled():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("TOK", "TOK;true"),
-         ("TOK;0", "TOK;0;true"),
-         ("TOK;1", "TOK;1;true"),
-         ("TOK;1", "TOK;1;false")]
-    ) as inst:
-        inst.write_enabled = True
-        inst.write_enabled = False
-        assert inst.write_enabled is True
-        assert inst.write_enabled is False
-
-
-def test_zero_status():
-    with expected_protocol(
-        ptwUNIDOS,
-        [("NUS", "NUS;Passed;0;82000")]
-    ) as inst:
-        assert inst.zero_status == {"status": "Passed",
-                                    "time_remaining": 0.0,
-                                    "time_total": 82000.0}
+    def test_wlan_config(self):
+        with expected_protocol(
+            ptwUNIDOS,
+            [("RAC", 'RAC;{"key1":"value1";"key2":"value2"}')]
+        ) as inst:
+            assert inst.wlan_config == {"key1": "value1",
+                                        "key2": "value2",
+                                        }

--- a/tests/instruments/ptw/test_ptwUNIDOS.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS.py
@@ -114,10 +114,9 @@ class TestProperties:
 
     @pytest.mark.parametrize("it", [-3, 0, 1E12])
     def test_integration_time_limits(self, it):
-        try:
-            ptwUNIDOS.integration_time = it
-        except ValueError:
-            pass
+        with expected_protocol(ptwUNIDOS,[]) as inst:
+            with pytest.raises(ValueError):
+                inst.integration_time = it
 
     def test_mac_address(self):
         with expected_protocol(
@@ -257,10 +256,9 @@ class TestProperties:
 
     @pytest.mark.parametrize("voltage", [-401, 401, 1E3])
     def test_voltage_limits(self, voltage):
-        try:
-            ptwUNIDOS.voltage = voltage
-        except ValueError:
-            pass
+        with expected_protocol(ptwUNIDOS, []) as inst:
+            with pytest.raises(ValueError):
+                inst.voltage = voltage
 
     def test_write_enabled(self):
         with expected_protocol(

--- a/tests/instruments/ptw/test_ptwUNIDOS_with_device.py
+++ b/tests/instruments/ptw/test_ptwUNIDOS_with_device.py
@@ -172,8 +172,8 @@ class TestPTWUnidosMethods:
         assert len(unidos.measurement_history) == 0
 
     @pytest.mark.parametrize("time", [2, 10])
-    def test_intervall(self, unidos, time):
-        unidos.intervall(time)
+    def test_interval_measurement(self, unidos, time):
+        unidos.interval_measurement(time)
         sleep(0.1 * time)
         assert unidos.status in ["INT"]
         assert unidos.integration_time == time


### PR DESCRIPTION
- Rename intervall() to interval_measurement, adapt tests to renaming
- Remove docstrings from tests
- Divide the tests in classes
- Add tests for methods
- Add tests for JSON configuration
- Add typing
- Change the docstrings to follow the guidelines