### PR TITLE
Add Chroma 63600 electronic load bank

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -110,3 +110,4 @@ Sung-Chieh Chiu
 Przemysław Piróg
 Haotian Zhang
 Maduka Ariyasiri
+Sam Gallagher

--- a/docs/api/instruments/chroma/chroma_63600.rst
+++ b/docs/api/instruments/chroma/chroma_63600.rst
@@ -6,10 +6,10 @@ Chroma 63600 Electronic Load Bank
     :members:
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.chroma.Chroma63610_80_20
+.. autoclass:: pymeasure.instruments.chroma.chroma_63600.Chroma63630_80_60
     :members:
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.chroma.Chroma63630_80_60
+.. autoclass:: pymeasure.instruments.chroma.chroma_63600.Chroma63610_80_20
     :members:
     :show-inheritance:

--- a/docs/api/instruments/chroma/chroma_63600.rst
+++ b/docs/api/instruments/chroma/chroma_63600.rst
@@ -1,7 +1,15 @@
-##################################
+#################################
 Chroma 63600 Electronic Load Bank
-##################################
+#################################
 
 .. autoclass:: pymeasure.instruments.chroma.Chroma63600
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.chroma.Chroma63610_80_20
+    :members:
+    :show-inheritance
+
+.. autoclass:: pymeasure.instruments.chroma.Chroma63630_80_60
+    :members:
+    :show-inheritance

--- a/docs/api/instruments/chroma/chroma_63600.rst
+++ b/docs/api/instruments/chroma/chroma_63600.rst
@@ -8,8 +8,8 @@ Chroma 63600 Electronic Load Bank
 
 .. autoclass:: pymeasure.instruments.chroma.Chroma63610_80_20
     :members:
-    :show-inheritance
+    :show-inheritance:
 
 .. autoclass:: pymeasure.instruments.chroma.Chroma63630_80_60
     :members:
-    :show-inheritance
+    :show-inheritance:

--- a/docs/api/instruments/chroma/chroma_63600.rst
+++ b/docs/api/instruments/chroma/chroma_63600.rst
@@ -1,0 +1,7 @@
+##################################
+Chroma 63600 Electronic Load Bank
+##################################
+
+.. autoclass:: pymeasure.instruments.chroma.Chroma63600
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -1,8 +1,8 @@
 .. module:: pymeasure.instruments.chroma
 
-############
+######
 Chroma
-############
+######
 
 This section contains specific documentation on the Chroma instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -4,9 +4,7 @@
 Chroma
 ############
 
-This section contains specific documentation on the Chroma instruments
-that are implemented. If you are interested in an instrument not included,
-please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+This section contains specific documentation on the Chroma instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -1,0 +1,14 @@
+.. module:: pymeasure.instruments.chroma
+
+############
+Chroma
+############
+
+This section contains specific documentation on the Chroma instruments
+that are implemented. If you are interested in an instrument not included,
+please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   chroma_63600

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -34,6 +34,7 @@ Instruments by manufacturer:
    anritsu/index
    attocube/index
    bkprecision/index
+   chroma/index
    danfysik/index
    deltaelektronica/index
    edwards/index

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -23,5 +23,3 @@
 #
 
 from .chroma_63600 import Chroma63600
-
-

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -22,6 +22,6 @@
 # THE SOFTWARE.
 #
 
-from .chroma_63600 import Chroma63600, Chroma63630_80_60, Chroma63610_80_20
+from .chroma_63600 import Chroma63600
 
 

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -22,6 +22,6 @@
 # THE SOFTWARE.
 #
 
-from .chroma_63600 import Chroma63600,Chroma63630_80_60,Chroma63610_80_20
+from .chroma_63600 import Chroma63600, Chroma63630_80_60, Chroma63610_80_20
 
 

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -1,0 +1,27 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .chroma_63600 import Chroma63600,Chroma63630_80_60,Chroma63610_80_20
+
+

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -89,6 +89,7 @@ class Chroma63600_Channel(Channel):
         values=_BOOLS,
         map_values=True,
     )
+
     enabled = Instrument.control(
         "LOAD?",
         "LOAD %s",

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -406,43 +406,10 @@ class Chroma63600(SCPIMixin, Instrument):
             **kwargs
         )
 
-        # Populate default channel for testing purposes
-        self.add_child(Chroma63630_80_60,1)
+        # Populate a default channel for fallback
+        self.add_child(Chroma63630_80_60, 1)
         # Auto-discover channels
         self.discover_channels()
-
-    def create_channels(self, channel_class_list: list[type[Chroma63600_Channel]]):
-        """Populate the channels of the Chroma 63600-x mainframe.
-
-        Pass a list of Chroma63600_Channel subclasses (not objects). The classes are
-        used to add channels, dependent on the type of load (single or double). The
-        mainframe always leaves space for two channels per load (left and right).
-        The 63610-80-20 has a left and right channel. Other loads (63630-80-60,
-        6363-600-16, 63640-80-80, 63640-150-60) have a single channel per load.
-
-        Note that even if a single-channel load is added, the channel ID increases by
-        _two_. For example, adding five 63630-80-60 loads would result in having channels
-        1, 3, 5, 7, and 9. If the third load were a 63610-80-20 (two channel load), the
-        channels would be 1, 3, 5, 6, 7, and 9.
-        """
-        if self.channels:
-            channels_copy = self.channels.copy()
-            for i,ch in channels_copy.items():
-                self.remove_child(ch)
-
-        i = 1
-        for ch_cls in channel_class_list:
-            if ch_cls == Chroma63610_80_20:  # Double, add two channels
-                self.add_child(ch_cls,i)
-                i += 1
-                self.add_child(ch_cls,i)
-                i += 1
-            elif ch_cls == Chroma63630_80_60:  # Single, add one channel
-                self.add_child(ch_cls,i)
-                i += 2  # Still add 2, one channel skipped
-            else:
-                raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels are" \
-                                          +" currently supported.")
 
     def discover_channels(self,Nslots: int = 5):
         """Discover and populate channels programmatically.

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -78,19 +78,19 @@ class Chroma63600_Channel(Channel):
              "UDWH"]
 
     def insert_id(self, command):
-        """Set current channel before performing command"""
+        """Set current channel before performing command."""
         return f"CHAN {self.id};{command}"
 
-    active = Instrument.control(
+    active = Channel.control(
         "CHANNEL:ACTIVE?",
         "CHANNEL:ACTIVE %s",
-        """Set enabled or disabled for the load module, can be ON or OFF""",
+        """Control whether to enable the load module (bool).""",
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
     )
 
-    enabled = Instrument.control(
+    enabled = Channel.control(
         "LOAD?",
         "LOAD %s",
         """Control current channel active status, can be ``True`` (ON) or ``False`` (OFF).""",
@@ -98,7 +98,7 @@ class Chroma63600_Channel(Channel):
         values=_BOOLS,
         map_values=True,
     )
-    status = Instrument.measurement(
+    status = Channel.measurement(
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
         """Get the status of the electronic load.
 
@@ -128,31 +128,31 @@ class Chroma63600_Channel(Channel):
         """,
         get_process=lambda v: InstrStatus(v)
     )
-    identify = Instrument.measurement(
+    identify = Channel.measurement(
         "CHAN:ID?",
         """Get module identification string."""
     )
-    current = Instrument.measurement(
+    current = Channel.measurement(
         "FETCH:CURRENT?",
         """Get current measured at electronic load input."""
     )
-    frequency = Instrument.measurement(
+    frequency = Channel.measurement(
         "FETCH:FREQUENCY?",
         """Get the frequency measured in frequency sweep mode or sine wave dynamic mode."""
     )
-    power = Instrument.measurement(
+    power = Channel.measurement(
         "FETCH:POWER?",
         """Get power measured at electronic load input."""
     )
-    voltage = Instrument.measurement(
+    voltage = Channel.measurement(
         "FETCH:VOLTAGE?",
         """Get the voltage measured at the electronic load input."""
     )
-    protection_clear = Instrument.setting(
+    protection_clear = Channel.setting(
         "LOAD:PROTECTION:CLEAR",
         """Set the status of the electronic load to a clear state."""
     )
-    activate_short = Instrument.control(
+    activate_short = Channel.control(
         "LOAD:SHORT?",
         "LOAD:SHORT %s",
         """Set active or unactive for the short-circuit simulation.""",
@@ -160,7 +160,7 @@ class Chroma63600_Channel(Channel):
         values=_BOOLS,
         map_values=True,
     )
-    mode = Instrument.control(
+    mode = Channel.control(
         ":MODE?",
         ":MODE %s",
         """Set the operational mode of the electronic load.
@@ -194,15 +194,15 @@ class Chroma63600_Channel(Channel):
     )
 
     # TIMING MODE
-    amp_hours = Instrument.measurement(
+    amp_hours = Channel.measurement(
         "FETCH:AH?",
         """Get ampere-hour measured in timing mode.""",
     )
-    time = Instrument.measurement(
+    time = Channel.measurement(
         "FETCH:TIME?",
         """Get time measured in timing mode."""
     )
-    watt_hours = Instrument.measurement(
+    watt_hours = Channel.measurement(
         "FETCH:WH?",
         """Get the watt-hour measured in timing mode."""
     )
@@ -212,96 +212,96 @@ class Chroma63630_80_60(Chroma63600_Channel):
     """Represents a Chroma 63630-80-60 single load module."""
 
     # CONSTANT CURRENT MODE (STATIC)
-    current_setpoint_1 = Instrument.control(
+    current_setpoint_1 = Channel.control(
         "CURRENT:STATIC:L1?",
         "CURRENT:STATIC:L1 %g",
-        """Control the L1 static current set point in constant current mode""",
+        """Control the L1 static current set point in constant current mode.""",
         validator=truncated_range,
         values=[0,60],
     )
-    current_setpoint_2 = Instrument.control(
+    current_setpoint_2 = Channel.control(
         "CURRENT:STATIC:L2?",
         "CURRENT:STATIC:L2 %g",
-        """Control the L2 static current set point in constant current mode""",
+        """Control the L2 static current set point in constant current mode.""",
         validator=truncated_range,
         values=[0,60],
     )
 
     # CONSTANT VOLTAGE MODE
-    voltage_setpoint_1 = Instrument.control(
+    voltage_setpoint_1 = Channel.control(
         "VOLTAGE:STATIC:L1?",
         "VOLTAGE:STATIC:L1 %g",
-        """Control the L1 voltage set point in constant voltage mode""",
+        """Control the L1 voltage set point in constant voltage mode.""",
         validator=truncated_range,
         values=[0,80],
     )
-    voltage_setpoint_2 = Instrument.control(
+    voltage_setpoint_2 = Channel.control(
         "VOLTAGE:STATIC:L2?",
         "VOLTAGE:STATIC:L2 %g",
-        """Control the L2 voltage set point in constant voltage mode""",
+        """Control the L2 voltage set point in constant voltage mode.""",
         validator=truncated_range,
         values=[0,80],
     )
-    current_limit = Instrument.control(
+    current_limit = Channel.control(
         "VOLTAGE:STATIC:ILIMIT?",
         "VOLTAGE:STATIC:ILIMIT %g",
-        """Set the current limit in constant voltage mode""",
+        """Set the current limit in constant voltage mode.""",
         validator=truncated_range,
         values=[0,60],
     )
     # CONSTANT POWER MODE
-    power_setpoint_1 = Instrument.control(
+    power_setpoint_1 = Channel.control(
         "POWER:STATIC:L1?",
         "POWER:STATIC:L1 %g",
-        """Control the L1 power set point in constant power mode""",
+        """Control the L1 power set point in constant power mode.""",
         validator=truncated_range,
         values=[0,300],
     )
-    power_setpoint_2 = Instrument.control(
+    power_setpoint_2 = Channel.control(
         "POWER:STATIC:L2?",
         "POWER:STATIC:L2 %g",
-        """Control the L2 power set point in constant power mode""",
+        """Control the L2 power set point in constant power mode.""",
         validator=truncated_range,
         values=[0,300],
     )
     # CONSTANT RESISTANCE MODE
-    resistance_setpoint_1 = Instrument.control(
+    resistance_setpoint_1 = Channel.control(
         "RESISTANCE:STATIC:L1?",
         "RESISTANCE:STATIC:L1 %g",
-        """Control the L1 resistance set point in constant resistance mode""",
+        """Control the L1 resistance set point in constant resistance mode.""",
         validator=truncated_range,
         values=[0.015,3000],
     )
-    resistance_setpoint_2 = Instrument.control(
+    resistance_setpoint_2 = Channel.control(
         "RESISTANCE:STATIC:L2?",
         "RESISTANCE:STATIC:L2 %g",
-        """Control the L2 resistance set point in constant resistance mode""",
+        """Control the L2 resistance set point in constant resistance mode.""",
         validator=truncated_range,
         values=[0.015,3000],
     )
     # CONSTANT IMPEDANCE MODE
-    parallel_load_capacitance_setpoint = Instrument.control(
+    parallel_load_capacitance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:CL?",
         "IMPEDANCE:STATIC:CL %g",
-        """Set the equivalent parallel load capacitance in constant impedance mode""",
+        """Set the equivalent parallel load capacitance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    series_inductance_setpoint = Instrument.control(
+    series_inductance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:LS?",
         "IMPEDANCE:STATIC:LS %g",
-        """Set the equivalent series inductance in constant impedance mode""",
+        """Set the equivalent series inductance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    series_resistance_setpoint = Instrument.control(
+    series_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RS?",
         "IMPEDANCE:STATIC:RS %g",
-        """Set the equivalent series resistance in constant impedance mode""",
+        """Set the equivalent series resistance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    parallel_load_resistance_setpoint = Instrument.control(
+    parallel_load_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RL?",
         "IMPEDANCE:STATIC:RL %g",
         """Set the equivalent parallel load resistance in constant impedance mode.""",
@@ -314,96 +314,96 @@ class Chroma63610_80_20(Chroma63600_Channel):
     """Represents one channel of a Chroma 63610-80-20 double load module."""
 
     # CONSTANT CURRENT MODE (STATIC)
-    current_setpoint_1 = Instrument.control(
+    current_setpoint_1 = Channel.control(
         "CURRENT:STATIC:L1?",
         "CURRENT:STATIC:L1 %g",
-        """Control the L1 static current set point in constant current mode""",
+        """Control the L1 static current set point in constant current mode.""",
         validator=truncated_range,
         values=[0,20],
     )
-    current_setpoint_2 = Instrument.control(
+    current_setpoint_2 = Channel.control(
         "CURRENT:STATIC:L2?",
         "CURRENT:STATIC:L2 %g",
-        """Control the L2 static current set point in constant current mode""",
+        """Control the L2 static current set point in constant current mode.""",
         validator=truncated_range,
         values=[0,20],
     )
 
     # CONSTANT VOLTAGE MODE
-    voltage_setpoint_1 = Instrument.control(
+    voltage_setpoint_1 = Channel.control(
         "VOLTAGE:STATIC:L1?",
         "VOLTAGE:STATIC:L1 %g",
-        """Control the L1 voltage set point in constant voltage mode""",
+        """Control the L1 voltage set point in constant voltage mode.""",
         validator=truncated_range,
         values=[0,80],
     )
-    voltage_setpoint_2 = Instrument.control(
+    voltage_setpoint_2 = Channel.control(
         "VOLTAGE:STATIC:L2?",
         "VOLTAGE:STATIC:L2 %g",
-        """Control the L2 voltage set point in constant voltage mode""",
+        """Control the L2 voltage set point in constant voltage mode.""",
         validator=truncated_range,
         values=[0,80],
     )
-    current_limit = Instrument.control(
+    current_limit = Channel.control(
         "VOLTAGE:STATIC:ILIMIT?",
         "VOLTAGE:STATIC:ILIMIT %g",
-        """Set the current limit in constant voltage mode""",
+        """Set the current limit in constant voltage mode.""",
         validator=truncated_range,
         values=[0,20],
     )
     # CONSTANT POWER MODE
-    power_setpoint_1 = Instrument.control(
+    power_setpoint_1 = Channel.control(
         "POWER:STATIC:L1?",
         "POWER:STATIC:L1 %g",
-        """Control the L1 power set point in constant power mode""",
+        """Control the L1 power set point in constant power mode.""",
         validator=truncated_range,
         values=[0,100],
     )
-    power_setpoint_2 = Instrument.control(
+    power_setpoint_2 = Channel.control(
         "POWER:STATIC:L2?",
         "POWER:STATIC:L2 %g",
-        """Control the L2 power set point in constant power mode""",
+        """Control the L2 power set point in constant power mode.""",
         validator=truncated_range,
         values=[0,100],
     )
     # CONSTANT RESISTANCE MODE
-    resistance_setpoint_1 = Instrument.control(
+    resistance_setpoint_1 = Channel.control(
         "RESISTANCE:STATIC:L1?",
         "RESISTANCE:STATIC:L1 %g",
-        """Control the L1 resistance set point in constant resistance mode""",
+        """Control the L1 resistance set point in constant resistance mode.""",
         validator=truncated_range,
         values=[0.04,12000],
     )
-    resistance_setpoint_2 = Instrument.control(
+    resistance_setpoint_2 = Channel.control(
         "RESISTANCE:STATIC:L2?",
         "RESISTANCE:STATIC:L2 %g",
-        """Control the L2 resistance set point in constant resistance mode""",
+        """Control the L2 resistance set point in constant resistance mode.""",
         validator=truncated_range,
         values=[0.04,12000],
     )
     # CONSTANT IMPEDANCE MODE
-    parallel_load_capacitance_setpoint = Instrument.control(
+    parallel_load_capacitance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:CL?",
         "IMPEDANCE:STATIC:CL %g",
-        """Set the equivalent parallel load capacitance in constant impedance mode""",
+        """Set the equivalent parallel load capacitance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    series_inductance_setpoint = Instrument.control(
+    series_inductance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:LS?",
         "IMPEDANCE:STATIC:LS %g",
-        """Set the equivalent series inductance in constant impedance mode""",
+        """Set the equivalent series inductance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    series_resistance_setpoint = Instrument.control(
+    series_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RS?",
         "IMPEDANCE:STATIC:RS %g",
-        """Set the equivalent series resistance in constant impedance mode""",
+        """Set the equivalent series resistance in constant impedance mode.""",
         # validator=truncated_range,
         # values=[0,0],
     )
-    parallel_load_resistance_setpoint = Instrument.control(
+    parallel_load_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RL?",
         "IMPEDANCE:STATIC:RL %g",
         """Set the equivalent parallel load resistance in constant impedance mode.""",

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -427,17 +427,10 @@ class Chroma63600(SCPIMixin, Instrument):
             **kwargs
         )
 
-        # Initialize default channels for a 63600-5. Makes testing easier.
-        self.init_default_channels()
-
-    def init_default_channels(self):
-        """Populate default channels."""
+        # Populate default channel for testing purposes
         self.add_child(Chroma63630_80_60,1)
-        self.add_child(Chroma63630_80_60,3)
-        self.add_child(Chroma63630_80_60,5)
-        self.add_child(Chroma63630_80_60,7)
-        self.add_child(Chroma63610_80_20,9)
-        self.add_child(Chroma63610_80_20,10)
+        # Auto-discover channels
+        self.discover_channels()
 
     def create_channels(self, channel_class_list: list[type[Chroma63600_Channel]]):
         """Populate the channels of the Chroma 63600-x mainframe.
@@ -472,10 +465,46 @@ class Chroma63600(SCPIMixin, Instrument):
                 raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels are" \
                                           +" currently supported.")
 
-    run = Instrument.setting(
-        ":RUN",
-        "Set all electronic loads to ON."
-    )
+    def discover_channels(self,Nslots : int = 5):
+        """Discover and populate channels programmatically.
+
+        The mainframe always leaves space for two channels per load (left and right).
+        The 63610-80-20 has a left and right channel. Other loads (63630-80-60,
+        6363-600-16, 63640-80-80, 63640-150-60) have a single channel per load.
+
+        Note that even if a single-channel load is added, the channel ID increases by
+        _two_. For example, adding five 63630-80-60 loads would result in having channels
+        1, 3, 5, 7, and 9. If the third load were a 63610-80-20 (two channel load), the
+        channels would be 1, 3, 5, 6, 7, and 9.
+
+        :param Nslots: Number of mainframe slots in the unit, either 1, 2, or 5 for the -1, -2,
+                       and -5 mainframes. For N slots, there are up to 2N channels.
+        """
+        # Reset channels
+        if self.channels:
+            channels_copy = self.channels.copy()
+            for i,ch in channels_copy.items():
+                self.remove_child(ch)
+
+        # Auto-discover and add channels
+        for i in range(1,Nslots*2+1):
+            if self.ask(f'CHAN {i};CHAN?') == str(i):
+                # This channel exists, get its id and add it
+                chid = self.ask('CHAN:ID?').split(',')[1]
+                if chid == '63630-80-60':
+                    self.add_child(Chroma63630_80_60,i)
+                elif chid in ['63610-80-20L','63610-80-20R']:
+                    self.add_child(Chroma63610_80_20,i)
+                else:
+                    raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels " \
+                                             +"are currently supported.")
+
+    def run(self, state: bool = True):
+        """Set all electronic loads to ON (True) or OFF (False).
+        :param state: True or False, determines Enabled state of loads.
+        """
+        for chid,ch in self.channels.items():
+            ch.enabled = state
 
     currents = Instrument.measurement(
         "MEAS:ALLC?",

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -1,0 +1,492 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from enum import StrEnum,IntFlag
+
+from pymeasure.instruments import Instrument,Channel
+from pymeasure.instruments.generic_types import SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set,truncated_range
+
+
+class InstrStatus(IntFlag):
+    """Instrument status flags.
+    Convert an error code (int) to status with ``InstrStatus(code)``."""
+    REMOTE_INHIBIT = 2**8
+    FAN_FAILURE = 2**7
+    MAX_SINE_WAVE_CURRENT_LIMIT = 2**6
+    SYNC_TIMEOUT = 2**5
+    REVERSE_VOLTAGE_ON_INPUT = 2**4
+    OVER_POWER = 2**3
+    OVER_CURRENT = 2**2
+    OVER_VOLTAGE = 2**1
+    OVER_TEMPERATURE = 2**0
+    OK = 0
+
+
+class InstrMode(StrEnum):
+    """Instrument modes. Each mode has low (L), medium (M), and high (H) ranges,
+    except for constant resistance (CR) mode, which only has L and H. The range
+    is not included in this enum."""
+    CONSTANT_CURRENT="CC"
+    CONSTANT_VOLTAGE="CV"
+    CONSTANT_POWER="CP"
+    CONSTANT_IMPEDANCE="CZ"
+    CONSTANT_RESISTANCE="CR"
+    CONSTANT_CURRENT_DYNAMIC="CCD"
+    SINE_WAVE_DYNAMIC="SWD"
+    TIMING_MEASUREMENT="TIM"
+    OVERCURRENT_TEST="OCP"
+    PROGRAM_SEQUENCE="PROG"
+    USER_DEFINED_WAVEFORM="UDW"
+    MAXIMUM_POWER_POINT_TRACKER="MPPT"
+
+
+class InstrModeRange(StrEnum):
+    """Instrument mode ranges."""
+    LOW_RANGE="L"
+    MEDIUM_RANGE="M"
+    HIGH_RANGE="H"
+
+
+class Chroma63600_Channel(Channel):
+    """Represents a Chroma 63600 channel of the electronic load bank."""
+    _BOOLS = {True: "ON", False: "OFF"}
+    MODES = ["CCL","CCM","CCH", "CRL","CRH", "CVL","CRM","CRH", "CPL","CPM","CPH", "CZL","CZM",
+             "CZH", "CCDL","CCDM","CCDH", "CCFSL","CCFSM","CCFSH", "TIML","TIMM","TIMH", "SWDL",
+             "SWDM","SWDH", "OCPL","OCPM","OCPH", "PROG", "MPPTL","MPPTM","MPPTH","UDWL,UDWM,UDWH"]
+
+    def insert_id(self, command):
+        """Set current channel before performing command"""
+        return f"CHAN {self.id};{command}"
+
+    active = Instrument.control(
+        "CHANNEL:ACTIVE?",
+        "CHANNEL:ACTIVE %s",
+        """Enable or disable load module, can be ON or OFF""",
+        validator=strict_discrete_set,
+        values=_BOOLS,
+        map_values=True,
+    )
+    enabled = Instrument.control(
+        "LOAD?",
+        "LOAD %s",
+        """Control current channel active status, can be ``True`` (ON) or ``False`` (OFF).""",
+        validator=strict_discrete_set,
+        values=_BOOLS,
+        map_values=True,
+    )
+    status = Instrument.measurement(
+        "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
+        """Return the status of the electronic load.
+
+        +--------+-----------------------------+
+        | bit(s) | description                 |
+        +--------+-----------------------------+
+        | 15-9   | Not assigned                |
+        +--------+-----------------------------+
+        |   8    | Remote inhibit              |
+        +--------+-----------------------------+
+        |   7    | Fan failure                 |
+        +--------+-----------------------------+
+        |   6    | Max sine wave current limit |
+        +--------+-----------------------------+
+        |   5    | Synchronization timeout     |
+        +--------+-----------------------------+
+        |   4    | Reverse voltage on input    |
+        +--------+-----------------------------+
+        |   3    | Over power                  |
+        +--------+-----------------------------+
+        |   2    | Over current                |
+        +--------+-----------------------------+
+        |   1    | Over voltage                |
+        +--------+-----------------------------+
+        |   0    | Over temperature            |
+        +--------+-----------------------------+
+        """,
+        get_process=lambda v: InstrStatus(v)
+    )
+    identify = Instrument.measurement(
+        "CHAN:ID?",
+        """Request the module to identify itself."""
+    )
+    current = Instrument.measurement(
+        "FETCH:CURRENT?",
+        """Get current measured at electronic load input."""
+    )
+    frequency = Instrument.measurement(
+        "FETCH:FREQUENCY?",
+        """Get the frequency measured in frequency sweep mode or sine wave dynamic mode."""
+    )
+    power = Instrument.measurement(
+        "FETCH:POWER?",
+        """Get power measured at electronic load input."""
+    )
+    voltage = Instrument.measurement(
+        "FETCH:VOLTAGE?",
+        """Get the voltage measured at the electronic load input."""
+    )
+    protection_clear = Instrument.setting(
+        "LOAD:PROTECTION:CLEAR",
+        """Resets the status of the electronic load."""
+    )
+    activate_short = Instrument.control(
+        "LOAD:SHORT?",
+        "LOAD:SHORT %s",
+        """Activate or deactivate the short-circuit simulation.""",
+        validator=strict_discrete_set,
+        values=_BOOLS,
+        map_values=True,
+    )
+    mode = Instrument.control(
+        ":MODE?",
+        ":MODE %s",
+        """Set the operational mode of the electronic load.
+
+        Basic modes include constant current (CC), constant resistance (CR), constant voltage (CV),
+        constant power (CP), and constant impedance (CZ). There are low (L), middle (M), and
+        high (H) ranges for most modes.
+
+        In addition to the basic modes, the unit supports dynamic constant current (CCD), dynamic
+        sine wave (SWD), timing measurement (TIM), overcurrent test (OCP), program sequences (PROG),
+        user defined waveform (UDW), and maximum power point tracker (MPPT) modes.
+
+            CCL|CCM|CCH
+            CRL|CRH
+            CVL|CRM|CRH
+            CPL|CPM|CPH
+            CZL|CZM|CZH
+            CCDL|CCDM|CCDH
+            CCFSL|CCFSM|CCFSH
+            TIML|TIMM|TIMH
+            SWDL|SWDM|SWDH
+            OCPL|OCPM|OCPH
+            PROG
+            MPPTL|MPPTM|MPPTH
+            UDWL|UDWM|UDWH
+        """,
+        validator=strict_discrete_set,
+        values=MODES,
+        get_process=lambda v: (InstrMode(v),) if v=="PROG" else \
+                            (InstrMode(v[:-1]),InstrModeRange(v[-1])),
+    )
+
+    # TIMING MODE
+    amp_hours = Instrument.measurement(
+        "FETCH:AH?",
+        """Get ampere-hour measured in timing mode.""",
+    )
+    time = Instrument.measurement(
+        "FETCH:TIME?",
+        """Get time measured in timing mode."""
+    )
+    watt_hours = Instrument.measurement(
+        "FETCH:WH?",
+        "Get the watt-hour measured in timing mode."
+    )
+
+
+class Chroma63630_80_60(Chroma63600_Channel):
+    """Represents a Chroma 63630-80-60 single load module."""
+
+    # CONSTANT CURRENT MODE (STATIC)
+    current_setpoint_1 = Instrument.control(
+        "CURRENT:STATIC:L1?",
+        "CURRENT:STATIC:L1 %g",
+        """Control the L1 static current set point in constant current mode""",
+        validator=truncated_range,
+        values=[0,60],
+    )
+    current_setpoint_2 = Instrument.control(
+        "CURRENT:STATIC:L2?",
+        "CURRENT:STATIC:L2 %g",
+        """Control the L2 static current set point in constant current mode""",
+        validator=truncated_range,
+        values=[0,60],
+    )
+
+    # CONSTANT VOLTAGE MODE
+    voltage_setpoint_1 = Instrument.control(
+        "VOLTAGE:STATIC:L1?",
+        "VOLTAGE:STATIC:L1 %g",
+        """Control the L1 voltage set point in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,80],
+    )
+    voltage_setpoint_2 = Instrument.control(
+        "VOLTAGE:STATIC:L2?",
+        "VOLTAGE:STATIC:L2 %g",
+        """Control the L2 voltage set point in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,80],
+    )
+    current_limit = Instrument.control(
+        "VOLTAGE:STATIC:ILIMIT?",
+        "VOLTAGE:STATIC:ILIMIT %g",
+        """Set the current limit in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,60],
+    )
+    # CONSTANT POWER MODE
+    power_setpoint_1 = Instrument.control(
+        "POWER:STATIC:L1?",
+        "POWER:STATIC:L1 %g",
+        """Control the L1 power set point in constant power mode""",
+        validator=truncated_range,
+        values=[0,300],
+    )
+    power_setpoint_2 = Instrument.control(
+        "POWER:STATIC:L2?",
+        "POWER:STATIC:L2 %g",
+        """Control the L2 power set point in constant power mode""",
+        validator=truncated_range,
+        values=[0,300],
+    )
+    # CONSTANT RESISTANCE MODE
+    resistance_setpoint_1 = Instrument.control(
+        "RESISTANCE:STATIC:L1?",
+        "RESISTANCE:STATIC:L1 %g",
+        """Control the L1 resistance set point in constant resistance mode""",
+        validator=truncated_range,
+        values=[0.015,3000],
+    )
+    resistance_setpoint_2 = Instrument.control(
+        "RESISTANCE:STATIC:L2?",
+        "RESISTANCE:STATIC:L2 %g",
+        """Control the L2 resistance set point in constant resistance mode""",
+        validator=truncated_range,
+        values=[0.015,3000],
+    )
+    # CONSTANT IMPEDANCE MODE
+    parallel_load_capacitance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:CL?",
+        "IMPEDANCE:STATIC:CL %g",
+        """Set the equivalent parallel load capacitance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    series_inductance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:LS?",
+        "IMPEDANCE:STATIC:LS %g",
+        """Set the equivalent series inductance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    series_resistance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:RS?",
+        "IMPEDANCE:STATIC:RS %g",
+        """Set the equivalent series resistance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    parallel_load_resistance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:RL?",
+        "IMPEDANCE:STATIC:RL %g",
+        """Set the equivalent parallel load resistance in constant impedance mode.""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+
+
+class Chroma63610_80_20(Chroma63600_Channel):
+    """Represents one channel of a Chroma 63610-80-20 double load module."""
+
+    # CONSTANT CURRENT MODE (STATIC)
+    current_setpoint_1 = Instrument.control(
+        "CURRENT:STATIC:L1?",
+        "CURRENT:STATIC:L1 %g",
+        """Control the L1 static current set point in constant current mode""",
+        validator=truncated_range,
+        values=[0,20],
+    )
+    current_setpoint_2 = Instrument.control(
+        "CURRENT:STATIC:L2?",
+        "CURRENT:STATIC:L2 %g",
+        """Control the L2 static current set point in constant current mode""",
+        validator=truncated_range,
+        values=[0,20],
+    )
+
+    # CONSTANT VOLTAGE MODE
+    voltage_setpoint_1 = Instrument.control(
+        "VOLTAGE:STATIC:L1?",
+        "VOLTAGE:STATIC:L1 %g",
+        """Control the L1 voltage set point in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,80],
+    )
+    voltage_setpoint_2 = Instrument.control(
+        "VOLTAGE:STATIC:L2?",
+        "VOLTAGE:STATIC:L2 %g",
+        """Control the L2 voltage set point in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,80],
+    )
+    current_limit = Instrument.control(
+        "VOLTAGE:STATIC:ILIMIT?",
+        "VOLTAGE:STATIC:ILIMIT %g",
+        """Set the current limit in constant voltage mode""",
+        validator=truncated_range,
+        values=[0,20],
+    )
+    # CONSTANT POWER MODE
+    power_setpoint_1 = Instrument.control(
+        "POWER:STATIC:L1?",
+        "POWER:STATIC:L1 %g",
+        """Control the L1 power set point in constant power mode""",
+        validator=truncated_range,
+        values=[0,100],
+    )
+    power_setpoint_2 = Instrument.control(
+        "POWER:STATIC:L2?",
+        "POWER:STATIC:L2 %g",
+        """Control the L2 power set point in constant power mode""",
+        validator=truncated_range,
+        values=[0,100],
+    )
+    # CONSTANT RESISTANCE MODE
+    resistance_setpoint_1 = Instrument.control(
+        "RESISTANCE:STATIC:L1?",
+        "RESISTANCE:STATIC:L1 %g",
+        """Control the L1 resistance set point in constant resistance mode""",
+        validator=truncated_range,
+        values=[0.04,12000],
+    )
+    resistance_setpoint_2 = Instrument.control(
+        "RESISTANCE:STATIC:L2?",
+        "RESISTANCE:STATIC:L2 %g",
+        """Control the L2 resistance set point in constant resistance mode""",
+        validator=truncated_range,
+        values=[0.04,12000],
+    )
+    # CONSTANT IMPEDANCE MODE
+    parallel_load_capacitance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:CL?",
+        "IMPEDANCE:STATIC:CL %g",
+        """Set the equivalent parallel load capacitance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    series_inductance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:LS?",
+        "IMPEDANCE:STATIC:LS %g",
+        """Set the equivalent series inductance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    series_resistance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:RS?",
+        "IMPEDANCE:STATIC:RS %g",
+        """Set the equivalent series resistance in constant impedance mode""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+    parallel_load_resistance_setpoint = Instrument.control(
+        "IMPEDANCE:STATIC:RL?",
+        "IMPEDANCE:STATIC:RL %g",
+        """Set the equivalent parallel load resistance in constant impedance mode.""",
+        # validator=truncated_range,
+        # values=[0,0],
+    )
+
+
+class Chroma63600(SCPIMixin, Instrument):
+    """Control the Chroma 63600-5 Electronic Load Bank.
+
+    Programming guide is UM-63600 (this interface is based on v2.6, Jan 2021), available from the
+    Chroma USA website.
+    https://www.chromausa.com/document-library/manuals-63600-series/
+    """
+
+    def __init__(self, adapter, name="Chroma 63600", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            read_termination='\n',
+            **kwargs
+        )
+
+        # Initialize default channels for a 63600-5. Makes testing easier.
+        self.init_default_channels()
+
+    def init_default_channels(self):
+        """Populate default channels."""
+        self.add_child(Chroma63630_80_60,1)
+        self.add_child(Chroma63630_80_60,3)
+        self.add_child(Chroma63630_80_60,5)
+        self.add_child(Chroma63630_80_60,7)
+        self.add_child(Chroma63610_80_20,9)
+        self.add_child(Chroma63610_80_20,10)
+
+    def create_channels(self, channel_class_list: list[type[Chroma63600_Channel]]):
+        """Populate the channels of the Chroma 63600-x mainframe.
+
+        Pass a list of Chroma63600_Channel subclasses (not objects). The classes are
+        used to add channels, dependent on the type of load (single or double). The
+        mainframe always leaves space for two channels per load (left and right).
+        The 63610-80-20 has a left and right channel. Other loads (63630-80-60,
+        6363-600-16, 63640-80-80, 63640-150-60) have a single channel per load.
+
+        Note that even if a single-channel load is added, the channel ID increases by
+        _two_. For example, adding five 63630-80-60 loads would result in having channels
+        1, 3, 5, 7, and 9. If the third load were a 63610-80-20 (two channel load), the
+        channels would be 1, 3, 5, 6, 7, and 9.
+        """
+        if self.channels:
+            channels_copy = self.channels.copy()
+            for i,ch in channels_copy.items():
+                self.remove_child(ch)
+
+        i = 1
+        for ch_cls in channel_class_list:
+            if ch_cls == Chroma63610_80_20:  # Double, add two channels
+                self.add_child(ch_cls,i)
+                i += 1
+                self.add_child(ch_cls,i)
+                i += 1
+            elif ch_cls == Chroma63630_80_60:  # Single, add one channel
+                self.add_child(ch_cls,i)
+                i += 2  # Still add 2, one channel skipped
+            else:
+                raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels are" \
+                                          +" currently supported.")
+
+    run = Instrument.setting(
+        ":RUN",
+        "Set all electronic loads to ON."
+    )
+
+    currents = Instrument.measurement(
+        "MEAS:ALLC?",
+        """Return all channel currents as a list."""
+    )
+
+    voltages = Instrument.measurement(
+        "MEAS:ALLV?",
+        """Return all channel voltages as a list."""
+    )
+
+    powers = Instrument.measurement(
+        "MEAS:ALLP?",
+        """Return all channel powers as a list."""
+    )

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -97,6 +97,7 @@ class Chroma63600_Channel(Channel):
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
+        cast=str,
     )
     status = Channel.measurement(
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
@@ -169,6 +170,7 @@ class Chroma63600_Channel(Channel):
         values=MODES,
         get_process=lambda v: (InstrMode(v),) if v=="PROG" else \
                               (InstrMode(v[:-1]),InstrModeRange(v[-1])),
+        cast=str,
     )
 
     # TIMING MODE

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -102,29 +102,7 @@ class Chroma63600_Channel(Channel):
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
         """Get the status of the electronic load.
 
-        +--------+-----------------------------+
-        | bit(s) | description                 |
-        +--------+-----------------------------+
-        | 15-9   | Not assigned                |
-        +--------+-----------------------------+
-        |   8    | Remote inhibit              |
-        +--------+-----------------------------+
-        |   7    | Fan failure                 |
-        +--------+-----------------------------+
-        |   6    | Max sine wave current limit |
-        +--------+-----------------------------+
-        |   5    | Synchronization timeout     |
-        +--------+-----------------------------+
-        |   4    | Reverse voltage on input    |
-        +--------+-----------------------------+
-        |   3    | Over power                  |
-        +--------+-----------------------------+
-        |   2    | Over current                |
-        +--------+-----------------------------+
-        |   1    | Over voltage                |
-        +--------+-----------------------------+
-        |   0    | Over temperature            |
-        +--------+-----------------------------+
+    Returns :class:`InstrStatus`.
         """,
         get_process=lambda v: InstrStatus(v)
     )

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -22,16 +22,18 @@
 # THE SOFTWARE.
 #
 
-from enum import Enum,IntFlag
+from enum import IntFlag
 
-from pymeasure.instruments import Instrument,Channel
+from pymeasure.instruments import Instrument, Channel
 from pymeasure.instruments.generic_types import SCPIMixin
-from pymeasure.instruments.validators import strict_discrete_set,truncated_range
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+from pymeasure.instruments._strenum import StrEnum
 
 
 class InstrStatus(IntFlag):
     """Instrument status flags.
     Convert an error code (int) to status with ``InstrStatus(code)``."""
+
     REMOTE_INHIBIT = 2**8
     FAN_FAILURE = 2**7
     MAX_SINE_WAVE_CURRENT_LIMIT = 2**6
@@ -44,38 +46,75 @@ class InstrStatus(IntFlag):
     OK = 0
 
 
-class InstrMode(str,Enum):
+class InstrMode(StrEnum):
     """Instrument modes. Each mode has low (L), medium (M), and high (H) ranges,
     except for constant resistance (CR) mode, which only has L and H. The range
     is not included in this enum."""
-    CONSTANT_CURRENT="CC"
-    CONSTANT_VOLTAGE="CV"
-    CONSTANT_POWER="CP"
-    CONSTANT_IMPEDANCE="CZ"
-    CONSTANT_RESISTANCE="CR"
-    CONSTANT_CURRENT_DYNAMIC="CCD"
-    SINE_WAVE_DYNAMIC="SWD"
-    TIMING_MEASUREMENT="TIM"
-    OVERCURRENT_TEST="OCP"
-    PROGRAM_SEQUENCE="PROG"
-    USER_DEFINED_WAVEFORM="UDW"
-    MAXIMUM_POWER_POINT_TRACKER="MPPT"
+
+    CONSTANT_CURRENT = "CC"
+    CONSTANT_VOLTAGE = "CV"
+    CONSTANT_POWER = "CP"
+    CONSTANT_IMPEDANCE = "CZ"
+    CONSTANT_RESISTANCE = "CR"
+    CONSTANT_CURRENT_DYNAMIC = "CCD"
+    SINE_WAVE_DYNAMIC = "SWD"
+    TIMING_MEASUREMENT = "TIM"
+    OVERCURRENT_TEST = "OCP"
+    PROGRAM_SEQUENCE = "PROG"
+    USER_DEFINED_WAVEFORM = "UDW"
+    MAXIMUM_POWER_POINT_TRACKER = "MPPT"
 
 
-class InstrModeRange(str,Enum):
+class InstrModeRange(StrEnum):
     """Instrument mode ranges."""
-    LOW_RANGE="L"
-    MEDIUM_RANGE="M"
-    HIGH_RANGE="H"
+
+    LOW_RANGE = "L"
+    MEDIUM_RANGE = "M"
+    HIGH_RANGE = "H"
 
 
 class Chroma63600_Channel(Channel):
     """Represents a Chroma 63600 channel of the electronic load bank."""
+
     _BOOLS = {True: "ON", False: "OFF"}
-    MODES = ["CCL","CCM","CCH", "CRL","CRH", "CVL","CRM","CRH", "CPL","CPM","CPH", "CZL","CZM",
-             "CZH", "CCDL","CCDM","CCDH", "CCFSL","CCFSM","CCFSH", "TIML","TIMM","TIMH", "SWDL",
-             "SWDM","SWDH", "OCPL","OCPM","OCPH", "PROG", "MPPTL","MPPTM","MPPTH","UDWL","UDWM",
-             "UDWH"]
+    MODES = [
+        "CCL",
+        "CCM",
+        "CCH",
+        "CRL",
+        "CRH",
+        "CVL",
+        "CRM",
+        "CRH",
+        "CPL",
+        "CPM",
+        "CPH",
+        "CZL",
+        "CZM",
+        "CZH",
+        "CCDL",
+        "CCDM",
+        "CCDH",
+        "CCFSL",
+        "CCFSM",
+        "CCFSH",
+        "TIML",
+        "TIMM",
+        "TIMH",
+        "SWDL",
+        "SWDM",
+        "SWDH",
+        "OCPL",
+        "OCPM",
+        "OCPH",
+        "PROG",
+        "MPPTL",
+        "MPPTM",
+        "MPPTH",
+        "UDWL",
+        "UDWM",
+        "UDWH",
+    ]
 
     def insert_id(self, command):
         """Set current channel before performing command."""
@@ -100,6 +139,7 @@ class Chroma63600_Channel(Channel):
         map_values=True,
         cast=str,
     )
+
     status = Channel.measurement(
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
         """
@@ -110,27 +150,27 @@ class Chroma63600_Channel(Channel):
         get_process=lambda v: InstrStatus(v),
         cast=int,
     )
+
     identify = Channel.measurement(
         "CHAN:ID?",
         """Get module identification string.""",
         cast=str,
     )
+
     current = Channel.measurement(
-        "FETCH:CURRENT?",
-        """Measure current at electronic load input in Amps (float)."""
+        "FETCH:CURRENT?", """Measure current at electronic load input in Amps (float)."""
     )
+
     frequency = Channel.measurement(
         "FETCH:FREQUENCY?",
-        """Get the frequency measured in frequency sweep mode or sine wave dynamic mode."""
+        """Measure the frequency measured in frequency sweep mode or sine wave dynamic mode.""",
     )
-    power = Channel.measurement(
-        "FETCH:POWER?",
-        """Get power measured at electronic load input."""
-    )
+
+    power = Channel.measurement("FETCH:POWER?", """Get power measured at electronic load input.""")
     voltage = Channel.measurement(
-        "FETCH:VOLTAGE?",
-        """Get the voltage measured at the electronic load input."""
+        "FETCH:VOLTAGE?", """Get the voltage measured at the electronic load input."""
     )
+
     def clear_protection_state(self):
         """Set the status of the electronic load to a clear state."""
         self.write("LOAD:PROTECTION:CLEAR")
@@ -138,16 +178,17 @@ class Chroma63600_Channel(Channel):
     short_circuit_enabled = Channel.control(
         "LOAD:SHORT?",
         "LOAD:SHORT %s",
-        """Set active or unactive for the short-circuit simulation.""",
+        """Control short-circuit simulation, ON (True) or OFF (False).""",
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
         cast=str,
     )
+
     mode = Channel.control(
         ":MODE?",
         ":MODE %s",
-        """Set the operational mode of the electronic load.
+        """Control the operational mode of the electronic load.
 
         Basic modes include constant current (CC), constant resistance (CR), constant voltage (CV),
         constant power (CP), and constant impedance (CZ). There are low (L), middle (M), and
@@ -173,24 +214,20 @@ class Chroma63600_Channel(Channel):
         """,
         validator=strict_discrete_set,
         values=MODES,
-        get_process=lambda v: (InstrMode(v),) if v=="PROG" else \
-                              (InstrMode(v[:-1]),InstrModeRange(v[-1])),
+        get_process=lambda v: (
+            (InstrMode(v),) if v == "PROG" else (InstrMode(v[:-1]), InstrModeRange(v[-1]))
+        ),
         cast=str,
     )
 
     # TIMING MODE
     amp_hours = Channel.measurement(
         "FETCH:AH?",
-        """Get ampere-hour measured in timing mode.""",
+        """Measure ampere-hour measured in timing mode.""",
     )
-    time = Channel.measurement(
-        "FETCH:TIME?",
-        """Get time measured in timing mode."""
-    )
-    watt_hours = Channel.measurement(
-        "FETCH:WH?",
-        """Get the watt-hour measured in timing mode."""
-    )
+
+    time = Channel.measurement("FETCH:TIME?", """Get time measured in timing mode.""")
+    watt_hours = Channel.measurement("FETCH:WH?", """Get the watt-hour measured in timing mode.""")
 
 
 class Chroma63630_80_60(Chroma63600_Channel):
@@ -201,15 +238,16 @@ class Chroma63630_80_60(Chroma63600_Channel):
         "CURRENT:STATIC:L1?",
         "CURRENT:STATIC:L1 %g",
         """Control the L1 static current set point in constant current mode.""",
-        validator=truncated_range,
-        values=[0,60],
+        validator=strict_range,
+        values=[0, 60],
     )
+
     current_setpoint_2 = Channel.control(
         "CURRENT:STATIC:L2?",
         "CURRENT:STATIC:L2 %g",
         """Control the L2 static current set point in constant current mode.""",
-        validator=truncated_range,
-        values=[0,60],
+        validator=strict_range,
+        values=[0, 60],
     )
 
     # CONSTANT VOLTAGE MODE
@@ -217,81 +255,83 @@ class Chroma63630_80_60(Chroma63600_Channel):
         "VOLTAGE:STATIC:L1?",
         "VOLTAGE:STATIC:L1 %g",
         """Control the L1 voltage set point in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,80],
+        validator=strict_range,
+        values=[0, 80],
     )
+
     voltage_setpoint_2 = Channel.control(
         "VOLTAGE:STATIC:L2?",
         "VOLTAGE:STATIC:L2 %g",
         """Control the L2 voltage set point in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,80],
+        validator=strict_range,
+        values=[0, 80],
     )
+
     current_limit = Channel.control(
         "VOLTAGE:STATIC:ILIMIT?",
         "VOLTAGE:STATIC:ILIMIT %g",
-        """Set the current limit in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,60],
+        """Control the current limit in constant voltage mode.""",
+        validator=strict_range,
+        values=[0, 60],
     )
+
     # CONSTANT POWER MODE
     power_setpoint_1 = Channel.control(
         "POWER:STATIC:L1?",
         "POWER:STATIC:L1 %g",
         """Control the L1 power set point in constant power mode.""",
-        validator=truncated_range,
-        values=[0,300],
+        validator=strict_range,
+        values=[0, 300],
     )
+
     power_setpoint_2 = Channel.control(
         "POWER:STATIC:L2?",
         "POWER:STATIC:L2 %g",
         """Control the L2 power set point in constant power mode.""",
-        validator=truncated_range,
-        values=[0,300],
+        validator=strict_range,
+        values=[0, 300],
     )
+
     # CONSTANT RESISTANCE MODE
     resistance_setpoint_1 = Channel.control(
         "RESISTANCE:STATIC:L1?",
         "RESISTANCE:STATIC:L1 %g",
         """Control the L1 resistance set point in constant resistance mode.""",
-        validator=truncated_range,
-        values=[0.015,3000],
+        validator=strict_range,
+        values=[0.015, 3000],
     )
+
     resistance_setpoint_2 = Channel.control(
         "RESISTANCE:STATIC:L2?",
         "RESISTANCE:STATIC:L2 %g",
         """Control the L2 resistance set point in constant resistance mode.""",
-        validator=truncated_range,
-        values=[0.015,3000],
+        validator=strict_range,
+        values=[0.015, 3000],
     )
+
     # CONSTANT IMPEDANCE MODE
     parallel_load_capacitance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:CL?",
         "IMPEDANCE:STATIC:CL %g",
-        """Set the equivalent parallel load capacitance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent parallel load capacitance in constant impedance mode.""",
     )
+
     series_inductance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:LS?",
         "IMPEDANCE:STATIC:LS %g",
-        """Set the equivalent series inductance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent series inductance in constant impedance mode.""",
     )
+
     series_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RS?",
         "IMPEDANCE:STATIC:RS %g",
-        """Set the equivalent series resistance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent series resistance in constant impedance mode.""",
     )
+
     parallel_load_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RL?",
         "IMPEDANCE:STATIC:RL %g",
-        """Set the equivalent parallel load resistance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent parallel load resistance in constant impedance mode.""",
     )
 
 
@@ -303,15 +343,16 @@ class Chroma63610_80_20(Chroma63600_Channel):
         "CURRENT:STATIC:L1?",
         "CURRENT:STATIC:L1 %g",
         """Control the L1 static current set point in constant current mode.""",
-        validator=truncated_range,
-        values=[0,20],
+        validator=strict_range,
+        values=[0, 20],
     )
+
     current_setpoint_2 = Channel.control(
         "CURRENT:STATIC:L2?",
         "CURRENT:STATIC:L2 %g",
         """Control the L2 static current set point in constant current mode.""",
-        validator=truncated_range,
-        values=[0,20],
+        validator=strict_range,
+        values=[0, 20],
     )
 
     # CONSTANT VOLTAGE MODE
@@ -319,81 +360,83 @@ class Chroma63610_80_20(Chroma63600_Channel):
         "VOLTAGE:STATIC:L1?",
         "VOLTAGE:STATIC:L1 %g",
         """Control the L1 voltage set point in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,80],
+        validator=strict_range,
+        values=[0, 80],
     )
+
     voltage_setpoint_2 = Channel.control(
         "VOLTAGE:STATIC:L2?",
         "VOLTAGE:STATIC:L2 %g",
         """Control the L2 voltage set point in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,80],
+        validator=strict_range,
+        values=[0, 80],
     )
+
     current_limit = Channel.control(
         "VOLTAGE:STATIC:ILIMIT?",
         "VOLTAGE:STATIC:ILIMIT %g",
-        """Set the current limit in constant voltage mode.""",
-        validator=truncated_range,
-        values=[0,20],
+        """Control the current limit in constant voltage mode.""",
+        validator=strict_range,
+        values=[0, 20],
     )
+
     # CONSTANT POWER MODE
     power_setpoint_1 = Channel.control(
         "POWER:STATIC:L1?",
         "POWER:STATIC:L1 %g",
         """Control the L1 power set point in constant power mode.""",
-        validator=truncated_range,
-        values=[0,100],
+        validator=strict_range,
+        values=[0, 100],
     )
+
     power_setpoint_2 = Channel.control(
         "POWER:STATIC:L2?",
         "POWER:STATIC:L2 %g",
         """Control the L2 power set point in constant power mode.""",
-        validator=truncated_range,
-        values=[0,100],
+        validator=strict_range,
+        values=[0, 100],
     )
+
     # CONSTANT RESISTANCE MODE
     resistance_setpoint_1 = Channel.control(
         "RESISTANCE:STATIC:L1?",
         "RESISTANCE:STATIC:L1 %g",
         """Control the L1 resistance set point in constant resistance mode.""",
-        validator=truncated_range,
-        values=[0.04,12000],
+        validator=strict_range,
+        values=[0.04, 12000],
     )
+
     resistance_setpoint_2 = Channel.control(
         "RESISTANCE:STATIC:L2?",
         "RESISTANCE:STATIC:L2 %g",
         """Control the L2 resistance set point in constant resistance mode.""",
-        validator=truncated_range,
-        values=[0.04,12000],
+        validator=strict_range,
+        values=[0.04, 12000],
     )
+
     # CONSTANT IMPEDANCE MODE
     parallel_load_capacitance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:CL?",
         "IMPEDANCE:STATIC:CL %g",
-        """Set the equivalent parallel load capacitance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent parallel load capacitance in constant impedance mode.""",
     )
+
     series_inductance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:LS?",
         "IMPEDANCE:STATIC:LS %g",
-        """Set the equivalent series inductance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent series inductance in constant impedance mode.""",
     )
+
     series_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RS?",
         "IMPEDANCE:STATIC:RS %g",
-        """Set the equivalent series resistance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent series resistance in constant impedance mode.""",
     )
+
     parallel_load_resistance_setpoint = Channel.control(
         "IMPEDANCE:STATIC:RL?",
         "IMPEDANCE:STATIC:RL %g",
-        """Set the equivalent parallel load resistance in constant impedance mode.""",
-        # validator=truncated_range,
-        # values=[0,0],
+        """Control the equivalent parallel load resistance in constant impedance mode.""",
     )
 
 
@@ -406,19 +449,14 @@ class Chroma63600(SCPIMixin, Instrument):
     """
 
     def __init__(self, adapter, name="Chroma 63600", **kwargs):
-        super().__init__(
-            adapter,
-            name,
-            read_termination='\n',
-            **kwargs
-        )
+        super().__init__(adapter, name, read_termination="\n", **kwargs)
 
         # Populate a default channel for fallback
         self.add_child(Chroma63630_80_60, 1)
         # Auto-discover channels
         self.discover_channels()
 
-    def discover_channels(self,Nslots: int = 5):
+    def discover_channels(self, Nslots: int = 5):
         """Discover and populate channels programmatically.
 
         The mainframe always leaves space for two channels per load (left and right).
@@ -440,18 +478,18 @@ class Chroma63600(SCPIMixin, Instrument):
                 self.remove_child(ch)
 
         # Auto-discover and add channels
-        for i in range(1, Nslots*2+1):
-            if self.ask(f'CHAN {i};CHAN?') == str(i):
+        for i in range(1, Nslots * 2 + 1):
+            if self.ask(f"CHAN {i};CHAN?") == str(i):
                 # This channel exists, get its id and add it
-                chid = self.ask('CHAN:ID?').split(',')[1]
-                if chid == '63630-80-60':
-                    self.add_child(Chroma63630_80_60,i)
-                elif chid in ['63610-80-20L','63610-80-20R']:
-                    self.add_child(Chroma63610_80_20,i)
+                chid = self.ask("CHAN:ID?").split(",")[1]
+                if chid == "63630-80-60":
+                    self.add_child(Chroma63630_80_60, i)
+                elif chid in ["63610-80-20L", "63610-80-20R"]:
+                    self.add_child(Chroma63610_80_20, i)
                 else:
                     raise NotImplementedError(
-                        "Only Chroma 63610-80-20 and 63630-80-60 channels "
-                        "are currently supported.")
+                        "Only Chroma 63610-80-20 and 63630-80-60 channels are currently supported."
+                    )
 
     def enable_all(self, state: bool = True):
         """Set all electronic loads to ON (True) or OFF (False).
@@ -460,17 +498,8 @@ class Chroma63600(SCPIMixin, Instrument):
         for chid, ch in self.channels.items():
             ch.enabled = state
 
-    currents = Instrument.measurement(
-        "MEAS:ALLC?",
-        """Get all channel currents as a list."""
-    )
+    currents = Instrument.measurement("MEAS:ALLC?", """Get all channel currents as a list.""")
 
-    voltages = Instrument.measurement(
-        "MEAS:ALLV?",
-        """Get all channel voltages as a list."""
-    )
+    voltages = Instrument.measurement("MEAS:ALLV?", """Get all channel voltages as a list.""")
 
-    powers = Instrument.measurement(
-        "MEAS:ALLP?",
-        """Get all channel powers as a list."""
-    )
+    powers = Instrument.measurement("MEAS:ALLP?", """Get all channel powers as a list.""")

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-from enum import StrEnum,IntFlag
+from enum import Enum,IntFlag
 
 from pymeasure.instruments import Instrument,Channel
 from pymeasure.instruments.generic_types import SCPIMixin
@@ -44,7 +44,7 @@ class InstrStatus(IntFlag):
     OK = 0
 
 
-class InstrMode(StrEnum):
+class InstrMode(str,Enum):
     """Instrument modes. Each mode has low (L), medium (M), and high (H) ranges,
     except for constant resistance (CR) mode, which only has L and H. The range
     is not included in this enum."""
@@ -62,7 +62,7 @@ class InstrMode(StrEnum):
     MAXIMUM_POWER_POINT_TRACKER="MPPT"
 
 
-class InstrModeRange(StrEnum):
+class InstrModeRange(str,Enum):
     """Instrument mode ranges."""
     LOW_RANGE="L"
     MEDIUM_RANGE="M"

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -446,7 +446,7 @@ class Chroma63600(SCPIMixin, Instrument):
                         "Only Chroma 63610-80-20 and 63630-80-60 channels "
                         "are currently supported.")
 
-    def run(self, state: bool = True):
+    def enable_all(self, state: bool = True):
         """Set all electronic loads to ON (True) or OFF (False).
         :param state: True or False, determines Enabled state of loads.
         """

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -112,7 +112,7 @@ class Chroma63600_Channel(Channel):
     )
     current = Channel.measurement(
         "FETCH:CURRENT?",
-        """Get current measured at electronic load input."""
+        """Measure current at electronic load input in Amps (float)."""
     )
     frequency = Channel.measurement(
         "FETCH:FREQUENCY?",
@@ -126,11 +126,11 @@ class Chroma63600_Channel(Channel):
         "FETCH:VOLTAGE?",
         """Get the voltage measured at the electronic load input."""
     )
-    protection_clear = Channel.setting(
-        "LOAD:PROTECTION:CLEAR",
+    def clear_protection_state(self):
         """Set the status of the electronic load to a clear state."""
-    )
-    activate_short = Channel.control(
+        self.write("LOAD:PROTECTION:CLEAR")
+
+    short_circuit_enabled = Channel.control(
         "LOAD:SHORT?",
         "LOAD:SHORT %s",
         """Set active or unactive for the short-circuit simulation.""",
@@ -444,7 +444,7 @@ class Chroma63600(SCPIMixin, Instrument):
                 raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels are" \
                                           +" currently supported.")
 
-    def discover_channels(self,Nslots : int = 5):
+    def discover_channels(self,Nslots: int = 5):
         """Discover and populate channels programmatically.
 
         The mainframe always leaves space for two channels per load (left and right).
@@ -462,11 +462,11 @@ class Chroma63600(SCPIMixin, Instrument):
         # Reset channels
         if self.channels:
             channels_copy = self.channels.copy()
-            for i,ch in channels_copy.items():
+            for i, ch in channels_copy.items():
                 self.remove_child(ch)
 
         # Auto-discover and add channels
-        for i in range(1,Nslots*2+1):
+        for i in range(1, Nslots*2+1):
             if self.ask(f'CHAN {i};CHAN?') == str(i):
                 # This channel exists, get its id and add it
                 chid = self.ask('CHAN:ID?').split(',')[1]
@@ -475,14 +475,15 @@ class Chroma63600(SCPIMixin, Instrument):
                 elif chid in ['63610-80-20L','63610-80-20R']:
                     self.add_child(Chroma63610_80_20,i)
                 else:
-                    raise NotImplementedError("Only Chroma 63610-80-20 and 63630-80-60 channels " \
-                                             +"are currently supported.")
+                    raise NotImplementedError(
+                        "Only Chroma 63610-80-20 and 63630-80-60 channels "
+                        "are currently supported.")
 
     def run(self, state: bool = True):
         """Set all electronic loads to ON (True) or OFF (False).
         :param state: True or False, determines Enabled state of loads.
         """
-        for chid,ch in self.channels.items():
+        for chid, ch in self.channels.items():
             ch.enabled = state
 
     currents = Instrument.measurement(

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -88,6 +88,7 @@ class Chroma63600_Channel(Channel):
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
+        cast=str,
     )
 
     enabled = Channel.control(
@@ -106,7 +107,8 @@ class Chroma63600_Channel(Channel):
 
         Returns :class:`InstrStatus`.
         """,
-        get_process=lambda v: InstrStatus(v)
+        get_process=lambda v: InstrStatus(v),
+        cast=int,
     )
     identify = Channel.measurement(
         "CHAN:ID?",
@@ -140,6 +142,7 @@ class Chroma63600_Channel(Channel):
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
+        cast=str,
     )
     mode = Channel.control(
         ":MODE?",

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -101,15 +101,17 @@ class Chroma63600_Channel(Channel):
     )
     status = Channel.measurement(
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
-        """Get the status of the electronic load.
+        """
+        Get the status of the electronic load.
 
-    Returns :class:`InstrStatus`.
+        Returns :class:`InstrStatus`.
         """,
         get_process=lambda v: InstrStatus(v)
     )
     identify = Channel.measurement(
         "CHAN:ID?",
-        """Get module identification string."""
+        """Get module identification string.""",
+        cast=str,
     )
     current = Channel.measurement(
         "FETCH:CURRENT?",

--- a/pymeasure/instruments/chroma/chroma_63600.py
+++ b/pymeasure/instruments/chroma/chroma_63600.py
@@ -74,7 +74,8 @@ class Chroma63600_Channel(Channel):
     _BOOLS = {True: "ON", False: "OFF"}
     MODES = ["CCL","CCM","CCH", "CRL","CRH", "CVL","CRM","CRH", "CPL","CPM","CPH", "CZL","CZM",
              "CZH", "CCDL","CCDM","CCDH", "CCFSL","CCFSM","CCFSH", "TIML","TIMM","TIMH", "SWDL",
-             "SWDM","SWDH", "OCPL","OCPM","OCPH", "PROG", "MPPTL","MPPTM","MPPTH","UDWL,UDWM,UDWH"]
+             "SWDM","SWDH", "OCPL","OCPM","OCPH", "PROG", "MPPTL","MPPTM","MPPTH","UDWL","UDWM",
+             "UDWH"]
 
     def insert_id(self, command):
         """Set current channel before performing command"""
@@ -83,7 +84,7 @@ class Chroma63600_Channel(Channel):
     active = Instrument.control(
         "CHANNEL:ACTIVE?",
         "CHANNEL:ACTIVE %s",
-        """Enable or disable load module, can be ON or OFF""",
+        """Set enabled or disabled for the load module, can be ON or OFF""",
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
@@ -98,7 +99,7 @@ class Chroma63600_Channel(Channel):
     )
     status = Instrument.measurement(
         "LOAD:PROTECTION?",  # Synonym: FETCH:STATUS?
-        """Return the status of the electronic load.
+        """Get the status of the electronic load.
 
         +--------+-----------------------------+
         | bit(s) | description                 |
@@ -128,7 +129,7 @@ class Chroma63600_Channel(Channel):
     )
     identify = Instrument.measurement(
         "CHAN:ID?",
-        """Request the module to identify itself."""
+        """Get module identification string."""
     )
     current = Instrument.measurement(
         "FETCH:CURRENT?",
@@ -148,12 +149,12 @@ class Chroma63600_Channel(Channel):
     )
     protection_clear = Instrument.setting(
         "LOAD:PROTECTION:CLEAR",
-        """Resets the status of the electronic load."""
+        """Set the status of the electronic load to a clear state."""
     )
     activate_short = Instrument.control(
         "LOAD:SHORT?",
         "LOAD:SHORT %s",
-        """Activate or deactivate the short-circuit simulation.""",
+        """Set active or unactive for the short-circuit simulation.""",
         validator=strict_discrete_set,
         values=_BOOLS,
         map_values=True,
@@ -188,7 +189,7 @@ class Chroma63600_Channel(Channel):
         validator=strict_discrete_set,
         values=MODES,
         get_process=lambda v: (InstrMode(v),) if v=="PROG" else \
-                            (InstrMode(v[:-1]),InstrModeRange(v[-1])),
+                              (InstrMode(v[:-1]),InstrModeRange(v[-1])),
     )
 
     # TIMING MODE
@@ -202,7 +203,7 @@ class Chroma63600_Channel(Channel):
     )
     watt_hours = Instrument.measurement(
         "FETCH:WH?",
-        "Get the watt-hour measured in timing mode."
+        """Get the watt-hour measured in timing mode."""
     )
 
 
@@ -478,15 +479,15 @@ class Chroma63600(SCPIMixin, Instrument):
 
     currents = Instrument.measurement(
         "MEAS:ALLC?",
-        """Return all channel currents as a list."""
+        """Get all channel currents as a list."""
     )
 
     voltages = Instrument.measurement(
         "MEAS:ALLV?",
-        """Return all channel voltages as a list."""
+        """Get all channel voltages as a list."""
     )
 
     powers = Instrument.measurement(
         "MEAS:ALLP?",
-        """Return all channel powers as a list."""
+        """Get all channel powers as a list."""
     )

--- a/tests/instruments/chroma/test_chroma_63600.py
+++ b/tests/instruments/chroma/test_chroma_63600.py
@@ -121,7 +121,7 @@ def test_ch_3_identify_getter():
             Chroma63600,
             [*init_cmds,(b'CHAN 3;CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92')],
     ) as inst:
-        assert inst.ch_3.identify == ['CHROMA', '63630-80-60', 636308007635.0, 1.92, 1.92]
+        assert inst.ch_3.identify == ['CHROMA', '63630-80-60', '636308007635', '1.92', '1.92']
 
 
 def test_ch_3_mode_setter():

--- a/tests/instruments/chroma/test_chroma_63600.py
+++ b/tests/instruments/chroma/test_chroma_63600.py
@@ -26,10 +26,28 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.chroma.chroma_63600 import Chroma63600
 
 
+init_cmds = [(b'CHAN 1;CHAN?', b'1'),
+             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007926,1.92,1.92'),
+             (b'CHAN 2;CHAN?', b'1'),
+             (b'CHAN 3;CHAN?', b'3'),
+             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92'),
+             (b'CHAN 4;CHAN?', b'3'),
+             (b'CHAN 5;CHAN?', b'5'),
+             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007572,1.92,1.92'),
+             (b'CHAN 6;CHAN?', b'5'),
+             (b'CHAN 7;CHAN?', b'7'),
+             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308008365,1.92,1.92'),
+             (b'CHAN 8;CHAN?', b'7'),
+             (b'CHAN 9;CHAN?', b'9'),
+             (b'CHAN:ID?', b'CHROMA,63610-80-20L,636108008723,1.92,1.92'),
+             (b'CHAN 10;CHAN?', b'10'),
+             (b'CHAN:ID?', b'CHROMA,63610-80-20R,636108008723,1.92,1.92')]
+
+
 def test_init():
     with expected_protocol(
             Chroma63600,
-            [],
+            init_cmds,
     ):
         pass  # Verify the expected communication.
 
@@ -37,7 +55,7 @@ def test_init():
 def test_ch_1_active_setter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;CHANNEL:ACTIVE ON', None)],
+            [*init_cmds,(b'CHAN 1;CHANNEL:ACTIVE ON', None)],
     ) as inst:
         inst.ch_1.active = True
 
@@ -45,7 +63,7 @@ def test_ch_1_active_setter():
 def test_ch_1_active_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;CHANNEL:ACTIVE?', b'ON')],
+            [*init_cmds,(b'CHAN 1;CHANNEL:ACTIVE?', b'ON')],
     ) as inst:
         assert inst.ch_1.active is True
 
@@ -53,7 +71,7 @@ def test_ch_1_active_getter():
 def test_ch_1_enabled_setter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;LOAD ON', None)],
+            [*init_cmds,(b'CHAN 1;LOAD ON', None)],
     ) as inst:
         inst.ch_1.enabled = True
 
@@ -61,7 +79,7 @@ def test_ch_1_enabled_setter():
 def test_ch_1_enabled_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;LOAD?', b'ON')],
+            [*init_cmds,(b'CHAN 1;LOAD?', b'ON')],
     ) as inst:
         assert inst.ch_1.enabled is True
 
@@ -69,7 +87,7 @@ def test_ch_1_enabled_getter():
 def test_ch_1_mode_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;:MODE?', b'CRH')],
+            [*init_cmds,(b'CHAN 1;:MODE?', b'CRH')],
     ) as inst:
         assert inst.ch_1.mode == ("CR","H")
 
@@ -77,7 +95,7 @@ def test_ch_1_mode_getter():
 def test_ch_1_status_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 1;LOAD:PROTECTION?', b'0')],
+            [*init_cmds,(b'CHAN 1;LOAD:PROTECTION?', b'0')],
     ) as inst:
         assert inst.ch_1.status == 0
 
@@ -85,7 +103,7 @@ def test_ch_1_status_getter():
 def test_ch_3_current_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;FETCH:CURRENT?', b'0.0038438')],
+            [*init_cmds,(b'CHAN 3;FETCH:CURRENT?', b'0.0038438')],
     ) as inst:
         assert inst.ch_3.current == 0.0038438
 
@@ -93,7 +111,7 @@ def test_ch_3_current_getter():
 def test_ch_3_frequency_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;FETCH:FREQUENCY?', b'-0000000000')],
+            [*init_cmds,(b'CHAN 3;FETCH:FREQUENCY?', b'-0000000000')],
     ) as inst:
         assert inst.ch_3.frequency == -0.0
 
@@ -101,7 +119,7 @@ def test_ch_3_frequency_getter():
 def test_ch_3_identify_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92')],
+            [*init_cmds,(b'CHAN 3;CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92')],
     ) as inst:
         assert inst.ch_3.identify == ['CHROMA', '63630-80-60', 636308007635.0, 1.92, 1.92]
 
@@ -109,7 +127,7 @@ def test_ch_3_identify_getter():
 def test_ch_3_mode_setter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;:MODE CRH', None)],
+            [*init_cmds,(b'CHAN 3;:MODE CRH', None)],
     ) as inst:
         inst.ch_3.mode = 'CRH'
 
@@ -117,7 +135,7 @@ def test_ch_3_mode_setter():
 def test_ch_3_power_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;FETCH:POWER?', b'0.0000054')],
+            [*init_cmds,(b'CHAN 3;FETCH:POWER?', b'0.0000054')],
     ) as inst:
         assert inst.ch_3.power == 5.4e-06
 
@@ -125,7 +143,7 @@ def test_ch_3_power_getter():
 def test_ch_3_resistance_setpoint_1_setter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;RESISTANCE:STATIC:L1 10', None)],
+            [*init_cmds,(b'CHAN 3;RESISTANCE:STATIC:L1 10', None)],
     ) as inst:
         inst.ch_3.resistance_setpoint_1 = 10
 
@@ -133,7 +151,7 @@ def test_ch_3_resistance_setpoint_1_setter():
 def test_ch_3_resistance_setpoint_1_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;RESISTANCE:STATIC:L1?', b'24.00')],
+            [*init_cmds,(b'CHAN 3;RESISTANCE:STATIC:L1?', b'24.00')],
     ) as inst:
         assert inst.ch_3.resistance_setpoint_1 == 24.0
 
@@ -141,31 +159,31 @@ def test_ch_3_resistance_setpoint_1_getter():
 def test_ch_3_voltage_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 3;FETCH:VOLTAGE?', b'0.0009822')],
+            [*init_cmds,(b'CHAN 3;FETCH:VOLTAGE?', b'0.0009822')],
     ) as inst:
         assert inst.ch_3.voltage == 0.0009822
 
 
-def test_ch_5_mode_getter():
+def test_ch_3_mode_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 5;:MODE?', b'CRH')],
+            [*init_cmds,(b'CHAN 3;:MODE?', b'CRH')],
     ) as inst:
-        assert inst.ch_5.mode == ("CR","H")
+        assert inst.ch_3.mode == ("CR","H")
 
 
-def test_ch_5_status_getter():
+def test_ch_3_status_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'CHAN 5;LOAD:PROTECTION?', b'0')],
+            [*init_cmds,(b'CHAN 3;LOAD:PROTECTION?', b'0')],
     ) as inst:
-        assert inst.ch_5.status == 0
+        assert inst.ch_3.status == 0
 
 
 def test_currents_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'MEAS:ALLC?',
+            [*init_cmds,(b'MEAS:ALLC?',
               b'0.0053471,0,0.0039698,0,0.0036226,0,0.5005162,0,0.0004139,0.0004023')],
     ) as inst:
         assert inst.currents == [0.0053471, 0.0, 0.0039698, 0.0, 0.0036226, 0.0, 0.5005162,
@@ -175,7 +193,7 @@ def test_currents_getter():
 def test_powers_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'MEAS:ALLP?',
+            [*init_cmds,(b'MEAS:ALLP?',
               b'0.0000085,0,0.0000034,0,0.0000046,0,0.4900631,0,0.0000001,0.0000002')],
     ) as inst:
         assert inst.powers == [8.5e-06, 0.0, 3.4e-06, 0.0, 4.6e-06, 0.0, 0.4900631, 0.0,
@@ -185,7 +203,7 @@ def test_powers_getter():
 def test_voltages_getter():
     with expected_protocol(
             Chroma63600,
-            [(b'MEAS:ALLV?',
+            [*init_cmds,(b'MEAS:ALLV?',
               b'0.0017520,0,0.0014331,0,0.0021199,0,0.9797283,0,0.0004860,0.0011949')],
     ) as inst:
         assert inst.voltages == [0.001752, 0.0, 0.0014331, 0.0, 0.0021199, 0.0,

--- a/tests/instruments/chroma/test_chroma_63600.py
+++ b/tests/instruments/chroma/test_chroma_63600.py
@@ -1,0 +1,196 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import pytest
+
+from pymeasure.test import expected_protocol
+
+from pymeasure.instruments.chroma.chroma_63600 import Chroma63600
+# from pymeasure.instruments.chroma.chroma_63600 import Chroma63610_80_20,Chroma63630_80_60
+
+
+def test_init():
+    with expected_protocol(
+            Chroma63600,
+            [],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_ch_1_active_setter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;CHANNEL:ACTIVE ON', None)],
+    ) as inst:
+        inst.ch_1.active = True
+
+
+def test_ch_1_active_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;CHANNEL:ACTIVE?', b'ON')],
+    ) as inst:
+        assert inst.ch_1.active is True
+
+
+def test_ch_1_enabled_setter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;LOAD ON', None)],
+    ) as inst:
+        inst.ch_1.enabled = True
+
+
+def test_ch_1_enabled_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;LOAD?', b'ON')],
+    ) as inst:
+        assert inst.ch_1.enabled is True
+
+
+def test_ch_1_mode_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;:MODE?', b'CRH')],
+    ) as inst:
+        assert inst.ch_1.mode == ("CR","H")
+
+
+def test_ch_1_status_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 1;LOAD:PROTECTION?', b'0')],
+    ) as inst:
+        assert inst.ch_1.status == 0
+
+
+def test_ch_3_current_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;FETCH:CURRENT?', b'0.0038438')],
+    ) as inst:
+        assert inst.ch_3.current == 0.0038438
+
+
+def test_ch_3_frequency_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;FETCH:FREQUENCY?', b'-0000000000')],
+    ) as inst:
+        assert inst.ch_3.frequency == -0.0
+
+
+def test_ch_3_identify_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92')],
+    ) as inst:
+        assert inst.ch_3.identify == ['CHROMA', '63630-80-60', 636308007635.0, 1.92, 1.92]
+
+
+def test_ch_3_mode_setter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;:MODE CRH', None)],
+    ) as inst:
+        inst.ch_3.mode = 'CRH'
+
+
+def test_ch_3_power_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;FETCH:POWER?', b'0.0000054')],
+    ) as inst:
+        assert inst.ch_3.power == 5.4e-06
+
+
+def test_ch_3_resistance_setpoint_1_setter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;RESISTANCE:STATIC:L1 10', None)],
+    ) as inst:
+        inst.ch_3.resistance_setpoint_1 = 10
+
+
+def test_ch_3_resistance_setpoint_1_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;RESISTANCE:STATIC:L1?', b'24.00')],
+    ) as inst:
+        assert inst.ch_3.resistance_setpoint_1 == 24.0
+
+
+def test_ch_3_voltage_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 3;FETCH:VOLTAGE?', b'0.0009822')],
+    ) as inst:
+        assert inst.ch_3.voltage == 0.0009822
+
+
+def test_ch_5_mode_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 5;:MODE?', b'CRH')],
+    ) as inst:
+        assert inst.ch_5.mode == ("CR","H")
+
+
+def test_ch_5_status_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'CHAN 5;LOAD:PROTECTION?', b'0')],
+    ) as inst:
+        assert inst.ch_5.status == 0
+
+
+def test_currents_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'MEAS:ALLC?',
+              b'0.0053471,0,0.0039698,0,0.0036226,0,0.5005162,0,0.0004139,0.0004023')],
+    ) as inst:
+        assert inst.currents == [0.0053471, 0.0, 0.0039698, 0.0, 0.0036226, 0.0, 0.5005162,
+                                 0.0, 0.0004139, 0.0004023]
+
+
+def test_powers_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'MEAS:ALLP?',
+              b'0.0000085,0,0.0000034,0,0.0000046,0,0.4900631,0,0.0000001,0.0000002')],
+    ) as inst:
+        assert inst.powers == [8.5e-06, 0.0, 3.4e-06, 0.0, 4.6e-06, 0.0, 0.4900631, 0.0,
+                               1e-07, 2e-07]
+
+
+def test_voltages_getter():
+    with expected_protocol(
+            Chroma63600,
+            [(b'MEAS:ALLV?',
+              b'0.0017520,0,0.0014331,0,0.0021199,0,0.9797283,0,0.0004860,0.0011949')],
+    ) as inst:
+        assert inst.voltages == [0.001752, 0.0, 0.0014331, 0.0, 0.0021199, 0.0,
+                                 0.9797283, 0.0, 0.000486, 0.0011949]
+

--- a/tests/instruments/chroma/test_chroma_63600.py
+++ b/tests/instruments/chroma/test_chroma_63600.py
@@ -26,186 +26,223 @@ from pymeasure.test import expected_protocol
 from pymeasure.instruments.chroma.chroma_63600 import Chroma63600
 
 
-init_cmds = [(b'CHAN 1;CHAN?', b'1'),
-             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007926,1.92,1.92'),
-             (b'CHAN 2;CHAN?', b'1'),
-             (b'CHAN 3;CHAN?', b'3'),
-             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92'),
-             (b'CHAN 4;CHAN?', b'3'),
-             (b'CHAN 5;CHAN?', b'5'),
-             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308007572,1.92,1.92'),
-             (b'CHAN 6;CHAN?', b'5'),
-             (b'CHAN 7;CHAN?', b'7'),
-             (b'CHAN:ID?', b'CHROMA,63630-80-60,636308008365,1.92,1.92'),
-             (b'CHAN 8;CHAN?', b'7'),
-             (b'CHAN 9;CHAN?', b'9'),
-             (b'CHAN:ID?', b'CHROMA,63610-80-20L,636108008723,1.92,1.92'),
-             (b'CHAN 10;CHAN?', b'10'),
-             (b'CHAN:ID?', b'CHROMA,63610-80-20R,636108008723,1.92,1.92')]
+init_cmds = [
+    (b"CHAN 1;CHAN?", b"1"),
+    (b"CHAN:ID?", b"CHROMA,63630-80-60,636308007926,1.92,1.92"),
+    (b"CHAN 2;CHAN?", b"1"),
+    (b"CHAN 3;CHAN?", b"3"),
+    (b"CHAN:ID?", b"CHROMA,63630-80-60,636308007635,1.92,1.92"),
+    (b"CHAN 4;CHAN?", b"3"),
+    (b"CHAN 5;CHAN?", b"5"),
+    (b"CHAN:ID?", b"CHROMA,63630-80-60,636308007572,1.92,1.92"),
+    (b"CHAN 6;CHAN?", b"5"),
+    (b"CHAN 7;CHAN?", b"7"),
+    (b"CHAN:ID?", b"CHROMA,63630-80-60,636308008365,1.92,1.92"),
+    (b"CHAN 8;CHAN?", b"7"),
+    (b"CHAN 9;CHAN?", b"9"),
+    (b"CHAN:ID?", b"CHROMA,63610-80-20L,636108008723,1.92,1.92"),
+    (b"CHAN 10;CHAN?", b"10"),
+    (b"CHAN:ID?", b"CHROMA,63610-80-20R,636108008723,1.92,1.92"),
+]
 
 
 def test_init():
     with expected_protocol(
-            Chroma63600,
-            init_cmds,
+        Chroma63600,
+        init_cmds,
     ):
         pass  # Verify the expected communication.
 
 
 def test_ch_1_active_setter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;CHANNEL:ACTIVE ON', None)],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;CHANNEL:ACTIVE ON", None)],
     ) as inst:
         inst.ch_1.active = True
 
 
 def test_ch_1_active_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;CHANNEL:ACTIVE?', b'ON')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;CHANNEL:ACTIVE?", b"ON")],
     ) as inst:
         assert inst.ch_1.active is True
 
 
 def test_ch_1_enabled_setter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;LOAD ON', None)],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;LOAD ON", None)],
     ) as inst:
         inst.ch_1.enabled = True
 
 
 def test_ch_1_enabled_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;LOAD?', b'ON')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;LOAD?", b"ON")],
     ) as inst:
         assert inst.ch_1.enabled is True
 
 
 def test_ch_1_mode_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;:MODE?', b'CRH')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;:MODE?", b"CRH")],
     ) as inst:
-        assert inst.ch_1.mode == ("CR","H")
+        assert inst.ch_1.mode == ("CR", "H")
 
 
 def test_ch_1_status_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 1;LOAD:PROTECTION?', b'0')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 1;LOAD:PROTECTION?", b"0")],
     ) as inst:
         assert inst.ch_1.status == 0
 
 
 def test_ch_3_current_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;FETCH:CURRENT?', b'0.0038438')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;FETCH:CURRENT?", b"0.0038438")],
     ) as inst:
         assert inst.ch_3.current == 0.0038438
 
 
 def test_ch_3_frequency_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;FETCH:FREQUENCY?', b'-0000000000')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;FETCH:FREQUENCY?", b"-0000000000")],
     ) as inst:
         assert inst.ch_3.frequency == -0.0
 
 
 def test_ch_3_identify_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;CHAN:ID?', b'CHROMA,63630-80-60,636308007635,1.92,1.92')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;CHAN:ID?", b"CHROMA,63630-80-60,636308007635,1.92,1.92")],
     ) as inst:
-        assert inst.ch_3.identify == ['CHROMA', '63630-80-60', '636308007635', '1.92', '1.92']
+        assert inst.ch_3.identify == ["CHROMA", "63630-80-60", "636308007635", "1.92", "1.92"]
 
 
 def test_ch_3_mode_setter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;:MODE CRH', None)],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;:MODE CRH", None)],
     ) as inst:
-        inst.ch_3.mode = 'CRH'
+        inst.ch_3.mode = "CRH"
 
 
 def test_ch_3_power_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;FETCH:POWER?', b'0.0000054')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;FETCH:POWER?", b"0.0000054")],
     ) as inst:
         assert inst.ch_3.power == 5.4e-06
 
 
 def test_ch_3_resistance_setpoint_1_setter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;RESISTANCE:STATIC:L1 10', None)],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;RESISTANCE:STATIC:L1 10", None)],
     ) as inst:
         inst.ch_3.resistance_setpoint_1 = 10
 
 
 def test_ch_3_resistance_setpoint_1_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;RESISTANCE:STATIC:L1?', b'24.00')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;RESISTANCE:STATIC:L1?", b"24.00")],
     ) as inst:
         assert inst.ch_3.resistance_setpoint_1 == 24.0
 
 
 def test_ch_3_voltage_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;FETCH:VOLTAGE?', b'0.0009822')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;FETCH:VOLTAGE?", b"0.0009822")],
     ) as inst:
         assert inst.ch_3.voltage == 0.0009822
 
 
 def test_ch_3_mode_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;:MODE?', b'CRH')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;:MODE?", b"CRH")],
     ) as inst:
-        assert inst.ch_3.mode == ("CR","H")
+        assert inst.ch_3.mode == ("CR", "H")
 
 
 def test_ch_3_status_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'CHAN 3;LOAD:PROTECTION?', b'0')],
+        Chroma63600,
+        [*init_cmds, (b"CHAN 3;LOAD:PROTECTION?", b"0")],
     ) as inst:
         assert inst.ch_3.status == 0
 
 
 def test_currents_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'MEAS:ALLC?',
-              b'0.0053471,0,0.0039698,0,0.0036226,0,0.5005162,0,0.0004139,0.0004023')],
+        Chroma63600,
+        [
+            *init_cmds,
+            (b"MEAS:ALLC?", b"0.0053471,0,0.0039698,0,0.0036226,0,0.5005162,0,0.0004139,0.0004023"),
+        ],
     ) as inst:
-        assert inst.currents == [0.0053471, 0.0, 0.0039698, 0.0, 0.0036226, 0.0, 0.5005162,
-                                 0.0, 0.0004139, 0.0004023]
+        assert inst.currents == [
+            0.0053471,
+            0.0,
+            0.0039698,
+            0.0,
+            0.0036226,
+            0.0,
+            0.5005162,
+            0.0,
+            0.0004139,
+            0.0004023,
+        ]
 
 
 def test_powers_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'MEAS:ALLP?',
-              b'0.0000085,0,0.0000034,0,0.0000046,0,0.4900631,0,0.0000001,0.0000002')],
+        Chroma63600,
+        [
+            *init_cmds,
+            (b"MEAS:ALLP?", b"0.0000085,0,0.0000034,0,0.0000046,0,0.4900631,0,0.0000001,0.0000002"),
+        ],
     ) as inst:
-        assert inst.powers == [8.5e-06, 0.0, 3.4e-06, 0.0, 4.6e-06, 0.0, 0.4900631, 0.0,
-                               1e-07, 2e-07]
+        assert inst.powers == [
+            8.5e-06,
+            0.0,
+            3.4e-06,
+            0.0,
+            4.6e-06,
+            0.0,
+            0.4900631,
+            0.0,
+            1e-07,
+            2e-07,
+        ]
 
 
 def test_voltages_getter():
     with expected_protocol(
-            Chroma63600,
-            [*init_cmds,(b'MEAS:ALLV?',
-              b'0.0017520,0,0.0014331,0,0.0021199,0,0.9797283,0,0.0004860,0.0011949')],
+        Chroma63600,
+        [
+            *init_cmds,
+            (b"MEAS:ALLV?", b"0.0017520,0,0.0014331,0,0.0021199,0,0.9797283,0,0.0004860,0.0011949"),
+        ],
     ) as inst:
-        assert inst.voltages == [0.001752, 0.0, 0.0014331, 0.0, 0.0021199, 0.0,
-                                 0.9797283, 0.0, 0.000486, 0.0011949]
-
+        assert inst.voltages == [
+            0.001752,
+            0.0,
+            0.0014331,
+            0.0,
+            0.0021199,
+            0.0,
+            0.9797283,
+            0.0,
+            0.000486,
+            0.0011949,
+        ]

--- a/tests/instruments/chroma/test_chroma_63600.py
+++ b/tests/instruments/chroma/test_chroma_63600.py
@@ -21,12 +21,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import pytest
-
 from pymeasure.test import expected_protocol
 
 from pymeasure.instruments.chroma.chroma_63600 import Chroma63600
-# from pymeasure.instruments.chroma.chroma_63600 import Chroma63610_80_20,Chroma63630_80_60
 
 
 def test_init():


### PR DESCRIPTION
This commit is part of my effort to add Chroma (and related) power test equipment to PyMeasure. The [Chroma 63600](https://www.chromausa.com/product/modular-dc-electronic-load-63600/) series of electronic load mainframes support up to 5 electronic loads and 10 channels. The user manual is available from the [Chroma USA website](https://www.chromausa.com/document-library/manuals-63600-series/). 

The basic interface is implemented here, with configurable channels basic formatting of outputs and status bits. Some protocol tests are included, and the documentation page.