### PR TITLE
Add uv.lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ settings.json
 
 # Vim
 *.swp
+
+# uv lock file
+uv.lock


### PR DESCRIPTION
As discussed in #1450, this PR adds the `uv.lock` file created by the uv package and project manager.

This removes friction for contributors using uv.