### PR TITLE
Add support for Chroma 66205 Digital Power Meter

### DIFF
--- a/docs/api/instruments/chroma/chroma_66205.rst
+++ b/docs/api/instruments/chroma/chroma_66205.rst
@@ -1,0 +1,7 @@
+################################
+Chroma 66205 Digital Power Meter
+################################
+
+.. autoclass:: pymeasure.instruments.chroma.Chroma66205
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.chroma
+
+############
+Chroma
+############
+
+This section contains specific documentation on the Chroma instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   chroma_66205

--- a/docs/api/instruments/chroma/index.rst
+++ b/docs/api/instruments/chroma/index.rst
@@ -1,8 +1,8 @@
 .. module:: pymeasure.instruments.chroma
 
-############
+######
 Chroma
-############
+######
 
 This section contains specific documentation on the Chroma instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
 

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -34,6 +34,7 @@ Instruments by manufacturer:
    anritsu/index
    attocube/index
    bkprecision/index
+   chroma/index
    danfysik/index
    deltaelektronica/index
    edwards/index

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -22,7 +22,6 @@
 # THE SOFTWARE.
 #
 
-# from .chroma_63600 import Chroma63600, Chroma63630_80_60, Chroma63610_80_20
 from .chroma_66205 import Chroma66205
 
 

--- a/pymeasure/instruments/chroma/__init__.py
+++ b/pymeasure/instruments/chroma/__init__.py
@@ -1,0 +1,28 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# from .chroma_63600 import Chroma63600, Chroma63630_80_60, Chroma63610_80_20
+from .chroma_66205 import Chroma66205
+
+

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -24,6 +24,7 @@
 
 import numpy as np
 from enum import Enum
+import time
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.generic_types import SCPIMixin
@@ -257,6 +258,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:FILT:FREQ?",
         "CONF:FILT:FREQ %s",
         """Set the low pass filter on the path of frequency detect, True (ON) or False (OFF).""",
+        validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
     )
@@ -307,7 +309,7 @@ class Chroma66205(SCPIMixin, Instrument):
         if A not in self.CHANNEL_A_DISPLAY_OPTS:
             raise ValueError(f"Parameter {A} not valid for display A. Must be "
                              f"one of: {self.CHANNEL_A_DISPLAY_OPTS}")
-        if B not in self.CHANNEL_A_DISPLAY_OPTS:
+        if B not in self.CHANNEL_B_DISPLAY_OPTS:
             raise ValueError(f"Parameter {B} not valid for display B. Must be "
                              f"one of: {self.CHANNEL_B_DISPLAY_OPTS}")
         if C not in self.CHANNEL_C_DISPLAY_OPTS:
@@ -444,8 +446,12 @@ class Chroma66205(SCPIMixin, Instrument):
         if tr != "RUNNING":
             print(f"Warning: Triggered but trigger is not set to 'RUNNING' (instead got {tr})")
         else:
+            timeout_duration = integration_time_s*1.5  # use 1.5x expected integration time
+            start_time = time.monotonic()
             while self.trigger == "RUNNING":
-                pass
+                if time.monotonic() - start_time > timeout_duration:
+                    raise TimeoutError(f"Integration was expected to take {integration_time_s} "
+                                       f"secs, but took longer than {timeout_duration} secs.")
         return self.energy_wh
 
     def capture_waveform(self,param:str='V'):
@@ -455,6 +461,8 @@ class Chroma66205(SCPIMixin, Instrument):
         timeout = 100
         while self.ask('WAVEFORM:CAPTURE?') != 'OK\n' and timeout > 0:
             timeout -= 1
+        if timeout  <= 0:
+            raise TimeoutError("Waveform capture timeout.")
         print("Receiving waveform. This may take a minute...")
         bvals = self.binary_values(f'WAVEFORM:DATA? {param}',dtype=np.uint8)
         print("Done.")

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -23,6 +23,7 @@
 #
 
 import numpy as np
+from enum import Enum
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.generic_types import SCPIMixin
@@ -32,9 +33,55 @@ from pymeasure.instruments.validators import strict_discrete_set,truncated_range
 class Chroma66205(SCPIMixin, Instrument):
     """Control the Chroma 66205 Digital Power Meter
 
-    The 66205 is a single-channel unit. Most of its interface is identical to the other
-    6620x instruments.
+    The 66205 is a single-channel digital power meter, with voltage, current, power,
+    energy, phase, and frequency measurements, and waveform capture. A Chinese user manual
+    with programming information in English is available.
     """
+
+    class Measure(str,Enum):
+        VOLTAGE="V"
+        DC_VOLTAGE="VDC"
+        MEAN_VOLTAGE="VMEAN"
+        CURRENT="I"
+        DC_CURRENT="IDC"
+        REAL_POWER="W"
+        APPARENT_POWER="VA"
+        PEAK_POS_VOLTAGE="VPK+"
+        PEAK_POS_CURRENT="IPK+"
+        PEAK_NEG_VOLTAGE="VPK-"
+        PEAK_NEG_CURRENT="IPK-"
+        POWER_FACTOR="PF"
+        PHASE="DEG"
+        THD_VOLTAGE="THDV"
+        THD_CURRENT="THDI"
+        INRUSH_CURRENT="IS"
+        REACTIVE_POWER="VAR"
+        VOLTAGE_CREST_FACTOR="CFV"
+        CURRENT_CREST_FACTOR="CFI"
+        CHARGE_AH="AH"
+        ENERGY_WH="WH"
+        VOLTAGE_FREQUENCY="VHZ"
+        CURRENT_FREQUENCY="IHZ"
+    _MEASURES = [
+        'V','I','W','VA','VPK+','VPK-','IPK+','IPK-','PF','DEG','THDV','THDI',
+        'IS','VAR','CFV','CFI','AH','WH','VHZ','IHZ'
+    ]
+
+    CHANNEL_A_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
+                              Measure.APPARENT_POWER,Measure.PEAK_POS_VOLTAGE,
+                              Measure.PEAK_NEG_VOLTAGE,Measure.PEAK_POS_CURRENT,
+                              Measure.PEAK_NEG_CURRENT]
+    CHANNEL_B_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
+                              Measure.POWER_FACTOR,Measure.PHASE,Measure.THD_VOLTAGE,
+                              Measure.THD_CURRENT,Measure.INRUSH_CURRENT]
+    CHANNEL_C_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
+                              Measure.REACTIVE_POWER,Measure.VOLTAGE_CREST_FACTOR,
+                              Measure.CURRENT_CREST_FACTOR,Measure.CHARGE_AH,
+                              Measure.ENERGY_WH]
+    CHANNEL_D_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
+                              Measure.POWER_FACTOR,Measure.VOLTAGE_FREQUENCY,
+                              Measure.CURRENT_FREQUENCY,Measure.THD_VOLTAGE,
+                              Measure.THD_CURRENT]
 
     def __init__(self, adapter, name="Chroma 66205", **kwargs):
         super().__init__(
@@ -42,6 +89,11 @@ class Chroma66205(SCPIMixin, Instrument):
             name,
             **kwargs
         )
+
+    system_error = Instrument.measurement(
+        "SYSTEM:ERROR?",
+        """Get the error string of the instrument."""
+    )
 
     # SETTINGS #
     mode = Instrument.control(
@@ -51,6 +103,24 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["RMS","DC","VMEAN"]
     )
+    voltage_range = Instrument.control(
+        "VOLT:RANG?",
+        "VOLT:RANG %s",
+        """Set the voltage range for measurement. Can be AUTO, V15, V30, V60, V150, V300, or
+        V600.""",
+        validator=strict_discrete_set,
+        values=["AUTO","V600","V300","V150","V60","V30","V15"],
+    )
+    current_range = Instrument.control(
+        "CURR:RANG?",
+        "CURR:RANG %s",
+        """Set the current range for measurement. Can be AUTO, A30, A20, A5, A2, A05, A03,
+        A02, A005, A002, or A0005 when external shunt is OFF, or AUTO, E015, E01, E005, E0025, or
+        E001 when external shunt is ON.""",
+        validator=strict_discrete_set,
+        values=["AUTO", "A30", "A20", "A5", "A2", "A05", 'A03', "A02", "A005", "A002", "A0005",
+                "E015","E01","E005","E0025","E001"],
+    )
     averages = Instrument.control(
         "CONF:MEAS:AVERAGE?",
         "CONF:MEAS:AVERAGE %d",
@@ -59,12 +129,92 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=[1,2,4,8,16,32,64],
     )
+    update_time = Instrument.control(
+        "MEAS:UPD?",
+        "MEAS:UPD %f",
+        """Set the time of measurement in seconds over which the data calculation is to
+        be performed. Can be 0.05, 0.1, 0.25, 0.5, 1, 2, 5, or 10.""",
+        validator=strict_discrete_set,
+        values=[0.05,0.1,0.25,0.5,1,2,5,10],
+    )
+    ct = Instrument.control(
+        "CONF:INP:CT?",
+        "CONF:INP:CT %s",
+        """Control CT function, ON (True) or OFF (False).""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    ct_ratio = Instrument.control(
+        "CONF:INP:CT:RAT?",
+        "CONF:INP:CT:RAT %f",
+        """Set the CT ratio, from 1.0 to 9999.9 with 0.1 resolution.""",
+        validator=truncated_range,
+        values=[1,9999.9],
+        set_process=lambda v: round(v, 1),
+    )
+    hv = Instrument.control(
+        "CONF:INP:HV?",
+        "CONF:INP:HV %s",
+        """Control the HV function ON (True) or OFF (False).""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    input_shunt = Instrument.control(
+        "CONF:INP:SHUN?",
+        "CONF:INP:SHUN %s",
+        """Control the external input shunt resistance ON (True) or OFF (False).""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    input_shunt_resistance = Instrument.control(
+        "CONF:INP:SHUNT:RES?",
+        "CONF:INP:SHUNT:RES %f",
+        """Set the external input shunt resistance. Can be between 0.0000001 and 99.9999999.""",
+        validator=truncated_range,
+        values=[0.0000001,99.9999999],
+        set_process=lambda v:round(v,7)
+    )
+    null_measure_current = Instrument.control(
+        "CURR:NULL?",
+        "CURR:NULL %s",
+        """Control null measurements function for measuring current, enabled (True) or disabled
+        (False).""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    hold = Instrument.control(
+        "CONF:HOLD?",
+        "CONF:HOLD %s",
+        """Control the hold function, ON (True) or OFF (False).""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    hold_mode = Instrument.control(
+        "CONF:HOLD:MODE?",
+        "CONF:HOLD:MODE %s",
+        """Control the hold function mode. Can be STOP, MAX, or MIN.""",
+        validator=strict_discrete_set,
+        values=["STOP","MAX","MIN"],
+    )
+    hold_time = Instrument.control(
+        "CONF:HOLD:TIME?",
+        "CONF:HOLD:TIME %d",
+        """Control the time of the hold function in seconds, from 0s to 9999s.""",
+        validator=truncated_range,
+        values=[0,9999],
+    )
     window_time = Instrument.control(
         "CONF:MEAS:WINDOW?",
         "CONF:MEAS:WINDOW %f",
         """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
         validator=truncated_range,
-        values = [0.1,60.]
+        values = [0.1,60.],
+        set_process=lambda v: round(v, 1),
     )
     window_interval = Instrument.control(
         "CONF:MEAS:WINDOW:UPDATE?",
@@ -118,6 +268,56 @@ class Chroma66205(SCPIMixin, Instrument):
         values=[0,35999999]
     )
 
+    # DISPLAY #
+    show = Instrument.setting(
+        "SHOW:DISP:ITEM %s",
+        """Control which items of measurement will be displayed on the four displays, A-D.
+        All four displays must get parameters, in a comma-separated list. There is no query
+        version of this command.
+
+        +---------+---------------------------------------+
+        | Display | Valid parameters                      |
+        +=========+=======================================+
+        | A       | V, I, W, VA, VPK+, IPK+, VPK-, IPK-   |
+        +---------+---------------------------------------+
+        | B       | V, I, W, PF, DEG, THDV, THDI, IS      |
+        +---------+---------------------------------------+
+        | C       | V, I, W, VAR, CFV, CFI, AH, WH        |
+        +---------+---------------------------------------+
+        | D       | V, I, W, PF, VHZ, IHZ, THDV, THDI     |
+        +---------+---------------------------------------+
+        """
+    )
+
+    def configure_display(self,A: Measure, B: Measure, C: Measure, D:Measure):
+        """Control the measurements shown on the four displays.
+
+        +---------+---------------------------------------+
+        | Display | Valid parameters                      |
+        +=========+=======================================+
+        | A       | V, I, W, VA, VPK+, IPK+, VPK-, IPK-   |
+        +---------+---------------------------------------+
+        | B       | V, I, W, PF, DEG, THDV, THDI, IS      |
+        +---------+---------------------------------------+
+        | C       | V, I, W, VAR, CFV, CFI, AH, WH        |
+        +---------+---------------------------------------+
+        | D       | V, I, W, PF, VHZ, IHZ, THDV, THDI     |
+        +---------+---------------------------------------+
+        """
+        if A not in self.CHANNEL_A_DISPLAY_OPTS:
+            raise ValueError(f"Parameter {A} not valid for display A. Must be "
+                             f"one of: {self.CHANNEL_A_DISPLAY_OPTS}")
+        if B not in self.CHANNEL_A_DISPLAY_OPTS:
+            raise ValueError(f"Parameter {B} not valid for display B. Must be "
+                             f"one of: {self.CHANNEL_B_DISPLAY_OPTS}")
+        if C not in self.CHANNEL_C_DISPLAY_OPTS:
+            raise ValueError(f"Parameter {C} not valid for display C. Must be "
+                             f"one of: {self.CHANNEL_C_DISPLAY_OPTS}")
+        if D not in self.CHANNEL_D_DISPLAY_OPTS:
+            raise ValueError(f"Parameter {D} not valid for display D. Must be "
+                             f"one of: {self.CHANNEL_D_DISPLAY_OPTS}")
+        self.show = f'{A.value}, {B.value}, {C.value}, {D.value}'
+
     # MEASUREMENTS #
     voltage_rms = Instrument.measurement(
         "FETCH? V",
@@ -159,9 +359,13 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? IS",
         """Get the last measured in-rush current."""
     )
-    crest_factor = Instrument.measurement(
+    current_crest_factor = Instrument.measurement(
         "FETCH? CFI",
         """Get the last measured current crest factor."""
+    )
+    voltage_crest_factor = Instrument.measurement(
+        "FETCH:VOLT:CRES?",
+        """Get the last measured voltage crest factor."""
     )
     power_real = Instrument.measurement(
         "FETCH? W",
@@ -222,6 +426,10 @@ class Chroma66205(SCPIMixin, Instrument):
         Status is STOP|FINISH|RUNNING.
         To trigger, pass 'ON'. To stop or reset integration cycle, pass 'OFF'.""",
     )
+
+    def measure(self,param: Measure):
+        """Get a measurement. See Chroma66205.Measure."""
+        return float(self.ask(f"MEAS? {param.value}").strip())
 
     def integrate_energy(self,integration_time_s: float=10.):
         # Set up

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -1,0 +1,189 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.generic_types import SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set,truncated_range
+
+
+class Chroma66205(SCPIMixin, Instrument):
+    """Control the Chroma 66205 Digital Power Meter
+
+    The 66205 is a single-channel unit. Most of its interface is identical to the other
+    6620x instruments.
+    """
+
+    def __init__(self, adapter, name="Chroma 63600", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            **kwargs
+        )
+
+    # SETTINGS #
+    mode = Instrument.control(
+        "CONF:MEAS:MODE?",
+        "CONF:MEAS:MODE %s",
+        """Control measurement mode. Can be WINDOW or AVERAGE.""",
+        validator=strict_discrete_set,
+        values=["WINDOW","AVERAGE"]
+    )
+    averages = Instrument.control(
+        "CONF:MEAS:AVERAGE?",
+        "CONF:MEAS:AVERAGE %d",
+        """Control number of measurements to average in averaging mode. Must be a power of 2
+        between 1 and 64 inclusive.""",
+        validator=strict_discrete_set,
+        values=[1,2,3,4,8,16,32,64],
+    )
+    window_time = Instrument.control(
+        "CONF:MEAS:WINDOW?",
+        "CONF:MEAS:WINDOW %f",
+        """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
+        validator=truncated_range,
+        values = [0.,60.]
+    )
+    window_interval = Instrument.control(
+        "CONF:MEAS:WINDOW:UPDATE?",
+        "CONF:MEAS:WINDOW:UPDATE %s",
+        """Set fixed or varied interval according to window time. Can be FIXED or WINDOW.""",
+        validator=strict_discrete_set,
+        values=["FIXED","WINDOW"]
+    )
+    integrate = Instrument.control(
+        "CONF:INTEGRATE?",
+        "CONF:INTEGERATE %s",
+        """Control meter integration ON or OFF.""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    integration_time = Instrument.control(
+        "CONF:INTEGRATE:TIME?",
+        "CONF:INTEGRATE:TIME %d",
+        """Set integration time in seconds, between 0s and 35,999,999s.""",
+        validator=truncated_range,
+        values=[0,35999999]
+    )
+    filter = Instrument.control(
+        "CONF:FILTER?",
+        "CONF:FILTER %s",
+        """Set the low pass filter ON or OFF.""",
+        validator=strict_discrete_set,
+        values={True:"ON",False:"OFF"},
+        map_values=True,
+    )
+    energy_unit = Instrument.control(
+        "CONF:ENERGY:MODE?",
+        "CONF:ENERGY:MODE %s",
+        """Set energy unit to joules (JOULES) or watt-hours (WHR).""",
+        validator=strict_discrete_set,
+        values=["JOULES","WHR"]
+    )
+    energy_time = Instrument.control(
+        "CONF:ENERGY:TIME?",
+        "CONF:ENERGY:TIME %d",
+        """Set energy measurement time in seconds, from 0s to 35,999,999s.""",
+        validator=truncated_range,
+        values=[0,35999999]
+    )
+
+    # MEASUREMENTS #
+    voltage = Instrument.measurement(
+        "FETCH? V",
+        """Get the last measured RMS voltage."""
+    )
+    voltage_dc = Instrument.measurement(
+        "FETCH? VDC",
+        """Get the last measured DC voltage."""
+    )
+    voltage_peak_pos = Instrument.measurement(
+        "FETCH? VPK+",
+        """Get the last measured positive peak voltage."""
+    )
+    voltage_peak_neg = Instrument.measurement(
+        "FETCH? VPK-",
+        """Get the last measured negative peak voltage."""
+    )
+    current = Instrument.measurement(
+        "FETCH? I",
+        """Get the last measured RMS current."""
+    )
+    current_dc = Instrument.measurement(
+        "FETCH? IDC",
+        """Get the last measured DC current."""
+    )
+    current = Instrument.measurement(
+        "FETCH? IPK+",
+        """Get the last measured positive peak current."""
+    )
+    current = Instrument.measurement(
+        "FETCH? IPK-",
+        """Get the last measured negative peak current."""
+    )
+    inrush_current = Instrument.measurement(
+        "FETCH? IS",
+        """Get the last measured in-rush current."""
+    )
+    crest_factor = Instrument.measurement(
+        "FETCH? CFI",
+        """Get the last measured current crest factor."""
+    )
+    power = Instrument.measurement(
+        "FETCH? W",
+        """Get the last measured RMS power."""
+    )
+    power_dc = Instrument.measurement(
+        "FETCH? WDC",
+        """Get the last measured DC power."""
+    )
+    power_factor = Instrument.measurement(
+        "FETCH? PF",
+        """Get the last measured power factor."""
+    )
+    power_apparent = Instrument.measurement(
+        "FETCH? VA",
+        """Get the last measured apparent power."""
+    )
+    power_reactive = Instrument.measurement(
+        "FETCH? VAR",
+        """Get the last measured reactive power."""
+    )
+    frequency = Instrument.measurement(
+        "FETCH? FREQ",
+        """Get the last measured frequency."""
+    )
+    voltage_THD = Instrument.measurement(
+        "FETCH? THDV",
+        """Get the last measured voltage THD."""
+    )
+    current_THD = Instrument.measurement(
+        "FETCH? THDI",
+        """Get the last measured current THD."""
+    )
+    energy = Instrument.measurement(
+        "MEAS:POW:ENER?",
+        """Get the last measured energy, with units according to CONF:ENERGY:MODE."""
+    )
+

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -93,7 +93,8 @@ class Chroma66205(SCPIMixin, Instrument):
 
     system_error = Instrument.measurement(
         "SYSTEM:ERROR?",
-        """Get the error string of the instrument."""
+        """Get the error string of the instrument.""",
+        cast=str,
     )
 
     # SETTINGS #
@@ -102,7 +103,8 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:MEAS:MODE %s",
         """Control measurement mode. Can be RMS, DC, or VMEAN.""",
         validator=strict_discrete_set,
-        values=["RMS","DC","VMEAN"]
+        values=["RMS","DC","VMEAN"],
+        cast=str,
     )
     voltage_range = Instrument.control(
         "VOLT:RANG?",
@@ -111,6 +113,7 @@ class Chroma66205(SCPIMixin, Instrument):
         V600.""",
         validator=strict_discrete_set,
         values=["AUTO","V600","V300","V150","V60","V30","V15"],
+        cast=str,
     )
     current_range = Instrument.control(
         "CURR:RANG?",
@@ -121,6 +124,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["AUTO", "A30", "A20", "A5", "A2", "A05", 'A03', "A02", "A005", "A002", "A0005",
                 "E015","E01","E005","E0025","E001"],
+        cast=str,
     )
     averages = Instrument.control(
         "CONF:MEAS:AVERAGE?",
@@ -145,6 +149,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     ct_ratio = Instrument.control(
         "CONF:INP:CT:RAT?",
@@ -161,6 +166,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     input_shunt = Instrument.control(
         "CONF:INP:SHUN?",
@@ -169,6 +175,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     input_shunt_resistance = Instrument.control(
         "CONF:INP:SHUNT:RES?",
@@ -186,6 +193,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     hold = Instrument.control(
         "CONF:HOLD?",
@@ -194,6 +202,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     hold_mode = Instrument.control(
         "CONF:HOLD:MODE?",
@@ -201,6 +210,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control the hold function mode. Can be STOP, MAX, or MIN.""",
         validator=strict_discrete_set,
         values=["STOP","MAX","MIN"],
+        cast=str,
     )
     hold_time = Instrument.control(
         "CONF:HOLD:TIME?",
@@ -222,7 +232,8 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:MEAS:WINDOW:UPDATE %s",
         """Set fixed or varied interval according to window time. Can be FIXED or WINDOW.""",
         validator=strict_discrete_set,
-        values=["FIXED","WINDOW"]
+        values=["FIXED","WINDOW"],
+        cast=str,
     )
     integrate = Instrument.control(
         "CONF:INTEGRATE?",
@@ -231,6 +242,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     integration_mode = Instrument.control(
         "CONF:INTEG:MODE?",
@@ -238,13 +250,14 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set the mode of execution in integration mode. Can be NORMAL or CONTINUE.""",
         validator=strict_discrete_set,
         values=["NORMAL","CONTINUE"],
+        cast=str,
     )
     integration_time = Instrument.control(
         "CONF:INTEGRATE:TIME?",
         "CONF:INTEGRATE:TIME %d",
         """Set integration time in seconds, between 0s and 35,999,999s.""",
         validator=truncated_range,
-        values=[0,35999999]
+        values=[0,35999999],
     )
     filter = Instrument.control(
         "CONF:FILTER?",
@@ -253,6 +266,7 @@ class Chroma66205(SCPIMixin, Instrument):
         Can be OFF, BW500, or BW5500.""",
         validator=strict_discrete_set,
         values=["OFF","BW500","BW5500"],
+        cast=str,
     )
     filter_frequency = Instrument.control(
         "CONF:FILT:FREQ?",
@@ -261,6 +275,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
+        cast=str,
     )
     energy_time = Instrument.control(
         "CONF:ENERGY:TIME?",
@@ -323,95 +338,95 @@ class Chroma66205(SCPIMixin, Instrument):
     # MEASUREMENTS #
     voltage_rms = Instrument.measurement(
         "FETCH? V",
-        """Get the last measured RMS voltage."""
+        """Get the last measured RMS voltage.""",
     )
     voltage_dc = Instrument.measurement(
         "FETCH? VDC",
-        """Get the last measured DC voltage."""
+        """Get the last measured DC voltage.""",
     )
     voltage_peak_pos = Instrument.measurement(
         "FETCH? VPK+",
-        """Get the last measured positive peak voltage."""
+        """Get the last measured positive peak voltage.""",
     )
     voltage_peak_neg = Instrument.measurement(
         "FETCH? VPK-",
-        """Get the last measured negative peak voltage."""
+        """Get the last measured negative peak voltage.""",
     )
     voltage_mean = Instrument.measurement(
         "FETCH? VMEAN",
-        """Get the last measured mean voltage."""
+        """Get the last measured mean voltage.""",
     )
     current_rms = Instrument.measurement(
         "FETCH? I",
-        """Get the last measured RMS current."""
+        """Get the last measured RMS current.""",
     )
     current_dc = Instrument.measurement(
         "FETCH? IDC",
-        """Get the last measured DC current."""
+        """Get the last measured DC current.""",
     )
     current_peak_pos = Instrument.measurement(
         "FETCH? IPK+",
-        """Get the last measured positive peak current."""
+        """Get the last measured positive peak current.""",
     )
     current_peak_neg = Instrument.measurement(
         "FETCH? IPK-",
-        """Get the last measured negative peak current."""
+        """Get the last measured negative peak current.""",
     )
     inrush_current = Instrument.measurement(
         "FETCH? IS",
-        """Get the last measured in-rush current."""
+        """Get the last measured in-rush current.""",
     )
     current_crest_factor = Instrument.measurement(
         "FETCH? CFI",
-        """Get the last measured current crest factor."""
+        """Get the last measured current crest factor.""",
     )
     voltage_crest_factor = Instrument.measurement(
         "FETCH:VOLT:CRES?",
-        """Get the last measured voltage crest factor."""
+        """Get the last measured voltage crest factor.""",
     )
     power_real = Instrument.measurement(
         "FETCH? W",
-        """Get the last measured RMS power."""
+        """Get the last measured RMS power.""",
     )
     power_dc = Instrument.measurement(
         "FETCH? WDC",
-        """Get the last measured DC power."""
+        """Get the last measured DC power.""",
     )
     power_factor = Instrument.measurement(
         "FETCH? PF",
-        """Get the last measured power factor."""
+        """Get the last measured power factor.""",
     )
     phase = Instrument.measurement(
         "FETCH? DEG",
-        """Get phase in degrees."""
+        """Get phase in degrees.""",
     )
     power_apparent = Instrument.measurement(
         "FETCH? VA",
-        """Get the last measured apparent power."""
+        """Get the last measured apparent power.""",
     )
     power_reactive = Instrument.measurement(
         "FETCH? VAR",
-        """Get the last measured reactive power."""
+        """Get the last measured reactive power.""",
     )
     frequency = Instrument.measurement(
         "FETCH? FREQ",
-        """Get the last measured frequency."""
+        """Get the last measured frequency.""",
     )
     voltage_THD = Instrument.measurement(
         "FETCH? THDV",
-        """Get the last measured voltage THD."""
+        """Get the last measured voltage THD.""",
     )
     current_THD = Instrument.measurement(
         "FETCH? THDI",
-        """Get the last measured current THD."""
+        """Get the last measured current THD.""",
     )
     energy_wh = Instrument.measurement(
         "FETCH? WH",
-        """Get the last measured energy in units of watt-hours."""
+        """Get the last measured energy in units of watt-hours.""",
     )
     charge_ah = Instrument.measurement(
         "FETCH? AH",
-        """Get the last measured charge in units of amp-hours."""
+        """Get the last measured charge in units of amp-hours.""",
     )
     trigger_mode = Instrument.control(
         "TRIG:MODE?",
@@ -420,6 +435,7 @@ class Chroma66205(SCPIMixin, Instrument):
         Can be NONE|INTEGRATION|INRUSH|LIMIT.""",
         validator=strict_discrete_set,
         values=["NONE","INTEGRATION","INRUSH","LIMIT"],
+        cast=str,
     )
     trigger = Instrument.control(
         "TRIGGER?",
@@ -427,6 +443,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set trigger for energy calculation, inrush, or limit (go/no-go).
         Status is STOP|FINISH|RUNNING.
         To trigger, pass 'ON'. To stop or reset integration cycle, pass 'OFF'.""",
+        cast=str,
     )
 
     def measure(self,param: Measure):

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -22,6 +22,8 @@
 # THE SOFTWARE.
 #
 
+import numpy as np
+
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.generic_types import SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set,truncated_range
@@ -45,9 +47,9 @@ class Chroma66205(SCPIMixin, Instrument):
     mode = Instrument.control(
         "CONF:MEAS:MODE?",
         "CONF:MEAS:MODE %s",
-        """Control measurement mode. Can be WINDOW or AVERAGE.""",
+        """Control measurement mode. Can be RMS, DC, or VMEAN.""",
         validator=strict_discrete_set,
-        values=["WINDOW","AVERAGE"]
+        values=["RMS","DC","VMEAN"]
     )
     averages = Instrument.control(
         "CONF:MEAS:AVERAGE?",
@@ -79,6 +81,13 @@ class Chroma66205(SCPIMixin, Instrument):
         values={True:"ON",False:"OFF"},
         map_values=True,
     )
+    integration_mode = Instrument.control(
+        "CONF:INTEG:MODE?",
+        "CONF:INTEG:MODE %s",
+        """Set the mode of execution in integration mode. Can be NORMAL or CONTINUE.""",
+        validator=strict_discrete_set,
+        values=["NORMAL","CONTINUE"],
+    )
     integration_time = Instrument.control(
         "CONF:INTEGRATE:TIME?",
         "CONF:INTEGRATE:TIME %d",
@@ -89,17 +98,17 @@ class Chroma66205(SCPIMixin, Instrument):
     filter = Instrument.control(
         "CONF:FILTER?",
         "CONF:FILTER %s",
-        """Set the low pass filter ON or OFF.""",
+        """Set the bandwidth of the digital low pass filter on input signal path.
+        Can be OFF, BW500, or BW5500.""",
         validator=strict_discrete_set,
+        values=["OFF","BW500","BW5500"],
+    )
+    filter_frequency = Instrument.control(
+        "CONF:FILT:FREQ?",
+        "CONF:FILT:FREQ %s",
+        """Set the low pass filter on the path of frequency detect, True (ON) or False (OFF).""",
         values={True:"ON",False:"OFF"},
         map_values=True,
-    )
-    energy_unit = Instrument.control(
-        "CONF:ENERGY:MODE?",
-        "CONF:ENERGY:MODE %s",
-        """Set energy unit to joules (JOULES) or watt-hours (WHR).""",
-        validator=strict_discrete_set,
-        values=["JOULES","WHR"]
     )
     energy_time = Instrument.control(
         "CONF:ENERGY:TIME?",
@@ -110,7 +119,7 @@ class Chroma66205(SCPIMixin, Instrument):
     )
 
     # MEASUREMENTS #
-    voltage = Instrument.measurement(
+    voltage_rms = Instrument.measurement(
         "FETCH? V",
         """Get the last measured RMS voltage."""
     )
@@ -126,7 +135,11 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? VPK-",
         """Get the last measured negative peak voltage."""
     )
-    current = Instrument.measurement(
+    voltage_mean = Instrument.measurement(
+        "FETCH? VMEAN",
+        """Get the last measured mean voltage."""
+    )
+    current_rms = Instrument.measurement(
         "FETCH? I",
         """Get the last measured RMS current."""
     )
@@ -150,7 +163,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? CFI",
         """Get the last measured current crest factor."""
     )
-    power = Instrument.measurement(
+    power_real = Instrument.measurement(
         "FETCH? W",
         """Get the last measured RMS power."""
     )
@@ -161,6 +174,10 @@ class Chroma66205(SCPIMixin, Instrument):
     power_factor = Instrument.measurement(
         "FETCH? PF",
         """Get the last measured power factor."""
+    )
+    phase = Instrument.measurement(
+        "FETCH? DEG",
+        """Get phase in degrees."""
     )
     power_apparent = Instrument.measurement(
         "FETCH? VA",
@@ -182,8 +199,64 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? THDI",
         """Get the last measured current THD."""
     )
-    energy = Instrument.measurement(
-        "MEAS:POW:ENER?",
-        """Get the last measured energy, with units according to CONF:ENERGY:MODE."""
+    energy_wh = Instrument.measurement(
+        "FETCH? WH",
+        """Get the last measured energy in units of watt-hours."""
     )
+    charge_ah = Instrument.measurement(
+        "FETCH? AH",
+        """Get the last measured charge in units of amp-hours."""
+    )
+    trigger_mode = Instrument.control(
+        "TRIG:MODE?",
+        "TRIG:MODE %s",
+        """Set which mode will be triggered by trigger command.
+        Can be NONE|INTEGRATION|INRUSH|LIMIT.""",
+        validator=strict_discrete_set,
+        values=["NONE","INTEGRATION","INRUSH","LIMIT"],
+    )
+    trigger = Instrument.control(
+        "TRIGGER?",
+        "TRIGGER %s",
+        """Trigger energy calculation, inrush, or limit (go/no-go).
+        Status is STOP|FINISH|RUNNING.
+        To trigger, pass 'ON'. To stop or reset integration cycle, pass 'OFF'.""",
+    )
+
+    def integrate_energy(self,integration_time_s: float=10.):
+        # Set up
+        self.energy_time = integration_time_s
+        self.trigger_mode = "INTEGRATION"
+        # Check state and reset if necessary
+        if self.trigger == "FINISH":
+            self.trigger = "OFF"  # Reset
+        # Trigger
+        self.trigger = "ON"
+        tr = self.trigger
+        if tr != "RUNNING":
+            print(f"Warning: Triggered but trigger is not set to 'RUNNING' (instead got {tr})")
+        else:
+            while self.trigger == "RUNNING":
+                pass
+        return self.energy_wh
+
+    def capture_waveform(self,param:str='V'):
+        """Get waveform as ts,wave for voltage (V) or current (I)."""
+        if param not in ['I','V']:
+            raise ValueError(f"Unexpected parameter {param}. Must be 'V' or 'I'.")
+        timeout = 100
+        while self.ask('WAVEFORM:CAPTURE?') != 'OK\n' and timeout > 0:
+            timeout -= 1
+        print("Receiving waveform. This may take a minute...")
+        bvals = self.binary_values(f'WAVEFORM:DATA? {param}',dtype=np.uint8)
+        print("Done.")
+        bvals = bvals[len('#48192'):-1]  # strip
+        wave = bvals.view(np.float32)
+
+        # Wave contains exactly two 60Hz cycles, so sample rate is 61440 (=2048 Samples / 2 * 60Hz)
+        # This might not be consistent across all settings and configurations?
+        Fs=61.44e3
+        ts = np.arange(0,len(wave)/Fs,1/Fs)
+        return ts,wave
+
 

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -28,7 +28,7 @@ import time
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.generic_types import SCPIMixin
-from pymeasure.instruments.validators import strict_discrete_set,truncated_range
+from pymeasure.instruments.validators import strict_discrete_set, truncated_range
 
 
 class Chroma66205(SCPIMixin, Instrument):
@@ -39,53 +39,74 @@ class Chroma66205(SCPIMixin, Instrument):
     with programming information in English is available.
     """
 
-    class Measure(str,Enum):
-        VOLTAGE="V"
-        DC_VOLTAGE="VDC"
-        MEAN_VOLTAGE="VMEAN"
-        CURRENT="I"
-        DC_CURRENT="IDC"
-        REAL_POWER="W"
-        APPARENT_POWER="VA"
-        PEAK_POS_VOLTAGE="VPK+"
-        PEAK_POS_CURRENT="IPK+"
-        PEAK_NEG_VOLTAGE="VPK-"
-        PEAK_NEG_CURRENT="IPK-"
-        POWER_FACTOR="PF"
-        PHASE="DEG"
-        THD_VOLTAGE="THDV"
-        THD_CURRENT="THDI"
-        INRUSH_CURRENT="IS"
-        REACTIVE_POWER="VAR"
-        VOLTAGE_CREST_FACTOR="CFV"
-        CURRENT_CREST_FACTOR="CFI"
-        CHARGE_AH="AH"
-        ENERGY_WH="WH"
-        VOLTAGE_FREQUENCY="VHZ"
-        CURRENT_FREQUENCY="IHZ"
+    class Measure(str, Enum):
+        VOLTAGE = "V"
+        DC_VOLTAGE = "VDC"
+        MEAN_VOLTAGE = "VMEAN"
+        CURRENT = "I"
+        DC_CURRENT = "IDC"
+        REAL_POWER = "W"
+        APPARENT_POWER = "VA"
+        PEAK_POS_VOLTAGE = "VPK+"
+        PEAK_POS_CURRENT = "IPK+"
+        PEAK_NEG_VOLTAGE = "VPK-"
+        PEAK_NEG_CURRENT = "IPK-"
+        POWER_FACTOR = "PF"
+        PHASE = "DEG"
+        THD_VOLTAGE = "THDV"
+        THD_CURRENT = "THDI"
+        INRUSH_CURRENT = "IS"
+        REACTIVE_POWER = "VAR"
+        VOLTAGE_CREST_FACTOR = "CFV"
+        CURRENT_CREST_FACTOR = "CFI"
+        CHARGE_AH = "AH"
+        ENERGY_WH = "WH"
+        VOLTAGE_FREQUENCY = "VHZ"
+        CURRENT_FREQUENCY = "IHZ"
 
-    CHANNEL_A_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
-                              Measure.APPARENT_POWER,Measure.PEAK_POS_VOLTAGE,
-                              Measure.PEAK_NEG_VOLTAGE,Measure.PEAK_POS_CURRENT,
-                              Measure.PEAK_NEG_CURRENT]
-    CHANNEL_B_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
-                              Measure.POWER_FACTOR,Measure.PHASE,Measure.THD_VOLTAGE,
-                              Measure.THD_CURRENT,Measure.INRUSH_CURRENT]
-    CHANNEL_C_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
-                              Measure.REACTIVE_POWER,Measure.VOLTAGE_CREST_FACTOR,
-                              Measure.CURRENT_CREST_FACTOR,Measure.CHARGE_AH,
-                              Measure.ENERGY_WH]
-    CHANNEL_D_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
-                              Measure.POWER_FACTOR,Measure.VOLTAGE_FREQUENCY,
-                              Measure.CURRENT_FREQUENCY,Measure.THD_VOLTAGE,
-                              Measure.THD_CURRENT]
+    CHANNEL_A_DISPLAY_OPTS = [
+        Measure.VOLTAGE,
+        Measure.CURRENT,
+        Measure.REAL_POWER,
+        Measure.APPARENT_POWER,
+        Measure.PEAK_POS_VOLTAGE,
+        Measure.PEAK_NEG_VOLTAGE,
+        Measure.PEAK_POS_CURRENT,
+        Measure.PEAK_NEG_CURRENT,
+    ]
+    CHANNEL_B_DISPLAY_OPTS = [
+        Measure.VOLTAGE,
+        Measure.CURRENT,
+        Measure.REAL_POWER,
+        Measure.POWER_FACTOR,
+        Measure.PHASE,
+        Measure.THD_VOLTAGE,
+        Measure.THD_CURRENT,
+        Measure.INRUSH_CURRENT,
+    ]
+    CHANNEL_C_DISPLAY_OPTS = [
+        Measure.VOLTAGE,
+        Measure.CURRENT,
+        Measure.REAL_POWER,
+        Measure.REACTIVE_POWER,
+        Measure.VOLTAGE_CREST_FACTOR,
+        Measure.CURRENT_CREST_FACTOR,
+        Measure.CHARGE_AH,
+        Measure.ENERGY_WH,
+    ]
+    CHANNEL_D_DISPLAY_OPTS = [
+        Measure.VOLTAGE,
+        Measure.CURRENT,
+        Measure.REAL_POWER,
+        Measure.POWER_FACTOR,
+        Measure.VOLTAGE_FREQUENCY,
+        Measure.CURRENT_FREQUENCY,
+        Measure.THD_VOLTAGE,
+        Measure.THD_CURRENT,
+    ]
 
     def __init__(self, adapter, name="Chroma 66205", **kwargs):
-        super().__init__(
-            adapter,
-            name,
-            **kwargs
-        )
+        super().__init__(adapter, name, **kwargs)
 
     system_error = Instrument.measurement(
         "SYSTEM:ERROR?",
@@ -99,7 +120,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:MEAS:MODE %s",
         """Control measurement mode. Can be RMS, DC, or VMEAN.""",
         validator=strict_discrete_set,
-        values=["RMS","DC","VMEAN"],
+        values=["RMS", "DC", "VMEAN"],
         cast=str,
     )
 
@@ -109,7 +130,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set the voltage range for measurement. Can be AUTO, V15, V30, V60, V150, V300, or
         V600.""",
         validator=strict_discrete_set,
-        values=["AUTO","V600","V300","V150","V60","V30","V15"],
+        values=["AUTO", "V600", "V300", "V150", "V60", "V30", "V15"],
         cast=str,
     )
 
@@ -120,8 +141,24 @@ class Chroma66205(SCPIMixin, Instrument):
         A02, A005, A002, or A0005 when external shunt is OFF, or AUTO, E015, E01, E005, E0025, or
         E001 when external shunt is ON.""",
         validator=strict_discrete_set,
-        values=["AUTO", "A30", "A20", "A5", "A2", "A05", 'A03', "A02", "A005", "A002", "A0005",
-                "E015","E01","E005","E0025","E001"],
+        values=[
+            "AUTO",
+            "A30",
+            "A20",
+            "A5",
+            "A2",
+            "A05",
+            "A03",
+            "A02",
+            "A005",
+            "A002",
+            "A0005",
+            "E015",
+            "E01",
+            "E005",
+            "E0025",
+            "E001",
+        ],
         cast=str,
     )
 
@@ -131,7 +168,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control number of measurements to average in averaging mode. Must be a power of 2
         between 1 and 64 inclusive.""",
         validator=strict_discrete_set,
-        values=[1,2,4,8,16,32,64],
+        values=[1, 2, 4, 8, 16, 32, 64],
     )
 
     update_time = Instrument.control(
@@ -140,7 +177,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set the time of measurement in seconds over which the data calculation is to
         be performed. Can be 0.05, 0.1, 0.25, 0.5, 1, 2, 5, or 10.""",
         validator=strict_discrete_set,
-        values=[0.05,0.1,0.25,0.5,1,2,5,10],
+        values=[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
     )
 
     ct_enabled = Instrument.control(
@@ -148,7 +185,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INP:CT %s",
         """Control current transformer (CT) function, ON (True) or OFF (False).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -158,7 +195,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INP:CT:RAT %f",
         """Set the CT ratio, from 1.0 to 9999.9 with 0.1 resolution.""",
         validator=truncated_range,
-        values=[1,9999.9],
+        values=[1, 9999.9],
         set_process=lambda v: round(v, 1),
     )
 
@@ -167,7 +204,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INP:HV %s",
         """Control the HV function ON (True) or OFF (False).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -177,7 +214,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INP:SHUN %s",
         """Control the external input shunt resistance ON (True) or OFF (False).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -187,8 +224,8 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INP:SHUNT:RES %f",
         """Set the external input shunt resistance. Can be between 0.0000001 and 99.9999999.""",
         validator=truncated_range,
-        values=[0.0000001,99.9999999],
-        set_process=lambda v:round(v,7)
+        values=[0.0000001, 99.9999999],
+        set_process=lambda v: round(v, 7),
     )
 
     null_measure_current = Instrument.control(
@@ -197,7 +234,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control null measurements function for measuring current, enabled (True) or disabled
         (False).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -207,7 +244,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:HOLD %s",
         """Control the hold function, ON (True) or OFF (False).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -217,7 +254,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:HOLD:MODE %s",
         """Control the hold function mode. Can be STOP, MAX, or MIN.""",
         validator=strict_discrete_set,
-        values=["STOP","MAX","MIN"],
+        values=["STOP", "MAX", "MIN"],
         cast=str,
     )
 
@@ -226,7 +263,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:HOLD:TIME %d",
         """Control the time of the hold function in seconds, from 0s to 9999s.""",
         validator=truncated_range,
-        values=[0,9999],
+        values=[0, 9999],
     )
 
     window_time = Instrument.control(
@@ -234,7 +271,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:MEAS:WINDOW %f",
         """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
         validator=truncated_range,
-        values = [0.1,60.],
+        values=[0.1, 60.0],
         set_process=lambda v: round(v, 1),
     )
 
@@ -243,7 +280,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:MEAS:WINDOW:UPDATE %s",
         """Set fixed or varied interval according to window time. Can be FIXED or WINDOW.""",
         validator=strict_discrete_set,
-        values=["FIXED","WINDOW"],
+        values=["FIXED", "WINDOW"],
         cast=str,
     )
 
@@ -252,7 +289,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INTEGRATE %s",
         """Control meter integration ON or OFF.""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -262,7 +299,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INTEG:MODE %s",
         """Set the mode of execution in integration mode. Can be NORMAL or CONTINUE.""",
         validator=strict_discrete_set,
-        values=["NORMAL","CONTINUE"],
+        values=["NORMAL", "CONTINUE"],
         cast=str,
     )
 
@@ -271,7 +308,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:INTEGRATE:TIME %d",
         """Set integration time in seconds, between 0s and 35,999,999s.""",
         validator=truncated_range,
-        values=[0,35999999],
+        values=[0, 35999999],
     )
 
     filter = Instrument.control(
@@ -280,7 +317,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set the bandwidth of the digital low pass filter on input signal path.
         Can be OFF, BW500, or BW5500.""",
         validator=strict_discrete_set,
-        values=["OFF","BW500","BW5500"],
+        values=["OFF", "BW500", "BW5500"],
         cast=str,
     )
 
@@ -290,7 +327,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control the low pass filter on the path of frequency detect, True (ON) or
         False (OFF).""",
         validator=strict_discrete_set,
-        values={True:"ON",False:"OFF"},
+        values={True: "ON", False: "OFF"},
         map_values=True,
         cast=str,
     )
@@ -300,7 +337,7 @@ class Chroma66205(SCPIMixin, Instrument):
         "CONF:ENERGY:TIME %d",
         """Set energy measurement time in seconds, from 0s to 35,999,999s.""",
         validator=truncated_range,
-        values=[0,35999999]
+        values=[0, 35999999],
     )
 
     # DISPLAY #
@@ -321,10 +358,10 @@ class Chroma66205(SCPIMixin, Instrument):
         +---------+---------------------------------------+
         | D       | V, I, W, PF, VHZ, IHZ, THDV, THDI     |
         +---------+---------------------------------------+
-        """
+        """,
     )
 
-    def configure_display(self,A: Measure, B: Measure, C: Measure, D:Measure):
+    def configure_display(self, A: Measure, B: Measure, C: Measure, D: Measure):
         """Control the measurements shown on the four displays.
 
         +---------+---------------------------------------+
@@ -340,18 +377,26 @@ class Chroma66205(SCPIMixin, Instrument):
         +---------+---------------------------------------+
         """
         if A not in self.CHANNEL_A_DISPLAY_OPTS:
-            raise ValueError(f"Parameter {A} not valid for display A. Must be "
-                             f"one of: {self.CHANNEL_A_DISPLAY_OPTS}")
+            raise ValueError(
+                f"Parameter {A} not valid for display A. Must be "
+                f"one of: {self.CHANNEL_A_DISPLAY_OPTS}"
+            )
         if B not in self.CHANNEL_B_DISPLAY_OPTS:
-            raise ValueError(f"Parameter {B} not valid for display B. Must be "
-                             f"one of: {self.CHANNEL_B_DISPLAY_OPTS}")
+            raise ValueError(
+                f"Parameter {B} not valid for display B. Must be "
+                f"one of: {self.CHANNEL_B_DISPLAY_OPTS}"
+            )
         if C not in self.CHANNEL_C_DISPLAY_OPTS:
-            raise ValueError(f"Parameter {C} not valid for display C. Must be "
-                             f"one of: {self.CHANNEL_C_DISPLAY_OPTS}")
+            raise ValueError(
+                f"Parameter {C} not valid for display C. Must be "
+                f"one of: {self.CHANNEL_C_DISPLAY_OPTS}"
+            )
         if D not in self.CHANNEL_D_DISPLAY_OPTS:
-            raise ValueError(f"Parameter {D} not valid for display D. Must be "
-                             f"one of: {self.CHANNEL_D_DISPLAY_OPTS}")
-        self.show = f'{A.value}, {B.value}, {C.value}, {D.value}'
+            raise ValueError(
+                f"Parameter {D} not valid for display D. Must be "
+                f"one of: {self.CHANNEL_D_DISPLAY_OPTS}"
+            )
+        self.show = f"{A.value}, {B.value}, {C.value}, {D.value}"
 
     # MEASUREMENTS #
     voltage_rms = Instrument.measurement(
@@ -475,7 +520,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Set which mode will be triggered by trigger command.
         Can be NONE|INTEGRATION|INRUSH|LIMIT.""",
         validator=strict_discrete_set,
-        values=["NONE","INTEGRATION","INRUSH","LIMIT"],
+        values=["NONE", "INTEGRATION", "INRUSH", "LIMIT"],
         cast=str,
     )
 
@@ -492,7 +537,7 @@ class Chroma66205(SCPIMixin, Instrument):
         """Get a measurement."""
         return float(self.ask(f"MEAS? {param.value}").strip())
 
-    def integrate_energy(self, integration_time_s: float=10.):
+    def integrate_energy(self, integration_time_s: float = 10.0):
         # Set up
         self.energy_time = integration_time_s
         self.trigger_mode = "INTEGRATION"
@@ -505,33 +550,33 @@ class Chroma66205(SCPIMixin, Instrument):
         if tr != "RUNNING":
             print(f"Warning: Triggered but trigger is not set to 'RUNNING' (instead got {tr})")
         else:
-            timeout_duration = integration_time_s*1.5  # use 1.5x expected integration time
+            timeout_duration = integration_time_s * 1.5  # use 1.5x expected integration time
             start_time = time.monotonic()
             while self.trigger == "RUNNING":
                 if time.monotonic() - start_time > timeout_duration:
-                    raise TimeoutError(f"Integration was expected to take {integration_time_s} "
-                                       f"secs, but took longer than {timeout_duration} secs.")
+                    raise TimeoutError(
+                        f"Integration was expected to take {integration_time_s} "
+                        f"secs, but took longer than {timeout_duration} secs."
+                    )
         return self.energy_wh
 
-    def capture_waveform(self, param:str='V'):
+    def capture_waveform(self, param: str = "V"):
         """Get waveform as ts,wave for voltage (V) or current (I)."""
-        if param not in ['I','V']:
+        if param not in ["I", "V"]:
             raise ValueError(f"Unexpected parameter {param}. Must be 'V' or 'I'.")
         timeout = 100
-        while self.ask('WAVEFORM:CAPTURE?') != 'OK\n' and timeout > 0:
+        while self.ask("WAVEFORM:CAPTURE?") != "OK\n" and timeout > 0:
             timeout -= 1
-        if timeout  <= 0:
+        if timeout <= 0:
             raise TimeoutError("Waveform capture timeout.")
         print("Receiving waveform. This may take a minute...")
-        bvals = self.binary_values(f'WAVEFORM:DATA? {param}',dtype=np.uint8)
+        bvals = self.binary_values(f"WAVEFORM:DATA? {param}", dtype=np.uint8)
         print("Done.")
-        bvals = bvals[len('#48192'):-1]  # strip
+        bvals = bvals[len("#48192"):-1]  # strip
         wave = bvals.view(np.float32)
 
         # Wave contains exactly two 60Hz cycles, so sample rate is 61440 (=2048 Samples / 2 * 60Hz)
         # This might not be consistent across all settings and configurations?
-        Fs=61.44e3
-        ts = np.arange(0,len(wave)/Fs, 1/Fs)
-        return ts,wave
-
-
+        Fs = 61.44e3
+        ts = np.arange(0, len(wave) / Fs, 1 / Fs)
+        return ts, wave

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -63,10 +63,6 @@ class Chroma66205(SCPIMixin, Instrument):
         ENERGY_WH="WH"
         VOLTAGE_FREQUENCY="VHZ"
         CURRENT_FREQUENCY="IHZ"
-    _MEASURES = [
-        'V','I','W','VA','VPK+','VPK-','IPK+','IPK-','PF','DEG','THDV','THDI',
-        'IS','VAR','CFV','CFI','AH','WH','VHZ','IHZ'
-    ]
 
     CHANNEL_A_DISPLAY_OPTS = [Measure.VOLTAGE,Measure.CURRENT,Measure.REAL_POWER,
                               Measure.APPARENT_POWER,Measure.PEAK_POS_VOLTAGE,
@@ -106,6 +102,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["RMS","DC","VMEAN"],
         cast=str,
     )
+
     voltage_range = Instrument.control(
         "VOLT:RANG?",
         "VOLT:RANG %s",
@@ -115,6 +112,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["AUTO","V600","V300","V150","V60","V30","V15"],
         cast=str,
     )
+
     current_range = Instrument.control(
         "CURR:RANG?",
         "CURR:RANG %s",
@@ -126,6 +124,7 @@ class Chroma66205(SCPIMixin, Instrument):
                 "E015","E01","E005","E0025","E001"],
         cast=str,
     )
+
     averages = Instrument.control(
         "CONF:MEAS:AVERAGE?",
         "CONF:MEAS:AVERAGE %d",
@@ -134,6 +133,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=[1,2,4,8,16,32,64],
     )
+
     update_time = Instrument.control(
         "MEAS:UPD?",
         "MEAS:UPD %f",
@@ -142,15 +142,17 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=[0.05,0.1,0.25,0.5,1,2,5,10],
     )
-    ct = Instrument.control(
+
+    ct_enabled = Instrument.control(
         "CONF:INP:CT?",
         "CONF:INP:CT %s",
-        """Control CT function, ON (True) or OFF (False).""",
+        """Control current transformer (CT) function, ON (True) or OFF (False).""",
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
         cast=str,
     )
+
     ct_ratio = Instrument.control(
         "CONF:INP:CT:RAT?",
         "CONF:INP:CT:RAT %f",
@@ -159,6 +161,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=[1,9999.9],
         set_process=lambda v: round(v, 1),
     )
+
     hv = Instrument.control(
         "CONF:INP:HV?",
         "CONF:INP:HV %s",
@@ -168,6 +171,7 @@ class Chroma66205(SCPIMixin, Instrument):
         map_values=True,
         cast=str,
     )
+
     input_shunt = Instrument.control(
         "CONF:INP:SHUN?",
         "CONF:INP:SHUN %s",
@@ -177,6 +181,7 @@ class Chroma66205(SCPIMixin, Instrument):
         map_values=True,
         cast=str,
     )
+
     input_shunt_resistance = Instrument.control(
         "CONF:INP:SHUNT:RES?",
         "CONF:INP:SHUNT:RES %f",
@@ -185,6 +190,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=[0.0000001,99.9999999],
         set_process=lambda v:round(v,7)
     )
+
     null_measure_current = Instrument.control(
         "CURR:NULL?",
         "CURR:NULL %s",
@@ -195,6 +201,7 @@ class Chroma66205(SCPIMixin, Instrument):
         map_values=True,
         cast=str,
     )
+
     hold = Instrument.control(
         "CONF:HOLD?",
         "CONF:HOLD %s",
@@ -204,6 +211,7 @@ class Chroma66205(SCPIMixin, Instrument):
         map_values=True,
         cast=str,
     )
+
     hold_mode = Instrument.control(
         "CONF:HOLD:MODE?",
         "CONF:HOLD:MODE %s",
@@ -212,6 +220,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["STOP","MAX","MIN"],
         cast=str,
     )
+
     hold_time = Instrument.control(
         "CONF:HOLD:TIME?",
         "CONF:HOLD:TIME %d",
@@ -219,6 +228,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=truncated_range,
         values=[0,9999],
     )
+
     window_time = Instrument.control(
         "CONF:MEAS:WINDOW?",
         "CONF:MEAS:WINDOW %f",
@@ -227,6 +237,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values = [0.1,60.],
         set_process=lambda v: round(v, 1),
     )
+
     window_interval = Instrument.control(
         "CONF:MEAS:WINDOW:UPDATE?",
         "CONF:MEAS:WINDOW:UPDATE %s",
@@ -235,6 +246,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["FIXED","WINDOW"],
         cast=str,
     )
+
     integrate = Instrument.control(
         "CONF:INTEGRATE?",
         "CONF:INTEGRATE %s",
@@ -244,6 +256,7 @@ class Chroma66205(SCPIMixin, Instrument):
         map_values=True,
         cast=str,
     )
+
     integration_mode = Instrument.control(
         "CONF:INTEG:MODE?",
         "CONF:INTEG:MODE %s",
@@ -252,6 +265,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["NORMAL","CONTINUE"],
         cast=str,
     )
+
     integration_time = Instrument.control(
         "CONF:INTEGRATE:TIME?",
         "CONF:INTEGRATE:TIME %d",
@@ -259,6 +273,7 @@ class Chroma66205(SCPIMixin, Instrument):
         validator=truncated_range,
         values=[0,35999999],
     )
+
     filter = Instrument.control(
         "CONF:FILTER?",
         "CONF:FILTER %s",
@@ -268,15 +283,17 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["OFF","BW500","BW5500"],
         cast=str,
     )
+
     filter_frequency = Instrument.control(
         "CONF:FILT:FREQ?",
         "CONF:FILT:FREQ %s",
-        """Set the low pass filter on the path of frequency detect, True (ON) or False (OFF).""",
+        """Control the low pass filter on the path of frequency detect, True (ON) or False (OFF).""",
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,
         cast=str,
     )
+
     energy_time = Instrument.control(
         "CONF:ENERGY:TIME?",
         "CONF:ENERGY:TIME %d",
@@ -340,94 +357,117 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? V",
         """Get the last measured RMS voltage.""",
     )
+
     voltage_dc = Instrument.measurement(
         "FETCH? VDC",
         """Get the last measured DC voltage.""",
     )
+
     voltage_peak_pos = Instrument.measurement(
         "FETCH? VPK+",
         """Get the last measured positive peak voltage.""",
     )
+
     voltage_peak_neg = Instrument.measurement(
         "FETCH? VPK-",
         """Get the last measured negative peak voltage.""",
     )
+
     voltage_mean = Instrument.measurement(
         "FETCH? VMEAN",
         """Get the last measured mean voltage.""",
     )
+
     current_rms = Instrument.measurement(
         "FETCH? I",
         """Get the last measured RMS current.""",
     )
+
     current_dc = Instrument.measurement(
         "FETCH? IDC",
         """Get the last measured DC current.""",
     )
+
     current_peak_pos = Instrument.measurement(
         "FETCH? IPK+",
         """Get the last measured positive peak current.""",
     )
+
     current_peak_neg = Instrument.measurement(
         "FETCH? IPK-",
         """Get the last measured negative peak current.""",
     )
+
     inrush_current = Instrument.measurement(
         "FETCH? IS",
         """Get the last measured in-rush current.""",
     )
+
     current_crest_factor = Instrument.measurement(
         "FETCH? CFI",
         """Get the last measured current crest factor.""",
     )
+
     voltage_crest_factor = Instrument.measurement(
         "FETCH:VOLT:CRES?",
         """Get the last measured voltage crest factor.""",
     )
+
     power_real = Instrument.measurement(
         "FETCH? W",
         """Get the last measured RMS power.""",
     )
+
     power_dc = Instrument.measurement(
         "FETCH? WDC",
         """Get the last measured DC power.""",
     )
+
     power_factor = Instrument.measurement(
         "FETCH? PF",
         """Get the last measured power factor.""",
     )
+
     phase = Instrument.measurement(
         "FETCH? DEG",
         """Get phase in degrees.""",
     )
+
     power_apparent = Instrument.measurement(
         "FETCH? VA",
         """Get the last measured apparent power.""",
     )
+
     power_reactive = Instrument.measurement(
         "FETCH? VAR",
         """Get the last measured reactive power.""",
     )
+
     frequency = Instrument.measurement(
         "FETCH? FREQ",
         """Get the last measured frequency.""",
     )
+
     voltage_THD = Instrument.measurement(
         "FETCH? THDV",
-        """Get the last measured voltage THD.""",
+        """Get the last measured voltage total harmonic distortion (THD).""",
     )
+
     current_THD = Instrument.measurement(
         "FETCH? THDI",
-        """Get the last measured current THD.""",
+        """Get the last measured current total harmonic distortion (THD).""",
     )
+
     energy_wh = Instrument.measurement(
         "FETCH? WH",
         """Get the last measured energy in units of watt-hours.""",
     )
+
     charge_ah = Instrument.measurement(
         "FETCH? AH",
         """Get the last measured charge in units of amp-hours.""",
     )
+
     trigger_mode = Instrument.control(
         "TRIG:MODE?",
         "TRIG:MODE %s",
@@ -437,6 +477,7 @@ class Chroma66205(SCPIMixin, Instrument):
         values=["NONE","INTEGRATION","INRUSH","LIMIT"],
         cast=str,
     )
+
     trigger = Instrument.control(
         "TRIGGER?",
         "TRIGGER %s",
@@ -446,11 +487,11 @@ class Chroma66205(SCPIMixin, Instrument):
         cast=str,
     )
 
-    def measure(self,param: Measure):
-        """Get a measurement. See Chroma66205.Measure."""
+    def measure(self, param: Measure):
+        """Get a measurement."""
         return float(self.ask(f"MEAS? {param.value}").strip())
 
-    def integrate_energy(self,integration_time_s: float=10.):
+    def integrate_energy(self, integration_time_s: float=10.):
         # Set up
         self.energy_time = integration_time_s
         self.trigger_mode = "INTEGRATION"
@@ -471,7 +512,7 @@ class Chroma66205(SCPIMixin, Instrument):
                                        f"secs, but took longer than {timeout_duration} secs.")
         return self.energy_wh
 
-    def capture_waveform(self,param:str='V'):
+    def capture_waveform(self, param:str='V'):
         """Get waveform as ts,wave for voltage (V) or current (I)."""
         if param not in ['I','V']:
             raise ValueError(f"Unexpected parameter {param}. Must be 'V' or 'I'.")

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -23,12 +23,12 @@
 #
 
 import numpy as np
-from enum import Enum
 import time
 
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.generic_types import SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set, truncated_range
+from pymeasure.instruments._strenum import StrEnum
 
 
 class Chroma66205(SCPIMixin, Instrument):
@@ -39,7 +39,7 @@ class Chroma66205(SCPIMixin, Instrument):
     with programming information in English is available.
     """
 
-    class Measure(str, Enum):
+    class Measure(StrEnum):
         VOLTAGE = "V"
         DC_VOLTAGE = "VDC"
         MEAN_VOLTAGE = "VMEAN"

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -531,7 +531,7 @@ class Chroma66205(SCPIMixin, Instrument):
         # Wave contains exactly two 60Hz cycles, so sample rate is 61440 (=2048 Samples / 2 * 60Hz)
         # This might not be consistent across all settings and configurations?
         Fs=61.44e3
-        ts = np.arange(0,len(wave)/Fs,1/Fs)
+        ts = np.arange(0,len(wave)/Fs, 1/Fs)
         return ts,wave
 
 

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -34,7 +34,7 @@ class Chroma66205(SCPIMixin, Instrument):
     6620x instruments.
     """
 
-    def __init__(self, adapter, name="Chroma 63600", **kwargs):
+    def __init__(self, adapter, name="Chroma 66205", **kwargs):
         super().__init__(
             adapter,
             name,
@@ -55,14 +55,14 @@ class Chroma66205(SCPIMixin, Instrument):
         """Control number of measurements to average in averaging mode. Must be a power of 2
         between 1 and 64 inclusive.""",
         validator=strict_discrete_set,
-        values=[1,2,3,4,8,16,32,64],
+        values=[1,2,4,8,16,32,64],
     )
     window_time = Instrument.control(
         "CONF:MEAS:WINDOW?",
         "CONF:MEAS:WINDOW %f",
         """Control window time, from 0.1s to 60.0s in 0.1s increments.""",
         validator=truncated_range,
-        values = [0.,60.]
+        values = [0.1,60.]
     )
     window_interval = Instrument.control(
         "CONF:MEAS:WINDOW:UPDATE?",
@@ -73,7 +73,7 @@ class Chroma66205(SCPIMixin, Instrument):
     )
     integrate = Instrument.control(
         "CONF:INTEGRATE?",
-        "CONF:INTEGERATE %s",
+        "CONF:INTEGRATE %s",
         """Control meter integration ON or OFF.""",
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
@@ -134,11 +134,11 @@ class Chroma66205(SCPIMixin, Instrument):
         "FETCH? IDC",
         """Get the last measured DC current."""
     )
-    current = Instrument.measurement(
+    current_peak_pos = Instrument.measurement(
         "FETCH? IPK+",
         """Get the last measured positive peak current."""
     )
-    current = Instrument.measurement(
+    current_peak_neg = Instrument.measurement(
         "FETCH? IPK-",
         """Get the last measured negative peak current."""
     )

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -422,7 +422,7 @@ class Chroma66205(SCPIMixin, Instrument):
     trigger = Instrument.control(
         "TRIGGER?",
         "TRIGGER %s",
-        """Trigger energy calculation, inrush, or limit (go/no-go).
+        """Set trigger for energy calculation, inrush, or limit (go/no-go).
         Status is STOP|FINISH|RUNNING.
         To trigger, pass 'ON'. To stop or reset integration cycle, pass 'OFF'.""",
     )

--- a/pymeasure/instruments/chroma/chroma_66205.py
+++ b/pymeasure/instruments/chroma/chroma_66205.py
@@ -287,7 +287,8 @@ class Chroma66205(SCPIMixin, Instrument):
     filter_frequency = Instrument.control(
         "CONF:FILT:FREQ?",
         "CONF:FILT:FREQ %s",
-        """Control the low pass filter on the path of frequency detect, True (ON) or False (OFF).""",
+        """Control the low pass filter on the path of frequency detect, True (ON) or
+        False (OFF).""",
         validator=strict_discrete_set,
         values={True:"ON",False:"OFF"},
         map_values=True,

--- a/tests/instruments/chroma/test_chroma66205.py
+++ b/tests/instruments/chroma/test_chroma66205.py
@@ -1,0 +1,178 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.chroma import Chroma66205
+
+
+def test_init():
+    with expected_protocol(
+            Chroma66205,
+            [],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_charge_ah_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? AH', b'-0.0000010\n')],
+    ) as inst:
+        assert inst.charge_ah == -1e-06
+
+
+def test_current_dc_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? IDC', b'-0.0040322\n')],
+    ) as inst:
+        assert inst.current_dc == -0.0040322
+
+
+def test_current_peak_neg_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? IPK-', b'-6.3593586\n')],
+    ) as inst:
+        assert inst.current_peak_neg == -6.3593586
+
+
+def test_current_peak_pos_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? IPK+', b'6.2793033\n')],
+    ) as inst:
+        assert inst.current_peak_pos == 6.2793033
+
+
+def test_current_rms_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? I', b'1.8464582\n')],
+    ) as inst:
+        assert inst.current_rms == 1.8464582
+
+
+def test_energy_time_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'CONF:ENERGY:TIME?', b'1\n')],
+    ) as inst:
+        assert inst.energy_time == 1.0
+
+
+def test_energy_wh_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? WH', b'-0.0121532\n')],
+    ) as inst:
+        assert inst.energy_wh == -0.0121532
+
+
+def test_id_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'*IDN?', b'Chroma ATE,66205,662050003223,1.03,1.02,1.00\n')],
+    ) as inst:
+        assert inst.id == 'Chroma ATE,66205,662050003223,1.03,1.02,1.00'
+
+
+def test_mode_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'CONF:MEAS:MODE?', b'RMS\n')],
+    ) as inst:
+        assert inst.mode == 'RMS'
+
+
+def test_phase_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? DEG', b'121.8150996\n')],
+    ) as inst:
+        assert inst.phase == 121.8150996
+
+
+def test_power_apparent_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? VA', b'110.6944053\n')],
+    ) as inst:
+        assert inst.power_apparent == 110.6944053
+
+
+def test_power_dc_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? WDC', b'-0.0000209\n')],
+    ) as inst:
+        assert inst.power_dc == -2.09e-05
+
+
+def test_power_reactive_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? VAR', b'94.0580139\n')],
+    ) as inst:
+        assert inst.power_reactive == 94.0580139
+
+
+def test_power_real_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? W', b'-58.3332768\n')],
+    ) as inst:
+        assert inst.power_real == -58.3332768
+
+
+def test_voltage_dc_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? VDC', b'0.0051855\n')],
+    ) as inst:
+        assert inst.voltage_dc == 0.0051855
+
+
+def test_voltage_peak_neg_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? VPK-', b'-84.8153858\n')],
+    ) as inst:
+        assert inst.voltage_peak_neg == -84.8153858
+
+
+def test_voltage_peak_pos_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? VPK+', b'84.8395147\n')],
+    ) as inst:
+        assert inst.voltage_peak_pos == 84.8395147
+
+
+def test_voltage_rms_getter():
+    with expected_protocol(
+            Chroma66205,
+            [(b'FETCH? V', b'59.9339914\n')],
+    ) as inst:
+        assert inst.voltage_rms == 59.9339914


### PR DESCRIPTION
This PR is part of an on-going effort to add support for some of the Chroma power test and measurement instruments. Support for basic functionality of the 66205 digital power meter is added. 

The programming manual is not available in English, or I at least could only find a Chinese manual. But the Chinese manual included a programming chapter in English, which I used to fix and elaborate on my previous implementation.

Tested on the bench, includes protocol tests, tests passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Chroma 66205 Digital Power Meter driver with SCPI measurement queries, multi-channel display configuration, energy integration support, and waveform capture.
* **Documentation**
  * Added Sphinx API docs for the Chroma instruments module, including a dedicated page for the Chroma 66205.
* **Tests**
  * Added protocol-based tests covering initialization and property getter parsing for the Chroma 66205 driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->