### PR TITLE
Add MAUI-specific waveform saving methods

### DIFF
--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -141,7 +141,7 @@ class MAUIWaveformDescriptor:
     wave_src            : int
 
     @classmethod
-    def parse_desc(cls,desc: bytes):
+    def parse_descriptor(cls,desc: bytes):
         """Parse waveform descriptor from bytes, assuming COMM_HEADER=="OFF".
 
         .. Note::
@@ -396,6 +396,16 @@ class TeledyneMAUI(TeledyneOscilloscope):
     #    Waveform    #
     ##################
 
+    def read_waveform_descriptor(self) -> MAUIWaveformDescriptor:
+        """Read and parse instrument waveform descriptor.
+
+        :return: MAUIWaveformDescriptor
+        """
+        self.write(f"{self.waveform_source}:WF? DESC")
+        dd = self.read_bytes(-1)
+        descb = dd[len('DESC,#9000000000'):]
+        return MAUIWaveformDescriptor.parse_descriptor(descb)
+
     def _digitize(self, src, num_bytes=None, block='DAT1'):
         """Acquire waveforms according to the settings of the acquire commands.
 
@@ -409,11 +419,8 @@ class TeledyneMAUI(TeledyneOscilloscope):
         :return: bytearray with raw data.
         """
         with _ChunkResizer(self.adapter, num_bytes):
-            # Get descriptor  TODO Refactor into its own method
-            self.write(f"{self.waveform_source}:WF? DESC")
-            dd = self.read_bytes(-1)
-            descb = dd[len('DESC,#9000000000'):]
-            self.waveform_descriptor = MAUIWaveformDescriptor.parse_desc(descb)
+            # Get descriptor
+            self.waveform_descriptor = self.read_waveform_descriptor()
             # Get data
             binary_values = self.binary_values(f"{src}:WF? {block}", dtype=np.uint8)
             # NOTE: Payload is stored as raw bytes for now. But it must be converted to bytes or

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -29,8 +29,7 @@ from pymeasure.instruments.teledyne.teledyne_oscilloscope import TeledyneOscillo
 from struct import unpack
 from dataclasses import dataclass
 import numpy as np
-from decimal import Decimal
-import re 
+import re
 
 
 def sanitize_source(source):
@@ -204,16 +203,15 @@ class MAUIWaveformDescriptor:
         acq_vos             = unpack('<f',desc[340:344])[0]
         wave_src            = unpack('<h',desc[344:346])[0]
 
-        return cls(desc_name, desc_templ_name, desc_comm_type, desc_comm_order, wave_desc_len  , user_txt_len   ,
-                    trig_time_arr, ris_time_arr, wave_arr_1, wave_arr_2, instr_name,
-                    instr_num, trace_label, wave_arr_count, pts_per_screen , first_valid,
-                    last_valid, first_pt, sparsing_factor, segment_num, subarr_count,
-                    sweeps_per_acq , pts_per_pair, pair_offset, vgain, vos,
-                    max_value, min_value, nominal_bits, nom_subarr_count, horiz_ival,
-                    horiz_os, pixel_os, vunit, hunit, huncert,
-                    acq_duration, ca_record_type , processing_done, ris_sweeps,
-                    time_base, vcoupling, probe_atten, fixed_vgain, bwlimit,
-                    vertical_vernier, acq_vos, wave_src)
+        return cls(desc_name, desc_templ_name, desc_comm_type, desc_comm_order, wave_desc_len,
+                    user_txt_len, trig_time_arr, ris_time_arr, wave_arr_1, wave_arr_2, instr_name,
+                    instr_num, trace_label, wave_arr_count, pts_per_screen , first_valid, 
+                    last_valid, first_pt, sparsing_factor, segment_num, subarr_count, 
+                    sweeps_per_acq , pts_per_pair, pair_offset, vgain, vos, max_value, 
+                    min_value, nominal_bits, nom_subarr_count, horiz_ival, horiz_os, 
+                    pixel_os, vunit, hunit, huncert, acq_duration, ca_record_type, 
+                    processing_done, ris_sweeps, time_base, vcoupling, probe_atten, 
+                    fixed_vgain, bwlimit, vertical_vernier, acq_vos, wave_src)
 
 
 class TeledyneMAUIChannel(TeledyneOscilloscopeChannel):
@@ -487,12 +485,15 @@ class TeledyneMAUI(TeledyneOscilloscope):
                 bytes_per_point = 2
             else:
                 raise ValueError(f"Expected data format {format}. Options are BYTE or WORD.")
-            requested_bytes = requested_points*bytes_per_point + self._header_size + self._footer_size
+            requested_bytes = requested_points*bytes_per_point + self._header_size \
+                + self._footer_size
             # read the next chunk starting from this points
             first_point = read_points * sparsing
             self.waveform_first_point = first_point
             # read chunk of points
-            values = self._digitize(src=self.waveform_source, block=block, num_bytes=requested_bytes)
+            values = self._digitize(src=self.waveform_source, 
+                                    block=block, 
+                                    num_bytes=requested_bytes)
             # perform many sanity checks on the received data
             self._header_footer_sanity_checks(values,block=block)
             self._npoints_sanity_checks(values)
@@ -501,7 +502,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
             i += 1
         data = np.concatenate(data)
         preamble = self.waveform_preamble
-        
+
         # Determine sampling rate (horizontal interval) from waveform descriptor
         preamble['sampling_rate'] = 1/self.waveform_descriptor.horiz_ival
 
@@ -512,19 +513,24 @@ class TeledyneMAUI(TeledyneOscilloscope):
         """Apply scale and offset to the data points acquired from the scope.
         - Y axis : the scale is given by descriptor.vgain and the offset -descriptor.vos. the
         offset is not applied for the MATH source.
-        - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for i = 0,1,...,N. 
-        :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble) """
+        - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for
+        i = 0,1,...,N.
+        :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble)"""
 
         if self.waveform_descriptor.desc_comm_type == 0:
             data_points = ydata.view(np.int8)
         elif self.waveform_descriptor.desc_comm_type == 1:
             data_points = ydata.view(np.int16)
         else:
-            raise ValueError(f"Unexpected communication type {self.waveform_descriptor.desc_comm_type}, expected 0 (byte) or 1 (word).")
+            raise ValueError(
+                f"Unexpected communication type {self.waveform_descriptor.desc_comm_type},"\
+                     +" expected 0 (byte) or 1 (word)."
+                )
         data_points = data_points*self.waveform_descriptor.vgain
         if preamble['source'] != 'MATH':
-            data_points = data_points - self.waveform_descriptor.vos 
-        time_points = np.arange(len(data_points))*self.waveform_descriptor.horiz_ival*preamble['sparsing'] + self.waveform_descriptor.horiz_os
+            data_points = data_points - self.waveform_descriptor.vos
+        time_points = np.arange(len(data_points))*self.waveform_descriptor.horiz_ival \
+            *preamble['sparsing'] + self.waveform_descriptor.horiz_os
         return data_points, time_points, preamble
 
 
@@ -580,8 +586,9 @@ class TeledyneMAUI(TeledyneOscilloscope):
         kwargs.setdefault("destination", "REMOTE")
         self.hardcopy_setup(**kwargs)
         return super().download_image()
-    
-    def download_waveform(self, source, requested_points=None, sparsing=None, block='DAT1', format='WORD'):
+
+    def download_waveform(self, source, requested_points=None, sparsing=None, 
+                          block='DAT1', format='WORD'):
         """Get data points from the specified source of the oscilloscope.
 
         The returned objects are two np.ndarray of data and time points and a dict with the
@@ -602,7 +609,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         """
         # Sanitize the input arguments
         if sparsing is None:
-            sparsing = self.waveform_sparsing 
+            sparsing = self.waveform_sparsing
         if sparsing == 0:
             sparsing = 1
         if requested_points is None:

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -389,7 +389,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         # Method instead of property since no reply is sent
         self.write("FRTR")
 
- 
+
 
     ##################
     #    Waveform    #

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -491,7 +491,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
             # number of points still to read
             remaining_points = expected_points - read_points
             # number of points requested in a single chunk
-            requested_points = chunk_points if remaining_points > chunk_points else remaining_points
+            requested_points = min(remaining_points, chunk_points)
             self.waveform_points = requested_points
             # number of bytes requested in a single chunk
             if format == 'BYTE':

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -205,12 +205,12 @@ class MAUIWaveformDescriptor:
 
         return cls(desc_name, desc_templ_name, desc_comm_type, desc_comm_order, wave_desc_len,
                     user_txt_len, trig_time_arr, ris_time_arr, wave_arr_1, wave_arr_2, instr_name,
-                    instr_num, trace_label, wave_arr_count, pts_per_screen , first_valid, 
-                    last_valid, first_pt, sparsing_factor, segment_num, subarr_count, 
-                    sweeps_per_acq , pts_per_pair, pair_offset, vgain, vos, max_value, 
-                    min_value, nominal_bits, nom_subarr_count, horiz_ival, horiz_os, 
-                    pixel_os, vunit, hunit, huncert, acq_duration, ca_record_type, 
-                    processing_done, ris_sweeps, time_base, vcoupling, probe_atten, 
+                    instr_num, trace_label, wave_arr_count, pts_per_screen , first_valid,
+                    last_valid, first_pt, sparsing_factor, segment_num, subarr_count,
+                    sweeps_per_acq , pts_per_pair, pair_offset, vgain, vos, max_value,
+                    min_value, nominal_bits, nom_subarr_count, horiz_ival, horiz_os,
+                    pixel_os, vunit, hunit, huncert, acq_duration, ca_record_type,
+                    processing_done, ris_sweeps, time_base, vcoupling, probe_atten,
                     fixed_vgain, bwlimit, vertical_vernier, acq_vos, wave_src)
 
 
@@ -389,7 +389,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         # Method instead of property since no reply is sent
         self.write("FRTR")
 
-    
+ 
 
     ##################
     #    Waveform    #
@@ -491,8 +491,8 @@ class TeledyneMAUI(TeledyneOscilloscope):
             first_point = read_points * sparsing
             self.waveform_first_point = first_point
             # read chunk of points
-            values = self._digitize(src=self.waveform_source, 
-                                    block=block, 
+            values = self._digitize(src=self.waveform_source,
+                                    block=block,
                                     num_bytes=requested_bytes)
             # perform many sanity checks on the received data
             self._header_footer_sanity_checks(values,block=block)
@@ -507,7 +507,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         preamble['sampling_rate'] = 1/self.waveform_descriptor.horiz_ival
 
         return data, preamble
-    
+
 
     def _process_data(self, ydata, preamble):
         """Apply scale and offset to the data points acquired from the scope.
@@ -587,7 +587,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         self.hardcopy_setup(**kwargs)
         return super().download_image()
 
-    def download_waveform(self, source, requested_points=None, sparsing=None, 
+    def download_waveform(self, source, requested_points=None, sparsing=None,
                           block='DAT1', format='WORD'):
         """Get data points from the specified source of the oscilloscope.
 

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -26,6 +26,195 @@ from pymeasure.instruments import Instrument
 from pymeasure.instruments.teledyne.teledyne_oscilloscope import TeledyneOscilloscope, \
     TeledyneOscilloscopeChannel, _results_list_to_dict
 
+from struct import unpack
+from dataclasses import dataclass
+import numpy as np
+from decimal import Decimal
+import re 
+
+
+def sanitize_source(source):
+    """Parse source string.
+
+    :param source: can be "cX", "ch X", "chan X", "channel X", "math" or "line", where X is
+    a single digit integer. The parser is case and white space insensitive.
+    :return: can be "C1", "C2", "C3", "C4", "MATH" or "LINE.
+    """
+
+    match = re.match(r"^\s*(C|CH|CHAN|CHANNEL)\s*(?P<number>\d)\s*$|"
+                     r"^\s*(?P<name_only>MATH|LINE)\s*$", source, re.IGNORECASE)
+    if match:
+        if match.group("number") is not None:
+            source = "C" + match.group("number")
+        else:
+            source = match.group("name_only")
+        source = source.upper()
+    else:
+        raise ValueError(f"source {source} not recognized")
+    return source
+
+
+class _ChunkResizer:
+    """The only purpose of this class is to resize the chunk size of the instrument adapter.
+
+    This is necessary when reading a big chunk of data from the oscilloscope like image dumps and
+    waveforms.
+
+    .. Note::
+        Only if the new chunk size is bigger than the current chunk size, it is resized.
+
+    """
+
+    def __init__(self, adapter, chunk_size):
+        """Just initialize the object attributes.
+
+        :param adapter: Adapter of the instrument. This is usually accessed through the
+                        Instrument::adapter attribute.
+        :param chunk_size: new chunk size (int).
+        """
+        self.adapter = adapter
+        self.old_chunk_size = None
+        self.new_chunk_size = int(chunk_size) if chunk_size else 0
+
+    def __enter__(self):
+        """Only resize the chunk size if the adapter support this feature."""
+        if (self.adapter.connection is not None
+                and hasattr(self.adapter.connection, "chunk_size")):
+            if self.new_chunk_size > self.adapter.connection.chunk_size:
+                self.old_chunk_size = self.adapter.connection.chunk_size
+                self.adapter.connection.chunk_size = self.new_chunk_size
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.old_chunk_size is not None:
+            self.adapter.connection.chunk_size = self.old_chunk_size
+
+
+@dataclass
+class MAUIWaveformDescriptor:
+    desc_name           : str
+    desc_templ_name     : str
+    desc_comm_type      : int
+    desc_comm_order     : int
+    wave_desc_len       : int
+    user_txt_len        : int
+    trig_time_arr       : int
+    ris_time_arr        : int
+    wave_arr_1          : int
+    wave_arr_2          : int
+    instr_name          : str
+    instr_num           : int
+    trace_label         : str
+    wave_arr_count      : int
+    pts_per_screen      : int
+    first_valid         : int
+    last_valid          : int
+    first_pt            : int
+    sparsing_factor     : int
+    segment_num         : int
+    subarr_count        : int
+    sweeps_per_acq      : int
+    pts_per_pair        : int
+    pair_offset         : int
+    vgain               : float
+    vos                 : float
+    max_value           : float
+    min_value           : float
+    nominal_bits        : int
+    nom_subarr_count    : int
+    horiz_ival          : float
+    horiz_os            : int
+    pixel_os            : int
+    vunit               : str
+    hunit               : str
+    huncert             : float
+    # trigger_time      : struct
+    acq_duration        : float
+    ca_record_type      : int
+    processing_done     : int
+    ris_sweeps          : int
+    time_base           : int
+    vcoupling           : int
+    probe_atten         : float
+    fixed_vgain         : int
+    bwlimit             : int
+    vertical_vernier    : float
+    acq_vos             : float
+    wave_src            : int
+
+    @classmethod
+    def parse_desc(cls,desc: bytes):
+        """
+        Get description with something like this:
+            self.write(f"{self.waveform_source}:WF? DESC")
+            desc = self.read_bytes(-1)
+        Assumes COMM_HEADER == OFF
+        """
+        # Check for header
+        if desc[0:7].decode('ascii') == 'DESC,#9':
+            desc = desc[len('DESC,#9000000000'):]  # don't need this
+
+        # parse
+        desc_name           = desc[0:16].split(b'\x00',1)[0].decode('ascii')
+        desc_templ_name     = desc[16:32].split(b'\x00',1)[0].decode('ascii')
+        desc_comm_type      = unpack('<h',desc[32:34])[0]
+        desc_comm_order     = unpack('<h',desc[34:36])[0]
+        wave_desc_len       = unpack('<l',desc[36:40])[0]
+        user_txt_len        = unpack('<l',desc[40:44])[0]
+        trig_time_arr       = unpack('<l',desc[48:52])[0]
+        ris_time_arr        = unpack('<l',desc[52:56])[0]
+        wave_arr_1          = unpack('<l',desc[60:64])[0]
+        wave_arr_2          = unpack('<l',desc[64:68])[0]
+        instr_name          = desc[76:92].split(b'\x00',1)[0].decode('ascii')
+        instr_num           = unpack('<L',desc[92:96])[0]
+        trace_label         = desc[96:112].split(b'\x00',1)[0].decode('ascii')
+        wave_arr_count      = unpack('<l',desc[116:120])[0]
+        pts_per_screen      = unpack('<l',desc[120:124])[0]
+        first_valid         = unpack('<l',desc[124:128])[0]
+        last_valid          = unpack('<l',desc[128:132])[0]
+        first_pt            = unpack('<l',desc[132:136])[0]
+        sparsing_factor     = unpack('<l',desc[136:140])[0]
+        segment_num         = unpack('<l',desc[140:144])[0]
+        subarr_count        = unpack('<l',desc[144:148])[0]
+        sweeps_per_acq      = unpack('<l',desc[148:152])[0]
+        pts_per_pair        = unpack('<h',desc[152:154])[0]
+        pair_offset         = unpack('<h',desc[154:156])[0]
+        vgain               = unpack('<f',desc[156:160])[0]  # units/lsb
+        vos                 = unpack('<f',desc[160:164])[0]  # offset in volts
+        max_value           = unpack('<f',desc[164:168])[0]
+        min_value           = unpack('<f',desc[168:172])[0]
+        nominal_bits        = unpack('<h',desc[172:174])[0]
+        nom_subarr_count    = unpack('<h',desc[174:176])[0]
+        horiz_ival          = unpack('<f',desc[176:180])[0]
+        horiz_os            = unpack('<d',desc[180:188])[0]
+        pixel_os            = unpack('<d',desc[188:196])[0]
+        vunit               = desc[196:244].split(b'\x00',1)[0].decode('ascii')
+        hunit               = desc[244:296].split(b'\x00',1)[0].decode('ascii')
+        huncert             = unpack('<f',desc[292:296])[0]
+        # trigger_time        = desc[296:312]    # structure
+        acq_duration        = unpack('<f',desc[312:316])[0]
+        ca_record_type      = unpack('<h',desc[316:318])[0]
+        processing_done     = unpack('<h',desc[318:320])[0]
+        ris_sweeps          = unpack('<h',desc[322:324])[0]
+        time_base           = unpack('<h',desc[324:326])[0]
+        vcoupling           = unpack('<h',desc[326:328])[0]
+        probe_atten         = unpack('<f',desc[328:332])[0]
+        fixed_vgain         = unpack('<h',desc[332:334])[0]
+        bwlimit             = unpack('<h',desc[334:336])[0]
+        vertical_vernier    = unpack('<f',desc[336:340])[0]
+        acq_vos             = unpack('<f',desc[340:344])[0]
+        wave_src            = unpack('<h',desc[344:346])[0]
+
+        return cls(desc_name, desc_templ_name, desc_comm_type, desc_comm_order, wave_desc_len  , user_txt_len   ,
+                    trig_time_arr, ris_time_arr, wave_arr_1, wave_arr_2, instr_name,
+                    instr_num, trace_label, wave_arr_count, pts_per_screen , first_valid,
+                    last_valid, first_pt, sparsing_factor, segment_num, subarr_count,
+                    sweeps_per_acq , pts_per_pair, pair_offset, vgain, vos,
+                    max_value, min_value, nominal_bits, nom_subarr_count, horiz_ival,
+                    horiz_os, pixel_os, vunit, hunit, huncert,
+                    acq_duration, ca_record_type , processing_done, ris_sweeps,
+                    time_base, vcoupling, probe_atten, fixed_vgain, bwlimit,
+                    vertical_vernier, acq_vos, wave_src)
+
 
 class TeledyneMAUIChannel(TeledyneOscilloscopeChannel):
     """Base class for channels on a :class:`TeledyneMAUI` device."""
@@ -119,6 +308,11 @@ class TeledyneMAUI(TeledyneOscilloscope):
     # Change listed values for existing commands:
     bwlimit_values = TeledyneMAUIChannel.BANDWIDTH_LIMITS
 
+
+    def __init__(self, adapter, name="Teledyne Oscilloscope", **kwargs):
+        super().__init__(adapter, name=name, **kwargs)
+        self.waveform_descriptor = None
+
     def vbs_write(self, message: str):
         """Write a VBS command directly to the device.
 
@@ -196,6 +390,132 @@ class TeledyneMAUI(TeledyneOscilloscope):
         # Method instead of property since no reply is sent
         self.write("FRTR")
 
+    
+
+    ##################
+    #    Waveform    #
+    ##################
+
+    def _digitize(self, src, num_bytes=None, block='DAT1'):
+        """Acquire waveforms according to the settings of the acquire commands.
+        Note.
+        If the requested number of bytes is not specified, the default chunk size is used,
+        but in such a case it cannot be guaranteed that the message is received in its entirety.
+
+        :param src: source of data: "C1", "C2", "C3", "C4", "MATH".
+        :param block: waveform block to be read: "DESC", "TEXT", "TIME", "DAT1", "DAT2"
+        :param: num_bytes: number of bytes expected from the scope (including the header and
+        footer).
+        :return: bytearray with raw data.
+        """
+        with _ChunkResizer(self.adapter, num_bytes):
+            # Get descriptor
+            self.write(f"{self.waveform_source}:WF? DESC")
+            dd = self.read_bytes(-1)
+            descb = dd[len('DESC,#9000000000'):]
+            self.waveform_descriptor = MAUIWaveformDescriptor.parse_desc(descb)
+            # Get data
+            binary_values = self.binary_values(f"{src}:WF? {block}", dtype=np.uint8)
+        if num_bytes is not None and len(binary_values) != num_bytes-1:
+            raise BufferError(f"read bytes ({len(binary_values)}) != requested bytes ({num_bytes})")
+        return binary_values
+
+    def _header_footer_sanity_checks(self, message, block='DAT1'):
+        """Check that the header follows the predefined format.
+        The format of the header is <block>,#9XXXXXXX where XXXXXXX is the number of acquired
+        points, and it is zero padded.
+        Then check that the footer is present. The footer is a double line-carriage \n\n
+        :param message: raw bytes received from the scope """
+        message_header = bytes(message[0:self._header_size]).decode("ascii")
+        # Sanity check on header and footer
+        if message_header[0:7] != f"{block},#9":
+            raise ValueError(f"Waveform data in invalid : header is {message_header}")
+
+    def _npoints_sanity_checks(self, message):
+        """Check that the number of transmitted points is consistent with the message length.
+        :param message: raw bytes received from the scope """
+        message_header = bytes(message[0:self._header_size]).decode("ascii")
+        transmitted_points = int(message_header[-9:])
+        received_points = len(message) - self._header_size - self._footer_size
+        if transmitted_points-1 != received_points:
+            raise ValueError(f"Number of transmitted points ({transmitted_points}) != "
+                             f"number of received points ({received_points})")
+
+    def _acquire_data(self, requested_points=0, sparsing=1, block='DAT1'):
+        """Acquire raw data points from the scope. The header, footer and number of points are
+        sanity-checked, but they are not processed otherwise. For a description of the input
+        arguments refer to the download_waveform method.
+        If the number of expected points is big enough, the transmission is split in smaller
+        chunks of 20k points and read one chunk at a time. I do not know the reason why,
+        but if the chunk size is big enough the transmission does not complete successfully.
+        :return: raw data points as numpy array and waveform preamble
+        """
+        # Setup waveform acquisition parameters
+        if sparsing == 0:
+            sparsing = 1
+        self.waveform_sparsing = sparsing
+        self.waveform_points = requested_points
+        self.waveform_first_point = 0
+
+        # Calculate how many points are to be expected
+        sample_points = self.acquisition_sample_size(self.waveform_source)
+        if requested_points > 0:
+            expected_points = min(requested_points, int(sample_points / sparsing))
+        else:
+            expected_points = int(sample_points / sparsing)
+
+        # If the number of points is big enough, split the data in small chunks and read it one
+        # chunk at a time. For less than a certain amount of points we do not bother splitting them.
+        chunk_bytes = 20000
+        chunk_points = chunk_bytes - self._header_size - self._footer_size
+        iterations = -(expected_points // -chunk_points)
+        i = 0
+        data = []
+        while i < iterations:
+            # number of points already read
+            read_points = i * chunk_points
+            # number of points still to read
+            remaining_points = expected_points - read_points
+            # number of points requested in a single chunk
+            requested_points = chunk_points if remaining_points > chunk_points else remaining_points
+            self.waveform_points = requested_points
+            # number of bytes requested in a single chunk
+            requested_bytes = requested_points + self._header_size + self._footer_size
+            # read the next chunk starting from this points
+            first_point = read_points * sparsing
+            self.waveform_first_point = first_point
+            # read chunk of points
+            values = self._digitize(src=self.waveform_source, block=block, num_bytes=requested_bytes)
+            # perform many sanity checks on the received data
+            self._header_footer_sanity_checks(values,block=block)
+            self._npoints_sanity_checks(values)
+            # append the points without the header and footer
+            data.append(values[self._header_size:-self._footer_size])
+            i += 1
+        data = np.concatenate(data)
+        preamble = self.waveform_preamble
+        
+        # Determine sampling rate (horizontal interval) from waveform descriptor
+        preamble['sampling_rate'] = 1/self.waveform_descriptor.horiz_ival
+
+        return data, preamble
+    
+
+    def _process_data(self, ydata, preamble):
+        """Apply scale and offset to the data points acquired from the scope.
+        - Y axis : the scale is given by descriptor.vgain and the offset -descriptor.vos. the
+        offset is not applied for the MATH source.
+        - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for i = 0,1,...,N. 
+        :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble) """
+
+        data_points = np.array(unpack('<'+'b'*len(ydata),ydata))
+        data_points = data_points*self.waveform_descriptor.vgain
+        if preamble['source'] != 'MATH':
+            data_points = data_points - self.waveform_descriptor.vos 
+        time_points = np.arange(len(data_points))*self.waveform_descriptor.horiz_ival*preamble['sparsing'] + self.waveform_descriptor.horiz_os
+        return data_points, time_points, preamble
+
+
     #################
     # Download data #
     #################
@@ -248,3 +568,46 @@ class TeledyneMAUI(TeledyneOscilloscope):
         kwargs.setdefault("destination", "REMOTE")
         self.hardcopy_setup(**kwargs)
         return super().download_image()
+    
+    def download_waveform(self, source, requested_points=None, sparsing=None, block='DAT1'):
+        """Get data points from the specified source of the oscilloscope.
+
+        The returned objects are two np.ndarray of data and time points and a dict with the
+        waveform preamble, that contains metadata about the waveform.
+
+        :param source: measurement source. It can be "C1", "C2", "C3", "C4", "MATH".
+        :param requested_points: number of points to acquire. If None the number of points
+               requested in the previous call will be assumed, i.e. the value of the number of
+               points stored in the oscilloscope memory. If 0 the maximum number of points will
+               be returned.
+        :param sparsing: interval between data points. For example if sparsing = 4, only one
+               point every 4 points is read. If 0 or None the sparsing of the previous call is
+               assumed, i.e. the value of the sparsing stored in the oscilloscope memory.
+        :param block: waveform data block. "DESC","TEXT","TIME","DAT1","DAT2","ALL"
+        :return: data_ndarray, time_ndarray, waveform_preamble_dict: see waveform_preamble
+                 property for dict format.
+        """
+        # Sanitize the input arguments
+        if not sparsing:
+            sparsing = self.waveform_sparsing
+        elif sparsing == 0:
+            sparsing = 1
+        if requested_points is None:
+            requested_points = self.waveform_points
+        self.waveform_source = sanitize_source(source)
+        # Acquire the Y data and the preamble
+        ydata, preamble = self._acquire_data(requested_points, sparsing, block=block)
+        # Update the preamble with info about actually acquired data
+        preamble["transmitted_points"] = len(ydata)
+        preamble["requested_points"] = requested_points
+        preamble["sparsing"] = sparsing
+        preamble["first_point"] = 0
+        # Scale the Y-data and create the X-data
+        return self._process_data(ydata, preamble)
+
+    ###############
+    # Acquisition #
+    ###############
+    def acquisition_sample_size(self,source = None):
+        """Get acquisition sample size. For MAUI oscilloscopes this seems to be the memory size."""
+        return self.memory_size

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -22,14 +22,15 @@
 # THE SOFTWARE.
 #
 
+from dataclasses import dataclass
+import re
+from struct import unpack
+
+import numpy as np
+
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.teledyne.teledyne_oscilloscope import TeledyneOscilloscope, \
     TeledyneOscilloscopeChannel, _results_list_to_dict
-
-from struct import unpack
-from dataclasses import dataclass
-import numpy as np
-import re
 
 
 def sanitize_source(source):
@@ -54,14 +55,13 @@ def sanitize_source(source):
 
 
 class _ChunkResizer:
-    """The only purpose of this class is to resize the chunk size of the instrument adapter.
+    """Resize the chunk size of the instrument adapter.
 
     This is necessary when reading a big chunk of data from the oscilloscope like image dumps and
     waveforms.
 
     .. Note::
-        Only if the new chunk size is bigger than the current chunk size, it is resized.
-
+        Chunk size is only resized if the new chunk size is bigger than the current chunk size.
     """
 
     def __init__(self, adapter, chunk_size):
@@ -142,15 +142,16 @@ class MAUIWaveformDescriptor:
 
     @classmethod
     def parse_desc(cls,desc: bytes):
-        """
-        Get description with something like this:
-            self.write(f"{self.waveform_source}:WF? DESC")
-            desc = self.read_bytes(-1)
-        Assumes COMM_HEADER == OFF
+        """Parse waveform descriptor from bytes, assuming COMM_HEADER=="OFF".
+
+        .. Note::
+            Assumes COMM_HEADER == OFF.
+
+        :return: MAUIWaveformDescriptor object.
         """
         # Check for header
         if desc[0:7].decode('ascii') == 'DESC,#9':
-            desc = desc[len('DESC,#9000000000'):]  # don't need this
+            desc = desc[len('DESC,#9000000000'):]  # Remove header
 
         # parse
         desc_name           = desc[0:16].split(b'\x00',1)[0].decode('ascii')
@@ -397,7 +398,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
 
     def _digitize(self, src, num_bytes=None, block='DAT1'):
         """Acquire waveforms according to the settings of the acquire commands.
-        Note.
+
         If the requested number of bytes is not specified, the default chunk size is used,
         but in such a case it cannot be guaranteed that the message is received in its entirety.
 
@@ -408,32 +409,35 @@ class TeledyneMAUI(TeledyneOscilloscope):
         :return: bytearray with raw data.
         """
         with _ChunkResizer(self.adapter, num_bytes):
-            # Get descriptor
+            # Get descriptor  TODO Refactor into its own method
             self.write(f"{self.waveform_source}:WF? DESC")
             dd = self.read_bytes(-1)
             descb = dd[len('DESC,#9000000000'):]
             self.waveform_descriptor = MAUIWaveformDescriptor.parse_desc(descb)
             # Get data
             binary_values = self.binary_values(f"{src}:WF? {block}", dtype=np.uint8)
-            # NOTE: data stored as bytes for now, but if format is WORD it must be converted
-            # to signed 16-bit integer
+            # NOTE: Payload is stored as raw bytes for now. But it must be converted to bytes or
+            # words according to the data format option before it can be interpreted. This is
+            # done in _process_data(), before scaling.
         if num_bytes is not None and len(binary_values) != num_bytes:
             raise BufferError(f"read bytes ({len(binary_values)}) != requested bytes ({num_bytes})")
         return binary_values
 
     def _header_footer_sanity_checks(self, message, block='DAT1'):
         """Check that the header follows the predefined format.
+
         The format of the header is <block>,#9XXXXXXX where XXXXXXX is the number of acquired
         points, and it is zero padded.
-        Then check that the footer is present. The footer is a double line-carriage \n\n
+
         :param message: raw bytes received from the scope """
         message_header = bytes(message[0:self._header_size]).decode("ascii")
         # Sanity check on header and footer
         if message_header[0:7] != f"{block},#9":
-            raise ValueError(f"Waveform data in invalid : header is {message_header}")
+            raise ValueError(f"Waveform data is invalid : header is {message_header}")
 
     def _npoints_sanity_checks(self, message):
         """Check that the number of transmitted points is consistent with the message length.
+
         :param message: raw bytes received from the scope """
         message_header = bytes(message[0:self._header_size]).decode("ascii")
         transmitted_points = int(message_header[-9:])
@@ -443,13 +447,17 @@ class TeledyneMAUI(TeledyneOscilloscope):
                              f"number of received points ({received_points})")
 
     def _acquire_data(self, requested_points=0, sparsing=1, block='DAT1', format='WORD'):
-        """Acquire raw data points from the scope. The header, footer and number of points are
-        sanity-checked, but they are not processed otherwise. For a description of the input
-        arguments refer to the download_waveform method.
-        If the number of expected points is big enough, the transmission is split in smaller
+        """Acquire raw data points from the scope.
+
+        The header, footer and number of points are sanity-checked, but they are not processed
+        otherwise. For a description of the input arguments refer to the :meth:`download_waveform`
+        method.
+
+        If the number of expected points is too large, the transmission is split into smaller
         chunks of 20k points and read one chunk at a time. I do not know the reason why,
-        but if the chunk size is big enough the transmission does not complete successfully.
-        :return: raw data points as numpy array and waveform preamble
+        but if the chunk size is too large the transmission does not complete successfully.
+
+        :return: raw data points as tuple of numpy array and waveform preamble.
         """
         # Setup waveform acquisition parameters
         self.waveform_sparsing = sparsing
@@ -463,7 +471,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         else:
             expected_points = int(sample_points / sparsing)
 
-        # If the number of points is big enough, split the data in small chunks and read it one
+        # If the number of points is too large, split the data in small chunks and read it one
         # chunk at a time. For less than a certain amount of points we do not bother splitting them.
         chunk_bytes = 20000
         chunk_points = chunk_bytes - self._header_size - self._footer_size
@@ -511,10 +519,12 @@ class TeledyneMAUI(TeledyneOscilloscope):
 
     def _process_data(self, ydata, preamble):
         """Apply scale and offset to the data points acquired from the scope.
+
         - Y axis : the scale is given by descriptor.vgain and the offset -descriptor.vos. the
         offset is not applied for the MATH source.
         - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for
         i = 0,1,...,N.
+
         :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble)"""
 
         if self.waveform_descriptor.desc_comm_type == 0:

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -188,7 +188,7 @@ class MAUIWaveformDescriptor:
         horiz_os            = unpack('<d',desc[180:188])[0]
         pixel_os            = unpack('<d',desc[188:196])[0]
         vunit               = desc[196:244].split(b'\x00',1)[0].decode('ascii')
-        hunit               = desc[244:296].split(b'\x00',1)[0].decode('ascii')
+        hunit               = desc[244:292].split(b'\x00',1)[0].decode('ascii')
         huncert             = unpack('<f',desc[292:296])[0]
         # trigger_time        = desc[296:312]    # structure
         acq_duration        = unpack('<f',desc[312:316])[0]
@@ -312,6 +312,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
     def __init__(self, adapter, name="Teledyne Oscilloscope", **kwargs):
         super().__init__(adapter, name=name, **kwargs)
         self.waveform_descriptor = None
+        self._footer_size = 1  # bytes
 
     def vbs_write(self, message: str):
         """Write a VBS command directly to the device.
@@ -416,7 +417,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
             self.waveform_descriptor = MAUIWaveformDescriptor.parse_desc(descb)
             # Get data
             binary_values = self.binary_values(f"{src}:WF? {block}", dtype=np.uint8)
-        if num_bytes is not None and len(binary_values) != num_bytes-1:
+        if num_bytes is not None and len(binary_values) != num_bytes:
             raise BufferError(f"read bytes ({len(binary_values)}) != requested bytes ({num_bytes})")
         return binary_values
 
@@ -437,7 +438,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         message_header = bytes(message[0:self._header_size]).decode("ascii")
         transmitted_points = int(message_header[-9:])
         received_points = len(message) - self._header_size - self._footer_size
-        if transmitted_points-1 != received_points:
+        if transmitted_points != received_points:
             raise ValueError(f"Number of transmitted points ({transmitted_points}) != "
                              f"number of received points ({received_points})")
 
@@ -508,7 +509,8 @@ class TeledyneMAUI(TeledyneOscilloscope):
         - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for i = 0,1,...,N. 
         :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble) """
 
-        data_points = np.array(unpack('<'+'b'*len(ydata),ydata))
+        # data_points = np.array(unpack('<'+'b'*len(ydata),ydata))
+        data_points = ydata.view(np.int8)
         data_points = data_points*self.waveform_descriptor.vgain
         if preamble['source'] != 'MATH':
             data_points = data_points - self.waveform_descriptor.vos 
@@ -590,7 +592,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         # Sanitize the input arguments
         if not sparsing:
             sparsing = self.waveform_sparsing
-        elif sparsing == 0:
+        if sparsing == 0:
             sparsing = 1
         if requested_points is None:
             requested_points = self.waveform_points

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -417,6 +417,8 @@ class TeledyneMAUI(TeledyneOscilloscope):
             self.waveform_descriptor = MAUIWaveformDescriptor.parse_desc(descb)
             # Get data
             binary_values = self.binary_values(f"{src}:WF? {block}", dtype=np.uint8)
+            # NOTE: data stored as bytes for now, but if format is WORD it must be converted
+            # to signed 16-bit integer
         if num_bytes is not None and len(binary_values) != num_bytes:
             raise BufferError(f"read bytes ({len(binary_values)}) != requested bytes ({num_bytes})")
         return binary_values
@@ -442,7 +444,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
             raise ValueError(f"Number of transmitted points ({transmitted_points}) != "
                              f"number of received points ({received_points})")
 
-    def _acquire_data(self, requested_points=0, sparsing=1, block='DAT1'):
+    def _acquire_data(self, requested_points=0, sparsing=1, block='DAT1', format='WORD'):
         """Acquire raw data points from the scope. The header, footer and number of points are
         sanity-checked, but they are not processed otherwise. For a description of the input
         arguments refer to the download_waveform method.
@@ -452,8 +454,6 @@ class TeledyneMAUI(TeledyneOscilloscope):
         :return: raw data points as numpy array and waveform preamble
         """
         # Setup waveform acquisition parameters
-        if sparsing == 0:
-            sparsing = 1
         self.waveform_sparsing = sparsing
         self.waveform_points = requested_points
         self.waveform_first_point = 0
@@ -481,7 +481,13 @@ class TeledyneMAUI(TeledyneOscilloscope):
             requested_points = chunk_points if remaining_points > chunk_points else remaining_points
             self.waveform_points = requested_points
             # number of bytes requested in a single chunk
-            requested_bytes = requested_points + self._header_size + self._footer_size
+            if format == 'BYTE':
+                bytes_per_point = 1
+            elif format == 'WORD':
+                bytes_per_point = 2
+            else:
+                raise ValueError(f"Expected data format {format}. Options are BYTE or WORD.")
+            requested_bytes = requested_points*bytes_per_point + self._header_size + self._footer_size
             # read the next chunk starting from this points
             first_point = read_points * sparsing
             self.waveform_first_point = first_point
@@ -509,8 +515,12 @@ class TeledyneMAUI(TeledyneOscilloscope):
         - X axis : the scale is given by descriptor.horiz_ival*i + descriptor.horiz_os for i = 0,1,...,N. 
         :return: tuple of (numpy array of Y points, numpy array of X points, waveform preamble) """
 
-        # data_points = np.array(unpack('<'+'b'*len(ydata),ydata))
-        data_points = ydata.view(np.int8)
+        if self.waveform_descriptor.desc_comm_type == 0:
+            data_points = ydata.view(np.int8)
+        elif self.waveform_descriptor.desc_comm_type == 1:
+            data_points = ydata.view(np.int16)
+        else:
+            raise ValueError(f"Unexpected communication type {self.waveform_descriptor.desc_comm_type}, expected 0 (byte) or 1 (word).")
         data_points = data_points*self.waveform_descriptor.vgain
         if preamble['source'] != 'MATH':
             data_points = data_points - self.waveform_descriptor.vos 
@@ -571,7 +581,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         self.hardcopy_setup(**kwargs)
         return super().download_image()
     
-    def download_waveform(self, source, requested_points=None, sparsing=None, block='DAT1'):
+    def download_waveform(self, source, requested_points=None, sparsing=None, block='DAT1', format='WORD'):
         """Get data points from the specified source of the oscilloscope.
 
         The returned objects are two np.ndarray of data and time points and a dict with the
@@ -586,19 +596,22 @@ class TeledyneMAUI(TeledyneOscilloscope):
                point every 4 points is read. If 0 or None the sparsing of the previous call is
                assumed, i.e. the value of the sparsing stored in the oscilloscope memory.
         :param block: waveform data block. "DESC","TEXT","TIME","DAT1","DAT2","ALL"
+        :param format: communication data format. "BYTE", "WORD"
         :return: data_ndarray, time_ndarray, waveform_preamble_dict: see waveform_preamble
                  property for dict format.
         """
         # Sanitize the input arguments
-        if not sparsing:
-            sparsing = self.waveform_sparsing
+        if sparsing is None:
+            sparsing = self.waveform_sparsing 
         if sparsing == 0:
             sparsing = 1
         if requested_points is None:
-            requested_points = self.waveform_points
+            requested_points = self.acquisition_sample_size()//sparsing # self.waveform_points
         self.waveform_source = sanitize_source(source)
+        # Configure format
+        self.write(f"COMM_FORMAT DEF9,{format},BIN")
         # Acquire the Y data and the preamble
-        ydata, preamble = self._acquire_data(requested_points, sparsing, block=block)
+        ydata, preamble = self._acquire_data(requested_points, sparsing, block=block, format=format)
         # Update the preamble with info about actually acquired data
         preamble["transmitted_points"] = len(ydata)
         preamble["requested_points"] = requested_points

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -29,7 +29,7 @@ import time
 from decimal import Decimal
 import numpy as np
 
-from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, Channel, SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set, strict_range, \
     strict_discrete_range
 
@@ -458,7 +458,7 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         return ch_setup
 
 
-class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
+class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
     """A base abstract class for any Teledyne Lecroy oscilloscope.
 
     All Teledyne oscilloscopes have a very similar interface, hence this base class to combine

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -610,7 +610,9 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
         return tb_setup
 
     def timebase_setup(self, scale=None, offset=None):
-        """Set up timebase. Unspecified parameters are not modified. Modifying a single parameter
+        """Set up timebase.
+
+        Unspecified parameters are not modified. Modifying a single parameter
         might impact other parameters. Refer to oscilloscope documentation and make multiple
         consecutive calls to timebase_setup if needed.
 
@@ -746,9 +748,10 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
 
     def _digitize(self, src, num_bytes=None):
         """Acquire waveforms according to the settings of the acquire commands.
-        Note.
-        If the requested number of bytes is not specified, the default chunk size is used,
-        but in such a case it cannot be quaranteed that the message is received in its entirety.
+
+        .. Note::
+            If the requested number of bytes is not specified, the default chunk size is used,
+            but in such a case it cannot be quaranteed that the message is received in its entirety.
 
         :param src: source of data: "C1", "C2", "C3", "C4", "MATH".
         :param: num_bytes: number of bytes expected from the scope (including the header and
@@ -763,6 +766,7 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
 
     def _header_footer_sanity_checks(self, message):
         """Check that the header follows the predefined format.
+
         The format of the header is DAT2,#9XXXXXXX where XXXXXXX is the number of acquired
         points, and it is zero padded.
         Then check that the footer is present. The footer is a double line-carriage \n\n
@@ -770,13 +774,14 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
         message_header = bytes(message[0:self._header_size]).decode("ascii")
         # Sanity check on header and footer
         if message_header[0:7] != "DAT2,#9":
-            raise ValueError(f"Waveform data in invalid : header is {message_header}")
+            raise ValueError(f"Waveform data is invalid : header is {message_header}")
         message_footer = bytes(message[-self._footer_size:]).decode("ascii")
         if message_footer != "\n\n":
-            raise ValueError(f"Waveform data in invalid : footer is {message_footer}")
+            raise ValueError(f"Waveform data is invalid : footer is {message_footer}")
 
     def _npoints_sanity_checks(self, message):
         """Check that the number of transmitted points is consistent with the message length.
+
         :param message: raw bytes received from the scope """
         message_header = bytes(message[0:self._header_size]).decode("ascii")
         transmitted_points = int(message_header[-9:])
@@ -786,13 +791,17 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
                              f"number of received points ({received_points})")
 
     def _acquire_data(self, requested_points=0, sparsing=1):
-        """Acquire raw data points from the scope. The header, footer and number of points are
-        sanity-checked, but they are not processed otherwise. For a description of the input
-        arguments refer to the download_waveform method.
-        If the number of expected points is big enough, the transmission is split in smaller
+        """Acquire raw data points from the scope.
+
+        The header, footer and number of points are sanity-checked, but they are not
+        processed otherwise. For a description of the input arguments refer to the
+        :meth:`download_waveform` method.
+
+        If the number of expected points is too large, the transmission is split in smaller
         chunks of 20k points and read one chunk at a time. I do not know the reason why,
-        but if the chunk size is big enough the transmission does not complete successfully.
-        :return: raw data points as numpy array and waveform preamble
+        but if the chunk size is too large the transmission does not complete successfully.
+
+        :return: raw data points as tuple of numpy array and waveform preamble
         """
         # Setup waveform acquisition parameters
         self.waveform_sparsing = sparsing

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -828,7 +828,7 @@ class TeledyneOscilloscope(SCPIMixin, Instrument, metaclass=ABCMeta):
             # number of points still to read
             remaining_points = expected_points - read_points
             # number of points requested in a single chunk
-            requested_points = chunk_points if remaining_points > chunk_points else remaining_points
+            requested_points = min(remaining_points, chunk_points)
             self.waveform_points = requested_points
             # number of bytes requested in a single chunk
             requested_bytes = requested_points + self._header_size + self._footer_size


### PR DESCRIPTION
The default methods in `teledyne/teledyne_oscilloscope.py` need to be overridden for MAUI-based oscilloscopes. It will fail to read for several reasons, including missing `sampling_rate` and a couple off-by-one errors in sanity-checking the sizes of payloads. The default scaling methods are also incorrect. [Per the manual](https://cdn.teledynelecroy.com/files/manuals/maui-remote-control-and-automation-manual.pdf), the vertical and horizontal scaling should be performed using data from the waveform descriptor, which must be read each time a channel is captured. 

This commit:
* Copies several auxiliary classes and member functions from the parent class `TeledyneOscilloscope` to provide the small adjustments required. 
* Adds a new `MAUIWaveformDescriptor` dataclass to parse and access the descriptor data. 
* Updates the horizontal and vertical scaling in `_process_data()` to use the data in the waveform descriptor instead of the previous defaults, and this was verified against the scope itself to be accurate, including with `sparsing` (decimating) of the data
* Adds a `block` parameter to several methods, because the default was `DAT2` which is not a sane default. 
* Adds a couple checks mapping `sparsing=0 -> 1`. This avoids any divide-by-zero errors, since e.g. the WaveSurfer uses `sparsing=0` as a default.

The waveform descriptor parsing was placed in the `_digitize()` method. The off-by-one errors appeared in the default `_header_footer_sanity_checks()` method and the `_npoints_sanity_checks()`. 

Testing and validation was performed on a WaveSurfer 4104HD. Example:
```python
from pymeasure.instruments.teledyne import TeledyneMAUI
import matplotlib.pyplot as plt

visa_addr = 'TCPIP0::LCRY4902C18134::INSTR'
scope = TeledyneMAUI(visa_addr)

wave = scope.download_waveform('c1',sparsing=4)

ch1 = wave[0]
ts = wave[1]
plt.plot(ts,ch1,'k')
plt.grid()
```

Test results:
```
======================= 8861 passed, 2194 skipped, 1 xfailed, 929 warnings in 71.49s (0:01:11) ========================
```