### PR TITLE
Update ESP_300 to use standard list instead of individual axes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Removed
 - Remove GUI dependencies from default dependencies. Install pymeasure with gui dependencies with :code:`pip install pymeasure[gui]`. Conda still installs all dependencies.
 - Remove deprecated :code:`control` parameters :code:`command_process` and :code:`kwargs`.
 - Remove deprecated Toptica Ibeamsmart methods: :code:`laser_enabled`, :code:`channel1_enabled` :code:`channel2_enabled`, use :code:`emission` and the driver channels.
+- Deprecate ESP300 attributes :code:`x`, :code:`y`, :code:`phi`, use :code:`axes` list instead.
 
 Deprecated
 ----------

--- a/docs/about/changes.rst
+++ b/docs/about/changes.rst
@@ -5,3 +5,5 @@ Changelog
 =========
 
 .. include:: ../../CHANGES.rst
+
+ESP300: x, y, phi are no longer attributes and have been replaced by axes[0], axes[1], axes[2]. 

--- a/docs/about/changes.rst
+++ b/docs/about/changes.rst
@@ -5,5 +5,3 @@ Changelog
 =========
 
 .. include:: ../../CHANGES.rst
-
-ESP300: x, y, phi are no longer attributes and have been replaced by axes[0], axes[1], axes[2]. 

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -257,8 +257,10 @@ class ESP300(SCPIMixin, Instrument):
     @property
     def x(self):
         """ Get the first axis of the controller.
+
         .. deprecated:: 0.17.0
             Use :attr:`axes[0]` instead.
+
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -269,8 +271,10 @@ class ESP300(SCPIMixin, Instrument):
     @property
     def y(self):
         """ Get the second axis of the controller.
+
         .. deprecated:: 0.17.0
             Use :attr:`axes[1]` instead.
+
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -281,8 +285,10 @@ class ESP300(SCPIMixin, Instrument):
     @property
     def phi(self):
         """ Get the third axis of the controller.
+
         .. deprecated:: 0.17.0
             Use :attr:`axes[2]` instead.
+
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -254,19 +254,23 @@ class ESP300(SCPIUnknownMixin, Instrument):
         )
         self.axes = [Axis(1, self), Axis(2, self), Axis(3, self)]
 
+    @property
     def x(self):
         warn("The x attribute is deprecated."
-             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+             "Axes are now directly accessed through the axes attribute.",
+               FutureWarning, stacklevel=2)
         return self.axes[0]
-
+    @property
     def y(self):
         warn("The y attribute is deprecated."
-             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+             "Axes are now directly accessed through the axes attribute.",
+               FutureWarning, stacklevel=2)
         return self.axes[1]
-
+    @property
     def phi(self):
         warn("The phi attribute is deprecated."
-             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+             "Axes are now directly accessed through the axes attribute.",
+               FutureWarning, stacklevel=2)
         return self.axes[2]
 
     def clear_errors(self):

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -233,9 +233,7 @@ class ESP300(SCPIUnknownMixin, Instrument):
     """ Represents the Newport ESP 300 Motion Controller
     and provides a high-level for interacting with the instrument.
 
-    By default this instrument is constructed with x, y, and phi
-    attributes that represent axes 1, 2, and 3. Custom implementations
-    can overwrite this depending on the available axes. Axes are controlled
+    By default this instrument is constructed with 3 axes. Axes are controlled
     through an :class:`Axis <pymeasure.instruments.newport.esp300.Axis>`
     class.
     """
@@ -253,10 +251,7 @@ class ESP300(SCPIUnknownMixin, Instrument):
             name,
             **kwargs
         )
-        # Defines default axes, which can be overwritten
-        self.x = Axis(1, self)
-        self.y = Axis(2, self)
-        self.phi = Axis(3, self)
+        self.axes = [Axis(1, self), Axis(2, self), Axis(3, self)]
 
     def clear_errors(self):
         """ Clears the error messages by checking until a 0 code is
@@ -279,23 +274,6 @@ class ESP300(SCPIUnknownMixin, Instrument):
                 errors.append(GeneralError(code))
             code = self.error
         return errors
-
-    @property
-    def axes(self):
-        """ Get a list of the :class:`Axis <pymeasure.instruments.newport.esp300.Axis>`
-        objects that are present. """
-        axes = []
-        directory = dir(self)
-        for name in directory:
-            if name == 'axes':
-                continue  # Skip this property
-            try:
-                item = getattr(self, name)
-                if isinstance(item, Axis):
-                    axes.append(item)
-            except TypeError:
-                continue
-        return axes
 
     def enable(self):
         """ Enables all of the axes associated with this controller.

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -256,7 +256,9 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def x(self):
-        """ Get the first axis of the controller. Deprecated, Use axes[0] instead.
+        """ Get the first axis of the controller.
+        .. deprecated:: 0.17.0
+            Use :attr:`axes[0]` instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -266,7 +268,9 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def y(self):
-        """ Get the second axis of the controller. Deprecated, Use axes[1] instead.
+        """ Get the second axis of the controller.
+        .. deprecated:: 0.17.0
+            Use :attr:`axes[1]` instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -276,7 +280,9 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def phi(self):
-        """ Get the third axis of the controller. Deprecated, Use axes[2] instead.
+        """ Get the third axis of the controller.
+        .. deprecated:: 0.17.0
+            Use :attr:`axes[2]` instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -24,7 +24,7 @@
 
 from time import sleep
 
-from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set
 from warnings import warn
 
@@ -230,7 +230,7 @@ class Axis:
             sleep(interval)
 
 
-class ESP300(SCPIUnknownMixin, Instrument):
+class ESP300(SCPIMixin, Instrument):
     """ Represents the Newport ESP 300 Motion Controller
     and provides a high-level for interacting with the instrument.
 

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -256,21 +256,32 @@ class ESP300(SCPIUnknownMixin, Instrument):
 
     @property
     def x(self):
-        warn("The x attribute is deprecated."
+        """ Deprecated. Use axes[0] instead.
+        """
+        warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
-               FutureWarning, stacklevel=2)
+             FutureWarning,
+             stacklevel=2)
         return self.axes[0]
+
     @property
     def y(self):
-        warn("The y attribute is deprecated."
+        """ Deprecated. Use axes[1] instead.
+        """
+        warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
-               FutureWarning, stacklevel=2)
+             FutureWarning,
+             stacklevel=2)
         return self.axes[1]
+
     @property
     def phi(self):
-        warn("The phi attribute is deprecated."
+        """ Deprecated. Use axes[2] instead.
+        """
+        warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
-               FutureWarning, stacklevel=2)
+             FutureWarning,
+             stacklevel=2)
         return self.axes[2]
 
     def clear_errors(self):

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -26,6 +26,7 @@ from time import sleep
 
 from pymeasure.instruments import Instrument, SCPIUnknownMixin
 from pymeasure.instruments.validators import strict_discrete_set
+from warnings import warn
 
 
 class AxisError(Exception):
@@ -252,6 +253,21 @@ class ESP300(SCPIUnknownMixin, Instrument):
             **kwargs
         )
         self.axes = [Axis(1, self), Axis(2, self), Axis(3, self)]
+
+    def x(self):
+        warn("The x attribute is deprecated."
+             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+        return self.axes[0]
+
+    def y(self):
+        warn("The y attribute is deprecated."
+             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+        return self.axes[1]
+
+    def phi(self):
+        warn("The phi attribute is deprecated."
+             "Axes are now directly accessed through the axes attribute.", FutureWarning)
+        return self.axes[2]
 
     def clear_errors(self):
         """ Clears the error messages by checking until a 0 code is

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -256,7 +256,7 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def x(self):
-        """ Deprecated. Use axes[0] instead.
+        """ Get the first axis of the controller. Deprecated, Use axes[0] instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -266,7 +266,7 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def y(self):
-        """ Deprecated. Use axes[1] instead.
+        """ Get the second axis of the controller. Deprecated, Use axes[1] instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",
@@ -276,7 +276,7 @@ class ESP300(SCPIMixin, Instrument):
 
     @property
     def phi(self):
-        """ Deprecated. Use axes[2] instead.
+        """ Get the third axis of the controller. Deprecated, Use axes[2] instead.
         """
         warn("The x attribute is deprecated. "
              "Axes are now directly accessed through the axes attribute.",


### PR DESCRIPTION
Axes in ESP300 are getting built dynamically from a property by comparing all the objects present in the controller class. and checking if they belong to the Axis class.

In my use, it leads to some problems as it will check with all the objects in Intruments and can go through some SCPI command such as `complete`. which leads to a crash/stall of the loop.

I suggest to remove the axes property and instead just store it during init as a bare list. This avoids the unrequired complexity and stays as general as possible without enforcing some specific names to the Axis. 

