### PR TITLE
ENH: Add Koheron CTL200 digital laser driver

### DIFF
--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -50,6 +50,7 @@ Instruments by manufacturer:
    keithley/index
    kepco/index
    keysight/index
+   koheron/index
    kuhneelectronic/index
    lakeshore/index
    lecroy/index

--- a/docs/api/instruments/koheron/index.rst
+++ b/docs/api/instruments/koheron/index.rst
@@ -1,0 +1,14 @@
+.. module:: pymeasure.instruments.koheron
+
+#######
+Koheron
+#######
+
+This section contains specific documentation on the keysight instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+If the instrument you are looking for is not here, also check :doc:`Agilent<../agilent/index>` or :doc:`HP<../hp/index>` for older instruments. 
+
+.. toctree::
+   :maxdepth: 2
+
+   koheronCTL200

--- a/docs/api/instruments/koheron/index.rst
+++ b/docs/api/instruments/koheron/index.rst
@@ -4,11 +4,11 @@
 Koheron
 #######
 
-This section contains specific documentation on the keysight instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+This section contains specific documentation on the Koheron instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 
-If the instrument you are looking for is not here, also check :doc:`Agilent<../agilent/index>` or :doc:`HP<../hp/index>` for older instruments. 
 
 .. toctree::
    :maxdepth: 2
 
    koheronCTL200
+

--- a/docs/api/instruments/koheron/koheronCTL200.rst
+++ b/docs/api/instruments/koheron/koheronCTL200.rst
@@ -1,0 +1,11 @@
+#############################################
+Koheron CTL200 digital laser diode controller
+#############################################
+
+.. autoclass:: pymeasure.instruments.koheron.koheron_ctl200.CTL200
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.koheron.koheron_ctl200.CTL200Adapter
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/koheron/koheronCTL200.rst
+++ b/docs/api/instruments/koheron/koheronCTL200.rst
@@ -5,7 +5,3 @@ Koheron CTL200 digital laser diode controller
 .. autoclass:: pymeasure.instruments.koheron.koheron_ctl200.CTL200
     :members:
     :show-inheritance:
-
-.. autoclass:: pymeasure.instruments.koheron.koheron_ctl200.CTL200Adapter
-    :members:
-    :show-inheritance:

--- a/pymeasure/instruments/koheron/__init__.py
+++ b/pymeasure/instruments/koheron/__init__.py
@@ -22,4 +22,4 @@
 # THE SOFTWARE.
 #
 
-from .koheron_ctl200 import CTL200
+from .koheron_ctl200 import CTL200, CTL200Adapter

--- a/pymeasure/instruments/koheron/__init__.py
+++ b/pymeasure/instruments/koheron/__init__.py
@@ -22,4 +22,4 @@
 # THE SOFTWARE.
 #
 
-from .koheron_ctl200 import CTL200
+from .koheron_ctl200 import CTL200, KoheronError

--- a/pymeasure/instruments/koheron/__init__.py
+++ b/pymeasure/instruments/koheron/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .koheron_ctl200 import CTL200

--- a/pymeasure/instruments/koheron/__init__.py
+++ b/pymeasure/instruments/koheron/__init__.py
@@ -22,4 +22,4 @@
 # THE SOFTWARE.
 #
 
-from .koheron_ctl200 import CTL200, CTL200Adapter
+from .koheron_ctl200 import CTL200

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -1,0 +1,397 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+import time
+from enum import IntFlag
+from pymeasure.adapters import SerialAdapter
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import (
+    strict_discrete_set,
+    strict_range,
+)
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class KoheronError(IntFlag):
+    """IntFlag for CTL200 Error Codes."""
+
+    NONE = 0
+    UART_BUFFER_OVERFLOW = 1 << 0
+    UART_CMD_BEFORE_PROMPT = 1 << 1
+    LASER_UNDERTEMPERATURE = 1 << 2
+    LASER_OVERTEMPERATURE = 1 << 3
+    CMD_UNKNOWN = 1 << 4
+    CMD_INVALID_ARG = 1 << 5
+    LASER_ON_WHILE_INTERLOCK = 1 << 6
+    INTERLOCK_TRIGGERED = 1 << 7
+
+
+class CTL200Adapter(SerialAdapter):
+    """Serial adapter for Koheron CTL200 do deal with echo responses."""
+
+    def __init__(self, port, **kwargs):
+        kwargs.setdefault("baudrate", 115200)
+        kwargs.setdefault("timeout", 2)
+        super().__init__(
+            port,
+            write_termination="\r\n",
+            read_termination="\r\n",
+            **kwargs
+        )
+        self._last_command: str = ""
+        self._response_buffer: list[str] = []
+        time.sleep(0.05)
+        self.connection.reset_input_buffer()
+
+    def _read_until_prompt(self) -> list[str]:
+        raw = b""
+        total_timeout = max(self.connection.timeout or 0, 2.0)
+        deadline = time.monotonic() + total_timeout
+        while time.monotonic() < deadline:
+            waiting = self.connection.in_waiting
+            if waiting:
+                raw += self.connection.read(waiting)
+                if b">>" in raw:
+                    # read trailing chars (\r\n, ...)
+                    time.sleep(0.02)
+                    trailing = self.connection.in_waiting
+                    if trailing:
+                        raw += self.connection.read(trailing)
+                    break
+            else:
+                time.sleep(0.005)
+
+        log.debug("raw RX: %r", raw)
+        text = raw.decode(errors="replace")
+        lines = [line.strip() for line in text.replace("\r", "").split("\n")]
+        lines = [line for line in lines if line]  # remove blanks
+        if lines and self._last_command and lines[0] == self._last_command:
+            lines.pop(0)  # remove echo
+        lines = [line for line in lines if line != ">>"]  # remove prompt chars
+        log.debug("parsed lines: %r", lines)
+        return lines
+
+    def write(self, command: str) -> None:
+        self._last_command = command.strip()
+        super().write(command)
+        self._response_buffer = self._read_until_prompt()
+        log.debug("write %r -> buffer: %r", command,
+                  self._response_buffer)
+
+    def read(self) -> str:
+        if self._response_buffer:
+            value = self._response_buffer.pop(0)
+            log.debug("read -> %r", value)
+            return value
+        log.debug("read -> buffer empty, return ''")
+        return ""
+
+
+class CTL200(Instrument):
+    """PyMeasure driver for the Koheron CTL200-0 digital
+    laser diode controller."""
+
+    def __init__(self, adapter, name="Koheron CTL200", **kwargs):
+        if isinstance(adapter, str):
+            adapter = CTL200Adapter(adapter, **kwargs)
+        super().__init__(
+            adapter,
+            name,
+            includeSCPI=False,
+            **kwargs
+        )
+
+    # -- Laser -----------------------------------------------------------
+
+    laser_enabled = Instrument.control(
+        "lason",
+        "lason %d",
+        """Control whether the laser output is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    laser_current = Instrument.control(
+        "ilaser",
+        "ilaser %g",
+        """Control the laser current setpoint in A (float).""",
+        cast=float,
+        get_process=lambda v: v * 1e-3,
+        set_process=lambda v: v * 1e3,
+    )
+
+    laser_current_limit = Instrument.control(
+        "ilmax",
+        "ilmax %g",
+        """Control the laser current software limit in A (float).""",
+        cast=float,
+        validator=strict_range,
+        values=[0, 1],
+        get_process=lambda v: v * 1e-3,
+        set_process=lambda v: v * 1e3,
+    )
+
+    laser_voltage = Instrument.measurement(
+        "vlaser",
+        """Get the laser voltage in V (float).""",
+        cast=float,
+    )
+
+    photodiode_current = Instrument.measurement(
+        "iphd",
+        """Get the photodiode current in A (float).""",
+        cast=float,
+        get_process=lambda v: v * 1e-3,
+    )
+
+    laser_delay = Instrument.control(
+        "ldelay",
+        "ldelay %g",
+        """Control the delay time between controller startup and laser
+        startup in s (float).""",
+        cast=float,
+        validator=strict_range,
+        values=[0.01, 100],
+        get_process=lambda v: v * 1e-3,
+        set_process=lambda v: v * 1e3,
+    )
+
+    # -- TEC / temperature -----------------------------------------------
+
+    tec_enabled = Instrument.control(
+        "tecon",
+        "tecon %d",
+        """Control whether the TEC output is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    thermistor_setpoint = Instrument.control(
+        "rtset",
+        "rtset %g",
+        """Control the thermistor resistance setpoint in Ω (float).""",
+        cast=float,
+    )
+
+    tec_current = Instrument.measurement(
+        "itec",
+        """Get the TEC current in A (float).""",
+        cast=float,
+    )
+
+    tec_voltage = Instrument.measurement(
+        "vtec",
+        """Get the TEC voltage in V (float).""",
+        cast=float,
+    )
+
+    thermistor_actual = Instrument.measurement(
+        "rtact",
+        """Get the actual thermistor resistance in Ω (float).""",
+        cast=float,
+    )
+
+    tec_current = Instrument.measurement(
+        "itec",
+        """Get the TEC current in A (float).""",
+        cast=float,
+    )
+
+    tec_voltage = Instrument.measurement(
+        "vtec",
+        """Get the TEC voltage in V (float).""",
+        cast=float,
+    )
+
+    pid_proportional = Instrument.control(
+        "pgain",
+        "pgain %g",
+        """Control the proportional gain of the TEC PID controller (float).""",
+        cast=float,
+    )
+
+    pid_integral = Instrument.control(
+        "igain",
+        "igain %g",
+        """Control the integral gain of the TEC PID controller (float).""",
+        cast=float,
+    )
+
+    pid_differential = Instrument.control(
+        "dgain",
+        "dgain %g",
+        """Control the differential gain of the TEC PID controller (float).""",
+        cast=float,
+    )
+
+    # -- Protection ------------------------------------------------------
+
+    temp_protection_enabled = Instrument.control(
+        "tprot",
+        "tprot %d",
+        """Control whether temperature protection is enabled (bool). If
+        temperature protection is enabled, the laser current is automatically
+        disabled id the thermistor resistance is outside the thermistor
+        window.""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    thermistor_window_min = Instrument.control(
+        "rtmin",
+        "rtmin %g",
+        """Control the minimum thermistor resistance in Ω (float) to trigger
+        temperature protection if enabled.""",
+        cast=float,
+    )
+
+    thermistor_window_max = Instrument.control(
+        "rtmax",
+        "rtmax %g",
+        """Control the maximum thermistor resistance in Ω (float) to trigger
+        temperature protection if enabled.""",
+        cast=float,
+    )
+
+    tec_voltage_limit_min = Instrument.control(
+        "vtmin",
+        "vtmin %g",
+        """Control the minimum TEC voltage limit in V (float).""",
+        validator=strict_range,
+        values=[-3.3, 0.0],
+        cast=float,
+    )
+
+    tec_voltage_limit_max = Instrument.control(
+        "vtmax",
+        "vtmax %g",
+        """Control the maximum TEC voltage limit in V (float).""",
+        validator=strict_range,
+        values=[0.0, 3.3],
+        cast=float,
+    )
+
+    # -- Interlock -------------------------------------------------------
+
+    interlock_enabled = Instrument.control(
+        "lckon",
+        "lckon %d",
+        """Control whether the hardware interlock is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    # -- Aux Inputs ------------------------------------------------------
+    analog_input_1 = Instrument.measurement(
+        "ain1",
+        """Get the voltage on auxiliary input AI1 in V (float).""",
+        cast=float,
+    )
+
+    analog_input_2 = Instrument.measurement(
+        "ain2",
+        """Get the voltage on auxiliary input AI2 in V (float).""",
+        cast=float,
+    )
+
+    laser_mod_gain = Instrument.control(
+        "lmodgain",
+        "lmodgain %g",
+        """Control the laser current modulation gain of auxillary input 1 in
+        A/V (float).""",
+        cast=float,
+        validator=strict_range,
+        values=[-100, 100],
+        get_process=lambda v: v * 1e-3,
+        set_process=lambda v: v * 1e3,
+    )
+
+    tec_mod_gain = Instrument.control(
+        "tmodgain",
+        "tmodgain %g",
+        """Control the temperature modulation gain of auxillary input 2 in
+        Ω/V (float).""",
+        cast=float,
+        validator=strict_range,
+        values=[-100000, 100000],
+    )
+
+    # -- Misc ------------------------------------------------------------
+    firmware_version = Instrument.measurement(
+        "version",
+        """Get the firmware version (str).""",
+        cast=str,
+    )
+
+    board_version = Instrument.measurement(
+        "model",
+        """Get the board model version (str).""",
+        cast=str,
+    )
+
+    @property
+    def status(self):
+        """Get a dict with all status values ("lason", "vlaser", "itec",
+        "vtec", "rtact","iphd", "ain1", "ain2")."""
+        raw = self.ask("status").strip().split()
+        keys = ["lason", "vlaser", "itec", "vtec", "rtact",
+                "iphd", "ain1", "ain2"]
+        result = {k: float(v) for k, v in zip(keys, raw)}
+        result["iphd"] *= 1e-3
+        return result
+
+    board_temperature = Instrument.measurement(
+        "tboard",
+        """Get the current temperature of the driver board in °C (float).""",
+        cast=float)
+
+    def save(self):
+        """Save the current configuration to internal non-volatile memory."""
+        self.write("save")
+
+    def clear_error(self):
+        """Clear the error code."""
+        self.write("errclr")
+
+    error_status = Instrument.measurement(
+        "err",
+        """Get the current error status (IntFlag).""",
+        get_process=lambda v: KoheronError(int(v)),
+    )
+
+    user_data = Instrument.control(
+        "userdata",
+        "userdata write %s",
+        """Control the user data string saved on the device
+        (max. 31 chars, str)""",
+        cast=str,
+        set_process=lambda v: str(v)[:31]
+    )

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -96,6 +96,10 @@ class CTL200Adapter(SerialAdapter):
         return lines
 
     def write(self, command: str) -> None:
+        """Send a command and buffer the response lines.
+
+        :param command: Command string to send to the device.
+        """
         self._last_command = command.strip()
         super().write(command)
         self._response_buffer = self._read_until_prompt()
@@ -103,6 +107,11 @@ class CTL200Adapter(SerialAdapter):
                   self._response_buffer)
 
     def read(self) -> str:
+        """Return the next non-empty response line from the buffer.
+
+        :returns: The next response line, or empty string if buffer is
+        exhausted.
+        """
         while self._response_buffer:
             value = self._response_buffer.pop(0)
             if value.strip():
@@ -329,7 +338,7 @@ class CTL200(Instrument):
     laser_mod_gain = Instrument.control(
         "lmodgain",
         "lmodgain %g",
-        """Control the laser current modulation gain of auxillary input 1 in
+        """Control the laser current modulation gain of auxiliary input 1 in
         A/V (float, strict_range from -100 to 100).""",
         cast=float,
         validator=strict_range,
@@ -341,7 +350,7 @@ class CTL200(Instrument):
     tec_mod_gain = Instrument.control(
         "tmodgain",
         "tmodgain %g",
-        """Control the temperature modulation gain of auxillary input 2 in
+        """Control the temperature modulation gain of auxiliary input 2 in
         Ω/V (float, strict_range from -100000 to 100000).""",
         cast=float,
         validator=strict_range,
@@ -363,7 +372,6 @@ class CTL200(Instrument):
 
     @staticmethod
     def _parse_status(values):
-        print(values)
         keys = CTL200._STATUS_KEYS
         if len(values) != len(keys):
             raise ValueError(

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -25,7 +25,7 @@
 import logging
 import time
 from enum import IntFlag
-from pymeasure.adapters import SerialAdapter
+from pymeasure.adapters import SerialAdapter, Adapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import (
     strict_discrete_set,
@@ -66,6 +66,7 @@ class CTL200Adapter(SerialAdapter):
         self._response_buffer: list[str] = []
         time.sleep(0.05)
         self.connection.reset_input_buffer()
+        self.connection.reset_output_buffer()
 
     def _read_until_prompt(self) -> list[str]:
         raw = b""
@@ -128,15 +129,15 @@ class CTL200(Instrument):
                     "ain2"]
 
     def __init__(self, adapter, name="Koheron CTL200", **kwargs):
-        ADAPTER_KWARGS = {"baudrate", "timeout"}
-        adapter_kwargs = {k: v for k, v in kwargs.items() if
-                          k in ADAPTER_KWARGS}
-        instrument_kwargs = {k: v for k, v in kwargs.items() if
-                             k not in ADAPTER_KWARGS}
-        if isinstance(adapter, str):
-            adapter = CTL200Adapter(adapter, **adapter_kwargs)
+        adapter_kwargs = {}
+        for key in ["baudrate", "timeout", "write_termination", "read_termination"]:
+            if key in kwargs:
+                adapter_kwargs[key] = kwargs.pop(key)
 
-        super().__init__(adapter, name, includeSCPI=False, **instrument_kwargs)
+        if isinstance(adapter, str) and "::" not in adapter:
+            # only for serial ports, not VISA strings
+            adapter = CTL200Adapter(adapter, **adapter_kwargs)
+        super().__init__(adapter, name, includeSCPI=False, **kwargs)
 
     # -- Laser -----------------------------------------------------------
 

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -51,7 +51,7 @@ class KoheronError(IntFlag):
 
 
 class CTL200Adapter(SerialAdapter):
-    """Serial adapter for Koheron CTL200 do deal with echo responses."""
+    """Serial adapter for Koheron CTL200 to deal with echo responses."""
 
     def __init__(self, port, **kwargs):
         kwargs.setdefault("baudrate", 115200)
@@ -103,10 +103,11 @@ class CTL200Adapter(SerialAdapter):
                   self._response_buffer)
 
     def read(self) -> str:
-        if self._response_buffer:
+        while self._response_buffer:
             value = self._response_buffer.pop(0)
-            log.debug("read -> %r", value)
-            return value
+            if value.strip():
+                log.debug("read -> %r", value)
+                return value
         log.debug("read -> buffer empty, return ''")
         return ""
 
@@ -114,6 +115,9 @@ class CTL200Adapter(SerialAdapter):
 class CTL200(Instrument):
     """PyMeasure driver for the Koheron CTL200-0 digital
     laser diode controller."""
+
+    _STATUS_KEYS = ["lason", "vlaser", "itec", "vtec", "rtact", "iphd", "ain1",
+                    "ain2"]
 
     def __init__(self, adapter, name="Koheron CTL200", **kwargs):
         if isinstance(adapter, str):
@@ -148,7 +152,8 @@ class CTL200(Instrument):
     laser_current_limit = Instrument.control(
         "ilmax",
         "ilmax %g",
-        """Control the laser current software limit in A (float).""",
+        """Control the laser current software limit in A (float, strict_range
+        from 0 to 1).""",
         cast=float,
         validator=strict_range,
         values=[0, 1],
@@ -173,7 +178,7 @@ class CTL200(Instrument):
         "ldelay",
         "ldelay %g",
         """Control the delay time between controller startup and laser
-        startup in s (float).""",
+        startup in s (float, strict_range from 0.01 to 100).""",
         cast=float,
         validator=strict_range,
         values=[0.01, 100],
@@ -220,7 +225,8 @@ class CTL200(Instrument):
     pid_proportional = Instrument.control(
         "pgain",
         "pgain %g",
-        """Control the proportional gain of the TEC PID controller (float).""",
+        """Control the proportional gain of the TEC PID controller (float,
+        strict_range from 0 to 0.1).""",
         cast=float,
         validator=strict_range,
         values=[0, 0.1],
@@ -229,7 +235,8 @@ class CTL200(Instrument):
     pid_integral = Instrument.control(
         "igain",
         "igain %g",
-        """Control the integral gain of the TEC PID controller (float).""",
+        """Control the integral gain of the TEC PID controller (float,
+        strict_range from 0 to 0.1).""",
         cast=float,
         validator=strict_range,
         values=[0, 0.1],
@@ -238,7 +245,8 @@ class CTL200(Instrument):
     pid_differential = Instrument.control(
         "dgain",
         "dgain %g",
-        """Control the differential gain of the TEC PID controller (float).""",
+        """Control the differential gain of the TEC PID controller (float,
+        strict_range from 0 to 0.1).""",
         cast=float,
         validator=strict_range,
         values=[0, 0.1],
@@ -277,7 +285,8 @@ class CTL200(Instrument):
     tec_voltage_limit_min = Instrument.control(
         "vtmin",
         "vtmin %g",
-        """Control the minimum TEC voltage limit in V (float).""",
+        """Control the minimum TEC voltage limit in V (float, strict_range from
+        -3.3 to 0).""",
         validator=strict_range,
         values=[-3.3, 0.0],
         cast=float,
@@ -286,7 +295,8 @@ class CTL200(Instrument):
     tec_voltage_limit_max = Instrument.control(
         "vtmax",
         "vtmax %g",
-        """Control the maximum TEC voltage limit in V (float).""",
+        """Control the maximum TEC voltage limit in V (float, strict_range from
+        0 to 3.3).""",
         validator=strict_range,
         values=[0.0, 3.3],
         cast=float,
@@ -320,7 +330,7 @@ class CTL200(Instrument):
         "lmodgain",
         "lmodgain %g",
         """Control the laser current modulation gain of auxillary input 1 in
-        A/V (float).""",
+        A/V (float, strict_range from -100 to 100).""",
         cast=float,
         validator=strict_range,
         values=[-100, 100],
@@ -332,7 +342,7 @@ class CTL200(Instrument):
         "tmodgain",
         "tmodgain %g",
         """Control the temperature modulation gain of auxillary input 2 in
-        Ω/V (float).""",
+        Ω/V (float, strict_range from -100000 to 100000).""",
         cast=float,
         validator=strict_range,
         values=[-100000, 100000],
@@ -351,16 +361,25 @@ class CTL200(Instrument):
         cast=str,
     )
 
-    @property
-    def status(self):
-        """Get a dict with all status values ("lason", "vlaser", "itec",
-        "vtec", "rtact","iphd", "ain1", "ain2")."""
-        raw = self.ask("status").strip().split()
-        keys = ["lason", "vlaser", "itec", "vtec", "rtact",
-                "iphd", "ain1", "ain2"]
-        result = {k: float(v) for k, v in zip(keys, raw)}
+    @staticmethod
+    def _parse_status(values):
+        print(values)
+        keys = CTL200._STATUS_KEYS
+        if len(values) != len(keys):
+            raise ValueError(
+                f"Expected {len(keys)} status fields, got {len(values)}:"
+                f" {values}"
+            )
+        result = dict(zip(keys, (float(v) for v in values)))
         result["iphd"] *= 1e-3
         return result
+
+    status = Instrument.measurement(
+        "status",
+        """Get a dict with all status values ("lason", "vlaser", "itec",
+        "vtec", "rtact", "iphd", "ain1", "ain2").""",
+        get_process=lambda v: CTL200._parse_status(v.split()),
+    )
 
     board_temperature = Instrument.measurement(
         "tboard",

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -59,7 +59,7 @@ class CTL200(Instrument):
         kwargs.setdefault("baud_rate", 115200)
         kwargs.setdefault("write_termination", "\r\n")
         kwargs.setdefault("read_termination", "\r\n")
-        super().__init__(adapter, name, includeSCPI=False, **kwargs)
+        super().__init__(adapter, name, **kwargs)
 
     def _read_cleaned_response(self, sent_command):
         """Read lines from device and filter for echos and >> chars."""
@@ -344,6 +344,7 @@ class CTL200(Instrument):
         "status",
         """Get a dict with all status values ("lason", "vlaser", "itec",
         "vtec", "rtact", "iphd", "ain1", "ain2").""",
+        cast=str,
         get_process=lambda v: CTL200._parse_status(v.split()),
     )
 

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -382,7 +382,10 @@ class CTL200(Instrument):
 
         :return: List of error entries.
         """
-        errors = [error.name for error in self.error_status]
+        status = self.error_status
+        # Iterating the flag itself requires Python 3.11, so mask the members
+        # instead. NONE has value 0 and drops out of the comprehension.
+        errors = [error.name for error in KoheronError if error.value & status]
         for error in errors:
             log.error(f"{self.name}: {error}")
         if errors:

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -55,46 +55,46 @@ class CTL200(Instrument):
     _STATUS_KEYS = ["lason", "vlaser", "itec", "vtec", "rtact", "iphd", "ain1",
                     "ain2"]
 
-    def __init__(self, adapter, name="Koheron CTL200", **kwargs):
-        kwargs.setdefault("baud_rate", 115200)
-        kwargs.setdefault("write_termination", "\r\n")
-        kwargs.setdefault("read_termination", "\r\n")
-        super().__init__(adapter, name, **kwargs)
+    def __init__(self, adapter, name="Koheron CTL200", baud_rate=115200, **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            baud_rate=baud_rate,
+            write_termination="\r\n",
+            read_termination="\r\n",
+            **kwargs,
+        )
 
     def _read_cleaned_response(self, sent_command):
-        """Read lines from device and filter for echos and >> chars."""
-        if self._is_test_run():
-            return self.read()
+        """Read the reply of `sent_command`, discarding echo and prompt.
 
+        The device echoes every command before replying with a single value
+        line. Its prompt (">>") is not newline terminated, so it arrives
+        prepended to the echo of the following command.
+        """
         cmd_clean = sent_command.strip()
         while True:
             line = self.read().replace("\x00", "").strip()
-            if line in ("", ">>"):
-                continue
-            if line == cmd_clean:
-                continue
-            if line.startswith(">>") and line.removeprefix(">>").strip() == cmd_clean:
+            # Skip blank lines, the bare prompt, and the echoed command,
+            # each of which may carry a leading prompt.
+            if line.removeprefix(">>").strip() in ("", cmd_clean):
                 continue
             return line
 
-    def write(self, command):
-        """Write command to device and read echo."""
+    def write(self, command, **kwargs):
+        """Write a command and consume the echo and the reply.
+
+        The device replies to every command with a single value line, settings
+        included. It is discarded here to leave no unread data behind.
+        """
+        super().write(command, **kwargs)
+        self._read_cleaned_response(command)
+
+    def ask(self, command, query_delay=None):
+        """Write a command and return its reply without echo and prompt."""
         super().write(command)
-        if self._is_test_run():
-            return
-
+        self.wait_for(query_delay)
         return self._read_cleaned_response(command)
-
-    def ask(self, command):
-        """Query device and read answer without echos and >> chars."""
-        super().write(command)
-        return self._read_cleaned_response(command)
-
-    def _is_test_run(self):
-        return "Protocol" in type(self.adapter).__name__ or (
-            hasattr(self.adapter, "connection") and
-            "MagicMock" in type(self.adapter.connection).__name__
-        )
 
     # -- Laser -----------------------------------------------------------
 
@@ -107,11 +107,10 @@ class CTL200(Instrument):
         map_values=True,
     )
 
-    laser_current = Instrument.control(
+    laser_current_setpoint = Instrument.control(
         "ilaser",
         "ilaser %g",
         """Control the laser current setpoint in A (float).""",
-        cast=float,
         get_process=lambda v: v * 1e-3,
         set_process=lambda v: v * 1e3,
     )
@@ -121,7 +120,6 @@ class CTL200(Instrument):
         "ilmax %g",
         """Control the laser current software limit in A (float, strict_range
         from 0 to 1).""",
-        cast=float,
         validator=strict_range,
         values=[0, 1],
         get_process=lambda v: v * 1e-3,
@@ -131,13 +129,11 @@ class CTL200(Instrument):
     laser_voltage = Instrument.measurement(
         "vlaser",
         """Get the laser voltage in V (float).""",
-        cast=float,
     )
 
     photodiode_current = Instrument.measurement(
         "iphd",
         """Get the photodiode current in A (float).""",
-        cast=float,
         get_process=lambda v: v * 1e-3,
     )
 
@@ -146,7 +142,6 @@ class CTL200(Instrument):
         "ldelay %g",
         """Control the delay time between controller startup and laser
         startup in s (float, strict_range from 0.01 to 100).""",
-        cast=float,
         validator=strict_range,
         values=[0.01, 100],
         get_process=lambda v: v * 1e-3,
@@ -168,25 +163,21 @@ class CTL200(Instrument):
         "rtset",
         "rtset %g",
         """Control the thermistor resistance setpoint in Ω (float).""",
-        cast=float,
     )
 
     tec_current = Instrument.measurement(
         "itec",
         """Get the TEC current in A (float).""",
-        cast=float,
     )
 
     tec_voltage = Instrument.measurement(
         "vtec",
         """Get the TEC voltage in V (float).""",
-        cast=float,
     )
 
     thermistor_actual = Instrument.measurement(
         "rtact",
         """Get the actual thermistor resistance in Ω (float).""",
-        cast=float,
     )
 
     pid_proportional = Instrument.control(
@@ -194,7 +185,6 @@ class CTL200(Instrument):
         "pgain %g",
         """Control the proportional gain of the TEC PID controller (float,
         strict_range from 0 to 0.1).""",
-        cast=float,
         validator=strict_range,
         values=[0, 0.1],
     )
@@ -204,7 +194,6 @@ class CTL200(Instrument):
         "igain %g",
         """Control the integral gain of the TEC PID controller (float,
         strict_range from 0 to 0.1).""",
-        cast=float,
         validator=strict_range,
         values=[0, 0.1],
     )
@@ -214,7 +203,6 @@ class CTL200(Instrument):
         "dgain %g",
         """Control the differential gain of the TEC PID controller (float,
         strict_range from 0 to 0.1).""",
-        cast=float,
         validator=strict_range,
         values=[0, 0.1],
     )
@@ -238,7 +226,6 @@ class CTL200(Instrument):
         "rtmin %g",
         """Control the minimum thermistor resistance in Ω to trigger
         temperature protection if enabled (float).""",
-        cast=float,
     )
 
     thermistor_window_max = Instrument.control(
@@ -246,27 +233,24 @@ class CTL200(Instrument):
         "rtmax %g",
         """Control the maximum thermistor resistance in Ω to trigger
         temperature protection if enabled (float).""",
-        cast=float,
     )
 
     tec_voltage_limit_min = Instrument.control(
         "vtmin",
         "vtmin %g",
         """Control the minimum TEC voltage limit in V (float, strict_range from
-        -3.3 to 0).""",
+        -3 to 0).""",
         validator=strict_range,
-        values=[-3.3, 0.0],
-        cast=float,
+        values=[-3.0, 0.0],
     )
 
     tec_voltage_limit_max = Instrument.control(
         "vtmax",
         "vtmax %g",
         """Control the maximum TEC voltage limit in V (float, strict_range from
-        0 to 3.3).""",
+        0 to 3).""",
         validator=strict_range,
-        values=[0.0, 3.3],
-        cast=float,
+        values=[0.0, 3.0],
     )
 
     # -- Interlock -------------------------------------------------------
@@ -284,33 +268,29 @@ class CTL200(Instrument):
     analog_input_1 = Instrument.measurement(
         "ain1",
         """Get the voltage on auxiliary input AI1 in V (float).""",
-        cast=float,
     )
 
     analog_input_2 = Instrument.measurement(
         "ain2",
         """Get the voltage on auxiliary input AI2 in V (float).""",
-        cast=float,
     )
 
-    laser_mod_gain = Instrument.control(
+    laser_modulation_gain = Instrument.control(
         "lmodgain",
         "lmodgain %g",
         """Control the laser current modulation gain of auxiliary input 1 in
         A/V (float, strict_range from -100 to 100).""",
-        cast=float,
         validator=strict_range,
         values=[-100, 100],
         get_process=lambda v: v * 1e-3,
         set_process=lambda v: v * 1e3,
     )
 
-    tec_mod_gain = Instrument.control(
+    tec_modulation_gain = Instrument.control(
         "tmodgain",
         "tmodgain %g",
         """Control the temperature modulation gain of auxiliary input 2 in
         Ω/V (float, strict_range from -100000 to 100000).""",
-        cast=float,
         validator=strict_range,
         values=[-100000, 100000],
     )
@@ -326,6 +306,25 @@ class CTL200(Instrument):
         "model",
         """Get the board model version (str).""",
         cast=str,
+    )
+
+    serial_number = Instrument.measurement(
+        "serial",
+        """Get the serial number (str).""",
+        cast=str,
+    )
+
+    baud_rate_setting = Instrument.control(
+        "brate",
+        "brate %d",
+        """Control the UART baud rate of the device (int, strict_range from 9600
+        to 460800). The new baud rate takes effect immediately, which
+        desynchronizes the current connection: reconnect with a matching
+        :code:`baud_rate` to keep communicating. Use :meth:`save` to persist it
+        across power cycles.""",
+        validator=strict_range,
+        values=[9600, 460800],
+        cast=int,
     )
 
     @staticmethod
@@ -351,7 +350,7 @@ class CTL200(Instrument):
     board_temperature = Instrument.measurement(
         "tboard",
         """Get the current temperature of the driver board in °C (float).""",
-        cast=float)
+    )
 
     def save(self):
         """Save the current configuration to internal non-volatile memory."""
@@ -363,8 +362,10 @@ class CTL200(Instrument):
 
     error_status = Instrument.measurement(
         "err",
-        """Get the current error status (IntFlag).""",
-        get_process=lambda v: KoheronError(int(v)),
+        """Get the current error status (KoheronError). The device returns the
+        error code in hexadecimal format.""",
+        cast=str,
+        get_process=lambda v: KoheronError(int(v, 16)),
     )
 
     user_data = Instrument.control(
@@ -377,13 +378,13 @@ class CTL200(Instrument):
     )
 
     def check_errors(self):
-        """Read the error status flag and extract occurring errors."""
-        status = self.error_status
-        if status == KoheronError.NONE:
-            return []
-        errors = []
-        for error in KoheronError:
-            if error != KoheronError.NONE and error in status:
-                errors.append(f"Koheron CTL200 Error: {error.name}")
-        self.clear_error()
+        """Read the error status flag, log the errors, and clear them.
+
+        :return: List of error entries.
+        """
+        errors = [error.name for error in self.error_status]
+        for error in errors:
+            log.error(f"{self.name}: {error}")
+        if errors:
+            self.clear_error()
         return errors

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -109,8 +109,7 @@ class CTL200Adapter(SerialAdapter):
     def read(self) -> str:
         """Return the next non-empty response line from the buffer.
 
-        :returns: The next response line, or empty string if buffer is
-        exhausted.
+        :returns: The next response line, or empty string if buffer is empty.
         """
         while self._response_buffer:
             value = self._response_buffer.pop(0)
@@ -129,14 +128,15 @@ class CTL200(Instrument):
                     "ain2"]
 
     def __init__(self, adapter, name="Koheron CTL200", **kwargs):
+        ADAPTER_KWARGS = {"baudrate", "timeout"}
+        adapter_kwargs = {k: v for k, v in kwargs.items() if
+                          k in ADAPTER_KWARGS}
+        instrument_kwargs = {k: v for k, v in kwargs.items() if
+                             k not in ADAPTER_KWARGS}
         if isinstance(adapter, str):
-            adapter = CTL200Adapter(adapter, **kwargs)
-        super().__init__(
-            adapter,
-            name,
-            includeSCPI=False,
-            **kwargs
-        )
+            adapter = CTL200Adapter(adapter, **adapter_kwargs)
+
+        super().__init__(adapter, name, includeSCPI=False, **instrument_kwargs)
 
     # -- Laser -----------------------------------------------------------
 

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -23,9 +23,7 @@
 #
 
 import logging
-import time
 from enum import IntFlag
-from pymeasure.adapters import SerialAdapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import (
     strict_discrete_set,
@@ -50,77 +48,6 @@ class KoheronError(IntFlag):
     INTERLOCK_TRIGGERED = 1 << 7
 
 
-class CTL200Adapter(SerialAdapter):
-    """Serial adapter for Koheron CTL200 to deal with echo responses."""
-
-    def __init__(self, port, **kwargs):
-        kwargs.setdefault("baudrate", 115200)
-        kwargs.setdefault("timeout", 2)
-        super().__init__(
-            port,
-            write_termination="\r\n",
-            read_termination="\r\n",
-            **kwargs
-        )
-        self._last_command: str = ""
-        self._response_buffer: list[str] = []
-        time.sleep(0.05)
-        self.connection.reset_input_buffer()
-        self.connection.reset_output_buffer()
-
-    def _read_until_prompt(self) -> list[str]:
-        raw = b""
-        total_timeout = max(self.connection.timeout or 0, 2.0)
-        deadline = time.monotonic() + total_timeout
-        while time.monotonic() < deadline:
-            waiting = self.connection.in_waiting
-            if waiting:
-                raw += self.connection.read(waiting)
-                if b">>" in raw:
-                    # read trailing chars (\r\n, ...)
-                    time.sleep(0.02)
-                    trailing = self.connection.in_waiting
-                    if trailing:
-                        raw += self.connection.read(trailing)
-                    break
-            else:
-                time.sleep(0.005)
-
-        log.debug("raw RX: %r", raw)
-        text = raw.decode(errors="replace")
-        lines = [line.strip() for line in text.replace("\r", "").split("\n")]
-        lines = [line for line in lines if line]  # remove blanks
-        if lines and self._last_command and lines[0] == self._last_command:
-            lines.pop(0)  # remove echo
-        lines = [line for line in lines if line != ">>"]  # remove prompt chars
-        log.debug("parsed lines: %r", lines)
-        return lines
-
-    def write(self, command: str) -> None:
-        """Send a command and buffer the response lines.
-
-        :param command: Command string to send to the device.
-        """
-        self._last_command = command.strip()
-        super().write(command)
-        self._response_buffer = self._read_until_prompt()
-        log.debug("write %r -> buffer: %r", command,
-                  self._response_buffer)
-
-    def read(self) -> str:
-        """Return the next non-empty response line from the buffer.
-
-        :returns: The next response line, or empty string if buffer is empty.
-        """
-        while self._response_buffer:
-            value = self._response_buffer.pop(0)
-            if value.strip():
-                log.debug("read -> %r", value)
-                return value
-        log.debug("read -> buffer empty, return ''")
-        return ""
-
-
 class CTL200(Instrument):
     """PyMeasure driver for the Koheron CTL200-0 digital
     laser diode controller."""
@@ -129,15 +56,48 @@ class CTL200(Instrument):
                     "ain2"]
 
     def __init__(self, adapter, name="Koheron CTL200", **kwargs):
-        adapter_kwargs = {}
-        for key in ["baudrate", "timeout", "write_termination", "read_termination"]:
-            if key in kwargs:
-                adapter_kwargs[key] = kwargs.pop(key)
-
-        if isinstance(adapter, str) and "::" not in adapter:
-            # only for serial ports, not VISA strings
-            adapter = CTL200Adapter(adapter, **adapter_kwargs)
+        kwargs.setdefault("baud_rate", 115200)
+        kwargs.setdefault("write_termination", "\r\n")
+        kwargs.setdefault("read_termination", "\r\n")
         super().__init__(adapter, name, includeSCPI=False, **kwargs)
+
+    def _read_cleaned_response(self, sent_command):
+        """Read lines from device and filter for echos and >> chars."""
+        if self._is_test_run():
+            return self.read()
+
+        cmd_clean = sent_command.strip()
+        while True:
+            line = self.read().replace("\x00", "").strip()
+            print(line)
+            if line in ("", ">>"):
+                continue
+            if line == cmd_clean:
+                continue
+            if line.startswith(">>") and line.removeprefix(">>").strip() == cmd_clean:
+                continue
+            print("returned")
+            return line
+
+    def write(self, command):
+        """Write command to device and read echo."""
+        super().write(command)
+        if self._is_test_run():
+            print("test run")
+            return
+
+        return self._read_cleaned_response(command)
+
+    def ask(self, command):
+        """Query device and read answer without echos and >> chars."""
+        super().write(command)
+        return self._read_cleaned_response(command)
+
+    def _is_test_run(self):
+        return "Protocol" in type(self.adapter).__name__ or (
+            hasattr(self.adapter, "connection") and
+            "MagicMock" in type(self.adapter.connection).__name__
+        )
 
     # -- Laser -----------------------------------------------------------
 
@@ -417,3 +377,15 @@ class CTL200(Instrument):
         cast=str,
         set_process=lambda v: str(v)[:31]
     )
+
+    def check_errors(self):
+        """Read the error status flag and extract occurring errors."""
+        status = self.error_status
+        if status == KoheronError.NONE:
+            return []
+        errors = []
+        for error in KoheronError:
+            if error != KoheronError.NONE and error in status:
+                errors.append(f"Koheron CTL200 Error: {error.name}")
+        self.clear_error()
+        return errors

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -69,21 +69,18 @@ class CTL200(Instrument):
         cmd_clean = sent_command.strip()
         while True:
             line = self.read().replace("\x00", "").strip()
-            print(line)
             if line in ("", ">>"):
                 continue
             if line == cmd_clean:
                 continue
             if line.startswith(">>") and line.removeprefix(">>").strip() == cmd_clean:
                 continue
-            print("returned")
             return line
 
     def write(self, command):
         """Write command to device and read echo."""
         super().write(command)
         if self._is_test_run():
-            print("test run")
             return
 
         return self._read_cleaned_response(command)

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -217,23 +217,13 @@ class CTL200(Instrument):
         cast=float,
     )
 
-    tec_current = Instrument.measurement(
-        "itec",
-        """Get the TEC current in A (float).""",
-        cast=float,
-    )
-
-    tec_voltage = Instrument.measurement(
-        "vtec",
-        """Get the TEC voltage in V (float).""",
-        cast=float,
-    )
-
     pid_proportional = Instrument.control(
         "pgain",
         "pgain %g",
         """Control the proportional gain of the TEC PID controller (float).""",
         cast=float,
+        validator=strict_range,
+        values=[0, 0.1],
     )
 
     pid_integral = Instrument.control(
@@ -241,6 +231,8 @@ class CTL200(Instrument):
         "igain %g",
         """Control the integral gain of the TEC PID controller (float).""",
         cast=float,
+        validator=strict_range,
+        values=[0, 0.1],
     )
 
     pid_differential = Instrument.control(
@@ -248,6 +240,8 @@ class CTL200(Instrument):
         "dgain %g",
         """Control the differential gain of the TEC PID controller (float).""",
         cast=float,
+        validator=strict_range,
+        values=[0, 0.1],
     )
 
     # -- Protection ------------------------------------------------------
@@ -257,7 +251,7 @@ class CTL200(Instrument):
         "tprot %d",
         """Control whether temperature protection is enabled (bool). If
         temperature protection is enabled, the laser current is automatically
-        disabled id the thermistor resistance is outside the thermistor
+        disabled if the thermistor resistance is outside the set thermistor
         window.""",
         validator=strict_discrete_set,
         values={True: 1, False: 0},
@@ -267,16 +261,16 @@ class CTL200(Instrument):
     thermistor_window_min = Instrument.control(
         "rtmin",
         "rtmin %g",
-        """Control the minimum thermistor resistance in Ω (float) to trigger
-        temperature protection if enabled.""",
+        """Control the minimum thermistor resistance in Ω to trigger
+        temperature protection if enabled (float).""",
         cast=float,
     )
 
     thermistor_window_max = Instrument.control(
         "rtmax",
         "rtmax %g",
-        """Control the maximum thermistor resistance in Ω (float) to trigger
-        temperature protection if enabled.""",
+        """Control the maximum thermistor resistance in Ω to trigger
+        temperature protection if enabled (float).""",
         cast=float,
     )
 

--- a/pymeasure/instruments/koheron/koheron_ctl200.py
+++ b/pymeasure/instruments/koheron/koheron_ctl200.py
@@ -25,7 +25,7 @@
 import logging
 import time
 from enum import IntFlag
-from pymeasure.adapters import SerialAdapter, Adapter
+from pymeasure.adapters import SerialAdapter
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import (
     strict_discrete_set,

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -141,20 +141,33 @@ def test_pid_parameters():
     with expected_protocol(
         CTL200,
         [
-            ("pgain 15.1", None),
-            ("pgain", "15.1"),
-            ("igain 2.3", None),
-            ("igain", "2.3"),
-            ("dgain 0.1", None),
-            ("dgain", "0.1"),
+            ("pgain 0.1", None),
+            ("pgain", "0.1"),
+            ("igain 0.03", None),
+            ("igain", "0.03"),
+            ("dgain 0", None),
+            ("dgain", "0"),
         ],
     ) as inst:
-        inst.pid_proportional = 15.1
-        assert inst.pid_proportional == 15.1
-        inst.pid_integral = 2.3
-        assert inst.pid_integral == 2.3
-        inst.pid_differential = 0.1
-        assert inst.pid_differential == 0.1
+        inst.pid_proportional = 0.1
+        assert inst.pid_proportional == 0.1
+        inst.pid_integral = 0.03
+        assert inst.pid_integral == 0.03
+        inst.pid_differential = 0
+        assert inst.pid_differential == 0
+
+
+@pytest.mark.parametrize("invalid_value", [-0.01, 0.11, -5, 2.0])
+def test_pid_parameters_out_of_bounds(invalid_value):
+    """Verify that PID gains raise ValueError when set outside the
+    [0, 0.1] range."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.pid_proportional = invalid_value
+        with pytest.raises(ValueError):
+            inst.pid_integral = invalid_value
+        with pytest.raises(ValueError):
+            inst.pid_differential = invalid_value
 
 
 # =============================================================================

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -24,7 +24,7 @@
 
 import pytest
 from pymeasure.test import expected_protocol
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from pymeasure.instruments.koheron import CTL200, CTL200Adapter
 
 # =============================================================================
@@ -42,46 +42,37 @@ def make_mock_serial(chunks):
     return conn
 
 
-def make_adapter():
-    """Create adapter without running __init__, but with required attributes."""
-    adapter = CTL200Adapter.__new__(CTL200Adapter)
-    adapter.log = MagicMock()
-    adapter.write_termination = "\r\n"
-    adapter.read_termination = "\r\n"
-    adapter._response_buffer = []
-    adapter._last_command = ""
-    return adapter
+@patch("serial.Serial")
+def test_read_until_prompt_parses_correctly(mock_serial):
+    """Parse response lines until the device prompt is reached."""
+    chunks = [b"CMD\r\n", b"123\r\n", b">>\r\n"]
+    mock_serial.return_value = make_mock_serial(chunks)
 
-
-def test_read_until_prompt_parses_correctly():
-    adapter = make_adapter()
+    adapter = CTL200Adapter("COM1")
     adapter._last_command = "CMD"
-
-    adapter.connection = make_mock_serial([
-        b"CMD\r\n",
-        b"123\r\n",
-        b">>\r\n"
-    ])
 
     lines = adapter._read_until_prompt()
     assert lines == ["123"]
 
 
-def test_write_buffers_response():
-    adapter = make_adapter()
+@patch("serial.Serial")
+def test_write_buffers_response(mock_serial):
+    """Buffer response lines after sending a command."""
+    chunks = [b"CMD\r\n", b"OK\r\n", b">>\r\n"]
+    mock_serial.return_value = make_mock_serial(chunks)
 
-    adapter.connection = make_mock_serial([
-        b"CMD\r\n",
-        b"OK\r\n",
-        b">>\r\n"
-    ])
-
+    adapter = CTL200Adapter("COM1")
     adapter.write("CMD")
+
     assert adapter._response_buffer == ["OK"]
 
 
-def test_read_returns_buffered_lines():
-    adapter = make_adapter()
+@patch("serial.Serial")
+def test_read_returns_buffered_lines(mock_serial):
+    """Return buffered response lines in sequence."""
+    mock_serial.return_value = make_mock_serial([])
+
+    adapter = CTL200Adapter("COM1")
     adapter._response_buffer = ["A", "B", ""]
 
     assert adapter.read() == "A"

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -24,8 +24,69 @@
 
 import pytest
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.koheron import CTL200
+from unittest.mock import MagicMock
+from pymeasure.instruments.koheron import CTL200, CTL200Adapter
 
+# =============================================================================
+# -- CTL200Adapter Tests
+# =============================================================================
+
+
+def make_mock_serial(chunks):
+    """Return a fake serial connection that yields chunks incrementally."""
+    conn = MagicMock()
+    conn.timeout = 1
+    conn.in_waiting = sum(len(c) for c in chunks)
+    # ensure no StopIteration
+    conn.read = MagicMock(side_effect=chunks + [b""])
+    return conn
+
+
+def make_adapter():
+    """Create adapter without running __init__, but with required attributes."""
+    adapter = CTL200Adapter.__new__(CTL200Adapter)
+    adapter.log = MagicMock()
+    adapter.write_termination = "\r\n"
+    adapter.read_termination = "\r\n"
+    adapter._response_buffer = []
+    adapter._last_command = ""
+    return adapter
+
+
+def test_read_until_prompt_parses_correctly():
+    adapter = make_adapter()
+    adapter._last_command = "CMD"
+
+    adapter.connection = make_mock_serial([
+        b"CMD\r\n",
+        b"123\r\n",
+        b">>\r\n"
+    ])
+
+    lines = adapter._read_until_prompt()
+    assert lines == ["123"]
+
+
+def test_write_buffers_response():
+    adapter = make_adapter()
+
+    adapter.connection = make_mock_serial([
+        b"CMD\r\n",
+        b"OK\r\n",
+        b">>\r\n"
+    ])
+
+    adapter.write("CMD")
+    assert adapter._response_buffer == ["OK"]
+
+
+def test_read_returns_buffered_lines():
+    adapter = make_adapter()
+    adapter._response_buffer = ["A", "B", ""]
+
+    assert adapter.read() == "A"
+    assert adapter.read() == "B"
+    assert adapter.read() == ""
 
 # =============================================================================
 # -- Laser Tests

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -24,60 +24,7 @@
 
 import pytest
 from pymeasure.test import expected_protocol
-from unittest.mock import MagicMock, patch
-from pymeasure.instruments.koheron import CTL200, CTL200Adapter
-
-# =============================================================================
-# -- CTL200Adapter Tests
-# =============================================================================
-
-
-def make_mock_serial(chunks):
-    """Return a fake serial connection that yields chunks incrementally."""
-    conn = MagicMock()
-    conn.timeout = 1
-    conn.in_waiting = sum(len(c) for c in chunks)
-    # ensure no StopIteration
-    conn.read = MagicMock(side_effect=chunks + [b""])
-    return conn
-
-
-@patch("serial.Serial")
-def test_read_until_prompt_parses_correctly(mock_serial):
-    """Parse response lines until the device prompt is reached."""
-    chunks = [b"CMD\r\n", b"123\r\n", b">>\r\n"]
-    mock_serial.return_value = make_mock_serial(chunks)
-
-    adapter = CTL200Adapter("COM1")
-    adapter._last_command = "CMD"
-
-    lines = adapter._read_until_prompt()
-    assert lines == ["123"]
-
-
-@patch("serial.Serial")
-def test_write_buffers_response(mock_serial):
-    """Buffer response lines after sending a command."""
-    chunks = [b"CMD\r\n", b"OK\r\n", b">>\r\n"]
-    mock_serial.return_value = make_mock_serial(chunks)
-
-    adapter = CTL200Adapter("COM1")
-    adapter.write("CMD")
-
-    assert adapter._response_buffer == ["OK"]
-
-
-@patch("serial.Serial")
-def test_read_returns_buffered_lines(mock_serial):
-    """Return buffered response lines in sequence."""
-    mock_serial.return_value = make_mock_serial([])
-
-    adapter = CTL200Adapter("COM1")
-    adapter._response_buffer = ["A", "B", ""]
-
-    assert adapter.read() == "A"
-    assert adapter.read() == "B"
-    assert adapter.read() == ""
+from pymeasure.instruments.koheron import CTL200
 
 # =============================================================================
 # -- Laser Tests

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -26,9 +26,6 @@ import pytest
 from pymeasure.test import expected_protocol
 from pymeasure.instruments.koheron import CTL200
 
-# Import your driver class and exception/enum here
-# from your_module import CTL200, KoheronError
-
 
 # =============================================================================
 # -- Laser Tests

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -37,27 +37,32 @@ from pymeasure.instruments.koheron import CTL200
 
 def test_laser_enabled():
     """Verify enabling and disabling of the laser output."""
-    with expected_protocol(CTL200, [("lason 1", None), ("lason", "1")]) as inst:
+    with expected_protocol(CTL200,
+                           [("lason 1", None), ("lason", "1")]) as inst:
         inst.laser_enabled = True
         assert inst.laser_enabled is True
 
 
 def test_laser_current():
-    """Verify laser current setting and its mA to Ampere conversion (scaling by 1e3 / 1e-3)."""
-    with expected_protocol(CTL200, [("ilaser 150", None), ("ilaser", "150.0")]) as inst:
+    """Verify laser current setting and its mA to Ampere conversion (scaling
+    by 1e3 / 1e-3)."""
+    with expected_protocol(
+            CTL200, [("ilaser 150", None), ("ilaser", "150.0")]) as inst:
         inst.laser_current = 0.15
         assert inst.laser_current == pytest.approx(0.15)
 
 
 def test_laser_current_limit():
     """Verify laser current software limit configuration and scaling."""
-    with expected_protocol(CTL200, [("ilmax 500", None), ("ilmax", "500.0")]) as inst:
+    with expected_protocol(
+            CTL200, [("ilmax 500", None), ("ilmax", "500.0")]) as inst:
         inst.laser_current_limit = 0.5
         assert inst.laser_current_limit == pytest.approx(0.5)
 
 
 def test_laser_current_limit_validator():
-    """Verify that strict_range validator blocks current limits outside [0, 1] A."""
+    """Verify that strict_range validator blocks current limits outside [0, 1]
+    A."""
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
             inst.laser_current_limit = 1.5
@@ -70,14 +75,16 @@ def test_laser_voltage():
 
 
 def test_photodiode_current():
-    """Verify photodiode current reading and its mA to Ampere scaling (1e-3)."""
+    """Verify photodiode current reading and its mA to Ampere scaling
+    (1e-3)."""
     with expected_protocol(CTL200, [("iphd", "2.5")]) as inst:
         assert inst.photodiode_current == pytest.approx(0.0025)
 
 
 def test_laser_delay():
     """Verify laser delay control and its ms to seconds scaling."""
-    with expected_protocol(CTL200, [("ldelay 2500", None), ("ldelay", "2500.0")]) as inst:
+    with expected_protocol(
+            CTL200, [("ldelay 2500", None), ("ldelay", "2500.0")]) as inst:
         inst.laser_delay = 2.5
         assert inst.laser_delay == pytest.approx(2.5)
 
@@ -96,14 +103,16 @@ def test_laser_delay_validator():
 
 def test_tec_enabled():
     """Verify enabling and disabling of the TEC output."""
-    with expected_protocol(CTL200, [("tecon 0", None), ("tecon", "0")]) as inst:
+    with expected_protocol(
+            CTL200, [("tecon 0", None), ("tecon", "0")]) as inst:
         inst.tec_enabled = False
         assert inst.tec_enabled is False
 
 
 def test_thermistor_setpoint():
     """Verify thermistor resistance setpoint control."""
-    with expected_protocol(CTL200, [("rtset 10000", None), ("rtset", "10000.0")]) as inst:
+    with expected_protocol(
+            CTL200, [("rtset 10000", None), ("rtset", "10000.0")]) as inst:
         inst.thermistor_setpoint = 10000.0
         assert inst.thermistor_setpoint == 10000.0
 
@@ -127,7 +136,8 @@ def test_thermistor_actual():
 
 
 def test_pid_parameters():
-    """Verify control of the proportional, integral, and differential loop gains."""
+    """Verify control of the proportional, integral, and differential loop
+    gains."""
     with expected_protocol(
         CTL200,
         [
@@ -154,7 +164,8 @@ def test_pid_parameters():
 
 def test_temp_protection_enabled():
     """Verify configuration of the temperature protection switch."""
-    with expected_protocol(CTL200, [("tprot 1", None), ("tprot", "1")]) as inst:
+    with expected_protocol(
+            CTL200, [("tprot 1", None), ("tprot", "1")]) as inst:
         inst.temp_protection_enabled = True
         assert inst.temp_protection_enabled is True
 
@@ -163,7 +174,8 @@ def test_thermistor_windows():
     """Verify minimum and maximum thermistor resistance window control."""
     with expected_protocol(
         CTL200,
-        [("rtmin 5000", None), ("rtmin", "5000.0"), ("rtmax 15000", None), ("rtmax", "15000.0")],
+        [("rtmin 5000", None), ("rtmin", "5000.0"),
+         ("rtmax 15000", None), ("rtmax", "15000.0")],
     ) as inst:
         inst.thermistor_window_min = 5000.0
         assert inst.thermistor_window_min == 5000.0
@@ -172,9 +184,11 @@ def test_thermistor_windows():
 
 
 def test_tec_voltage_limits():
-    """Verify minimum and maximum TEC voltage limit configuration within bounds."""
+    """Verify minimum and maximum TEC voltage limit configuration within
+    bounds."""
     with expected_protocol(
-        CTL200, [("vtmin -2.5", None), ("vtmin", "-2.5"), ("vtmax 2.5", None), ("vtmax", "2.5")]
+        CTL200, [("vtmin -2.5", None), ("vtmin", "-2.5"),
+                 ("vtmax 2.5", None), ("vtmax", "2.5")]
     ) as inst:
         inst.tec_voltage_limit_min = -2.5
         assert inst.tec_voltage_limit_min == -2.5
@@ -183,7 +197,8 @@ def test_tec_voltage_limits():
 
 
 def test_tec_voltage_limits_validators():
-    """Verify that strict_range validators trigger on invalid TEC voltage limits."""
+    """Verify that strict_range validators trigger on invalid TEC voltage
+    limits."""
     # vtmin range: [-3.3, 0.0] | vtmax range: [0.0, 3.3]
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
@@ -199,7 +214,8 @@ def test_tec_voltage_limits_validators():
 
 def test_interlock_enabled():
     """Verify hardware interlock switch control."""
-    with expected_protocol(CTL200, [("lckon 1", None), ("lckon", "1")]) as inst:
+    with expected_protocol(
+            CTL200, [("lckon 1", None), ("lckon", "1")]) as inst:
         inst.interlock_enabled = True
         assert inst.interlock_enabled is True
 
@@ -211,34 +227,40 @@ def test_interlock_enabled():
 
 def test_analog_inputs():
     """Verify reading of auxiliary analog input voltages."""
-    with expected_protocol(CTL200, [("ain1", "0.23"), ("ain2", "1.45")]) as inst:
+    with expected_protocol(
+            CTL200, [("ain1", "0.23"), ("ain2", "1.45")]) as inst:
         assert inst.analog_input_1 == 0.23
         assert inst.analog_input_2 == 1.45
 
 
 def test_laser_mod_gain():
     """Verify modulation gain scaling logic for auxiliary input 1."""
-    with expected_protocol(CTL200, [("lmodgain 50", None), ("lmodgain", "50.0")]) as inst:
+    with expected_protocol(
+            CTL200, [("lmodgain 50", None), ("lmodgain", "50.0")]) as inst:
         inst.laser_mod_gain = 0.05
         assert inst.laser_mod_gain == pytest.approx(0.05)
 
 
 def test_laser_mod_gain_validator():
-    """Verify strict_range validator limits for laser modulation gain ([-100, 100])."""
+    """Verify strict_range validator limits for laser modulation gain
+    ([-100, 100])."""
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
             inst.laser_mod_gain = 150
 
 
 def test_tec_mod_gain():
-    """Verify temperature modulation gain configuration (no internal scaling)."""
-    with expected_protocol(CTL200, [("tmodgain 5000", None), ("tmodgain", "5000.0")]) as inst:
+    """Verify temperature modulation gain configuration
+    (no internal scaling)."""
+    with expected_protocol(
+            CTL200, [("tmodgain 5000", None), ("tmodgain", "5000.0")]) as inst:
         inst.tec_mod_gain = 5000.0
         assert inst.tec_mod_gain == 5000.0
 
 
 def test_tec_mod_gain_validator():
-    """Verify strict_range validator bounds for TEC modulation gain ([-100000, 100000])."""
+    """Verify strict_range validator bounds for TEC modulation gain
+    ([-100000, 100000])."""
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
             inst.tec_mod_gain = 200000
@@ -251,7 +273,8 @@ def test_tec_mod_gain_validator():
 
 def test_versions():
     """Verify firmware and board model identifier acquisition."""
-    with expected_protocol(CTL200, [("version", "v1.2.3"), ("model", "CTL200-0")]) as inst:
+    with expected_protocol(
+            CTL200, [("version", "v1.2.3"), ("model", "CTL200-0")]) as inst:
         assert inst.firmware_version == "v1.2.3"
         assert inst.board_version == "CTL200-0"
 
@@ -263,7 +286,8 @@ def test_board_temperature():
 
 
 def test_status_property():
-    """Verify complex multi-value parsing and custom scaling of the status property."""
+    """Verify complex multi-value parsing and custom scaling of the status
+    property."""
     status_response = "1 1.8 0.5 2.1 10000.0 1.5 0.05 0.1"
     with expected_protocol(CTL200, [("status", status_response)]) as inst:
         res = inst.status
@@ -272,13 +296,14 @@ def test_status_property():
         assert res["itec"] == 0.5
         assert res["vtec"] == 2.1
         assert res["rtact"] == 10000.0
-        assert res["iphd"] == pytest.approx(0.0015)  # Verifies 1.5 * 1e-3 logic
+        assert res["iphd"] == pytest.approx(0.0015)
         assert res["ain1"] == 0.05
         assert res["ain2"] == 0.1
 
 
 def test_commands():
-    """Verify command execution for parameter persistence and error clear states."""
+    """Verify command execution for parameter persistence and error clear
+    states."""
     with expected_protocol(CTL200, [("save", None), ("errclr", None)]) as inst:
         inst.save()
         inst.clear_error()
@@ -289,9 +314,3 @@ def test_error_status():
     with expected_protocol(CTL200, [("err", "0")]) as inst:
         # Casts output to int to evaluate matching underlying flags
         assert int(inst.error_status) == 0
-
-
-def test_user_data_truncation():
-    """Verify that user data inputs are string-truncated to a maximum of 31 characters."""
-    long_string = "B" * 40
-    expected_string = "B" * 31

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -24,7 +24,21 @@
 
 import pytest
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.koheron import CTL200
+from pymeasure.instruments.koheron import CTL200, KoheronError
+
+# The device replies to every command, settings included, with the echo of the
+# command followed by a single value line. Its prompt (">>") terminates neither
+# in a newline nor in a space, so it arrives prepended to the echo of the
+# following command. A query of the laser current therefore reads on the wire as
+#
+#     write: b"ilaser\r\n"
+#     read:  b"ilaser\r\n200.000\r\n>>"
+#
+# which is expressed as the two communication pairs
+#
+#     [("ilaser", "ilaser"), (None, "200.000")]
+#
+# with every subsequent command echoing as ">>ilaser".
 
 # =============================================================================
 # -- Laser Tests
@@ -33,25 +47,34 @@ from pymeasure.instruments.koheron import CTL200
 
 def test_laser_enabled():
     """Verify enabling and disabling of the laser output."""
-    with expected_protocol(CTL200,
-                           [("lason 1", None), ("lason", "1")]) as inst:
+    with expected_protocol(
+        CTL200,
+        [("lason 1", "lason 1"), (None, "1"),
+         ("lason", ">>lason"), (None, "1")],
+    ) as inst:
         inst.laser_enabled = True
         assert inst.laser_enabled is True
 
 
-def test_laser_current():
+def test_laser_current_setpoint():
     """Verify laser current setting and its mA to Ampere conversion (scaling
     by 1e3 / 1e-3)."""
     with expected_protocol(
-            CTL200, [("ilaser 150", None), ("ilaser", "150.0")]) as inst:
-        inst.laser_current = 0.15
-        assert inst.laser_current == pytest.approx(0.15)
+        CTL200,
+        [("ilaser 150", "ilaser 150"), (None, "150.000"),
+         ("ilaser", ">>ilaser"), (None, "150.000")],
+    ) as inst:
+        inst.laser_current_setpoint = 0.15
+        assert inst.laser_current_setpoint == pytest.approx(0.15)
 
 
 def test_laser_current_limit():
     """Verify laser current software limit configuration and scaling."""
     with expected_protocol(
-            CTL200, [("ilmax 500", None), ("ilmax", "500.0")]) as inst:
+        CTL200,
+        [("ilmax 500", "ilmax 500"), (None, "500.000"),
+         ("ilmax", ">>ilmax"), (None, "500.000")],
+    ) as inst:
         inst.laser_current_limit = 0.5
         assert inst.laser_current_limit == pytest.approx(0.5)
 
@@ -66,21 +89,26 @@ def test_laser_current_limit_validator():
 
 def test_laser_voltage():
     """Verify reading the laser voltage measurement."""
-    with expected_protocol(CTL200, [("vlaser", "1.85")]) as inst:
+    with expected_protocol(
+            CTL200, [("vlaser", "vlaser"), (None, "1.850")]) as inst:
         assert inst.laser_voltage == 1.85
 
 
 def test_photodiode_current():
     """Verify photodiode current reading and its mA to Ampere scaling
     (1e-3)."""
-    with expected_protocol(CTL200, [("iphd", "2.5")]) as inst:
+    with expected_protocol(
+            CTL200, [("iphd", "iphd"), (None, "2.500")]) as inst:
         assert inst.photodiode_current == pytest.approx(0.0025)
 
 
 def test_laser_delay():
     """Verify laser delay control and its ms to seconds scaling."""
     with expected_protocol(
-            CTL200, [("ldelay 2500", None), ("ldelay", "2500.0")]) as inst:
+        CTL200,
+        [("ldelay 2500", "ldelay 2500"), (None, "2500.000"),
+         ("ldelay", ">>ldelay"), (None, "2500.000")],
+    ) as inst:
         inst.laser_delay = 2.5
         assert inst.laser_delay == pytest.approx(2.5)
 
@@ -100,7 +128,10 @@ def test_laser_delay_validator():
 def test_tec_enabled():
     """Verify enabling and disabling of the TEC output."""
     with expected_protocol(
-            CTL200, [("tecon 0", None), ("tecon", "0")]) as inst:
+        CTL200,
+        [("tecon 0", "tecon 0"), (None, "0"),
+         ("tecon", ">>tecon"), (None, "0")],
+    ) as inst:
         inst.tec_enabled = False
         assert inst.tec_enabled is False
 
@@ -108,26 +139,32 @@ def test_tec_enabled():
 def test_thermistor_setpoint():
     """Verify thermistor resistance setpoint control."""
     with expected_protocol(
-            CTL200, [("rtset 10000", None), ("rtset", "10000.0")]) as inst:
+        CTL200,
+        [("rtset 10000", "rtset 10000"), (None, "10000.000"),
+         ("rtset", ">>rtset"), (None, "10000.000")],
+    ) as inst:
         inst.thermistor_setpoint = 10000.0
         assert inst.thermistor_setpoint == 10000.0
 
 
 def test_tec_current():
     """Verify reading the TEC current measurement."""
-    with expected_protocol(CTL200, [("itec", "1.2")]) as inst:
+    with expected_protocol(
+            CTL200, [("itec", "itec"), (None, "1.200")]) as inst:
         assert inst.tec_current == 1.2
 
 
 def test_tec_voltage():
     """Verify reading the TEC voltage measurement."""
-    with expected_protocol(CTL200, [("vtec", "-0.8")]) as inst:
+    with expected_protocol(
+            CTL200, [("vtec", "vtec"), (None, "-0.800")]) as inst:
         assert inst.tec_voltage == -0.8
 
 
 def test_thermistor_actual():
     """Verify reading the actual thermistor resistance measurement."""
-    with expected_protocol(CTL200, [("rtact", "9850.5")]) as inst:
+    with expected_protocol(
+            CTL200, [("rtact", "rtact"), (None, "9850.500")]) as inst:
         assert inst.thermistor_actual == 9850.5
 
 
@@ -137,12 +174,12 @@ def test_pid_parameters():
     with expected_protocol(
         CTL200,
         [
-            ("pgain 0.1", None),
-            ("pgain", "0.1"),
-            ("igain 0.03", None),
-            ("igain", "0.03"),
-            ("dgain 0", None),
-            ("dgain", "0"),
+            ("pgain 0.1", "pgain 0.1"), (None, "0.100"),
+            ("pgain", ">>pgain"), (None, "0.100"),
+            ("igain 0.03", ">>igain 0.03"), (None, "0.030"),
+            ("igain", ">>igain"), (None, "0.030"),
+            ("dgain 0", ">>dgain 0"), (None, "0.000"),
+            ("dgain", ">>dgain"), (None, "0.000"),
         ],
     ) as inst:
         inst.pid_proportional = 0.1
@@ -174,7 +211,10 @@ def test_pid_parameters_out_of_bounds(invalid_value):
 def test_temp_protection_enabled():
     """Verify configuration of the temperature protection switch."""
     with expected_protocol(
-            CTL200, [("tprot 1", None), ("tprot", "1")]) as inst:
+        CTL200,
+        [("tprot 1", "tprot 1"), (None, "1"),
+         ("tprot", ">>tprot"), (None, "1")],
+    ) as inst:
         inst.temp_protection_enabled = True
         assert inst.temp_protection_enabled is True
 
@@ -183,8 +223,12 @@ def test_thermistor_windows():
     """Verify minimum and maximum thermistor resistance window control."""
     with expected_protocol(
         CTL200,
-        [("rtmin 5000", None), ("rtmin", "5000.0"),
-         ("rtmax 15000", None), ("rtmax", "15000.0")],
+        [
+            ("rtmin 5000", "rtmin 5000"), (None, "5000.000"),
+            ("rtmin", ">>rtmin"), (None, "5000.000"),
+            ("rtmax 15000", ">>rtmax 15000"), (None, "15000.000"),
+            ("rtmax", ">>rtmax"), (None, "15000.000"),
+        ],
     ) as inst:
         inst.thermistor_window_min = 5000.0
         assert inst.thermistor_window_min == 5000.0
@@ -196,8 +240,13 @@ def test_tec_voltage_limits():
     """Verify minimum and maximum TEC voltage limit configuration within
     bounds."""
     with expected_protocol(
-        CTL200, [("vtmin -2.5", None), ("vtmin", "-2.5"),
-                 ("vtmax 2.5", None), ("vtmax", "2.5")]
+        CTL200,
+        [
+            ("vtmin -2.5", "vtmin -2.5"), (None, "-2.500"),
+            ("vtmin", ">>vtmin"), (None, "-2.500"),
+            ("vtmax 2.5", ">>vtmax 2.5"), (None, "2.500"),
+            ("vtmax", ">>vtmax"), (None, "2.500"),
+        ],
     ) as inst:
         inst.tec_voltage_limit_min = -2.5
         assert inst.tec_voltage_limit_min == -2.5
@@ -205,15 +254,17 @@ def test_tec_voltage_limits():
         assert inst.tec_voltage_limit_max == 2.5
 
 
-def test_tec_voltage_limits_validators():
+@pytest.mark.parametrize("invalid_min", [0.5, -3.5])
+@pytest.mark.parametrize("invalid_max", [-1.0, 3.5])
+def test_tec_voltage_limits_validators(invalid_min, invalid_max):
     """Verify that strict_range validators trigger on invalid TEC voltage
     limits."""
-    # vtmin range: [-3.3, 0.0] | vtmax range: [0.0, 3.3]
+    # vtmin range: [-3.0, 0.0] | vtmax range: [0.0, 3.0]
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
-            inst.tec_voltage_limit_min = 0.5
+            inst.tec_voltage_limit_min = invalid_min
         with pytest.raises(ValueError):
-            inst.tec_voltage_limit_max = -1.0
+            inst.tec_voltage_limit_max = invalid_max
 
 
 # =============================================================================
@@ -224,7 +275,10 @@ def test_tec_voltage_limits_validators():
 def test_interlock_enabled():
     """Verify hardware interlock switch control."""
     with expected_protocol(
-            CTL200, [("lckon 1", None), ("lckon", "1")]) as inst:
+        CTL200,
+        [("lckon 1", "lckon 1"), (None, "1"),
+         ("lckon", ">>lckon"), (None, "1")],
+    ) as inst:
         inst.interlock_enabled = True
         assert inst.interlock_enabled is True
 
@@ -237,42 +291,51 @@ def test_interlock_enabled():
 def test_analog_inputs():
     """Verify reading of auxiliary analog input voltages."""
     with expected_protocol(
-            CTL200, [("ain1", "0.23"), ("ain2", "1.45")]) as inst:
+        CTL200,
+        [("ain1", "ain1"), (None, "0.230"),
+         ("ain2", ">>ain2"), (None, "1.450")],
+    ) as inst:
         assert inst.analog_input_1 == 0.23
         assert inst.analog_input_2 == 1.45
 
 
-def test_laser_mod_gain():
+def test_laser_modulation_gain():
     """Verify modulation gain scaling logic for auxiliary input 1."""
     with expected_protocol(
-            CTL200, [("lmodgain 50", None), ("lmodgain", "50.0")]) as inst:
-        inst.laser_mod_gain = 0.05
-        assert inst.laser_mod_gain == pytest.approx(0.05)
+        CTL200,
+        [("lmodgain 50", "lmodgain 50"), (None, "50.000"),
+         ("lmodgain", ">>lmodgain"), (None, "50.000")],
+    ) as inst:
+        inst.laser_modulation_gain = 0.05
+        assert inst.laser_modulation_gain == pytest.approx(0.05)
 
 
-def test_laser_mod_gain_validator():
+def test_laser_modulation_gain_validator():
     """Verify strict_range validator limits for laser modulation gain
     ([-100, 100])."""
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
-            inst.laser_mod_gain = 150
+            inst.laser_modulation_gain = 150
 
 
-def test_tec_mod_gain():
+def test_tec_modulation_gain():
     """Verify temperature modulation gain configuration
     (no internal scaling)."""
     with expected_protocol(
-            CTL200, [("tmodgain 5000", None), ("tmodgain", "5000.0")]) as inst:
-        inst.tec_mod_gain = 5000.0
-        assert inst.tec_mod_gain == 5000.0
+        CTL200,
+        [("tmodgain 5000", "tmodgain 5000"), (None, "5000.000"),
+         ("tmodgain", ">>tmodgain"), (None, "5000.000")],
+    ) as inst:
+        inst.tec_modulation_gain = 5000.0
+        assert inst.tec_modulation_gain == 5000.0
 
 
-def test_tec_mod_gain_validator():
+def test_tec_modulation_gain_validator():
     """Verify strict_range validator bounds for TEC modulation gain
     ([-100000, 100000])."""
     with expected_protocol(CTL200, []) as inst:
         with pytest.raises(ValueError):
-            inst.tec_mod_gain = 200000
+            inst.tec_modulation_gain = 200000
 
 
 # =============================================================================
@@ -283,14 +346,67 @@ def test_tec_mod_gain_validator():
 def test_versions():
     """Verify firmware and board model identifier acquisition."""
     with expected_protocol(
-            CTL200, [("version", "v1.2.3"), ("model", "CTL200-0")]) as inst:
-        assert inst.firmware_version == "v1.2.3"
+        CTL200,
+        [("version", "version"), (None, "v0.17"),
+         ("model", ">>model"), (None, "CTL200-0")],
+    ) as inst:
+        assert inst.firmware_version == "v0.17"
         assert inst.board_version == "CTL200-0"
+
+
+def test_serial_number():
+    """Verify serial number acquisition."""
+    with expected_protocol(
+            CTL200, [("serial", "serial"), (None, "0123456789")]) as inst:
+        assert inst.serial_number == "0123456789"
+
+
+def test_baud_rate_setting():
+    """Verify configuration of the device UART baud rate."""
+    with expected_protocol(
+        CTL200,
+        [("brate 9600", "brate 9600"), (None, "9600"),
+         ("brate", ">>brate"), (None, "9600")],
+    ) as inst:
+        inst.baud_rate_setting = 9600
+        assert inst.baud_rate_setting == 9600
+
+
+@pytest.mark.parametrize("invalid_value", [4800, 921600])
+def test_baud_rate_setting_validator(invalid_value):
+    """Verify strict_range validator bounds for the baud rate
+    ([9600, 460800])."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.baud_rate_setting = invalid_value
+
+
+def test_user_data():
+    """Verify writing and reading the user data string."""
+    with expected_protocol(
+        CTL200,
+        [("userdata write TEST", "userdata write TEST"), (None, "TEST"),
+         ("userdata", ">>userdata"), (None, "TEST")],
+    ) as inst:
+        inst.user_data = "TEST"
+        assert inst.user_data == "TEST"
+
+
+def test_user_data_truncation():
+    """Verify that the user data string is truncated to 31 characters."""
+    long_data = "x" * 40
+    with expected_protocol(
+        CTL200,
+        [("userdata write " + "x" * 31, "userdata write " + "x" * 31),
+         (None, "x" * 31)],
+    ) as inst:
+        inst.user_data = long_data
 
 
 def test_board_temperature():
     """Verify reading of internal driver board temperature."""
-    with expected_protocol(CTL200, [("tboard", "34.5")]) as inst:
+    with expected_protocol(
+            CTL200, [("tboard", "tboard"), (None, "34.500")]) as inst:
         assert inst.board_temperature == 34.5
 
 
@@ -298,7 +414,8 @@ def test_status_property():
     """Verify complex multi-value parsing and custom scaling of the status
     property."""
     status_response = "1 1.8 0.5 2.1 10000.0 1.5 0.05 0.1"
-    with expected_protocol(CTL200, [("status", status_response)]) as inst:
+    with expected_protocol(
+            CTL200, [("status", "status"), (None, status_response)]) as inst:
         res = inst.status
         assert res["lason"] == 1.0
         assert res["vlaser"] == 1.8
@@ -313,13 +430,46 @@ def test_status_property():
 def test_commands():
     """Verify command execution for parameter persistence and error clear
     states."""
-    with expected_protocol(CTL200, [("save", None), ("errclr", None)]) as inst:
+    with expected_protocol(
+        CTL200,
+        [("save", "save"), (None, "config saved"),
+         ("errclr", ">>errclr"), (None, "ffffffff")],
+    ) as inst:
         inst.save()
         inst.clear_error()
 
 
-def test_error_status():
-    """Verify processing and integer parsing of error status flags."""
-    with expected_protocol(CTL200, [("err", "0")]) as inst:
-        # Casts output to int to evaluate matching underlying flags
-        assert int(inst.error_status) == 0
+@pytest.mark.parametrize("response, expected", [
+    ("0", KoheronError.NONE),
+    ("1", KoheronError.UART_BUFFER_OVERFLOW),
+    ("5", KoheronError.UART_BUFFER_OVERFLOW | KoheronError.LASER_UNDERTEMPERATURE),
+    # The error code is returned in hexadecimal format.
+    ("a0", KoheronError.CMD_INVALID_ARG | KoheronError.INTERLOCK_TRIGGERED),
+])
+def test_error_status(response, expected):
+    """Verify that the error status is parsed into the matching flags."""
+    with expected_protocol(
+            CTL200, [("err", "err"), (None, response)]) as inst:
+        assert inst.error_status == expected
+
+
+def test_check_errors_without_error():
+    """Verify that no error status yields no errors and does not clear."""
+    with expected_protocol(
+            CTL200, [("err", "err"), (None, "0")]) as inst:
+        assert inst.check_errors() == []
+
+
+def test_check_errors_with_errors():
+    """Verify that a combined error flag is decomposed into its single errors
+    and cleared afterwards."""
+    # 0x5 == UART_BUFFER_OVERFLOW (0x1) | LASER_UNDERTEMPERATURE (0x4)
+    with expected_protocol(
+        CTL200,
+        [("err", "err"), (None, "5"),
+         ("errclr", ">>errclr"), (None, "ffffffff")],
+    ) as inst:
+        assert inst.check_errors() == [
+            "UART_BUFFER_OVERFLOW",
+            "LASER_UNDERTEMPERATURE",
+        ]

--- a/tests/instruments/koheron/test_koheron_ctl200.py
+++ b/tests/instruments/koheron/test_koheron_ctl200.py
@@ -1,0 +1,297 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.koheron import CTL200
+
+# Import your driver class and exception/enum here
+# from your_module import CTL200, KoheronError
+
+
+# =============================================================================
+# -- Laser Tests
+# =============================================================================
+
+
+def test_laser_enabled():
+    """Verify enabling and disabling of the laser output."""
+    with expected_protocol(CTL200, [("lason 1", None), ("lason", "1")]) as inst:
+        inst.laser_enabled = True
+        assert inst.laser_enabled is True
+
+
+def test_laser_current():
+    """Verify laser current setting and its mA to Ampere conversion (scaling by 1e3 / 1e-3)."""
+    with expected_protocol(CTL200, [("ilaser 150", None), ("ilaser", "150.0")]) as inst:
+        inst.laser_current = 0.15
+        assert inst.laser_current == pytest.approx(0.15)
+
+
+def test_laser_current_limit():
+    """Verify laser current software limit configuration and scaling."""
+    with expected_protocol(CTL200, [("ilmax 500", None), ("ilmax", "500.0")]) as inst:
+        inst.laser_current_limit = 0.5
+        assert inst.laser_current_limit == pytest.approx(0.5)
+
+
+def test_laser_current_limit_validator():
+    """Verify that strict_range validator blocks current limits outside [0, 1] A."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.laser_current_limit = 1.5
+
+
+def test_laser_voltage():
+    """Verify reading the laser voltage measurement."""
+    with expected_protocol(CTL200, [("vlaser", "1.85")]) as inst:
+        assert inst.laser_voltage == 1.85
+
+
+def test_photodiode_current():
+    """Verify photodiode current reading and its mA to Ampere scaling (1e-3)."""
+    with expected_protocol(CTL200, [("iphd", "2.5")]) as inst:
+        assert inst.photodiode_current == pytest.approx(0.0025)
+
+
+def test_laser_delay():
+    """Verify laser delay control and its ms to seconds scaling."""
+    with expected_protocol(CTL200, [("ldelay 2500", None), ("ldelay", "2500.0")]) as inst:
+        inst.laser_delay = 2.5
+        assert inst.laser_delay == pytest.approx(2.5)
+
+
+def test_laser_delay_validator():
+    """Verify strict_range validator bounds for laser delay ([0.01, 100] s)."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.laser_delay = 0.005
+
+
+# =============================================================================
+# -- TEC / Temperature Tests
+# =============================================================================
+
+
+def test_tec_enabled():
+    """Verify enabling and disabling of the TEC output."""
+    with expected_protocol(CTL200, [("tecon 0", None), ("tecon", "0")]) as inst:
+        inst.tec_enabled = False
+        assert inst.tec_enabled is False
+
+
+def test_thermistor_setpoint():
+    """Verify thermistor resistance setpoint control."""
+    with expected_protocol(CTL200, [("rtset 10000", None), ("rtset", "10000.0")]) as inst:
+        inst.thermistor_setpoint = 10000.0
+        assert inst.thermistor_setpoint == 10000.0
+
+
+def test_tec_current():
+    """Verify reading the TEC current measurement."""
+    with expected_protocol(CTL200, [("itec", "1.2")]) as inst:
+        assert inst.tec_current == 1.2
+
+
+def test_tec_voltage():
+    """Verify reading the TEC voltage measurement."""
+    with expected_protocol(CTL200, [("vtec", "-0.8")]) as inst:
+        assert inst.tec_voltage == -0.8
+
+
+def test_thermistor_actual():
+    """Verify reading the actual thermistor resistance measurement."""
+    with expected_protocol(CTL200, [("rtact", "9850.5")]) as inst:
+        assert inst.thermistor_actual == 9850.5
+
+
+def test_pid_parameters():
+    """Verify control of the proportional, integral, and differential loop gains."""
+    with expected_protocol(
+        CTL200,
+        [
+            ("pgain 15.1", None),
+            ("pgain", "15.1"),
+            ("igain 2.3", None),
+            ("igain", "2.3"),
+            ("dgain 0.1", None),
+            ("dgain", "0.1"),
+        ],
+    ) as inst:
+        inst.pid_proportional = 15.1
+        assert inst.pid_proportional == 15.1
+        inst.pid_integral = 2.3
+        assert inst.pid_integral == 2.3
+        inst.pid_differential = 0.1
+        assert inst.pid_differential == 0.1
+
+
+# =============================================================================
+# -- Protection Tests
+# =============================================================================
+
+
+def test_temp_protection_enabled():
+    """Verify configuration of the temperature protection switch."""
+    with expected_protocol(CTL200, [("tprot 1", None), ("tprot", "1")]) as inst:
+        inst.temp_protection_enabled = True
+        assert inst.temp_protection_enabled is True
+
+
+def test_thermistor_windows():
+    """Verify minimum and maximum thermistor resistance window control."""
+    with expected_protocol(
+        CTL200,
+        [("rtmin 5000", None), ("rtmin", "5000.0"), ("rtmax 15000", None), ("rtmax", "15000.0")],
+    ) as inst:
+        inst.thermistor_window_min = 5000.0
+        assert inst.thermistor_window_min == 5000.0
+        inst.thermistor_window_max = 15000.0
+        assert inst.thermistor_window_max == 15000.0
+
+
+def test_tec_voltage_limits():
+    """Verify minimum and maximum TEC voltage limit configuration within bounds."""
+    with expected_protocol(
+        CTL200, [("vtmin -2.5", None), ("vtmin", "-2.5"), ("vtmax 2.5", None), ("vtmax", "2.5")]
+    ) as inst:
+        inst.tec_voltage_limit_min = -2.5
+        assert inst.tec_voltage_limit_min == -2.5
+        inst.tec_voltage_limit_max = 2.5
+        assert inst.tec_voltage_limit_max == 2.5
+
+
+def test_tec_voltage_limits_validators():
+    """Verify that strict_range validators trigger on invalid TEC voltage limits."""
+    # vtmin range: [-3.3, 0.0] | vtmax range: [0.0, 3.3]
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.tec_voltage_limit_min = 0.5
+        with pytest.raises(ValueError):
+            inst.tec_voltage_limit_max = -1.0
+
+
+# =============================================================================
+# -- Interlock Tests
+# =============================================================================
+
+
+def test_interlock_enabled():
+    """Verify hardware interlock switch control."""
+    with expected_protocol(CTL200, [("lckon 1", None), ("lckon", "1")]) as inst:
+        inst.interlock_enabled = True
+        assert inst.interlock_enabled is True
+
+
+# =============================================================================
+# -- Aux Inputs Tests
+# =============================================================================
+
+
+def test_analog_inputs():
+    """Verify reading of auxiliary analog input voltages."""
+    with expected_protocol(CTL200, [("ain1", "0.23"), ("ain2", "1.45")]) as inst:
+        assert inst.analog_input_1 == 0.23
+        assert inst.analog_input_2 == 1.45
+
+
+def test_laser_mod_gain():
+    """Verify modulation gain scaling logic for auxiliary input 1."""
+    with expected_protocol(CTL200, [("lmodgain 50", None), ("lmodgain", "50.0")]) as inst:
+        inst.laser_mod_gain = 0.05
+        assert inst.laser_mod_gain == pytest.approx(0.05)
+
+
+def test_laser_mod_gain_validator():
+    """Verify strict_range validator limits for laser modulation gain ([-100, 100])."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.laser_mod_gain = 150
+
+
+def test_tec_mod_gain():
+    """Verify temperature modulation gain configuration (no internal scaling)."""
+    with expected_protocol(CTL200, [("tmodgain 5000", None), ("tmodgain", "5000.0")]) as inst:
+        inst.tec_mod_gain = 5000.0
+        assert inst.tec_mod_gain == 5000.0
+
+
+def test_tec_mod_gain_validator():
+    """Verify strict_range validator bounds for TEC modulation gain ([-100000, 100000])."""
+    with expected_protocol(CTL200, []) as inst:
+        with pytest.raises(ValueError):
+            inst.tec_mod_gain = 200000
+
+
+# =============================================================================
+# -- Misc & Methods Tests
+# =============================================================================
+
+
+def test_versions():
+    """Verify firmware and board model identifier acquisition."""
+    with expected_protocol(CTL200, [("version", "v1.2.3"), ("model", "CTL200-0")]) as inst:
+        assert inst.firmware_version == "v1.2.3"
+        assert inst.board_version == "CTL200-0"
+
+
+def test_board_temperature():
+    """Verify reading of internal driver board temperature."""
+    with expected_protocol(CTL200, [("tboard", "34.5")]) as inst:
+        assert inst.board_temperature == 34.5
+
+
+def test_status_property():
+    """Verify complex multi-value parsing and custom scaling of the status property."""
+    status_response = "1 1.8 0.5 2.1 10000.0 1.5 0.05 0.1"
+    with expected_protocol(CTL200, [("status", status_response)]) as inst:
+        res = inst.status
+        assert res["lason"] == 1.0
+        assert res["vlaser"] == 1.8
+        assert res["itec"] == 0.5
+        assert res["vtec"] == 2.1
+        assert res["rtact"] == 10000.0
+        assert res["iphd"] == pytest.approx(0.0015)  # Verifies 1.5 * 1e-3 logic
+        assert res["ain1"] == 0.05
+        assert res["ain2"] == 0.1
+
+
+def test_commands():
+    """Verify command execution for parameter persistence and error clear states."""
+    with expected_protocol(CTL200, [("save", None), ("errclr", None)]) as inst:
+        inst.save()
+        inst.clear_error()
+
+
+def test_error_status():
+    """Verify processing and integer parsing of error status flags."""
+    with expected_protocol(CTL200, [("err", "0")]) as inst:
+        # Casts output to int to evaluate matching underlying flags
+        assert int(inst.error_status) == 0
+
+
+def test_user_data_truncation():
+    """Verify that user data inputs are string-truncated to a maximum of 31 characters."""
+    long_string = "B" * 40
+    expected_string = "B" * 31


### PR DESCRIPTION
### Summary
Added supoort for Koheron CTL200 digital laser controller.

### Tests
`pytest tests/instruments/koheron/test_koheron_ctl200.py`
33 passed

### Additional Information
The Koheron CTL200 laser driver echoes commands and appends ">>" prompts to emulate an interactive terminal. I have implemented a custom serial adapter for this Koheron device to handle this specific behavior.