### PR TITLE
Update datetime format for `date` and `time` placeholders

### DIFF
--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def replace_placeholders(string, procedure, date_format="%Y-%m-%d", time_format="%H:%M:%S"):
+def replace_placeholders(string, procedure, date_format="%Y_%m_%d", time_format="%H_%M_%S"):
     """Replace placeholders in string with values from procedure parameters.
 
     Replaces the placeholders in the provided string with the values of the

--- a/tests/experiment/test_replace_placeholders.py
+++ b/tests/experiment/test_replace_placeholders.py
@@ -61,3 +61,7 @@ def test_replace_placeholders():
     assert replace_placeholders(
         "{date}--{time}", fake, date_format=date_format, time_format=time_format
     ) == date + '--' + time
+
+    # The default time format must not contain characters that are invalid in
+    # filenames on Windows (e.g. the colon ":"), see issue #1468.
+    assert ":" not in replace_placeholders("{time}", fake)


### PR DESCRIPTION
Closes #1468 
Updates time format for `time` placeholder to work on Windows. Also updates date format as discussed in the issue.