### PR TITLE
Add support for Chroma 66205 Digital Power Meter

### DIFF
--- a/docs/api/instruments/chroma/chroma_66205.rst
+++ b/docs/api/instruments/chroma/chroma_66205.rst
@@ -1,0 +1,7 @@
+################################
+Chroma 66205 Digital Power Meter
+################################
+
+.. autoclass:: pymeasure.instruments.chroma.Chroma66205
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.chroma
+
+############
+Chroma
+############
+
+This section contains specific documentation on the Chroma instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   chroma_66205

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -34,6 +34,7 @@ Instruments by manufacturer:
    anritsu/index
    attocube/index
    bkprecision/index
+   chroma/index
    danfysik/index
    deltaelektronica/index
    edwards/index

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -1,0 +1,28 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# from .chroma_63600 import Chroma63600, Chroma63630_80_60, Chroma63610_80_20
+from .chroma_66205 import Chroma66205
+
+

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -1,0 +1,189 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.generic_types import SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set,truncated_range
+
+
+class Chroma66205(SCPIMixin, Instrument):
+    """Control the Chroma 66205 Digital Power Meter
+
+    The 66205 is a single-channel unit. Most of its interface is identical to the other
+    6620x instruments.
+    """
+
+    def __init__(self, adapter, name="Chroma 63600", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )
+
+    # SETTINGS #
+    mode = Instrument.control(
+        "CONF:MEAS:MODE?",
+        "CONF:MEAS:MODE %s",
+        """Control measurement mode. Can be WINDOW or AVERAGE.""",
+        validator=strict_discrete_set,
+        values=["WINDOW","AVERAGE"]
+    )
+    averages = Instrument.control(
+        "CONF:MEAS:AVERAGE?",
+        "CONF:MEAS:AVERAGE %d",
+        """Control number of measurements to average in averaging mode. Must be a power of 2
+        between 1 and 64 inclusive.""",
+        validator=strict_discrete_set,
+        values=[1,2,3,4,8,16,32,64],
+    )
+    window_time = Instrument.control(
+        "CONF:MEAS:WINDOW?",
+        "CONF:MEAS:WINDOW %f",
+        """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
+        validator=truncated_range,
+        values = [0.,60.]
+    )
+    window_interval = Instrument.control(
+        "CONF:MEAS:WINDOW:UPDATE?",
+        "CONF:MEAS:WINDOW:UPDATE %s",
+        """Set fixed or varied interval according to window time. Can be FIXED or WINDOW.""",
+        validator=strict_discrete_set,
+        values=["FIXED","WINDOW"]
+    )
+    integrate = Instrument.control(
+        "CONF:INTEGRATE?",
+        "CONF:INTEGERATE %s",
+        """Control meter integration ON or OFF.""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    integration_time = Instrument.control(
+        "CONF:INTEGRATE:TIME?",
+        "CONF:INTEGRATE:TIME %d",
+        """Set integration time in seconds, between 0s and 35,999,999s.""",
+        validator=truncated_range,
+        values=[0,35999999]
+    )
+    filter = Instrument.control(
+        "CONF:FILTER?",
+        "CONF:FILTER %s",
+        """Set the low pass filter ON or OFF.""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    energy_unit = Instrument.control(
+        "CONF:ENERGY:MODE?",
+        "CONF:ENERGY:MODE %s",
+        """Set energy unit to joules (JOULES) or watt-hours (WHR).""",
+        validator=strict_discrete_set,
+        values=["JOULES","WHR"]
+    )
+    energy_time = Instrument.control(
+        "CONF:ENERGY:TIME?",
+        "CONF:ENERGY:TIME %d",
+        """Set energy measurement time in seconds, from 0s to 35,999,999s.""",
+        validator=truncated_range,
+        values=[0,35999999]
+    )
+
+    # MEASUREMENTS #
+    voltage = Instrument.measurement(
+        "FETCH? V",
+        """Get the last measured RMS voltage."""
+    )
+    voltage_dc = Instrument.measurement(
+        "FETCH? VDC",
+        """Get the last measured DC voltage."""
+    )
+    voltage_peak_pos = Instrument.measurement(
+        "FETCH? VPK+",
+        """Get the last measured positive peak voltage."""
+    )
+    voltage_peak_neg = Instrument.measurement(
+        "FETCH? VPK-",
+        """Get the last measured negative peak voltage."""
+    )
+    current = Instrument.measurement(
+        "FETCH? I",
+        """Get the last measured RMS current."""
+    )
+    current_dc = Instrument.measurement(
+        "FETCH? IDC",
+        """Get the last measured DC current."""
+    )
+    current = Instrument.measurement(
+        "FETCH? IPK+",
+        """Get the last measured positive peak current."""
+    )
+    current = Instrument.measurement(
+        "FETCH? IPK-",
+        """Get the last measured negative peak current."""
+    )
+    inrush_current = Instrument.measurement(
+        "FETCH? IS",
+        """Get the last measured in-rush current."""
+    )
+    crest_factor = Instrument.measurement(
+        "FETCH? CFI",
+        """Get the last measured current crest factor."""
+    )
+    power = Instrument.measurement(
+        "FETCH? W",
+        """Get the last measured RMS power."""
+    )
+    power_dc = Instrument.measurement(
+        "FETCH? WDC",
+        """Get the last measured DC power."""
+    )
+    power_factor = Instrument.measurement(
+        "FETCH? PF",
+        """Get the last measured power factor."""
+    )
+    power_apparent = Instrument.measurement(
+        "FETCH? VA",
+        """Get the last measured apparent power."""
+    )
+    power_reactive = Instrument.measurement(
+        "FETCH? VAR",
+        """Get the last measured reactive power."""
+    )
+    frequency = Instrument.measurement(
+        "FETCH? FREQ",
+        """Get the last measured frequency."""
+    )
+    voltage_THD = Instrument.measurement(
+        "FETCH? THDV",
+        """Get the last measured voltage THD."""
+    )
+    current_THD = Instrument.measurement(
+        "FETCH? THDI",
+        """Get the last measured current THD."""
+    )
+    energy = Instrument.measurement(
+        "MEAS:POW:ENER?",
+        """Get the last measured energy, with units according to CONF:ENERGY:MODE."""
+    )
+

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -34,7 +34,7 @@ class Chroma66205(SCPIMixin, Instrument):
     6620x instruments.
     """
 
-    def __init__(self, adapter, name="Chroma 63600", **kwargs):
+    def __init__(self, adapter, name="Chroma 66205", **kwargs):
         super().__init__(
             adapter,
             name,
@@ -55,14 +55,14 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control number of measurements to average in averaging mode. Must be a power of 2
         between 1 and 64 inclusive.""",
         validator=strict_discrete_set,
-        values=[1,2,3,4,8,16,32,64],
+        values=[1,2,4,8,16,32,64],
     )
     window_time = Instrument.control(
         "CONF:MEAS:WINDOW?",
         "CONF:MEAS:WINDOW %f",
         """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
         validator=truncated_range,
-        values = [0.,60.]
+        values = [0.1,60.]
     )
     window_interval = Instrument.control(
         "CONF:MEAS:WINDOW:UPDATE?",
@@ -73,7 +73,7 @@ class Chroma66205(SCPIMixin, Instrument):
     )
     integrate = Instrument.control(
         "CONF:INTEGRATE?",
-        "CONF:INTEGERATE %s",
+        "CONF:INTEGRATE %s",
         """Control meter integration ON or OFF.""",
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
@@ -134,11 +134,11 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? IDC",
         """Get the last measured DC current."""
     )
-    current = Instrument.measurement(
+    current_peak_pos = Instrument.measurement(
         "FETCH? IPK+",
         """Get the last measured positive peak current."""
     )
-    current = Instrument.measurement(
+    current_peak_neg = Instrument.measurement(
         "FETCH? IPK-",
         """Get the last measured negative peak current."""
     )


### PR DESCRIPTION
This PR is part of an on-going effort to add support for some of the Chroma power test and measurement instruments. Support for basic functionality of the 66205 digital power meter is added. Because it's such a simple instrument, no tests were added, but can be if desired.