### PR TITLE
Deprecate values fallback to str

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Removed
 
 Deprecated
 ----------
+- Deprecate to silently fall back to str in :code:`values` (and the property creators :code:`control` etc.) if casting fails. Use a dedicated method, for example :code:`cast_or_str(float)`, instead.
 - Deprecate Toptica Ibeamsmart :code:`enable_continous`, use :code:`enable_continuous` instead.
 - Deprecate Thermotron 3800 :code:`initalize_oven`, use :code:`initialize_oven` instead.
 

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -24,5 +24,6 @@
 
 from .channel import Channel
 from .instrument import Instrument
+from .common_base import cast_or_str
 from .resources import find_serial_port, list_resources
 from .generic_types import SCPIMixin, SCPIUnknownMixin

--- a/pymeasure/instruments/activetechnologies/AWG401x.py
+++ b/pymeasure/instruments/activetechnologies/AWG401x.py
@@ -251,14 +251,14 @@ class ChannelAFG(ChannelBase):
         "SOURce{ch}:VOLTage:LEVel:IMMediate:AMPLitude? MAXimum",
         """Get the maximum amplitude voltage level that can
         be set to the output waveform.""",
-        get_process=lambda value: float(value.replace("VPP", ""))
+        preprocess_reply=lambda s: s.removeprefix("VPP"),
     )
 
     voltage_amplitude_min = Instrument.measurement(
         "SOURce{ch}:VOLTage:LEVel:IMMediate:AMPLitude? MINimum",
         """Get the minimum amplitude voltage level that can
         be set to the output waveform.""",
-        get_process=lambda value: float(value.replace("VPP", ""))
+        preprocess_reply=lambda s: s.removeprefix("VPP"),
     )
 
     voltage_offset = Instrument.control(
@@ -736,7 +736,7 @@ class AWG401x_AWG(AWG401x_base):
         """This class inherit from MutableMapping in order to create a custom
         dict to lazy load, modify, delete and create instrument waveform."""
 
-        def __init__(self, parent):
+        def __init__(self, parent: Instrument):
             self.parent = parent
             self.reset()
 
@@ -811,7 +811,7 @@ class AWG401x_AWG(AWG401x_base):
 
         def reset(self):
             """Reset the class reloading the waveforms from instrument"""
-            waveforms_name = self.parent.values("WLISt:LIST?")
+            waveforms_name = self.parent.values("WLISt:LIST?", cast=str)
             self._data = {v: None for v in waveforms_name}
 
         def _get_waveform(self, waveform_name):
@@ -838,12 +838,12 @@ class AWG401x_AWG(AWG401x_base):
         def __getitem__(self, key):
             if key <= 0:
                 raise IndexError("Entry numeration start from 1")
-            if key > int(self.parent.values("SEQuence:LENGth?")[0]):
+            if key > int(self.parent.values("SEQuence:LENGth?", cast=int)[0]):
                 raise IndexError("Index out of range")
             return SequenceEntry(self.parent, self.num_ch, key)
 
         def __len__(self):
-            return int(self.parent.values("SEQuence:LENGth?")[0])
+            return int(self.parent.values("SEQuence:LENGth?", cast=int)[0])
 
 
 class SequenceEntry(Channel):

--- a/pymeasure/instruments/agilent/agilent33500.py
+++ b/pymeasure/instruments/agilent/agilent33500.py
@@ -25,7 +25,7 @@
 # Parts of this code were copied and adapted from the Agilent33220A class.
 
 import logging
-from pymeasure.instruments import Instrument, Channel, SCPIMixin
+from pymeasure.instruments import Instrument, Channel, SCPIMixin, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 from time import time
 from pyvisa.errors import VisaIOError
@@ -56,6 +56,7 @@ class Agilent33500Channel(Channel):
         validator=strict_discrete_set,
         values=["SIN", "SQU", "TRI", "RAMP", "PULS", "PRBS", "NOIS", "ARB", "DC"],
         dynamic=True,
+        cast=str,
     )
 
     frequency = Instrument.control(
@@ -83,6 +84,7 @@ class Agilent33500Channel(Channel):
         validator=strict_discrete_set,
         values=["VPP", "VRMS", "DBM"],
         dynamic=True,
+        cast=str,
     )
 
     offset = Instrument.control(
@@ -157,6 +159,7 @@ class Agilent33500Channel(Channel):
         validator=strict_discrete_set,
         values=["WIDT", "WIDTH", "DCYC", "DCYCLE"],
         dynamic=True,
+        cast=str,
     )
 
     pulse_width = Instrument.control(
@@ -203,6 +206,7 @@ class Agilent33500Channel(Channel):
         is always 50 Ohm, this setting can be used to correct the displayed voltage for
         loads unmatched to 50 Ohm.""",
         dynamic=True,
+        cast=cast_or_str(float),
     )
 
     burst_state = Instrument.control(
@@ -222,6 +226,7 @@ class Agilent33500Channel(Channel):
         validator=strict_discrete_set,
         values=["TRIG", "TRIGGERED", "GAT", "GATED"],
         dynamic=True,
+        cast=str,
     )
 
     burst_period = Instrument.control(
@@ -247,6 +252,7 @@ class Agilent33500Channel(Channel):
         "SOUR{ch}:FUNC:ARB %s",
         """ Control the arbitrary signal to use from the volatile memory of the device.""",
         dynamic=True,
+        cast=str,
     )
 
     arb_advance = Instrument.control(
@@ -256,6 +262,7 @@ class Agilent33500Channel(Channel):
         Can be set to 'TRIG<GER>' or 'SRAT<E>' (default).""",
         validator=strict_discrete_set,
         values=["TRIG", "TRIGGER", "SRAT", "SRATE"],
+        cast=str,
     )
 
     arb_filter = Instrument.control(
@@ -265,6 +272,7 @@ class Agilent33500Channel(Channel):
         Can be set to 'NORM<AL>', 'STEP' and 'OFF'.""",
         validator=strict_discrete_set,
         values=["NORM", "NORMAL", "STEP", "OFF"],
+        cast=str,
     )
 
     arb_srate = Instrument.control(
@@ -389,6 +397,7 @@ class Agilent33500(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["SIN", "SQU", "TRI", "RAMP", "PULS", "PRBS", "NOIS", "ARB", "DC"],
         dynamic=True,
+        cast=str,
     )
 
     frequency = Instrument.control(
@@ -416,6 +425,7 @@ class Agilent33500(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["VPP", "VRMS", "DBM"],
         dynamic=True,
+        cast=str,
     )
 
     offset = Instrument.control(
@@ -490,6 +500,7 @@ class Agilent33500(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["WIDT", "WIDTH", "DCYC", "DCYCLE"],
         dynamic=True,
+        cast=str,
     )
 
     pulse_width = Instrument.control(
@@ -536,6 +547,7 @@ class Agilent33500(SCPIMixin, Instrument):
         is always 50 Ohm, this setting can be used to correct the displayed voltage for
         loads unmatched to 50 Ohm.""",
         dynamic=True,
+        cast=cast_or_str(float),
     )
 
     burst_state = Instrument.control(
@@ -555,6 +567,7 @@ class Agilent33500(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["TRIG", "TRIGGERED", "GAT", "GATED"],
         dynamic=True,
+        cast=str,
     )
 
     burst_period = Instrument.control(
@@ -580,6 +593,7 @@ class Agilent33500(SCPIMixin, Instrument):
         "FUNC:ARB %s",
         """ Control the arbitrary signal to use from the volatile memory of the device.""",
         dynamic=True,
+        cast=str,
     )
 
     arb_advance = Instrument.control(
@@ -589,6 +603,7 @@ class Agilent33500(SCPIMixin, Instrument):
         Can be set to 'TRIG<GER>' or 'SRAT<E>' (default).""",
         validator=strict_discrete_set,
         values=["TRIG", "TRIGGER", "SRAT", "SRATE"],
+        cast=str,
     )
 
     arb_filter = Instrument.control(
@@ -598,6 +613,7 @@ class Agilent33500(SCPIMixin, Instrument):
         Can be set to 'NORM<AL>', 'STEP' and 'OFF'.""",
         validator=strict_discrete_set,
         values=["NORM", "NORMAL", "STEP", "OFF"],
+        cast=str,
     )
     # TODO: This implementation is currently not working. Do not know why.
     # arb_period = Instrument.control(
@@ -751,6 +767,7 @@ class Agilent33500(SCPIMixin, Instrument):
         """ Control the trigger source (str).""",
         validator=strict_discrete_set,
         values=["IMM", "IMMEDIATE", "EXT", "EXTERNAL", "BUS"],
+        cast=str,
     )
 
     ext_trig_out = Instrument.control(

--- a/pymeasure/instruments/agilent/agilent34450A.py
+++ b/pymeasure/instruments/agilent/agilent34450A.py
@@ -25,7 +25,7 @@
 import re
 import logging
 
-from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, SCPIUnknownMixin, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set
 
 log = logging.getLogger(__name__)
@@ -102,7 +102,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         as well as "MIN", "MAX", or "DEF" (100 mA).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100E-6, 1E-3, 10E-3, 100E-3, 1, 10, "MIN", "DEF", "MAX"]
+        values=[100E-6, 1E-3, 10E-3, 100E-3, 1, 10, "MIN", "DEF", "MAX"],
+        cast=cast_or_str(float),
     )
     current_auto_range = Instrument.control(
         ":SENS:CURR:RANG:AUTO?", ":SENS:CURR:RANG:AUTO %d",
@@ -117,7 +118,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         readings, which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
         as well as "MIN", "MAX", and "DEF" (3.00E-5). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     current_ac_range = Instrument.control(
         ":SENS:CURR:AC:RANG?", ":SENS:CURR:AC:RANG:AUTO 0;:SENS:CURR:AC:RANG %s",
@@ -125,7 +127,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         values 10E-3, 100E-3, 1, 10, as well as "MIN", "MAX", or "DEF" (100 mA).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[10E-3, 100E-3, 1, 10, "MIN", "MAX", "DEF"]
+        values=[10E-3, 100E-3, 1, 10, "MIN", "MAX", "DEF"],
+        cast=cast_or_str(float),
     )
     current_ac_auto_range = Instrument.control(
         ":SENS:CURR:AC:RANG:AUTO?", ":SENS:CURR:AC:RANG:AUTO %d",
@@ -138,9 +141,10 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         ":SENS:CURR:AC:RES?", ":SENS:CURR:AC:RES %s",
         """ Control the resolution in the AC current
         readings, which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
-        as well as "MIN", "MAX", or "DEF" (1.50E-6). """,
+        as well as "MIN", "MAX", and "DEF" (1.50E-6). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
 
     ###############
@@ -161,7 +165,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         can take values 100E-3, 1, 10, 100, 1000, as well as "MIN", "MAX", or
         "DEF" (10 V). Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100E-3, 1, 10, 100, 1000, "MAX", "MIN", "DEF"]
+        values=[100E-3, 1, 10, 100, 1000, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     voltage_auto_range = Instrument.control(
         ":SENS:VOLT:RANG:AUTO?", ":SENS:VOLT:RANG:AUTO %d",
@@ -176,7 +181,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         readings, which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
         as well as "MIN", "MAX", or "DEF" (1.50E-6). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     voltage_ac_range = Instrument.control(
         ":SENS:VOLT:AC:RANG?", ":SENS:VOLT:AC:RANG:AUTO 0;:SENS:VOLT:AC:RANG %s",
@@ -185,7 +191,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         (10 V).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100E-3, 1, 10, 100, 750, "MAX", "MIN", "DEF"]
+        values=[100E-3, 1, 10, 100, 750, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     voltage_ac_auto_range = Instrument.control(
         ":SENS:VOLT:AC:RANG:AUTO?", ":SENS:VOLT:AC:RANG:AUTO %d",
@@ -200,7 +207,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
         as well as "MIN", "MAX", or "DEF" (1.50E-6). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
 
     ####################
@@ -224,7 +232,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         or "DEF" (1E3).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100, 1E3, 10E3, 100E3, 1E6, 10E6, 100E6, "MAX", "MIN", "DEF"]
+        values=[100, 1E3, 10E3, 100E3, 1E6, 10E6, 100E6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     resistance_auto_range = Instrument.control(
         ":SENS:RES:RANG:AUTO?", ":SENS:RES:RANG:AUTO %d",
@@ -237,9 +246,10 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         ":SENS:RES:RES?", ":SENS:RES:RES %s",
         """ Control the resolution in the 2-wire
         resistance readings, which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
-        as well as "MIN", "MAX", or "DEF" (1.50E-6). """,
+        as well as "MIN", "MAX", and "DEF" (1.50E-6). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     resistance_4w_range = Instrument.control(
         ":SENS:FRES:RANG?", ":SENS:FRES:RANG:AUTO 0;:SENS:FRES:RANG %s",
@@ -248,7 +258,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         as well as "MIN", "MAX", or "DEF" (1E3).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100, 1E3, 10E3, 100E3, 1E6, 10E6, 100E6, "MAX", "MIN", "DEF"]
+        values=[100, 1E3, 10E3, 100E3, 1E6, 10E6, 100E6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     resistance_4w_auto_range = Instrument.control(
         ":SENS:FRES:RANG:AUTO?", ":SENS:FRES:RANG:AUTO %d",
@@ -261,9 +272,10 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         ":SENS:FRES:RES?", ":SENS:FRES:RES %s",
         """ Control the resolution in the 4-wire
         resistance readings, which can take values 3.00E-5, 2.00E-5, 1.50E-6 (5 1/2 digits),
-        as well as "MIN", "MAX", or "DEF" (1.50E-6). """,
+        as well as "MIN", "MAX", and "DEF" (1.50E-6). """,
         validator=strict_discrete_set,
-        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"]
+        values=[3.00E-5, 2.00E-5, 1.50E-6, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
 
     ##################
@@ -281,7 +293,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         "MAX", or "DEF" (100 mA).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[10E-3, 100E-3, 1, 10, "MIN", "MAX", "DEF"]
+        values=[10E-3, 100E-3, 1, 10, "MIN", "MAX", "DEF"],
+        cast=cast_or_str(float),
     )
     frequency_current_auto_range = Instrument.control(
         ":SENS:FREQ:CURR:RANG:AUTO?", ":SENS:FREQ:CURR:RANG:AUTO %d",
@@ -297,7 +310,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         as well as "MIN", "MAX", or "DEF" (10 V).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[100E-3, 1, 10, 100, 750, "MAX", "MIN", "DEF"]
+        values=[100E-3, 1, 10, 100, 750, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     frequency_voltage_auto_range = Instrument.control(
         ":SENS:FREQ:VOLT:RANG:AUTO?", ":SENS:FREQ:VOLT:RANG:AUTO %d",
@@ -312,7 +326,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         which sets the integration period and measurement speed. Takes values
         100 ms, 1 s, as well as "MIN", "MAX", or "DEF" (1 s). """,
         validator=strict_discrete_set,
-        values=[100E-3, 1, "MIN", "MAX", "DEF"]
+        values=[100E-3, 1, "MIN", "MAX", "DEF"],
+        cast=cast_or_str(float),
     )
 
     ###################
@@ -351,7 +366,8 @@ class Agilent34450A(SCPIUnknownMixin, Instrument):
         1E-3, 10E-3, as well as "MIN", "MAX", or "DEF" (1E-6).
         Auto-range is disabled when this property is set. """,
         validator=strict_discrete_set,
-        values=[1E-9, 10E-9, 100E-9, 1E-6, 10E-6, 100E-6, 1E-3, 10E-3, "MAX", "MIN", "DEF"]
+        values=[1E-9, 10E-9, 100E-9, 1E-6, 10E-6, 100E-6, 1E-3, 10E-3, "MAX", "MIN", "DEF"],
+        cast=cast_or_str(float),
     )
     capacitance_auto_range = Instrument.control(
         ":SENS:CAP:RANG:AUTO?", ":SENS:CAP:RANG:AUTO %d",

--- a/pymeasure/instruments/agilent/agilent4156.py
+++ b/pymeasure/instruments/agilent/agilent4156.py
@@ -451,6 +451,7 @@ class AgilentMeasurementChannel(Channel):
             instr.smu1.voltage_name = "Vbase"
         """,
         set_process=check_current_voltage_name,
+        cast=str,
     )
 
     def reset_settings(self):
@@ -482,6 +483,7 @@ class AgilentMeasurementChannel(Channel):
         check_get_errors=True,
         check_set_errors=True,
         dynamic=True,
+        cast=str,
     )
 
     channel_function = Channel.control(
@@ -495,6 +497,7 @@ class AgilentMeasurementChannel(Channel):
         check_set_errors=True,
         validator=strict_discrete_set,
         values=["VAR1", "VAR2", "VARD", "CONS"],
+        cast=str,
     )
 
 
@@ -525,6 +528,7 @@ class SMU(AgilentMeasurementChannel):
         check_set_errors=True,
         validator=strict_discrete_set,
         values=["0OHM", "10KOHM", "100KOHM", "1MOHM"],
+        cast=str,
     )
 
     @property
@@ -606,6 +610,7 @@ class SMU(AgilentMeasurementChannel):
             instr.smu1.voltage_name = "Vbase"
         """,
         set_process=check_current_voltage_name,
+        cast=str,
     )
 
     def __validate_cons(self):

--- a/pymeasure/instruments/agilent/agilent4284A.py
+++ b/pymeasure/instruments/agilent/agilent4284A.py
@@ -75,7 +75,8 @@ class Agilent4284ASpot(Channel):
         See :attr:`.Agilent4284A.impedance_mode` for detailed explanation.
         """,
         validator=strict_discrete_set,
-        values=IMPEDANCE_MODES
+        values=IMPEDANCE_MODES,
+        cast=str,
         )
 
 
@@ -130,7 +131,8 @@ class Agilent4284ACorrection(Channel):
         See :attr:`.Agilent4284A.impedance_mode` for detailed explanation.
         """,
         validator=strict_discrete_set,
-        values=IMPEDANCE_MODES
+        values=IMPEDANCE_MODES,
+        cast=str,
         )
 
     cable_length = Channel.control(
@@ -261,7 +263,8 @@ class Agilent4284A(SCPIMixin, Instrument):
         * YTR: Admittance magnitude [Ohm] and phase [rad]
         """,
         validator=strict_discrete_set,
-        values=IMPEDANCE_MODES
+        values=IMPEDANCE_MODES,
+        cast=str,
     )
 
     impedance_range = Instrument.control(

--- a/pymeasure/instruments/agilent/agilentB298x.py
+++ b/pymeasure/instruments/agilent/agilentB298x.py
@@ -25,7 +25,7 @@
 from typing import Any
 
 from pymeasure.adapters import Adapter
-from pymeasure.instruments import SCPIMixin, Instrument
+from pymeasure.instruments import SCPIMixin, Instrument, cast_or_str
 from pymeasure.instruments.validators import (strict_discrete_set,
                                               strict_range,
                                               joined_validators
@@ -110,7 +110,8 @@ class AgilentB2981(SCPIMixin, Instrument):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``, ``UP``, ``DOWN``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2E-12, 20E-3]]
+        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2E-12, 20E-3]],
+        cast=cast_or_str(float),
         )
 
     interlock_enabled = Instrument.measurement(
@@ -172,7 +173,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         map_values=True,
-        values={True: 'ONCE', False: 'OFF'}
+        values={True: 'ONCE', False: 'OFF'},
+        cast=str,
         )
 
     arm_acquisition_count = Instrument.control(
@@ -185,7 +187,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         ``INF`` is equivalent to ``2147483647``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]]
+        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]],
+        cast=cast_or_str(float),
         )
 
     arm_acquisition_delay = Instrument.control(
@@ -196,7 +199,8 @@ class AgilentB2981(SCPIMixin, Instrument):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [0, 100000]]
+        values=[['MIN', 'MAX', 'DEF'], [0, 100000]],
+        cast=cast_or_str(float),
         )
 
     arm_acquisition_source = Instrument.control(
@@ -221,7 +225,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=['AINT', 'BUS', 'TIM', 'INT1', 'INT2', 'LAN', 'TIN',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     arm_acquisition_source_lan_id = Instrument.control(
@@ -231,7 +236,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         :type: str, strictly from ``LAN0`` to ``LAN7``
         """,
         validator=strict_discrete_set,
-        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7']
+        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7'],
+        cast=str,
         )
 
     arm_acquisition_timer = Instrument.control(
@@ -242,7 +248,8 @@ class AgilentB2981(SCPIMixin, Instrument):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]]
+        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]],
+        cast=cast_or_str(float),
         )
 
     arm_acquisition_output_signal = Instrument.control(
@@ -262,7 +269,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=['INT1', 'INT2', 'LAN', 'TOUT',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     arm_acquisition_output_enabled = Instrument.control(
@@ -293,7 +301,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         map_values=True,
-        values={True: 'ONCE', False: 'OFF'}
+        values={True: 'ONCE', False: 'OFF'},
+        cast=str,
         )
 
     trigger_acquisition_count = Instrument.control(
@@ -306,7 +315,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         ``INF`` is equivalent to ``2147483647``.
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]]
+        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]],
+        cast=cast_or_str(float),
         )
 
     trigger_acquisition_delay = Instrument.control(
@@ -317,7 +327,8 @@ class AgilentB2981(SCPIMixin, Instrument):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [0, 100000]]
+        values=[['MIN', 'MAX', 'DEF'], [0, 100000]],
+        cast=cast_or_str(float),
         )
 
     trigger_acquisition_source = Instrument.control(
@@ -341,7 +352,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=['AINT', 'BUS', 'TIM', 'INT1', 'INT2', 'LAN', 'TIN',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     trigger_acquisition_source_lan_id = Instrument.control(
@@ -351,7 +363,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         :type: str, strictly from ``LAN0`` to ``LAN7``
         """,
         validator=strict_discrete_set,
-        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7']
+        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7'],
+        cast=str,
         )
 
     trigger_acquisition_timer = Instrument.control(
@@ -362,7 +375,8 @@ class AgilentB2981(SCPIMixin, Instrument):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]]
+        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]],
+        cast=cast_or_str(float),
         )
 
     trigger_acquisition_output_signal = Instrument.control(
@@ -383,7 +397,8 @@ class AgilentB2981(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=['INT1', 'INT2', 'LAN', 'TOUT',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     trigger_acquisition_output_enabled = Instrument.control(
@@ -655,6 +670,7 @@ class AgilentB2985(AgilentB2981):
         values=['CURR', 'CHAR', 'VOLT', 'RES'],
         get_process=lambda v: v.strip('"'),
         get_process_list=lambda v: [x.strip('"') for x in v],
+        cast=str,
         )
 
     charge = Instrument.measurement(
@@ -673,7 +689,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``, ``UP``, ``DOWN``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2E-9, 2E-6]]
+        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2E-9, 2E-6]],
+        cast=cast_or_str(float),
         )
 
     resistance = Instrument.measurement(
@@ -692,7 +709,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``, ``UP``, ``DOWN``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [1E6, 1E15]]
+        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [1E6, 1E15]],
+        cast=cast_or_str(float),
         )
 
     voltage = Instrument.measurement(
@@ -711,7 +729,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``, ``UP``, ``DOWN``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2, 20]]
+        values=[['MIN', 'MAX', 'DEF', 'UP', 'DOWN'], [2, 20]],
+        cast=cast_or_str(float),
         )
 
     humidity = Instrument.measurement(
@@ -742,7 +761,8 @@ class AgilentB2985(AgilentB2981):
         - ``HSEN`` selects the temperature sensor within the humidity sensor.
         """,
         validator=strict_discrete_set,
-        values=['TC', 'HSEN']
+        values=['TC', 'HSEN'],
+        cast=str,
         )
 
     temperature_unit = Instrument.control(
@@ -758,7 +778,8 @@ class AgilentB2985(AgilentB2981):
         - ``K`` selects Kelvin.
         """,
         validator=strict_discrete_set,
-        values=['C', 'CEL', 'F', 'FAR', 'K']
+        values=['C', 'CEL', 'F', 'FAR', 'K'],
+        cast=str,
         )
 
 ############################################################
@@ -792,7 +813,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         map_values=True,
-        values={True: 'ONCE', False: 'OFF'}
+        values={True: 'ONCE', False: 'OFF'},
+        cast=str,
         )
 
     arm_transient_count = Instrument.control(
@@ -805,18 +827,20 @@ class AgilentB2985(AgilentB2981):
         ``INF`` is equivalent to ``2147483647``.
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]]
+        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]],
+        cast=cast_or_str(float),
         )
 
     arm_transient_delay = Instrument.control(
         ":ARM:TRAN:DEL?", ":ARM:TRAN:DEL %s",
         """Control the arm trigger delay for action 'TRANSient' in seconds.
 
-        :type: - float, strictly from ``0`` to ``1E5`` or
+        :type: - float, strictly from ``0`` to ``1E5`` or
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [0, 100000]]
+        values=[['MIN', 'MAX', 'DEF'], [0, 100000]],
+        cast=cast_or_str(float),
         )
 
     arm_transient_source = Instrument.control(
@@ -840,7 +864,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         values=['AINT', 'BUS', 'TIM', 'INT1', 'INT2', 'LAN', 'TIN',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     arm_transient_source_lan_id = Instrument.control(
@@ -850,7 +875,8 @@ class AgilentB2985(AgilentB2981):
         :type: str, strictly from ``LAN0`` to ``LAN7``
         """,
         validator=strict_discrete_set,
-        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7']
+        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7'],
+        cast=str,
         )
 
     arm_transient_timer = Instrument.control(
@@ -861,7 +887,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]]
+        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]],
+        cast=cast_or_str(float),
         )
 
     arm_transient_output_signal = Instrument.control(
@@ -881,7 +908,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         values=['INT1', 'INT2', 'LAN', 'TOUT',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     arm_transient_output_enabled = Instrument.control(
@@ -912,7 +940,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         map_values=True,
-        values={True: 'ONCE', False: 'OFF'}
+        values={True: 'ONCE', False: 'OFF'},
+        cast=str,
         )
 
     trigger_transient_count = Instrument.control(
@@ -925,7 +954,8 @@ class AgilentB2985(AgilentB2981):
         ``INF`` is equivalent to ``2147483647``.
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]]
+        values=[['MIN', 'MAX', 'DEF', 'INF', 2147483647], [1, 100000]],
+        cast=cast_or_str(float),
         )
 
     trigger_transient_delay = Instrument.control(
@@ -936,7 +966,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [0, 100000]]
+        values=[['MIN', 'MAX', 'DEF'], [0, 100000]],
+        cast=cast_or_str(float),
         )
 
     trigger_transient_source = Instrument.control(
@@ -961,7 +992,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         values=['AINT', 'BUS', 'TIM', 'INT1', 'INT2', 'LAN', 'TIN',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     trigger_transient_source_lan_id = Instrument.control(
@@ -971,7 +1003,8 @@ class AgilentB2985(AgilentB2981):
         :type: str, strictly from ``LAN0`` to ``LAN7``
         """,
         validator=strict_discrete_set,
-        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7']
+        values=['LAN0', 'LAN1', 'LAN2', 'LAN3', 'LAN4', 'LAN5', 'LAN6', 'LAN7'],
+        cast=str,
         )
 
     trigger_transient_timer = Instrument.control(
@@ -982,7 +1015,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]]
+        values=[['MIN', 'MAX', 'DEF'], [1E-5, 1E5]],
+        cast=cast_or_str(float),
         )
 
     trigger_transient_output_signal = Instrument.control(
@@ -1002,7 +1036,8 @@ class AgilentB2985(AgilentB2981):
         """,
         validator=strict_discrete_set,
         values=['INT1', 'INT2', 'LAN', 'TOUT',
-                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7']
+                'EXT1', 'EXT2', 'EXT3', 'EXT4', 'EXT5', 'EXT6', 'EXT7'],
+        cast=str,
         )
 
     trigger_transient_output_enabled = Instrument.control(
@@ -1038,7 +1073,8 @@ class AgilentB2985(AgilentB2981):
         - ``COMM``: low terminal is connected to Common.
         """,
         validator=strict_discrete_set,
-        values=['FLO', 'COMM']
+        values=['FLO', 'COMM'],
+        cast=str,
         )
 
     source_off_state = Instrument.control(
@@ -1059,7 +1095,8 @@ class AgilentB2985(AgilentB2981):
         +------------+--------------------------------------------------------------+
         """,
         validator=strict_discrete_set,
-        values=['ZERO', 'HIZ', 'NORM']
+        values=['ZERO', 'HIZ', 'NORM'],
+        cast=str,
         )
 
     source_voltage = Instrument.control(
@@ -1092,7 +1129,8 @@ class AgilentB2985(AgilentB2981):
                - str, strictly in ``MIN``, ``MAX``, ``DEF``
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[['MIN', 'MAX', 'DEF'], [-1000, 1000]]
+        values=[['MIN', 'MAX', 'DEF'], [-1000, 1000]],
+        cast=cast_or_str(float),
         )
 
 

--- a/pymeasure/instruments/agilent/agilentE5062A.py
+++ b/pymeasure/instruments/agilent/agilentE5062A.py
@@ -65,7 +65,8 @@ class VNATrace(Channel):
         """Control the measurement parameter of the trace (str). Can be
         S11, S21, S12, or S22""",
         validator=strict_discrete_set,
-        values=['S11', 'S12', 'S21', 'S22']
+        values=['S11', 'S12', 'S21', 'S22'],
+        cast=str,
     )
 
 
@@ -155,7 +156,8 @@ class VNAChannel(Channel):
         Defaults to linear. Note that the API for configuring segment type
         sweeps is not implememented in this class.""",
         validator=strict_discrete_set,
-        values=['LIN', 'LOG', 'SEGM', 'POW']
+        values=['LIN', 'LOG', 'SEGM', 'POW'],
+        cast=str,
     )
 
     averaging_enabled = Channel.control(
@@ -271,7 +273,8 @@ class VNAChannel(Channel):
 
         """,
         validator=strict_discrete_set,
-        values=DISPLAY_LAYOUT_OPTIONS
+        values=DISPLAY_LAYOUT_OPTIONS,
+        cast=str,
     )
 
     TRACE_FORMAT = [
@@ -324,7 +327,8 @@ class VNAChannel(Channel):
 
         """,
         validator=strict_discrete_set,
-        values=TRACE_FORMAT
+        values=TRACE_FORMAT,
+        cast=str,
         )
 
     def _read_binary_data(self):
@@ -520,7 +524,8 @@ class AgilentE5062A(SCPIMixin, Instrument):
         e.g. ``AgilentE5062A.channels[1].visible_traces``
         """,
         validator=strict_discrete_set,
-        values=DISPLAY_LAYOUT_OPTIONS
+        values=DISPLAY_LAYOUT_OPTIONS,
+        cast=str,
     )
 
     output_enabled = Instrument.control(
@@ -558,7 +563,9 @@ class AgilentE5062A(SCPIMixin, Instrument):
             'INT',
             'EXT',
             'MAN',
-            'BUS'])
+            'BUS'],
+        cast=str,
+    )
 
     def trigger_bus(self):
         """If the trigger source is BUS and the VNA is waiting for a trigger

--- a/pymeasure/instruments/agilent/agilentE5270B.py
+++ b/pymeasure/instruments/agilent/agilentE5270B.py
@@ -165,6 +165,7 @@ class SMUChannel(Channel):
         "TI{ch}",
         """Measure the current in Amps (float).""",
         get_process=lambda v: float(v[3:]),
+        cast=str,
     )
 
     voltage_setpoint = Instrument.setting(
@@ -195,6 +196,7 @@ class SMUChannel(Channel):
         "TV{ch}",
         """Measure the voltage in Volts (float).""",
         get_process=lambda v: float(v[3:]),
+        cast=str,
     )
 
 
@@ -273,5 +275,6 @@ class AgilentE5270B(SCPIMixin, Instrument):
 
         """,
         maxsplit=0,
-        get_process=lambda v: v.split(";")
+        get_process=lambda v: v.split(";"),
+        cast=str,
     )

--- a/pymeasure/instruments/agilent/agilentN8975A.py
+++ b/pymeasure/instruments/agilent/agilentN8975A.py
@@ -64,6 +64,7 @@ class AgilentN8975AFrequency(Channel):
                 "fixed": "FIX",
                 "list": "LIST",
                 },
+        cast=str,
         )
 
     fixed_value = Channel.control(

--- a/pymeasure/instruments/aimtti/aimttiPL.py
+++ b/pymeasure/instruments/aimtti/aimttiPL.py
@@ -46,6 +46,7 @@ class PLChannel(Channel):
         values=[0, 6],
         dynamic=True,
         get_process=lambda x: float(x[3:]),
+        cast=str,
     )
 
     current_limit = Channel.control(
@@ -55,18 +56,21 @@ class PLChannel(Channel):
         values=[0, 1.5],
         dynamic=True,
         get_process=lambda x: float(x[3:]),
+        cast=str,
     )
 
     voltage = Channel.measurement(
         "V{ch}O?",
         """ Measure the output readback voltage for this output channel in Volts.""",
         get_process=lambda x: float(x[:-1]),
+        cast=str,
     )
 
     current = Channel.measurement(
         "I{ch}O?",
         """ Measure the output readback current for this output channel in Amps.""",
         get_process=lambda x: float(x[:-1]),
+        cast=str,
     )
 
     current_range = Channel.control(

--- a/pymeasure/instruments/aimtti/ld400p.py
+++ b/pymeasure/instruments/aimtti/ld400p.py
@@ -67,6 +67,7 @@ class LD400P(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["C", "P", "R", "G", "V"],
         get_process=lambda v: v.replace("MODE ", ""),
+        cast=str,
     )
 
     level_select = Instrument.control(
@@ -79,6 +80,7 @@ class LD400P(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["A", "B", "T", "V", "E"],
         get_process=lambda v: v.replace("LVLSEL ", ""),
+        cast=str,
     )
 
     level_a = Instrument.control(

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -22,7 +22,10 @@
 # THE SOFTWARE.
 #
 
+from typing import Literal
+
 from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import modular_range, truncated_discrete_set, truncated_range
 
 import logging
@@ -30,7 +33,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-def check_read_not_empty(value):
+def check_read_not_empty(value: Literal[""] | float) -> float:
     """Called by some properties to check if the reply is not an empty string
     that would mean the properties is currently invalid (probably because the reference mode
     is on single or dual)"""
@@ -102,54 +105,63 @@ class Ametek7270(SCPIUnknownMixin, Instrument):
     x = Instrument.measurement(
         "X.",
         """Get X value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     y = Instrument.measurement(
         "Y.",
         """Get Y value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     x1 = Instrument.measurement(
         "X1.",
         """Get first harmonic X value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     y1 = Instrument.measurement(
         "Y1.",
         """Get first harmonic Y value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     x2 = Instrument.measurement(
         "X2.",
         """Get second harmonic X value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     y2 = Instrument.measurement(
         "Y2.",
         """Get second harmonic Y value in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     xy = Instrument.measurement(
         "XY.",
         """Get both X and Y values in Volts (float, tuple).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     mag = Instrument.measurement(
         "MAG.",
         """Get magnitude in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     theta = Instrument.measurement(
         "PHA.",
         """Get signal phase in degrees (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
@@ -221,24 +233,28 @@ class Ametek7270(SCPIUnknownMixin, Instrument):
     adc1 = Instrument.measurement(
         "ADC. 1",
         """Get the input value of ADC1 in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     adc2 = Instrument.measurement(
         "ADC. 2",
         """Get the input value of ADC2 in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     adc3 = Instrument.measurement(
         "ADC. 3",
         """Get the input value of ADC3 in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 
     adc4 = Instrument.measurement(
         "ADC. 4",
         """Get the input value of ADC4 in Volts (float).""",
+        cast=cast_or_str(float),
         get_process=check_read_not_empty,
     )
 

--- a/pymeasure/instruments/anritsu/anritsuMS2090A.py
+++ b/pymeasure/instruments/anritsu/anritsuMS2090A.py
@@ -176,7 +176,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:CONT?",
         """
         Returns the Control Channel measurement in json format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_eirpower = Instrument.measurement(
@@ -204,14 +205,16 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:EMF?",
         """
         Return the current EMF measurement data. JSON format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_emf_meter = Instrument.measurement(
         "FET:EMF:MET?",
         """
         Return the live EMF measurement data. JSON format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_emf_meter_sample = Instrument.measurement(
@@ -233,7 +236,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:MIMO:ANT?",
         """
         Returns the sync power measurement in json format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_ocupied_bw = Instrument.measurement(
@@ -255,7 +259,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:PAN?",
         """
         Return the current Pulse Analyzer measurement data. JSON format
-        """
+        """,
+        cast=str,
     )
 
     fetch_pci = Instrument.measurement(
@@ -269,7 +274,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:PDSC?",
         """
         Returns the Data Channel Measurements in JSON format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_peak = Instrument.measurement(
@@ -283,14 +289,16 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:RRM?",
         """
         Returns the Radio Resource Management in JSON format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_scan = Instrument.measurement(
         "FET:SCAN?",
         """
         Returns the cell scanner measurements in JSON format
-        """
+        """,
+        cast=str,
     )
 
     fetch_semask = Instrument.measurement(
@@ -311,21 +319,24 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "FET:SYNC:EVM?",
         """
         Returns the Sync EVM measurement in JSON format.
-        """
+        """,
+        cast=str,
     )
 
     fetch_sync_power = Instrument.measurement(
         "FET:SYNC:POW?",
         """
         Returns the sync power measurements in JSON format
-        """
+        """,
+        cast=str,
     )
 
     fetch_tae = Instrument.measurement(
         "FET:TAE?",
         """
         Returns the Time Alignment Error in JSON format.
-        """
+        """,
+        cast=str,
     )
 
     init_continuous = Instrument.control(
@@ -333,7 +344,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         "Specified whether the sweep/measurement is triggered continuously",
         values=ONOFF,
         map_values=True,
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
+        cast=str,
     )
 
     init_spa_self = Instrument.measurement(
@@ -350,7 +362,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         """,
         values=ONOFF,
         map_values=True,
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
+        cast=str,
     )
 
     meas_acpower = Instrument.measurement(
@@ -417,7 +430,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         """,
         values=ONOFF,
         map_values=True,
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
+        cast=str,
     )
 
     meas_int_power = Instrument.measurement(
@@ -443,7 +457,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         Sets or queries whether the instrument will automatically save an IQ capture when
         losing sync
         """,
-        values=OFFFIRSTREPEAT
+        values=OFFFIRSTREPEAT,
+        cast=str,
     )
 
     meas_ota_mapp = Instrument.measurement(
@@ -462,7 +477,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         """,
         values=ONOFF,
         map_values=True,
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
+        cast=str,
     )
 
     view_sense_modes = Instrument.measurement(
@@ -471,7 +487,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         Returns a list of available modes for the Spa application. The response is a
         comma-separated list of mode names. See command [:SENSe]:MODE for the mode name
         specification.
-        """
+        """,
+        cast=str,
     )
 
     sense_mode = Instrument.control(
@@ -480,6 +497,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         Set the operational mode of the Spa app.
         """,
         values=SPAMODES,
+        cast=str,
     )
 
     preamp = Instrument.control(
@@ -490,7 +508,8 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
         """,
         values=ONOFF,
         map_values=True,
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
+        cast=str,
     )
 
     def init_sweep(self):

--- a/pymeasure/instruments/anritsu/anritsuMS2090A.py
+++ b/pymeasure/instruments/anritsu/anritsuMS2090A.py
@@ -340,7 +340,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     init_continuous = Instrument.control(
-        "INIT:CONT?", "INIT:CONT %g",
+        "INIT:CONT?", "INIT:CONT %s",
         "Specified whether the sweep/measurement is triggered continuously",
         values=ONOFF,
         map_values=True,
@@ -356,7 +356,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     active_state = Instrument.control(
-        "INST:ACT:STAT?", "INST:ACT:STAT %g",
+        "INST:ACT:STAT?", "INST:ACT:STAT %s",
         docs="""
         The "set" state indicates that the instrument is used by someone.
         """,
@@ -424,7 +424,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     meas_emf_meter_sample = Instrument.control(
-        "MEASure:EMF:METer:SAMPle:STATe?", "MEASure:EMF:METer:SAMPle:STATe%g",
+        "MEASure:EMF:METer:SAMPle:STATe?", "MEASure:EMF:METer:SAMPle:STATe%s",
         docs="""
         Start or Stop applying the measurement results to the currently selected sample
         """,
@@ -452,7 +452,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     meas_iq_capture_fail = Instrument.control(
-        "MEASure:IQ:CAPTure:FAIL?", "MEASure:IQ:CAPTure:FAIL %g",
+        "MEASure:IQ:CAPTure:FAIL?", "MEASure:IQ:CAPTure:FAIL %s",
         """
         Sets or queries whether the instrument will automatically save an IQ capture when
         losing sync
@@ -470,7 +470,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     meas_ota_run = Instrument.control(
-        "MEASure:OTA:MAPPing:RUN?", "MEASure:OTA:MAPPing:RUN %g",
+        "MEASure:OTA:MAPPing:RUN?", "MEASure:OTA:MAPPing:RUN %s",
         """
         Turn on/off OTA Coverage Mapping Data Collection. The instrument must be in
         Coverage Mapping measurement for the command to be effective
@@ -492,7 +492,7 @@ class AnritsuMS2090A(SCPIMixin, Instrument):
     )
 
     sense_mode = Instrument.control(
-        "MODE?", ":MODE %g",
+        "MODE?", ":MODE %s",
         """
         Set the operational mode of the Spa app.
         """,

--- a/pymeasure/instruments/anritsu/anritsuMS464xB.py
+++ b/pymeasure/instruments/anritsu/anritsuMS464xB.py
@@ -23,7 +23,7 @@
 #
 import logging
 
-from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin, cast_or_str
 from pymeasure.instruments.validators import (
     strict_discrete_set,
     strict_range
@@ -118,14 +118,14 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
                            frequency_range=self.FREQUENCY_RANGE,
                            **kwargs)
 
-    def check_errors(self):
+    def check_errors(self) -> list[list[str | float]]:
         """ Read all errors from the instrument.
 
         :return: list of error entries
         """
         errors = []
         while True:
-            err = self.values("SYST:ERR?")
+            err = self.values("SYST:ERR?", cast=cast_or_str(float))
             if err[0] != "No Error":
                 log.error(f"{self.name}: {err[0]}")
                 errors.append(err)
@@ -160,6 +160,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["HZ", "KHZ", "MHZ", "GHZ"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     datablock_numeric_format = Instrument.control(
@@ -178,6 +179,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values={"ASCII": "ASC", "8byte": "REAL", "4byte": "REAL32"},
         map_values=True,
+        cast=str,
     )
 
     datafile_include_heading = Instrument.control(
@@ -203,6 +205,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["LINPH", "LOGPH", "REIM"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     data_drawing_enabled = Instrument.control(
@@ -263,6 +266,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["NORM", "SWAP"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     max_number_of_points = Instrument.control(
@@ -346,6 +350,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["AUTO", "MAN", "EXTT", "EXT", "REM"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     external_trigger_type = Instrument.control(
@@ -356,6 +361,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=TRIGGER_TYPES,
         validator=strict_discrete_set,
+        cast=str,
     )
 
     external_trigger_delay = Instrument.control(
@@ -376,6 +382,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["POS", "NEG"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     external_trigger_handshake = Instrument.control(
@@ -393,6 +400,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=TRIGGER_TYPES,
         validator=strict_discrete_set,
+        cast=str,
     )
 
     manual_trigger_type = Instrument.control(
@@ -403,6 +411,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=TRIGGER_TYPES,
         validator=strict_discrete_set,
+        cast=str,
     )
 
     def trigger(self):
@@ -433,6 +442,7 @@ class AnritsuMS464xB(SCPIUnknownMixin, Instrument):
         """,
         values=["CONT", "HOLD", "SING"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     def load_data_file(self, filename):
@@ -560,6 +570,7 @@ class Trace(Channel):
         """,
         values=AnritsuMS464xB.SPARAM_LIST + ["MIX", "NFIG", "NPOW", "NTEMP", "AGA", "IGA"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
 
@@ -678,6 +689,7 @@ class MeasurementChannel(Channel):
         """,
         values=["TRAN", "NFIG", "PULS"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     hold_function = Channel.control(
@@ -696,6 +708,7 @@ class MeasurementChannel(Channel):
         """,
         values=["CONT", "HOLD", "SING"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     cw_mode_enabled = Channel.control(
@@ -811,6 +824,7 @@ class MeasurementChannel(Channel):
         """,
         values=["POIN", "SWE"],
         validator=strict_discrete_set,
+        cast=str,
     )
 
     averaging_enabled = Channel.control(
@@ -839,6 +853,7 @@ class MeasurementChannel(Channel):
         """,
         validator=strict_discrete_set,
         values=["LIN", "LOG", "FSEGM", "ISEGM", "POW", "MFGC"],
+        cast=str,
     )
 
     sweep_mode = Channel.control(
@@ -850,6 +865,7 @@ class MeasurementChannel(Channel):
         frequencies in the range).""",
         validator=strict_discrete_set,
         values=["VNA", "CLAS"],
+        cast=str,
     )
 
     sweep_time = Channel.control(

--- a/pymeasure/instruments/common_base.py
+++ b/pymeasure/instruments/common_base.py
@@ -26,6 +26,7 @@ from inspect import getmembers
 import logging
 from typing import Any, cast, Protocol, TypeVar
 from collections.abc import Callable, Sequence
+from warnings import warn
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -49,6 +50,30 @@ T = TypeVar("T")
 V0 = TypeVar("V0")
 Vs = TypeVar("Vs")
 V2 = TypeVar("V2")
+
+
+def cast_or_str(cast_func: Callable[[str], T]) -> Callable[[str], T | str]:
+    """Return a cast function that tries to cast but falls back to the original string.
+
+    This is useful for instrument responses that may contain a mix of numeric
+    and string values (e.g. ``"SP,5,NP,1000"`` or ``"0,No Error"``).
+
+    :param cast_func: A callable to attempt casting with (e.g. ``float`` or ``int``).
+    :returns: A callable that returns the cast value on success, or the original
+        string on failure.
+
+    Example usage with :meth:`CommonBase.values`::
+
+        inst.values("SYST:ERR?", cast=cast_or_str(float))
+    """
+
+    def _cast_or_str(value: str) -> T | str:
+        try:
+            return cast_func(value)
+        except (ValueError, TypeError):
+            return value
+
+    return _cast_or_str
 
 
 class DynamicProperty(property):
@@ -436,11 +461,11 @@ class CommonBase:
         self,
         command: str,
         separator: str | None = ",",
-        cast: Callable[[str], T] = float,  # type: ignore[assignment]
+        cast: type[T] | Callable[[str], T] = float,  # type: ignore[assignment,ty:invalid-parameter-default]
         preprocess_reply: Callable[[str], str] | None = None,
         maxsplit: int = -1,
         **kwargs,
-    ) -> list[T | str]:
+    ) -> list[T]:
         """Write a command to the instrument and return a list of formatted values from the result.
 
         :param command: SCPI command to be sent to the instrument.
@@ -452,24 +477,41 @@ class CommonBase:
         :param maxsplit: The string returned by the device is split at most `maxsplit` times.
             -1 (default) indicates no limit.
         :param cast: A type to cast each element of the split string.
+
+            .. deprecated:: 0.17.0
+                If casting fails, the element is kept as a string. In a future version this
+                will raise an error instead. To explicitly allow mixed types, use a dedicated
+                function, e.g. with :func:`cast_or_str` as cast function.
+
         :param \\**kwargs: Keyword arguments to be passed to the :meth:`ask` method.
-        :returns: A list of the desired type, or strings where the casting fails.
+        :returns: A list of the desired type, or (deprecated) of str where the casting fails.
         """
         response = self.ask(command, **kwargs).strip()
         if callable(preprocess_reply):
             response = preprocess_reply(response)
-        results: list[T | str] = []
+        if cast is str:
+            result = response.split(separator, maxsplit=maxsplit)
+            return result # type: ignore[return-type]  # ty:ignore[invalid-return-type]
+        results: list[T] = []
         for result in response.split(separator, maxsplit=maxsplit):
             try:
                 if cast is bool:
                     # Need to cast to float first since results are usually
                     # strings and bool of a non-empty string is always True
-                    results.append(bool(float(result)))  # type: ignore[arg-type]
+                    results.append(bool(float(result)))  # type: ignore[arg-type]  # ty:ignore[invalid-argument-type]
                 else:
-                    results.append(cast(result))
+                    results.append(cast(result)) # type: ignore[call-arg]
             except Exception:
                 # Keep as string
-                results.append(result)
+                warn(
+                    f"Cannot cast '{result}' with '{cast}' for command '{command}'. "
+                    f"In a future version this will raise an error. "
+                    f"Use `cast=str` to return strings, or `cast=cast_or_str({cast})` "
+                    f"to allow mixed types.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
+                results.append(result)  # type: ignore[arg-type]
         return results
 
     def binary_values(self, command: str, query_delay: float | None = None, **kwargs):
@@ -537,6 +579,11 @@ class CommonBase:
         :param maxsplit: The string returned by the device is split at most `maxsplit` times.
             -1 (default) indicates no limit.
         :param cast: A type to cast each element of the split string.
+
+            .. deprecated:: 0.17.0
+                If casting fails, the element is kept as a string, see :meth:`values`.
+                To explicitly allow mixed types, use :func:`cast_or_str` as the cast function.
+
         :param dict values_kwargs: Further keyword arguments for :meth:`values`.
 
         Example of usage of dynamic parameter is as follows:
@@ -715,6 +762,11 @@ class CommonBase:
         :param maxsplit: The string returned by the device is split at most `maxsplit` times.
             -1 (default) indicates no limit.
         :param cast: A type to cast each element of the split string.
+
+            .. deprecated:: 0.17.0
+                If casting fails, the element is kept as a string, see :meth:`values`.
+                To explicitly allow mixed types, use :func:`cast_or_str` as the cast function.
+
         :param dict values_kwargs: Further keyword arguments for :meth:`values`.
         """
         if values_kwargs is None:

--- a/pymeasure/instruments/eurotest/eurotestHPP120256.py
+++ b/pymeasure/instruments/eurotest/eurotestHPP120256.py
@@ -126,6 +126,7 @@ class EurotestHPP120256(Instrument):
         # getter device response: "U, RANGE=3.000kV, VALUE=2.458kV"
         validator=strict_range,
         values=VOLTAGE_RANGE,
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[2].strip()).groups()[0])
     )
@@ -138,6 +139,7 @@ class EurotestHPP120256(Instrument):
         # hence the convenience of the get_process.
         validator=strict_range,
         values=CURRENT_RANGE,
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[2].strip()).groups()[0])
     )
@@ -150,6 +152,7 @@ class EurotestHPP120256(Instrument):
         # hence the convenience of the get_process.
         validator=strict_range,
         values=VOLTAGE_RAMP_RANGE,
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[2].strip()).groups()[0])
     )
@@ -160,6 +163,7 @@ class EurotestHPP120256(Instrument):
         # This property is a get so, the instrument will return a string like this:
         # "U, RANGE=3.000kV, VALUE=2.458kV", then voltage will return 2458.0,
         # hence the convenience of the get_process.
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[2].strip()).groups()[0])
     )
@@ -170,8 +174,9 @@ class EurotestHPP120256(Instrument):
         # This property is a get so, the instrument will return a string like this:
         # "U, RANGE=3.000kV, VALUE=2.458kV", then voltage_range will return 3000.0,
         # hence the convenience of the get_process.
+        cast=str,
         get_process_list=lambda r:
-        float(EurotestHPP120256.regex.search(r[1]).groups()[0])
+        float(EurotestHPP120256.regex.search(r[1].strip()).groups()[0])
     )
 
     current = Instrument.measurement(
@@ -180,6 +185,7 @@ class EurotestHPP120256(Instrument):
         # This property is a get so, the instrument will return a string like this:
         # "I, RANGE=5000mA, VALUE=1739mA", then current will return a 1739.0,
         # hence the convenience of the get_process."""
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[2].strip()).groups()[0])
     )
@@ -190,6 +196,7 @@ class EurotestHPP120256(Instrument):
         # This property is a get so, the instrument will return a string like this:
         # "I, RANGE=5000mA, VALUE=1739mA, then current_range will return a 5000.0,
         # hence the convenience of the get_process.
+        cast=str,
         get_process_list=lambda r:
         float(EurotestHPP120256.regex.search(r[1].strip()).groups()[0])
     )
@@ -202,6 +209,7 @@ class EurotestHPP120256(Instrument):
         validator=strict_discrete_set,
         values={True: 'ENable', False: 'DISable'},
         map_values=True,
+        cast=str,
         get_process_list=lambda r:
         EurotestHPP120256.EurotestHPP120256Status(
             int(r[1].strip()[:-1].encode(EurotestHPP120256.response_encoding).
@@ -217,6 +225,7 @@ class EurotestHPP120256(Instrument):
         validator=strict_discrete_set,
         values={True: 'ON', False: 'OFF'},
         map_values=True,
+        cast=str,
         get_process_list=lambda r:
         EurotestHPP120256.EurotestHPP120256Status(
             int(r[1].strip()[:-1].encode(EurotestHPP120256.response_encoding).
@@ -227,6 +236,7 @@ class EurotestHPP120256(Instrument):
     id = Instrument.measurement(
         "ID",
         """Get the identification of the instrument (string) """,
+        cast=str,
         get_process_list=lambda r:
         r[1].strip().encode(EurotestHPP120256.response_encoding).decode('utf-8', 'ignore')
     )
@@ -253,6 +263,7 @@ class EurotestHPP120256(Instrument):
         # local  b2     remote              local
         # kilena b1     kill disable        kill enable
         # on     b0     off                 high voltage is ON
+        cast=str,
         get_process_list=lambda r:
         EurotestHPP120256.EurotestHPP120256Status(
             int(r[1].strip()[:-1].encode(EurotestHPP120256.response_encoding).
@@ -271,6 +282,7 @@ class EurotestHPP120256(Instrument):
         # LAM,TRIP ERROR Software current trip occurred
         # LAM,INPUT ERROR Wrong command received
         # LAM,OK Status OK
+        cast=str,
         get_process_list=lambda r:
         r[1].strip().encode(EurotestHPP120256.response_encoding).decode('utf-8', 'ignore')
     )

--- a/pymeasure/instruments/fluke/fluke7341.py
+++ b/pymeasure/instruments/fluke/fluke7341.py
@@ -64,6 +64,7 @@ class Fluke7341(Instrument):
         """Control the temperature unit: `c` for Celsius and `f` for Fahrenheit`.""",
         validator=strict_discrete_set,
         values=('c', 'f'),
+        cast=str,
     )
 
     temperature = Instrument.measurement("t",

--- a/pymeasure/instruments/formfactor/velox.py
+++ b/pymeasure/instruments/formfactor/velox.py
@@ -26,6 +26,7 @@
 import logging
 
 from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 log = logging.getLogger(__name__)
@@ -159,7 +160,7 @@ class WaferMap(Channel):
         """
         return self.values("StepNextDie",
                            separator=" ",
-                           cast=int,
+                           cast=cast_or_str(int),
                            )
 
     def step_to_die(self, x_pos, y_pos, s_pos=None):
@@ -231,6 +232,7 @@ class Velox(SCPIMixin, Instrument):
     version = Instrument.measurement(
         "ReportSoftwareVersion",
         """Get the main software version of Velox (str).""",
+        cast=str,
         )
 
     def read(self):

--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -23,6 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set
 from time import sleep
 
@@ -62,7 +63,7 @@ class FWBell5080(SCPIMixin, Instrument):
         ":MEASure:FLUX?",
         """ Measure the field in the appropriate units (float).
         """,
-        # Remove units
+        cast=cast_or_str(float),
         get_process=lambda v: float(v.replace('T', '').replace('G', '').replace('Am', ''))
 
     )
@@ -81,7 +82,8 @@ class FWBell5080(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=UNITS,
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     range = Instrument.control(

--- a/pymeasure/instruments/generic_types.py
+++ b/pymeasure/instruments/generic_types.py
@@ -26,6 +26,7 @@ import logging
 from warnings import warn
 
 from .instrument import Instrument
+from .common_base import cast_or_str
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -74,6 +75,7 @@ class SCPIMixin:
         """Get the next error in the queue.
         If you want to read and log all errors, use :meth:`check_errors` instead.
         """,
+        cast=cast_or_str(float),
     )
 
     # SCPI default methods

--- a/pymeasure/instruments/hcp/tc038.py
+++ b/pymeasure/instruments/hcp/tc038.py
@@ -153,7 +153,7 @@ class TC038(Instrument):
         "WRD" + registers["setpoint"] + ",01",
         "WWR" + registers["setpoint"] + ",01,%s",
         """Control the setpoint of the temperature controller in °C.""",
-        get_process=_data_to_temp,
+        cast=_data_to_temp,
         set_process=lambda temp: f"{int(round(temp * 10)):04X}",
         check_set_errors=True,
     )
@@ -161,18 +161,19 @@ class TC038(Instrument):
     temperature = Instrument.measurement(
         "WRD" + registers["temperature"] + ",01",
         """Measure the current temperature in °C.""",
-        get_process=_data_to_temp,
+        cast=_data_to_temp,
     )
 
     monitored_value = Instrument.measurement(
         "WRM",
         """Measure the currently monitored value. For default it is the current
         temperature in °C.""",
-        get_process=_data_to_temp,
+        cast=_data_to_temp,
     )
 
     information = Instrument.measurement(
         "INF6",
         """Get the information about the device and its capabilities.""",
         get_process=lambda got: got[7:-1],
+        cast=str,
     )

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -55,7 +55,8 @@ class HP33120A(SCPIUnknownMixin, Instrument):
         noise, dc, and user. (str)""",
         validator=strict_discrete_set,
         values=SHAPES,
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     frequency = Instrument.control(
@@ -120,7 +121,8 @@ class HP33120A(SCPIUnknownMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=AMPLITUDE_UNITS,
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     burst_enabled = Instrument.control(
@@ -136,6 +138,7 @@ class HP33120A(SCPIUnknownMixin, Instrument):
         """Control internal or external gate source for burst modulation""",
         validator=strict_discrete_set,
         values=['INT', 'EXT'],
+        cast=str,
     )
 
     burst_count = Instrument.control(

--- a/pymeasure/instruments/hp/hp34401A.py
+++ b/pymeasure/instruments/hp/hp34401A.py
@@ -24,6 +24,7 @@
 
 from warnings import warn
 from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set
 
 
@@ -111,6 +112,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         validator=strict_discrete_set,
         values=FUNCTIONS,
         map_values=True,
+        cast=str,
         get_process=lambda v: v.strip('"'),
     )
 
@@ -152,6 +154,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         2-wire ohms, and 4-wire ohms.""",
         validator=strict_discrete_set,
         values=[0.02, 0.2, 1, 10, 100, "MIN", "MAX"],
+        cast=cast_or_str(float),
     )
 
     gate_time = Instrument.control(
@@ -163,6 +166,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         or 1 second (6.5 digits).""",
         validator=strict_discrete_set,
         values=[0.01, 0.1, 1, "MIN", "MAX"],
+        cast=cast_or_str(float),
     )
 
     detector_bandwidth = Instrument.control(
@@ -172,6 +176,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         Valid values: 3, 20, 200, "MIN", "MAX".""",
         validator=strict_discrete_set,
         values=[3, 20, 200, "MIN", "MAX"],
+        cast=cast_or_str(float),
     )
 
     autozero_enabled = Instrument.control(
@@ -209,6 +214,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         Returns "FRONT" or "REAR".""",
         values={"FRONT": "FRON", "REAR": "REAR"},
         map_values=True,
+        cast=str,
     )
 
     # Trigger related commands
@@ -238,6 +244,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         Ext Trig (external trigger) terminal.""",
         validator=strict_discrete_set,
         values=["IMM", "BUS", "EXT"],
+        cast=str,
     )
 
     trigger_delay = Instrument.control(
@@ -245,6 +252,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         """Control the trigger delay in seconds.
 
         Valid values (incl. floats): 0 to 3600 seconds, "MIN", "MAX".""",
+        cast=cast_or_str(float),
     )
 
     trigger_auto_delay_enabled = Instrument.control(
@@ -264,6 +272,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         """Controls the number of samples per trigger event.
 
         Valid values: 1 to 50000, "MIN", "MAX".""",
+        cast=cast_or_str(float),
     )
 
     trigger_count = Instrument.control(
@@ -273,6 +282,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
         Valid values: 1 to 50000, "MIN", "MAX", "INF".
         The INFinite parameter instructs the multimeter to continuously accept triggers
         (you must send a device clear to return to the "idle" state).""",
+        cast=cast_or_str(float),
     )
 
     stored_reading = Instrument.measurement(
@@ -298,6 +308,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
 
         The text can be up to 12 characters long;
         any additional characters are truncated my the multimeter.""",
+        cast=str,
         get_process=lambda x: x.strip('"'),
     )
 
@@ -333,6 +344,7 @@ class HP34401A(SCPIUnknownMixin, Instrument):
     scpi_version = Instrument.measurement(
         "SYST:VERS?",
         """The SCPI version of the multimeter.""",
+        cast=str,
     )
 
     stored_readings_count = Instrument.measurement(

--- a/pymeasure/instruments/hp/hp437b.py
+++ b/pymeasure/instruments/hp/hp437b.py
@@ -199,7 +199,7 @@ class HP437B(Instrument):
     def check_errors(self):
         errors = []
         while True:
-            err = self.values("ERR?")
+            err = self.values("ERR?", cast=int)
             # exclude upper limit and lower limit hit from real errors
             if int(err[0]) != 0 and int(err[0]) != 21 and int(err[0]) != 23:
                 log.error(f"{self.name}: {err[0]}, {Errors[err[0]]}")
@@ -312,7 +312,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.DutyCycleStatus),
         check_set_errors=True
     )
@@ -351,7 +351,7 @@ class HP437B(Instrument):
         Control the filter mode. By switching over from automatic to manual (true to false)
         the instrument implicitly keeps (holds) the filter value from the automatic selection.
         """,
-        cast=bool,
+        cast=str,
         get_process=_getstatus(StatusMessage.AutoFilterStatus),
         set_process=lambda v: "FA" if v else "FH",
         check_set_errors=True
@@ -365,6 +365,7 @@ class HP437B(Instrument):
         """,
         values=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
         validator=strict_discrete_set,
+        cast=str,
         get_process=_getstatus(StatusMessage.Filter, (lambda x: 2 ** x)),
         check_set_errors=True
     )
@@ -404,7 +405,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.LimitsCheckingStatus),
         check_set_errors=True
     )
@@ -462,7 +463,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.LimitsStatus),
     )
 
@@ -473,7 +474,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 2, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.LimitsStatus),
     )
 
@@ -496,7 +497,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.PowerRefStatus),
         check_set_errors=True
     )
@@ -508,7 +509,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.OffsetStatus),
         check_set_errors=True
     )
@@ -591,7 +592,7 @@ class HP437B(Instrument):
         """,
         map_values=True,
         values={True: 1, False: 0},
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.RelativeModeStatus),
         check_set_errors=True
     )
@@ -613,7 +614,7 @@ class HP437B(Instrument):
 
         """,
         values=[e for e in MeasurementUnit],
-        cast=int,
+        cast=str,
         get_process=_getstatus(StatusMessage.MeasurementUnits, lambda v: MeasurementUnit(v)),
     )
 
@@ -632,7 +633,7 @@ class HP437B(Instrument):
         """,
         validator=strict_discrete_set,
         values={True: "LN", False: "LG"},
-        cast=bool,
+        cast=str,
         map_values=True,
         get_process=_getstatus(StatusMessage.LinearLogStatus, lambda v: {0: "LN", 1: "LG"}[v])
     )
@@ -837,10 +838,11 @@ class HP437B(Instrument):
         "SM", "%s",
         """
         Control the automatic range.
-        The power meter divides each sensor’s power range into 5 ranges of 10 dB each. Range 1
+        The power meter divides each sensor's power range into 5 ranges of 10 dB each. Range 1
         is the most sensitive (lowest power levels), and Range 5 is the least sensitive (highest
         power levels). The range can be set either automatically or manually.
         """,
+        cast=str,
         get_process=_getstatus(StatusMessage.AutomaticRangeStatus, lambda v: bool(v)),
         set_process=lambda v: "RM0EN" if v is True else "RH"
     )
@@ -853,6 +855,7 @@ class HP437B(Instrument):
         """,
         values=[1, 5],
         validator=strict_range,
+        cast=str,
         get_process=_getstatus(StatusMessage.Range)
     )
 
@@ -888,6 +891,7 @@ class HP437B(Instrument):
         """
         Get the operating mode the power meter is currently in.
         """,
+        cast=str,
         get_process=_getstatus(StatusMessage.OperatingMode, lambda v: OperatingMode(v))
     )
 
@@ -917,6 +921,7 @@ class HP437B(Instrument):
         """,
         values=[e for e in TriggerMode],
         validator=strict_discrete_set,
+        cast=str,
         get_process=_getstatus(StatusMessage.TriggerMode, lambda v: TriggerMode(v)),
         set_process=lambda v: int(v)
     )
@@ -964,6 +969,7 @@ class HP437B(Instrument):
         """,
         values=[e for e in GroupTriggerMode],
         validator=strict_discrete_set,
+        cast=str,
         get_process=_getstatus(StatusMessage.GroupTriggerMode, lambda v: GroupTriggerMode(v)),
         set_process=lambda v: int(v)
     )

--- a/pymeasure/instruments/hp/hp8116a.py
+++ b/pymeasure/instruments/hp/hp8116a.py
@@ -29,6 +29,7 @@ from enum import Enum, IntFlag
 from typing import Any
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import (
     strict_discrete_set, strict_range, truncated_discrete_set
 )
@@ -90,6 +91,7 @@ class HP8116A(Instrument):
             'CST', identifier + '%d', docs,
             validator=strict_discrete_set,
             values=[True, False],
+            cast=cast_or_str(float),
             get_process_list=lambda x: inverted ^ bool(int(x[state_index][1])),
             set_process=lambda x: int(inverted ^ x),
             **kwargs
@@ -267,6 +269,7 @@ class HP8116A(Instrument):
         validator=strict_discrete_set,
         values=OPERATING_MODES,
         map_values=True,
+        cast=cast_or_str(float),
         get_process_list=lambda x: HP8116A.OPERATING_MODES_INV[x[0]]
     )
 
@@ -278,6 +281,7 @@ class HP8116A(Instrument):
         validator=strict_discrete_set,
         values=CONTROL_MODES,
         map_values=True,
+        cast=cast_or_str(float),
         get_process_list=lambda x: HP8116A.CONTROL_MODES_INV[x[1]]
     )
 
@@ -289,6 +293,7 @@ class HP8116A(Instrument):
         validator=strict_discrete_set,
         values=TRIGGER_SLOPES,
         map_values=True,
+        cast=cast_or_str(float),
         get_process_list=lambda x: HP8116A.TRIGGER_SLOPES_INV[x[2]]
     )
 
@@ -300,6 +305,7 @@ class HP8116A(Instrument):
         validator=strict_discrete_set,
         values=SHAPES,
         map_values=True,
+        cast=cast_or_str(float),
         get_process_list=lambda x: HP8116A.SHAPES_INV[x[3]]
     )
 
@@ -338,6 +344,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[1e-3, 52.5001e6],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_frequency),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_frequency)
     )
@@ -361,6 +368,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[8e-9, 999.001e-3],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_time),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_time)
     )
@@ -372,6 +380,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[10e-3, 16.001],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_voltage),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_voltage)
     )
@@ -383,6 +392,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[-7.95, 7.95001],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_voltage),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_voltage)
     )
@@ -394,6 +404,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[-7.9, 8.001],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_voltage),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_voltage)
     )
@@ -405,6 +416,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[-8, 7.9001],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_voltage),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_voltage)
     )
@@ -416,6 +428,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[1, 1999],
+        cast=cast_or_str(float),
         get_process=lambda x: int(x[4:8])
     )
 
@@ -426,6 +439,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[20e-9, 999.001e-3],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_time),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_time)
     )
@@ -437,6 +451,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[1e-3, 52.5001e6],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_frequency),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_frequency)
     )
@@ -447,6 +462,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[1e-3, 52.5001e6],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_frequency),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_frequency)
     )
@@ -459,6 +475,7 @@ class HP8116A(Instrument):
         """,
         validator=strict_range,
         values=[1e-3, 52.5001e6],
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_frequency),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_frequency)
     )
@@ -470,6 +487,7 @@ class HP8116A(Instrument):
         """,
         validator=truncated_discrete_set,
         values=_generate_1_2_5_sequence(10e-3, 500),
+        cast=cast_or_str(float),
         set_process=lambda x: HP8116A._get_value_with_unit(x, HP8116A._units_time),
         get_process=lambda x: HP8116A._parse_value_with_unit(x, HP8116A._units_time)
     )

--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -30,6 +30,7 @@ from datetime import datetime
 import numpy as np
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, truncated_discrete_set, \
     joined_validators, strict_range
 
@@ -648,7 +649,7 @@ class HP856Xx(Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "1", False: "0", "FULL": "FULL", "CURR": "CURR"},
-        cast=str
+        cast=str,
     )
 
     trace_a_minus_b_enabled = Instrument.control(
@@ -672,7 +673,7 @@ class HP856Xx(Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     trace_a_minus_b_plus_dl_enabled = Instrument.control(
@@ -695,7 +696,7 @@ class HP856Xx(Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     annotation_enabled = Instrument.control(
@@ -708,7 +709,7 @@ class HP856Xx(Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     attenuation = Instrument.control(
@@ -746,7 +747,8 @@ class HP856Xx(Instrument):
         """,
         validator=strict_discrete_set,
         values=[str(e).upper() for e in AmplitudeUnits],
-        set_process=lambda v: str(v).upper()
+        cast=str,
+        set_process=lambda v: str(v).upper(),
     )
 
     def write(self, command, **kwargs):
@@ -828,7 +830,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[0, 1],
-        dynamic=True
+        dynamic=True,
     )
 
     def clear_write_trace(self, trace):
@@ -887,7 +889,8 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_discrete_set,
-        values=[e for e in CouplingMode]
+        values=[e for e in CouplingMode],
+        cast=str,
     )
 
     demodulation_mode = Instrument.control(
@@ -915,7 +918,8 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_discrete_set,
-        values=[e for e in DemodulationMode]
+        values=[e for e in DemodulationMode],
+        cast=str,
     )
 
     demodulation_agc_enabled = Instrument.control(
@@ -938,7 +942,7 @@ class HP856Xx(Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     demodulation_time = Instrument.control(
@@ -987,7 +991,8 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_discrete_set,
-        values=[e for e in DetectionModes]
+        values=[e for e in DetectionModes],
+        cast=str,
     )
 
     # now implemented as a property but due to the ability of the underlying gpib command to
@@ -1010,7 +1015,7 @@ class HP856Xx(Instrument):
             if instr.display_line == 0:
                 pass
 
-        """
+        """,
     )
 
     display_line_enabled = Instrument.setting(
@@ -1025,7 +1030,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         validator=strict_discrete_set,
-        values={True: "ON", False: "OFF"}
+        values={True: "ON", False: "OFF"},
     )
 
     done = Instrument.measurement(
@@ -1046,7 +1051,7 @@ class HP856Xx(Instrument):
             if instr.done:
                 do_something()
 
-        """
+        """,
     )
 
     def check_done(self):
@@ -1101,7 +1106,7 @@ class HP856Xx(Instrument):
             yeah
 
         """,
-        cast=ErrorCode,
+        cast=cast_or_str(ErrorCode),
         get_process=lambda value: [],
     )
 
@@ -1119,7 +1124,7 @@ class HP856Xx(Instrument):
             1998
 
         """,
-        cast=int
+        cast=int,
     )
 
     start_frequency = Instrument.control(
@@ -1141,7 +1146,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[0, 1],
-        dynamic=True
+        dynamic=True,
     )
 
     stop_frequency = Instrument.control(
@@ -1163,7 +1168,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[0, 1],
-        dynamic=True
+        dynamic=True,
     )
 
     sampling_frequency = Instrument.measurement(
@@ -1174,7 +1179,7 @@ class HP856Xx(Instrument):
         Diagnostic Attribute
 
         Type: :code:`float`
-        """
+        """,
     )
 
     lo_frequency = Instrument.measurement(
@@ -1185,7 +1190,7 @@ class HP856Xx(Instrument):
         Diagnostic Attribute
 
         Type: :code:`float`
-        """
+        """,
     )
 
     mroll_frequency = Instrument.measurement(
@@ -1197,7 +1202,7 @@ class HP856Xx(Instrument):
         Diagnostic Attribute
 
         Type: :code:`float`
-        """
+        """,
     )
 
     oroll_frequency = Instrument.measurement(
@@ -1209,7 +1214,7 @@ class HP856Xx(Instrument):
         Diagnostic Attribute
 
         Type: :code:`float`
-        """
+        """,
     )
 
     xroll_frequency = Instrument.measurement(
@@ -1221,7 +1226,7 @@ class HP856Xx(Instrument):
         Diagnostic Attribute
 
         Type: :code:`float`
-        """
+        """,
     )
 
     sampler_harmonic_number = Instrument.measurement(
@@ -1234,7 +1239,7 @@ class HP856Xx(Instrument):
 
         Type: :code:`int`
         """,
-        get_process=lambda v: int(float(v))
+        get_process=lambda v: int(float(v)),
     )
 
     # practically you could also write "OFF" to actively disable it or reset via "IP"
@@ -1257,7 +1262,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     def do_fft(self, source, destination, window):
@@ -1340,7 +1345,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[0, 1],
-        dynamic=True
+        dynamic=True,
     )
 
     frequency_reference_source = Instrument.control(
@@ -1366,7 +1371,8 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_discrete_set,
-        values=[e for e in FrequencyReference]
+        values=[e for e in FrequencyReference],
+        cast=str,
     )
 
     def set_full_span(self):
@@ -1396,7 +1402,7 @@ class HP856Xx(Instrument):
         map_values=True,
         values={True: "1", False: "0"},
         validator=strict_discrete_set,
-        cast=str
+        cast=str,
     )
 
     def hold(self):
@@ -1421,7 +1427,7 @@ class HP856Xx(Instrument):
 
         """,
         maxsplit=0,
-        cast=str
+        cast=str,
     )
 
     def preset(self):
@@ -1453,7 +1459,7 @@ class HP856Xx(Instrument):
         """,
         cast=int,
         validator=strict_discrete_set,
-        values=[0, 1, 2, 5, 10]
+        values=[0, 1, 2, 5, 10],
     )
 
     def set_linear_scale(self):
@@ -1504,7 +1510,7 @@ class HP856Xx(Instrument):
             unit = instr.amplitude_unit
             print("Level: %f %s" % (level, unit))
 
-        """
+        """,
     )
 
     def set_marker_to_center_frequency(self):
@@ -1529,7 +1535,7 @@ class HP856Xx(Instrument):
             # print frequency of second marker in case it got moved automatically
             print(instr.marker_delta)
 
-        """
+        """,
     )
 
     # the documentation mentions this command, but it doesn't work on my unit and a
@@ -1562,7 +1568,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[0, 1],
-        dynamic=True
+        dynamic=True,
     )
 
     frequency_counter_mode_enabled = Instrument.setting(
@@ -1583,7 +1589,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     frequency_counter_resolution = Instrument.control(
@@ -1610,7 +1616,7 @@ class HP856Xx(Instrument):
         values=[1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6],
         maxsplit=0,
         preprocess_reply=lambda v: str(int(float(v))),
-        cast=int
+        cast=int,
     )
 
     def set_marker_minimum(self):
@@ -1646,7 +1652,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     def deactivate_marker(self, all_markers=False):
@@ -1720,7 +1726,7 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_range,
-        values=[-200, 30]
+        values=[-200, 30],
     )
 
     peak_excursion = Instrument.control(
@@ -1747,7 +1753,7 @@ class HP856Xx(Instrument):
 
         """,
         validator=strict_range,
-        values=[0.1, 99]
+        values=[0.1, 99],
     )
 
     def set_marker_to_reference_level(self):
@@ -1789,7 +1795,7 @@ class HP856Xx(Instrument):
             if instr.marker_time == 2:
                 pass
 
-        """
+        """,
     )
 
     marker_signal_tracking_enabled = Instrument.control(
@@ -1808,7 +1814,7 @@ class HP856Xx(Instrument):
         map_values=True,
         validator=strict_discrete_set,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     mixer_level = Instrument.control(
@@ -1822,7 +1828,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         cast=int,
-        values=[-80, -10]
+        values=[-80, -10],
     )
 
     def set_maximum_hold(self, trace):
@@ -1877,7 +1883,7 @@ class HP856Xx(Instrument):
         map_values=True,
         validator=strict_discrete_set,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     normalized_reference_level = Instrument.control(
@@ -1911,7 +1917,7 @@ class HP856Xx(Instrument):
         """,
         validator=strict_range,
         values=[-200, 30],
-        cast=int
+        cast=int,
     )
 
     normalized_reference_position = Instrument.control(
@@ -1933,7 +1939,7 @@ class HP856Xx(Instrument):
                 pass
         """,
         validator=strict_range,
-        values=[0.0, 10.0]
+        values=[0.0, 10.0],
     )
 
     display_parameters = Instrument.measurement(
@@ -1952,7 +1958,7 @@ class HP856Xx(Instrument):
         """,
         maxsplit=4,
         cast=int,
-        get_process_list=tuple
+        get_process_list=tuple,
     )
 
     def plot(self, p1x, p1y, p2x, p2y):
@@ -1992,7 +1998,7 @@ class HP856Xx(Instrument):
         map_values=True,
         validator=strict_discrete_set,
         values={True: "1", False: "0"},
-        cast=str
+        cast=str,
     )
 
     def get_power_bandwidth(self, trace, percent):
@@ -2058,8 +2064,9 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
         values=[["AUTO", "MAN"], np.arange(10, 2e6)],
+        cast=cast_or_str(float),
         set_process=lambda v: v if isinstance(v, str) else f"{int(v)} Hz",
-        get_process=lambda v: v if isinstance(v, str) else int(v)
+        get_process=lambda v: v if isinstance(v, str) else int(v),
     )
 
     resolution_bandwidth_to_span_ratio = Instrument.control(
@@ -2071,7 +2078,7 @@ class HP856Xx(Instrument):
         parameters adjust the ratio in a 1, 2, 5 sequence. The default ratio is 0.011.
         """,
         validator=strict_range,
-        values=np.arange(0.002, 0.10, 0.001)
+        values=np.arange(0.002, 0.10, 0.001),
     )
 
     def recall_open_short_average(self):
@@ -2193,8 +2200,8 @@ class HP856Xx(Instrument):
 
         Type: :code:`datetime.date`
         """,
-        get_process=lambda v: datetime.strptime(v, '%y%m%d').date(),
-        cast=str
+        get_process=lambda v: datetime.strptime(v, "%y%m%d").date(),
+        cast=str,
     )
 
     reference_level = Instrument.control(
@@ -2208,7 +2215,7 @@ class HP856Xx(Instrument):
         :attr:`amplitude_unit`. Minimum reference level is -120.0 dBm or 2.2 uV
 
         Type: :code:`float`
-        """
+        """,
     )
 
     reference_level_calibration = Instrument.control(
@@ -2241,7 +2248,7 @@ class HP856Xx(Instrument):
         """,
         cast=int,
         validator=strict_range,
-        values=[-33, 33]
+        values=[-33, 33],
     )
 
     reference_offset = Instrument.control(
@@ -2257,7 +2264,7 @@ class HP856Xx(Instrument):
         """,
         cast=int,
         values=[-100, 100],
-        validator=strict_range
+        validator=strict_range,
     )
 
     request_service_conditions = Instrument.control(
@@ -2273,7 +2280,7 @@ class HP856Xx(Instrument):
             print(instr.request_service_conditions)
             StatusRegister.ERROR_PRESENT|TRIGGER
         """,
-        get_process=lambda v: StatusRegister(int(v))
+        get_process=lambda v: StatusRegister(int(v)),
     )
 
     def save_state(self, inp):
@@ -2340,7 +2347,7 @@ class HP856Xx(Instrument):
         """
         Get the spectrum analyzer serial number.
         """,
-        cast=str
+        cast=str,
     )
 
     def sweep_single(self):
@@ -2363,8 +2370,9 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["FULL", "ZERO"], [float("-inf"), float("inf")]],
+        cast=cast_or_str(float),
         set_process=lambda v: v if isinstance(v, str) else f"{v:.11E} Hz",
-        get_process=lambda v: v if isinstance(v, str) else v
+        get_process=lambda v: v if isinstance(v, str) else v,
     )
 
     squelch = Instrument.control(
@@ -2391,7 +2399,8 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["ON", "OFF"], range(-220, 30)],
-        set_process=lambda v: v if isinstance(v, str) else f"{v} {{amplitude_unit}}"
+        cast=cast_or_str(float),
+        set_process=lambda v: v if isinstance(v, str) else f"{v} {{amplitude_unit}}",
     )
 
     squelch_enabled = Instrument.setting(
@@ -2401,7 +2410,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     def request_service(self, input):
@@ -2437,8 +2446,9 @@ class HP856Xx(Instrument):
         cannot be adjusted.
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
-        values=[["AUTO", "MAN"], np.arange(50E-6, 100)],
-        set_process=lambda v: v if isinstance(v, str) else (f"{v:.3f} S")
+        values=[["AUTO", "MAN"], np.arange(50e-6, 100)],
+        cast=cast_or_str(float),
+        set_process=lambda v: v if isinstance(v, str) else (f"{v:.3f} S"),
     )
 
     status = Instrument.measurement(
@@ -2449,7 +2459,7 @@ class HP856Xx(Instrument):
         The RQS and associated bits are cleared in the same way that a serial poll command would
         clear them.
         """,
-        get_process=lambda v: StatusRegister(int(v))
+        get_process=lambda v: StatusRegister(int(v)),
     )
 
     def store_open(self):
@@ -2496,13 +2506,14 @@ class HP856Xx(Instrument):
         Control the sweep couple mode which is either a stimulus-response or spectrum-analyzer
         auto-coupled sweep time. In stimulus-response mode, auto-coupled sweep times are usually
         much faster for swept-response measurements. Stimulus-response auto-coupled sweep times
-        are typicallly valid in stimulus-response measurements when the system’s frequency span is
+        are typically valid in stimulus-response measurements when the system's frequency span is
         less than 20 times the bandwidth of the device under test.
 
         Type: :code:`str` or :class:`SweepCoupleMode`
         """,
         validator=strict_discrete_set,
-        values=[e for e in SweepCoupleMode]
+        values=[e for e in SweepCoupleMode],
+        cast=str,
     )
 
     sweep_output = Instrument.control(
@@ -2516,7 +2527,8 @@ class HP856Xx(Instrument):
         Type: :code:`str` or :class:`SweepOut`
         """,
         validator=strict_discrete_set,
-        values=[e for e in SweepOut]
+        values=[e for e in SweepOut],
+        cast=str,
     )
 
     trace_data_format = Instrument.control(
@@ -2534,7 +2546,8 @@ class HP856Xx(Instrument):
             You are doing.
         """,
         validator=strict_discrete_set,
-        values=[e for e in TraceDataFormat]
+        values=[e for e in TraceDataFormat],
+        cast=str,
     )
 
     threshold = Instrument.control(
@@ -2560,7 +2573,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     def set_title(self, string):
@@ -2587,7 +2600,8 @@ class HP856Xx(Instrument):
         a "T" appears on the left edge of the display.
         """,
         validator=strict_discrete_set,
-        values=[e for e in TriggerMode]
+        values=[e for e in TriggerMode],
+        cast=str,
     )
 
     def _get_trace_data(self, trace):
@@ -2656,7 +2670,7 @@ class HP856Xx(Instrument):
             The string based method this attribute is using takes its time. Something around 5000ms
             timeout at the adapter seems to work well.
         """,
-        set_process=lambda v: (','.join([str(i) for i in v])),
+        set_process=lambda v: ",".join([str(i) for i in v]),
     )
 
     set_trace_data_b = Instrument.setting(
@@ -2669,7 +2683,7 @@ class HP856Xx(Instrument):
             The string based method this attribute is using takes its time. Something around 5000ms
             timeout at the adapter seems to work well.
         """,
-        set_process=lambda v: (','.join([str(i) for i in v]))
+        set_process=lambda v: ",".join([str(i) for i in v]),
     )
 
     def trigger_sweep(self):
@@ -2743,7 +2757,7 @@ class HP856Xx(Instrument):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     video_bandwidth = Instrument.control(
@@ -2767,8 +2781,8 @@ class HP856Xx(Instrument):
         """,
         validator=joined_validators(strict_discrete_set, strict_range),
         values=[["AUTO", "MAN"], np.arange(1, 3e6)],
-        cast=int,
-        set_process=lambda v: v if isinstance(v, str) else f"{v} Hz"
+        cast=cast_or_str(float),
+        set_process=lambda v: v if isinstance(v, str) else f"{v} Hz",
     )
 
     video_bandwidth_to_resolution_bandwidth = Instrument.control(
@@ -2781,7 +2795,7 @@ class HP856Xx(Instrument):
         new ratio—the resolution bandwidth does not change value.
         """,
         validator=strict_range,
-        values=np.arange(0.002, 0.10, 0.001)
+        values=np.arange(0.002, 0.10, 0.001),
     )
 
     def view_trace(self, trace):
@@ -2812,7 +2826,7 @@ class HP856Xx(Instrument):
         Type: :code:`float`
         """,
         validator=strict_range,
-        values=[-220, 30]
+        values=[-220, 30],
     )
 
 
@@ -2879,7 +2893,8 @@ class HP8560A(HP856Xx):
             Only available with an HP 8560A Option 002.
         """,
         validator=strict_discrete_set,
-        values=[e for e in SourceLevelingControlMode]
+        values=[e for e in SourceLevelingControlMode],
+        cast=str,
     )
 
     tracking_adjust_coarse = Instrument.control(
@@ -2897,7 +2912,7 @@ class HP8560A(HP856Xx):
         """,
         validator=strict_range,
         values=[0, 255],
-        cast=int
+        cast=int,
     )
 
     tracking_adjust_fine = Instrument.control(
@@ -2915,7 +2930,7 @@ class HP8560A(HP856Xx):
         """,
         validator=strict_range,
         values=[0, 255],
-        cast=int
+        cast=int,
     )
 
     source_power_offset = Instrument.control(
@@ -2933,7 +2948,7 @@ class HP8560A(HP856Xx):
         """,
         validator=strict_range,
         values=[-100, 100],
-        cast=int
+        cast=int,
     )
 
     source_power_step = Instrument.control(
@@ -2948,7 +2963,7 @@ class HP8560A(HP856Xx):
             Only available with an HP 8560A Option 002.
         """,
         validator=strict_range,
-        values=np.arange(0.1, 12.75, 0.05)
+        values=np.arange(0.1, 12.75, 0.05),
     )
 
     source_power_sweep = Instrument.control(
@@ -2975,7 +2990,7 @@ class HP8560A(HP856Xx):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     source_power = Instrument.control(
@@ -2990,7 +3005,8 @@ class HP8560A(HP856Xx):
         """,
         validator=joined_validators(strict_discrete_set, truncated_discrete_set),
         values=[["OFF", "ON"], np.arange(-10, 2.8, 0.05)],
-        set_process=lambda v: v if isinstance(v, str) else (f"{v:.2f} {{amplitude_unit}}")
+        cast=cast_or_str(float),
+        set_process=lambda v: v if isinstance(v, str) else (f"{v:.2f} {{amplitude_unit}}"),
     )
 
     source_power_enabled = Instrument.setting(
@@ -3000,7 +3016,7 @@ class HP8560A(HP856Xx):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     def activate_source_peak_tracking(self):
@@ -3067,7 +3083,7 @@ class HP8561B(HP856Xx):
         querying 'conversion_loss' returns a zero.
         """,
         validator=strict_range,
-        values=[0, float("inf")]
+        values=[0, float("inf")],
     )
 
     def set_fullband(self, band):
@@ -3176,7 +3192,7 @@ class HP8561B(HP856Xx):
         """,
         validator=strict_range,
         values=[1, 54],
-        cast=int
+        cast=int,
     )
 
     harmonic_number_lock_enabled = Instrument.setting(
@@ -3186,7 +3202,7 @@ class HP8561B(HP856Xx):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     def unlock_harmonic_number(self):
@@ -3216,7 +3232,7 @@ class HP8561B(HP856Xx):
         """
         Measure the frequency of the last identified signal. After an instrument preset or an
         invalid signal identification, IDFREQ returns a “0”.
-        """
+        """,
     )
 
     mixer_bias = Instrument.control(
@@ -3229,8 +3245,8 @@ class HP8561B(HP856Xx):
         turned off, MBIAS is set to 0. Default units are in milliamps.
         """,
         validator=strict_range,
-        values=[(-10E3), int(10E3)],
-        cast=float
+        values=[(-10e3), int(10e3)],
+        cast=float,
     )
 
     mixer_bias_enabled = Instrument.setting(
@@ -3240,7 +3256,7 @@ class HP8561B(HP856Xx):
         """,
         map_values=True,
         values={True: "ON", False: "OFF"},
-        validator=strict_discrete_set
+        validator=strict_discrete_set,
     )
 
     mixer_mode = Instrument.control(
@@ -3250,7 +3266,8 @@ class HP8561B(HP856Xx):
         or supply an external mixer. Takes enum 'MixerMode' or string 'INT', 'EXT'
         """,
         validator=strict_discrete_set,
-        values=[e for e in MixerMode]
+        values=[e for e in MixerMode],
+        cast=str,
     )
 
     def peak_preselector(self):
@@ -3298,5 +3315,5 @@ class HP8561B(HP856Xx):
         map_values=True,
         validator=strict_discrete_set,
         values={True: "1", False: "0", "AUTO": "AUTO", "MAN": "MAN"},
-        cast=str
+        cast=str,
     )

--- a/pymeasure/instruments/ilxlightwave/ldp3811.py
+++ b/pymeasure/instruments/ilxlightwave/ldp3811.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from pymeasure.instruments import Instrument
+from pymeasure.instruments import Instrument, cast_or_str
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
 try:
@@ -61,8 +61,8 @@ class LDP3811(Instrument):
     def __init__(self, adapter, name="ILX Lightwave LDP 3811", includeSCPI=False, **kwargs):
         super().__init__(adapter, name, includeSCPI, **kwargs)
 
-    def check_errors(self):
-        errors = self.values("ERRORS?")
+    def check_errors(self) -> list[float | str]:
+        errors = self.values("ERRORS?", cast=cast_or_str(float))
         for err in errors:
             log.error(err)
         return errors
@@ -82,6 +82,7 @@ class LDP3811(Instrument):
         """Control the mode as an :class:`LDP3811Mode` enum.""",
         validator=strict_discrete_set,
         values=LDP3811Mode,
+        cast=str,
         get_process=lambda v: LDP3811Mode(v),
     )
 

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -28,7 +28,7 @@ from typing import TypeVar
 from collections.abc import Sequence
 from warnings import warn
 
-from .common_base import CommonBase
+from .common_base import CommonBase, cast_or_str
 from ..adapters.adapter import Adapter
 from ..adapters.visa import VISAAdapter
 
@@ -156,7 +156,7 @@ class Instrument(CommonBase):
     def next_error(self):
         """Get the next error of the instrument (tuple of code and message)."""
         if self.SCPI:
-            return self.values("SYST:ERR?")
+            return self.values("SYST:ERR?", cast=cast_or_str(float))
         else:
             raise NotImplementedError("Non SCPI instruments require implementation in subclasses")
 

--- a/pymeasure/instruments/ipgphotonics/yar.py
+++ b/pymeasure/instruments/ipgphotonics/yar.py
@@ -24,8 +24,10 @@
 
 import logging
 from enum import IntFlag
+from typing import Literal
+from collections.abc import Callable
 
-from pymeasure.instruments import Instrument, validators
+from pymeasure.instruments import Instrument, cast_or_str, validators
 from pyvisa.constants import Parity, StopBits
 
 
@@ -48,10 +50,10 @@ def setpoint_validator(value, values):
         return validators.strict_range(value, values)
 
 
-def power_get_process_generator(minimum):
+def power_get_process_generator(minimum: float) -> Callable[..., float]:
     """Generate a get_process for the power property."""
-    def get_process(value):
-        if isinstance(value, float):
+    def get_process(value: float | Literal["Off"] | Literal["Low"]) -> float:
+        if isinstance(value, (float, int)):
             return value
         elif value == "Off":
             return 0
@@ -121,7 +123,7 @@ class YAR(Instrument):
     @property
     def id(self):
         """Get the model number."""
-        return self.values("RMN")[0]
+        return self.values("RMN", cast=str)[0]
 
     @property
     def status(self):
@@ -143,6 +145,7 @@ class YAR(Instrument):
     power = Instrument.measurement(
         "ROP",
         "Measure current output power in W.",
+        cast=cast_or_str(float),
         get_process=power_get_process_generator(0.1),
         dynamic=True,
     )

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -65,6 +65,7 @@ class Keithley2000(KeithleyBuffer, SCPIUnknownMixin, Instrument):
         validator=strict_discrete_set,
         values=MODES,
         map_values=True,
+        cast=str,
         get_process=lambda v: v.replace('"', '')
     )
 

--- a/pymeasure/instruments/keithley/keithley2182.py
+++ b/pymeasure/instruments/keithley/keithley2182.py
@@ -227,7 +227,8 @@ class Keithley2182(SCPIMixin, KeithleyBuffer, Instrument):
         Valid options are `voltage` and `temperature`.""",
         validator=strict_discrete_set,
         values={'voltage': '"VOLT:DC"', 'temperature': '"TEMP"'},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     ###############
@@ -266,7 +267,8 @@ class Keithley2182(SCPIMixin, KeithleyBuffer, Instrument):
         """Control the thermocouple type for temperature measurements.
         Valid options are B, E, J, K, N, R, S, and T.""",
         validator=strict_discrete_set,
-        values=('B', 'E', 'J', 'K', 'N', 'R', 'S', 'T')
+        values=('B', 'E', 'J', 'K', 'N', 'R', 'S', 'T'),
+        cast=str,
     )
 
     temperature_nplc = Instrument.control(
@@ -286,6 +288,7 @@ class Keithley2182(SCPIMixin, KeithleyBuffer, Instrument):
         simulated (SIM). Default is INT.""",
         validator=strict_discrete_set,
         values=('SIM', 'INT'),
+        cast=str,
     )
 
     temperature_simulated_reference = Instrument.control(

--- a/pymeasure/instruments/keithley/keithley2281S.py
+++ b/pymeasure/instruments/keithley/keithley2281S.py
@@ -330,6 +330,7 @@ class BatterySimulationChannel(Channel):
         validator=strict_discrete_set,
         values={True: "DYN", False: "STAT"},
         map_values=True,
+        cast=str,
     )
 
     capacity_limit = Instrument.control(
@@ -475,6 +476,7 @@ class Keithley2281S(SCPIMixin, Instrument, KeithleyBuffer):
         """,
         validator=strict_discrete_set,
         values=["POWER", "TEST", "SIMULATOR"],
+        cast=str,
     )
 
     buffer_points = Instrument.control(

--- a/pymeasure/instruments/keithley/keithley2306.py
+++ b/pymeasure/instruments/keithley/keithley2306.py
@@ -51,6 +51,7 @@ class Keithley2306Channel(Channel):
         validator=strict_discrete_set,
         values={'low': 'LOW', 'high': 'HIGH'},
         map_values=True,
+        cast=str,
     )
 
     sense_mode = Channel.control(
@@ -62,6 +63,7 @@ class Keithley2306Channel(Channel):
         values={'voltage': 'VOLT', 'current': 'CURR', 'dvm': 'DVM',
                 'pulse_current': 'PCUR', 'long_integration': 'LINT'},
         map_values=True,
+        cast=str,
         get_process=lambda v: v.replace('"', ''),
     )
 
@@ -142,6 +144,7 @@ class Keithley2306Channel(Channel):
         validator=strict_discrete_set,
         values={'high': 'HIGH', 'low': 'LOW', 'average': 'AVER'},
         map_values=True,
+        cast=str,
     )
 
     def pulse_current_time_auto(self):
@@ -226,6 +229,7 @@ class Keithley2306Channel(Channel):
         validator=strict_discrete_set,
         values={'rising': 'RISING', 'falling': 'FALLING', 'neither': 'NEITHER'},
         map_values=True,
+        cast=str,
     )
 
     long_integration_time = Channel.control(
@@ -333,6 +337,7 @@ class Keithley2306Channel(Channel):
         validator=strict_discrete_set,
         values={'limit': 'LIM', 'trip': 'TRIP'},
         map_values=True,
+        cast=str,
     )
 
     source_current_limit_enabled = Channel.measurement(
@@ -563,7 +568,8 @@ class Relay(Channel):
         or open (False). """,
         validator=strict_discrete_set,
         values={True: 'ONE', False: 'ZERO'},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
 
@@ -617,6 +623,7 @@ class Keithley2306(SCPIUnknownMixin, Instrument):
         ":DISP:TEXT:DATA?", ":DISP:TEXT:DATA \"%s\"",
         """Control text to be displayed, takes strings
         up to 32 characters. """,
+        cast=str,
         get_process=lambda v: v.replace('"', '')
     )
 

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -28,7 +28,7 @@ from warnings import warn
 
 import numpy as np
 
-from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments import Instrument, SCPIMixin, cast_or_str
 from pymeasure.errors import RangeException
 from pymeasure.instruments.validators import (
     strict_range,
@@ -107,6 +107,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={"current": "CURR", "voltage": "VOLT"},
         map_values=True,
+        cast=str,
     )
 
     source_delay = Instrument.control(
@@ -171,6 +172,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
            Instead use :attr:`~.auto_zero_enabled` or :meth:`~.auto_zero_once`.""",
         values={True: 1, False: 0, "ONCE": "ONCE"},
         map_values=True,
+        cast=cast_or_str(float),
         get_process=_deprecate_process(
             "Deprecated to use `Keithley2400.auto_zero`. "
             "Instead use `Keithley2400.auto_zero_enabled` or `Keithley2400.auto_zero_once`"
@@ -208,6 +210,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             "GUAR": "GUAR",  # ''
         },
         map_values=True,
+        cast=str,
     )
 
     auto_output_off_enabled = Instrument.control(
@@ -286,6 +289,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["ON", "OFF"],
         map_values=False,
+        cast=str,
         get_process=_deprecate_process(
             "Deprecated to use `Keithley2400.filter_state`. "
             "Instead use `Keithley2400.filter_enabled`."
@@ -303,6 +307,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True: "REP", False: "MOV"},
         map_values=True,
+        cast=str,
     )
 
     filter_type = Instrument.control(
@@ -318,6 +323,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=["REP", "MOV"],
         map_values=False,
+        cast=str,
         get_process=_deprecate_process(
             "Deprecated to use `Keithley2400.filter_type`. "
             "Instead use `Keithley2400.repeat_filter_enabled`."
@@ -700,6 +706,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         selected. When `False`, `source_current` and `voltage_range` are controlled manually.""",
         values={True: "AUTO", False: "MAN"},
         map_values=True,
+        cast=str,
     )
 
     resistance_range = Instrument.control(
@@ -919,6 +926,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={"immediate": "IMM", "trigger_link": "TLIN"},
         map_values=True,
+        cast=str,
     )
 
     arm_source = Instrument.control(
@@ -935,6 +943,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             "bus": "BUS",
         },
         map_values=True,
+        cast=str,
     )
 
     trigger_output_event = Instrument.control(
@@ -950,6 +959,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             "none": "NONE",
         },
         map_values=True,
+        cast=str,
     )
 
     arm_output_event = Instrument.control(
@@ -964,6 +974,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
             "none": "NONE",
         },
         map_values=True,
+        cast=str,
     )
 
     def disable_output_triggers(self):
@@ -1216,6 +1227,7 @@ class Keithley2400(KeithleyBuffer, SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True: "FRON", False: "REAR"},
         map_values=True,
+        cast=str,
     )
 
     def use_rear_terminals(self):

--- a/pymeasure/instruments/keithley/keithley4200.py
+++ b/pymeasure/instruments/keithley/keithley4200.py
@@ -23,6 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument, Channel
+from pymeasure.instruments.common_base import cast_or_str
 from enum import IntFlag
 
 
@@ -83,6 +84,7 @@ class SMU(Channel):
     voltage = Channel.measurement(
         "US;TV{ch}",
         """Measure the voltage in Volts (float).""",
+        cast=str,
         get_process=lambda v: float(v[3:]),
         )
 
@@ -121,6 +123,7 @@ class SMU(Channel):
     current = Channel.measurement(
         "US;TI{ch}",
         """Measure the current in Amps.""",
+        cast=str,
         get_process=lambda v: float(v[3:]),
         )
 
@@ -193,6 +196,7 @@ class Keithley4200(Instrument):
     status = Instrument.measurement(
         "SP",
         """Get the status byte (IntFlag).""",
+        cast=cast_or_str(float),
         get_process=lambda v: StatusCode(int(v)),
         )
 

--- a/pymeasure/instruments/keithley/keithleyDMM6500.py
+++ b/pymeasure/instruments/keithley/keithleyDMM6500.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from pymeasure.instruments import Instrument, Channel, SCPIMixin
+from pymeasure.instruments import Instrument, Channel, SCPIMixin, cast_or_str
 from pymeasure.instruments.validators import (
     truncated_range,
     truncated_discrete_set,
@@ -68,6 +68,7 @@ class ScannerCard2000Channel(Channel):
         validator=strict_discrete_set,
         values=MODES,
         map_values=True,
+        cast=str,
         get_process=lambda v: v.replace('"', ""),
     )
 
@@ -255,6 +256,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=["TSP", "SCPI", "SCPI2000", "SCPI34401"],
+        cast=str,
     )
     mode = Instrument.control(
         ":SENS:FUNC?",
@@ -268,6 +270,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values=MODES,
         map_values=True,
+        cast=str,
         get_process=lambda v: v.replace('"', ""),
     )
 
@@ -378,6 +381,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         Valid values: 3, 30, 300, ``MIN``, ``DEF``, ``MAX``.""",
         validator=strict_discrete_set,
         values=[3, 30, 300, "MIN", "DEF", "MAX"],
+        cast=cast_or_str(float),
     )
 
     autozero_enabled = Instrument.control(
@@ -399,6 +403,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         Example: Using ``time`` package to set instrument's clock:
         ``dmm.system_time = time.strftime("%Y, %m, %d, %H, %M, %S")``
         """,
+        cast=str,
     )
 
     def trigger_single_autozero(self):
@@ -413,6 +418,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
             Return can be ``FRONT`` or ``REAR``.""",
         values={"FRONT": "FRON", "REAR": "REAR"},
         map_values=True,
+        cast=str,
     )
 
     ###########
@@ -1126,6 +1132,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         or ``SRE`` (single-precision).""",
         validator=strict_discrete_set,
         values=("ASC", "REAL", "SRE"),
+        cast=str,
     )
 
     ################
@@ -1136,6 +1143,7 @@ class KeithleyDMM6500(SCPIMixin, Instrument):
         ":SYST:CARD1:IDN?",
         """ Get scanner card's ID.""",
         separator="|",
+        cast=str,
     )
 
     scan_vch_start = Instrument.measurement(

--- a/pymeasure/instruments/keysight/keysight33250A.py
+++ b/pymeasure/instruments/keysight/keysight33250A.py
@@ -177,6 +177,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the output waveform shape.""",
         validator=strict_discrete_set,
         values=["SIN", "SQU", "RAMP", "PULS", "NOIS", "DC", "USER"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -206,6 +207,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the output amplitude unit.""",
         validator=strict_discrete_set,
         values=["VPP", "VRMS", "DBM"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -328,6 +330,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the output polarity (string, strict from NORM, INV).""",
         validator=strict_discrete_set,
         values=["NORM", "INV"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -357,6 +360,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the burst mode.""",
         validator=strict_discrete_set,
         values=["TRIG", "GAT"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -395,6 +399,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the external trigger slope (string, strict from POS, NEG).""",
         validator=strict_discrete_set,
         values=["POS", "NEG"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -414,6 +419,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the trigger output slope (string, strict from POS, NEG).""",
         validator=strict_discrete_set,
         values=["POS", "NEG"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )
@@ -423,6 +429,7 @@ class Keysight33250A(SCPIMixin, Instrument):
         """Control the trigger source.""",
         validator=strict_discrete_set,
         values=["IMM", "EXT", "BUS"],
+        cast=str,
         check_set_errors=True,
         check_get_errors=True,
     )

--- a/pymeasure/instruments/keysight/keysight81160A.py
+++ b/pymeasure/instruments/keysight/keysight81160A.py
@@ -182,6 +182,7 @@ class Keysight81160AChannel(Agilent33500Channel):
         ":DATA{ch}:NVOL:CAT?",
         """Get the available user waveforms in memory (list[str]).""",
         preprocess_reply=lambda v: v.replace('"', "").replace("\n", ""),
+        cast=str,
     )
 
     trigger_mode = Instrument.control(
@@ -191,6 +192,7 @@ class Keysight81160AChannel(Agilent33500Channel):
         validator=strict_discrete_set,
         values=TRIGGER_MODES,
         dynamic=True,
+        cast=str,
     )
 
     trigger_count = Instrument.control(

--- a/pymeasure/instruments/keysight/keysightDSOX1102G.py
+++ b/pymeasure/instruments/keysight/keysightDSOX1102G.py
@@ -25,7 +25,7 @@ import logging
 
 import numpy as np
 
-from pymeasure.instruments import Instrument, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, SCPIUnknownMixin, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 log = logging.getLogger(__name__)
@@ -413,7 +413,7 @@ class KeysightDSOX1102G(SCPIUnknownMixin, Instrument):
         # Other waveform formats raise UnicodeDecodeError
         self.waveform_format = "ascii"
 
-        data = self.values(":waveform:data?")
+        data = self.values(":waveform:data?", cast=cast_or_str(float))
         # Strip header from first data element
         data[0] = float(data[0][10:])
 

--- a/pymeasure/instruments/keysight/keysightPNA.py
+++ b/pymeasure/instruments/keysight/keysightPNA.py
@@ -108,6 +108,7 @@ class Trace(Channel):
         """Get the measurement parameter of the trace (str).""",
         preprocess_reply=lambda v: v.strip('"'),
         maxsplit=0,
+        cast=str,
         )
 
     @property
@@ -127,6 +128,7 @@ class Trace(Channel):
 
         :return: ``FREQ``, ``POW``, ``PHAS``, ``DC``, ``POIN`` or ``DEF``
         """,
+        cast=str,
         )
 
     @property
@@ -169,6 +171,7 @@ class Trace(Channel):
             ``PRH``, ``VPH``, ``DBV`` or ``DEF``
 
         """,
+        cast=str,
         )
 
 
@@ -329,7 +332,7 @@ class KeysightPNA(SCPIMixin, Instrument):
         Control whether the byte order is swapped for data transfer (bool).
 
         Some computers read data from the analyzer in the reverse order. This property is only
-        effective if :attr:`.data_format` set to ``real32`` or ``real64``. If :attr:`.data_format`
+        effective if :attr:`.data_format` set to ``real32`` or ``real64``. If :attr:`data_format`
         is set to ``ascii``, :attr:`.byte_order_swapped` is ignored.
 
         - ``True``: Use for IBM compatible computers.
@@ -342,6 +345,7 @@ class KeysightPNA(SCPIMixin, Instrument):
         values={False: "NORM",
                 True: "SWAP",
                 },
+        cast=str,
         )
 
     data_format = Instrument.control(
@@ -373,6 +377,7 @@ class KeysightPNA(SCPIMixin, Instrument):
                 "real64": "REAL,64",
                 },
         maxsplit=0,
+        cast=str,
         )
 
     measurement_channels = Instrument.measurement(

--- a/pymeasure/instruments/kuhneelectronic/kusg245_250a.py
+++ b/pymeasure/instruments/kuhneelectronic/kusg245_250a.py
@@ -89,7 +89,7 @@ class Kusg245_250A(Instrument):
         self._power_limit = power_limit
         self.power_setpoint_values = [0, power_limit]
 
-    version = Instrument.measurement("v", """Get firmware version.""")
+    version = Instrument.measurement("v", """Get firmware version.""", cast=str)
 
     @property
     def voltage_5v(self):
@@ -242,6 +242,7 @@ class Kusg245_250A(Instrument):
         """,
         validator=truncated_range,
         values=[2400, 2500],
+        cast=str,
         get_process=lambda v: int(v[:-3]) if v.endswith("MHz") else None,
     )
 
@@ -257,6 +258,7 @@ class Kusg245_250A(Instrument):
         """,
         validator=truncated_range,
         values=[2400000, 2500000],
+        cast=str,
         set_process=lambda v: round(v, -1),
         get_process=lambda v: int(v[:-3]) if v.endswith("kHz") else None,
     )

--- a/pymeasure/instruments/lakeshore/lakeshore421.py
+++ b/pymeasure/instruments/lakeshore/lakeshore421.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument
+from pymeasure.instruments import Instrument, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, \
     truncated_discrete_set
 
@@ -86,6 +86,7 @@ class LakeShore421(Instrument):
         "FIELD?",
         """ Get the field in the current units and multiplier
         """,
+        cast=cast_or_str(float),
     )
 
     field_multiplier = Instrument.measurement(
@@ -94,6 +95,7 @@ class LakeShore421(Instrument):
         """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property
@@ -109,6 +111,7 @@ class LakeShore421(Instrument):
         Valid values are G (Gauss), T (Tesla). """,
         validator=strict_discrete_set,
         values=UNITS,
+        cast=str,
     )
 
     field_range_raw = Instrument.control(
@@ -193,11 +196,13 @@ class LakeShore421(Instrument):
         """,
         values=PROBE_TYPES,
         map_values=True,
+        cast=int,
     )
 
     serial_number = Instrument.measurement(
         "SNUM?",
-        """ Get the serial number of the probe. """
+        """ Get the serial number of the probe. """,
+        cast=str,
     )
 
     display_filter_enabled = Instrument.control(
@@ -243,6 +248,7 @@ class LakeShore421(Instrument):
         """ Get the largest field since the last reset in the current units
         and multiplier.
         """,
+        cast=cast_or_str(float),
     )
 
     max_hold_multiplier = Instrument.measurement(
@@ -251,6 +257,7 @@ class LakeShore421(Instrument):
         """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property
@@ -279,6 +286,7 @@ class LakeShore421(Instrument):
         "RELR?",
         """ Get the relative field in the current units and the current
         multiplier. """,
+        cast=cast_or_str(float),
     )
 
     relative_multiplier = Instrument.measurement(
@@ -287,6 +295,7 @@ class LakeShore421(Instrument):
         field. """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property
@@ -308,6 +317,7 @@ class LakeShore421(Instrument):
         """ Get the multiplier for the setpoint field. """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property
@@ -375,6 +385,7 @@ class LakeShore421(Instrument):
         """ Get the multiplier for the lower alarm setpoint field. """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property
@@ -398,6 +409,7 @@ class LakeShore421(Instrument):
         """ Get the multiplier for the upper alarm setpoint field. """,
         values=MULTIPLIERS,
         map_values=True,
+        cast=str,
     )
 
     @property

--- a/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
+++ b/pymeasure/instruments/lecroy/lecroyT3DSO1204.py
@@ -24,7 +24,7 @@
 import logging
 import re
 
-from pymeasure.instruments import Instrument
+from pymeasure.instruments import Instrument, cast_or_str
 from pymeasure.instruments.teledyne.teledyne_oscilloscope import TeledyneOscilloscope, \
     TeledyneOscilloscopeChannel, sanitize_source
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
@@ -86,7 +86,8 @@ class LeCroyT3DSO1204Channel(TeledyneOscilloscopeChannel):
         """,
         validator=strict_discrete_set,
         values=TeledyneOscilloscopeChannel._BOOLS,
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     invert = Instrument.control(
@@ -94,7 +95,8 @@ class LeCroyT3DSO1204Channel(TeledyneOscilloscopeChannel):
         """Control the inversion of the input signal (strict bool).""",
         validator=strict_discrete_set,
         values=TeledyneOscilloscopeChannel._BOOLS,
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     skew_factor = Instrument.control(
@@ -126,7 +128,8 @@ class LeCroyT3DSO1204Channel(TeledyneOscilloscopeChannel):
         Volts).
         """,
         validator=strict_discrete_set,
-        values=["A", "V"]
+        values=["A", "V"],
+        cast=str,
     )
 
 
@@ -256,6 +259,7 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
             "highres": "HIGH_RES",
         },
         map_values=True,
+        cast=str,
         get_process_list=lambda v: [v[0].lower(), int(v[1])]
         if len(v) == 2 and v[0] == "AVERAGE"
         else v,
@@ -272,7 +276,8 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
         "SAST?", """Get the acquisition status of the scope.""",
         values={"stopped": "Stop", "triggered": "Trig'd", "ready": "Ready", "auto": "Auto",
                 "armed": "Arm"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     acquisition_sampling_rate = Instrument.measurement(
@@ -354,7 +359,8 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
         validator=strict_discrete_set,
         values={7e3: "7K", 7e4: "70K", 7e5: "700K", 7e6: "7M",
                 14e3: "14K", 14e4: "140K", 14e5: "1.4M", 14e6: "14M"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     @property
@@ -382,7 +388,7 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
         - "ydiv": vertical scale (units per division) in Volts
         - "yoffset": value that is represented at center of screen in Volts
         """
-        vals = self.values("WFSU?")
+        vals = self.values("WFSU?", cast=cast_or_str(float))
         preamble = {
             "sparsing": vals[vals.index("SP") + 1],
             "requested_points": vals[vals.index("NP") + 1],
@@ -435,7 +441,8 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
 
         """,
         validator=_math_define_validator,
-        values=[["C1", "C2", "C3", "C4"], ["*", "/", "+", "-"], ["C1", "C2", "C3", "C4"]]
+        values=[["C1", "C2", "C3", "C4"], ["*", "/", "+", "-"], ["C1", "C2", "C3", "C4"]],
+        cast=str,
     )
 
     math_vdiv = Instrument.control(
@@ -509,7 +516,8 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
         """Control the bottom menu enabled state (strict bool).""",
         validator=strict_discrete_set,
         values=TeledyneOscilloscope._BOOLS,
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     grid_display = Instrument.control(
@@ -517,5 +525,6 @@ class LeCroyT3DSO1204(TeledyneOscilloscope):
         """Control the type of the grid which is used to display (FULL, HALF, OFF).""",
         validator=strict_discrete_set,
         values={"full": "FULL", "half": "HALF", "off": "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )

--- a/pymeasure/instruments/mksinst/mks937b.py
+++ b/pymeasure/instruments/mksinst/mks937b.py
@@ -73,6 +73,7 @@ class Relay(RelayChannel):
                 True: "ENABLE",
                 "SET": "SET",
                 },
+        cast=str,
         check_set_errors=True,
     )
 
@@ -89,6 +90,7 @@ class PressureChannel(Channel):
         validator=strict_discrete_set,
         map_values=True,
         values={True: "ON", False: "OFF"},
+        cast=str,
         check_set_errors=True,
     )
 
@@ -100,6 +102,7 @@ class IonGaugeAndPressureChannel(PressureChannel):
         """Get ion gauge status of the channel.""",
         map_values=True,
         values=_ion_gauge_status,
+        cast=str,
     )
 
 
@@ -192,5 +195,6 @@ class MKS937B(MKSInstrument):
         validator=strict_discrete_set,
         map_values=True,
         values={u: u.value for u in Unit},
+        cast=str,
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mks974b.py
+++ b/pymeasure/instruments/mksinst/mks974b.py
@@ -58,6 +58,7 @@ class Relay(RelayChannel):
                 "piezo": "PZ",
                 "cold cathode": "CC",
                 },
+        cast=str,
         check_set_errors=True,
     )
 
@@ -152,6 +153,7 @@ class MKS974B(MKSInstrument):
                 "pressure dose setpoint exceeded": "R",
                 "Cold Cathode On": "G",
                 },
+        cast=str,
     )
 
     pirani_pressure = Instrument.measurement(
@@ -178,6 +180,7 @@ class MKS974B(MKSInstrument):
         validator=strict_discrete_set,
         map_values=True,
         values={u: u.value for u in Unit},
+        cast=str,
         check_set_errors=True,
     )
 
@@ -196,5 +199,6 @@ class MKS974B(MKSInstrument):
         values={True: "ON",
                 False: "OFF",
                 },
+        cast=str,
         check_set_errors=True,
     )

--- a/pymeasure/instruments/mksinst/mksinst.py
+++ b/pymeasure/instruments/mksinst/mksinst.py
@@ -46,6 +46,7 @@ class RelayChannel(Channel):
         "SS{ch}?",
         """Get the setpoint relay status""",
         values={True: "SET", False: "CLEAR"},
+        cast=str,
     )
 
     setpoint = Channel.control(
@@ -65,6 +66,7 @@ class RelayChannel(Channel):
         """Control the switching direction""",
         validator=strict_discrete_set,
         values=["ABOVE", "BELOW"],
+        cast=str,
         check_set_errors=True,
     )
 

--- a/pymeasure/instruments/novanta/fpu60.py
+++ b/pymeasure/instruments/novanta/fpu60.py
@@ -52,6 +52,7 @@ class Fpu60(Instrument):
         """Get the interlock enabled status (bool).""",
         values={True: "ENABLED", False: "DISABLED"},
         map_values=True,
+        cast=str,
     )
 
     emission_enabled = Instrument.measurement(
@@ -59,6 +60,7 @@ class Fpu60(Instrument):
         """Measure the emission status (bool).""",
         values={True: "ENABLED", False: "DISABLED"},
         map_values=True,
+        cast=str,
     )
 
     power = Instrument.measurement(
@@ -83,6 +85,7 @@ class Fpu60(Instrument):
         # get response: "SHUTTER OPEN", "SHUTTER CLOSED"
         values={True: "OPEN", False: "CLOSE"},
         map_values=True,
+        cast=str,
         preprocess_reply=lambda r: r.replace("SHUTTER ", "").replace("D", ""),
         check_set_errors=True,
     )

--- a/pymeasure/instruments/ophir/ophir_base.py
+++ b/pymeasure/instruments/ophir/ophir_base.py
@@ -28,7 +28,7 @@ from typing import Any, TypedDict, TypeVar
 from collections.abc import Callable, Sequence
 
 from pymeasure.adapters import Adapter
-from pymeasure.instruments.common_base import CommonBase
+from pymeasure.instruments.common_base import CommonBase, cast_or_str
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
 
@@ -395,6 +395,7 @@ class OphirBase(OphirCommunication):
         "AW",
         "WI%i",
         """Control the index of the wavelength in the wavelength list.""",
+        cast=cast_or_str(float),
         get_process_list=lambda v: int(v[3]) if v[0] == "CONTINUOUS" else int(v[1]),
         set_process=lambda v: v + 1,
         check_set_errors=True,

--- a/pymeasure/instruments/oxfordinstruments/ips120_10.py
+++ b/pymeasure/instruments/oxfordinstruments/ips120_10.py
@@ -140,6 +140,7 @@ class IPS120_10(OxfordInstrumentsBase):
     version = Instrument.measurement(
         "V",
         """ A string property that returns the version of the IPS. """,
+        cast=str,
     )
 
     control_mode = Instrument.control(

--- a/pymeasure/instruments/oxfordinstruments/mercuryitc.py
+++ b/pymeasure/instruments/oxfordinstruments/mercuryitc.py
@@ -78,7 +78,8 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1],
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     control_loop_P = Channel.control(
@@ -147,7 +148,8 @@ class TemperatureSensor(Channel):
         preprocess_reply=lambda v: v.split(":")[-1],
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
 
@@ -276,7 +278,8 @@ class MercuryiTC(Instrument):
 
     identity = Instrument.measurement(
         "*IDN?",
-        """Get identity of unit."""
+        """Get identity of unit.""",
+        cast=str,
     )
 
     TS_MB = Instrument.ChannelCreator(

--- a/pymeasure/instruments/pendulum/cnt91.py
+++ b/pymeasure/instruments/pendulum/cnt91.py
@@ -74,6 +74,7 @@ class CNT91(SCPIUnknownMixin, Instrument):
         validator=strict_discrete_set,
         values={"A": "EXT1", "B": "EXT2", "E": "EXT4", "IMM": "IMM"},
         map_values=True,
+        cast=str,
     )
 
     external_arming_start_slope = Instrument.control(
@@ -82,6 +83,7 @@ class CNT91(SCPIUnknownMixin, Instrument):
         """Control slope for the start arming condition (str 'POS' or 'NEG').""",
         validator=strict_discrete_set,
         values=["POS", "NEG"],
+        cast=str,
     )
 
     continuous = Instrument.control(
@@ -124,6 +126,7 @@ class CNT91(SCPIUnknownMixin, Instrument):
         validator=strict_discrete_set,
         values={"ASCII": "ASC", "REAL": "REAL"},
         map_values=True,
+        cast=str,
     )
 
     interpolator_autocalibrated = Instrument.control(

--- a/pymeasure/instruments/philips/PM6669.py
+++ b/pymeasure/instruments/philips/PM6669.py
@@ -26,6 +26,7 @@ from enum import Enum, IntFlag
 from queue import Queue
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 
@@ -133,7 +134,7 @@ class PM6669(Instrument):
         """Reset the instruments to default settings"""
         self.write("DCL")
 
-    id = Instrument.measurement("ID?", """Get the instrument identification """)
+    id = Instrument.measurement("ID?", """Get the instrument identification """, cast=str)
 
 
 PM6669.measuring_function = Instrument.control(
@@ -156,6 +157,7 @@ PM6669.measuring_function = Instrument.control(
         Functions.TOT_A: "TOTM   A",
     },
     map_values=True,
+    cast=str,
 )
 
 PM6669.gate_enabled = Instrument.control(
@@ -179,7 +181,8 @@ PM6669.measurement_time = Instrument.control(
     """Control the measurement time in seconds""",
     validator=strict_range,
     values=[0, 10],
-    get_process_list=lambda x: float(x[0][5:]) if x[0].startswith("MTIME") is True else 0,
+    cast=cast_or_str(float),
+    get_process_list=lambda x: float(x[0][5:]) if x[0].startswith("MTIME") else 0,
 )
 
 PM6669.freerun_enabled = Instrument.control(
@@ -189,8 +192,9 @@ PM6669.freerun_enabled = Instrument.control(
     validator=strict_discrete_set,
     values={True: "ON", False: "OFF"},
     map_values=True,
+    cast=cast_or_str(float),
     get_process_list=lambda x: (x[1].split("\n")[0][5:] == " ON")
-    if x[0].startswith("MTIME") is True
+    if x[0].startswith("MTIME")
     else 0,
 )
 
@@ -202,17 +206,20 @@ PM6669.measurement_timeout = Instrument.control(
         this timeout only has meaning when freerun is off.""",
     validator=strict_range,
     values=[0, 25.5],
-    get_process_list=lambda x: float(x[2][5:]) if x[0].startswith("MTIME") is True else 0,
+    cast=cast_or_str(float),
+    get_process_list=lambda x: float(x[2][5:]) if x[0].startswith("MTIME") else 0,
 )
 
 PM6669.SRQMask = Instrument.control(
     "BUS?",
     "MSR %i",
     """Control the SRQ mask""",
+    cast=cast_or_str(float),
     get_process_list=lambda x: MSRFlag(int(x[0].split(",")[0].split(" ")[-1])),
 )
 
 PM6669.measurement_settings = Instrument.measurement(
     "MEAC?",
-    """Get the measurement settings from the device """
+    """Get the measurement settings from the device """,
+    cast=str,
 )

--- a/pymeasure/instruments/ptw/ptwDIAMENTOR.py
+++ b/pymeasure/instruments/ptw/ptwDIAMENTOR.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from pymeasure.adapters import Adapter
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import (strict_discrete_set,
                                               strict_range)
 
@@ -119,7 +120,7 @@ class ptwDIAMENTOR(Instrument):
         """Control the baudrate
         (int, strictly ``9600``, ``19200``, ``38400``, ``57600`` or ``115200``).
 
-        The baudrate is changed after sending the respone.
+        The baudrate is changed after sending the response.
         """,
         map_values=True,
         validator=strict_discrete_set,
@@ -130,6 +131,7 @@ class ptwDIAMENTOR(Instrument):
                 115200: 4,
                 },
         check_set_errors=True,
+        cast=str,
         get_process=lambda v: int(v[2])
         )
 
@@ -138,19 +140,22 @@ class ptwDIAMENTOR(Instrument):
         """Get the DIAMENTOR electrical constancy check result (bool).""",
         map_values=True,
         values={True: "P", False: "F"},
+        cast=str,
         get_process=lambda v: v[1]
         )
 
     is_calibrated = Instrument.measurement(
         "CRC",
         """Get the calibration status (bool).""",
+        cast=cast_or_str(float),
         get_process_list=lambda v: not int(v[1])
         )
 
     is_eeprom_ok = Instrument.measurement(
         "CRC",
         """Get the EEPROM CRC ok status (bool).""",
-        get_process_list=lambda v: not int(v[0][3])
+        cast=cast_or_str(float),
+        get_process_list=lambda v: not int(v[0][3:])
         )
 
     pressure = Instrument.control(
@@ -164,7 +169,7 @@ class ptwDIAMENTOR(Instrument):
         values=[500, 1500],
         check_set_errors=True,
         get_process=lambda v: int(v[3:]),
-        cast=int
+        cast=str
         )
 
     id = Instrument.measurement(
@@ -173,6 +178,7 @@ class ptwDIAMENTOR(Instrument):
 
         Example response: ``CRS 2.33``
         """,
+        cast=str,
         )
 
     measurement = Instrument.measurement(
@@ -187,15 +193,17 @@ class ptwDIAMENTOR(Instrument):
         The units of ``dap`` and ``dap_rate`` depend on the :attr:`dap_unit` property.
         Time is in seconds.
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {"dap": float(v[0][1:]),
                                     "dap_rate": float(v[1]),
                                     "time": 60*int(v[2]) + int(v[3])
-                                    }
+                                    },
         )
 
     serial_number = Instrument.measurement(
         "SER",
         """Get the serial number (int).""",
+        cast=str,
         get_process=lambda v: int(v[3:])
         )
 
@@ -210,7 +218,7 @@ class ptwDIAMENTOR(Instrument):
         values=[0, 70],
         check_set_errors=True,
         get_process=lambda v: int(v[4:]),
-        cast=int
+        cast=str
         )
 
     dap_unit = Instrument.control(
@@ -231,6 +239,7 @@ class ptwDIAMENTOR(Instrument):
                 "Rcm2": 4,
                 },
         check_set_errors=True,
+        cast=str,
         get_process=lambda v: int(v[1:])
         )
 
@@ -253,6 +262,7 @@ class ptwDIAMENTOR(Instrument):
         values=[1E8, 9.999E12],
         check_set_errors=True,
         set_process=lambda v: f"{v:.4E}".replace('+', ''),  # remove '+' from scientific notation
+        cast=str,
         get_process=lambda v: float(v[2:])
         )
 
@@ -264,5 +274,6 @@ class ptwDIAMENTOR(Instrument):
         validator=strict_range,
         values=[0, 9.999],
         check_set_errors=True,
+        cast=str,
         get_process=lambda v: float(v[3:])
         )

--- a/pymeasure/instruments/ptw/ptwUNIDOS.py
+++ b/pymeasure/instruments/ptw/ptwUNIDOS.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from pymeasure.adapters import Adapter
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import (strict_discrete_set,
                                               strict_range)
 
@@ -232,7 +233,8 @@ wrong format of the parameter",
         """,
         validator=strict_discrete_set,
         values=["LOW", "MEDIUM", "HIGH"],
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
         )
 
     id = Instrument.measurement(
@@ -240,7 +242,8 @@ wrong format of the parameter",
         """Get the dosemeter ID (list[str]).
 
         .. [name, type number, firmware version, hardware revision]
-        """
+        """,
+        cast=str,
         )
 
     integration_time = Instrument.control(
@@ -256,7 +259,8 @@ wrong format of the parameter",
 
     mac_address = Instrument.measurement(
         "MAC",
-        """Get the dosemeter MAC address (str)."""
+        """Get the dosemeter MAC address (str).""",
+        cast=str,
         )
 
     measurement_result = Instrument.measurement(
@@ -273,6 +277,7 @@ wrong format of the parameter",
                     ``voltage``,
                     ``error``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {
             "status": v[0],
             "charge": float(str(v[1]) + str(v[2])),
@@ -293,7 +298,8 @@ wrong format of the parameter",
         """,
         validator=strict_discrete_set,
         values=["VERY_LOW", "LOW", "MEDIUM", "HIGH"],
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
         )
 
     range_max = Instrument.measurement(
@@ -305,6 +311,7 @@ wrong format of the parameter",
                     ``doserate``,
                     ``timebase``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {
             "range": v[0],
             "current": float(str(v[1]) + str(v[2])),
@@ -324,6 +331,7 @@ wrong format of the parameter",
                     ``doserate``,
                     ``timebase``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {
             "range": v[0],
             "charge": float(str(v[1]) + str(v[2])),
@@ -345,6 +353,7 @@ wrong format of the parameter",
                     ``medium``,
                     ``high``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {
             "status": v[0],
             "time_remaining": v[1],
@@ -369,7 +378,8 @@ wrong format of the parameter",
         ``MEAS``, ``HOLD``, ``INT``, ``INTHLD``, ``ZERO``, ``AUTO``,
         ``AUTO_MEAS``, ``AUTO_HOLD``, ``EOM``, ``WAIT``, ``INIT``,
         ``ERROR``, ``SELF_TEST`` or ``TST``
-        """
+        """,
+        cast=str,
         )
 
     tfi = Instrument.measurement(
@@ -377,7 +387,8 @@ wrong format of the parameter",
         """Get the telegram failure information (str).
 
         The property provides information about the last failed command with HTTP request.
-        """
+        """,
+        cast=str,
         )
 
     autostart_enabled = Instrument.control(
@@ -386,7 +397,8 @@ wrong format of the parameter",
         validator=strict_discrete_set,
         map_values=True,
         values={True: "true", False: "false"},
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
         )
 
     autoreset_enabled = Instrument.control(
@@ -395,7 +407,8 @@ wrong format of the parameter",
         validator=strict_discrete_set,
         map_values=True,
         values={True: "true", False: "false"},
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
         )
 
     electrical_units_enabled = Instrument.control(
@@ -404,7 +417,8 @@ wrong format of the parameter",
         validator=strict_discrete_set,
         map_values=True,
         values={True: "true", False: "false"},
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
         )
 
     voltage = Instrument.control(
@@ -432,7 +446,8 @@ wrong format of the parameter",
         set_process=lambda v: "" if (v) else f";{int(v)}",  # "TOK" = request write permission
                                                             # "TOK;0" = release write permision
                                                             # "TOK;1" = get status
-        get_process_list=lambda v: True if (v[1] == "true") else False,
+        cast=str,
+        get_process_list=lambda v: v[1] == "true",
         check_set_errors=True
         )
 
@@ -444,6 +459,7 @@ wrong format of the parameter",
                      ``time_remaining``,
                      ``time_total``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: {"status": v[0], "time_remaining": v[1], "time_total": v[2]},
     )
 
@@ -502,6 +518,7 @@ wrong format of the parameter",
                     ``ipv4``,
                     ``ipv6``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: json.loads(",".join(v))  # list -> str -> dict
         )
 
@@ -540,6 +557,7 @@ wrong format of the parameter",
                     ``triggerReset``,
                     ``triggerSensitivity``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: json.loads(",".join(v))  # list -> str -> dict
         )
 
@@ -560,6 +578,7 @@ wrong format of the parameter",
                     ``testTemperature``,
                     ``typeNumber``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: json.loads(",".join(v))  # list -> str -> dict
         )
 
@@ -577,6 +596,7 @@ wrong format of the parameter",
                     ``timezone``,
                     ``volume``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: json.loads(",".join(v))  # list -> str -> dict
         )
 
@@ -587,5 +607,6 @@ wrong format of the parameter",
         :dict keys: ``enabled``,
                     ``ssid``
         """,
+        cast=cast_or_str(float),
         get_process_list=lambda v: json.loads(",".join(v))  # list -> str -> dict
         )

--- a/pymeasure/instruments/racal/racal1992.py
+++ b/pymeasure/instruments/racal/racal1992.py
@@ -95,7 +95,7 @@ class Racal1992(Instrument):
     }
 
     @staticmethod
-    def decode(v, allowed_types=None):
+    def decode(v: str, allowed_types=None):
         """Decode received message.
 
         All values returned follow the same format: 2 letters to indicate
@@ -144,7 +144,8 @@ class Racal1992(Instrument):
             "SRS %d",
             """Control the resolution of the counter with an integer from 3 to 10 that
             specifies the number of significant digits. """,
-            get_process=(lambda v: Racal1992.decode(v, "RS"))
+            get_process=(lambda v: Racal1992.decode(v, "RS")),
+            cast=str,
         )
 
     delay_enable = Instrument.setting(
@@ -158,7 +159,8 @@ class Racal1992(Instrument):
             "RDT",
             "SDT %f",
             """Control delay time.""",
-            get_process=(lambda v: Racal1992.decode(v, "DT"))
+            get_process=(lambda v: Racal1992.decode(v, "DT")),
+            cast=str,
         )
 
     special_function_enable = Instrument.setting(
@@ -173,33 +175,38 @@ class Racal1992(Instrument):
             "RSF",
             "S%d",
             """Control special function.""",
-            get_process=(lambda v: Racal1992.decode(v, "SF"))
+            get_process=(lambda v: Racal1992.decode(v, "SF")),
+            cast=str,
         )
 
     # FIXME: not tested on real instrument!
     total_so_far = Instrument.measurement(
             "RF",
             """Get total number of events so far.""",
-            get_process=(lambda v: Racal1992.decode(v, "RF"))
+            get_process=(lambda v: Racal1992.decode(v, "RF")),
+            cast=str,
         )
 
     software_version = Instrument.measurement(
             "RMS",
             "Get instrument software version",
-            get_process=(lambda v: Racal1992.decode(v, "MS"))
+            get_process=(lambda v: Racal1992.decode(v, "MS")),
+            cast=str,
         )
 
     gpib_software_version = Instrument.measurement(
             "RGS",
             "Get GPIB software version",
-            get_process=(lambda v: Racal1992.decode(v, "GS"))
+            get_process=(lambda v: Racal1992.decode(v, "GS")),
+            cast=str,
         )
 
     device_type = Instrument.measurement(
             "RUT",
             """Get unit device type. Should return 1992 for a Racal-Dana 1992
             or 1991 for a Racal-Dana 1991.""",
-            get_process=(lambda v: Racal1992.decode(v, "UT"))
+            get_process=(lambda v: Racal1992.decode(v, "UT")),
+            cast=str,
         )
 
     math_mode = Instrument.setting(
@@ -213,28 +220,32 @@ class Racal1992(Instrument):
             "RMX",
             "SMX %f",
             """Control math constant X.""",
-            get_process=(lambda v: Racal1992.decode(v, "MX"))
+            get_process=(lambda v: Racal1992.decode(v, "MX")),
+            cast=str,
         )
 
     math_z = Instrument.control(
             "RMZ",
             "SMZ %f",
             """Control math constant Z.""",
-            get_process=(lambda v: Racal1992.decode(v, "MZ"))
+            get_process=(lambda v: Racal1992.decode(v, "MZ")),
+            cast=str,
         )
 
     trigger_level_a = Instrument.control(
             "RLA",
             "SLA %f",
             """Control trigger level for channel A""",
-            get_process=(lambda v: Racal1992.decode(v, "LA"))
+            get_process=(lambda v: Racal1992.decode(v, "LA")),
+            cast=str,
         )
 
     trigger_level_b = Instrument.control(
             "RLB",
             "SLB %f",
             """Control trigger level for channel B""",
-            get_process=(lambda v: Racal1992.decode(v, "LB"))
+            get_process=(lambda v: Racal1992.decode(v, "LB")),
+            cast=str,
         )
 
     def read(self, **kwargs):

--- a/pymeasure/instruments/redpitaya/redpitaya_scpi.py
+++ b/pymeasure/instruments/redpitaya/redpitaya_scpi.py
@@ -43,6 +43,7 @@ class DigitalChannelP(Channel):
         validator=strict_discrete_set,
         map_values=True,
         values={True: 'IN', False: 'OUT'},
+        cast=str,
     )
 
     enabled = Channel.control(
@@ -63,6 +64,7 @@ class DigitalChannelN(Channel):
         validator=strict_discrete_set,
         map_values=True,
         values={True: 'IN', False: 'OUT'},
+        cast=str,
     )
 
     enabled = Channel.control(
@@ -117,9 +119,10 @@ class AnalogInputFastChannel(Channel):
         """,
         validator=strict_discrete_set,
         values=['LV', 'HV'],
+        cast=str,
     )
 
-    def get_data(self, npts: int = None, format='ASCII') -> np.ndarray:
+    def get_data(self, npts: int | None = None, format='ASCII') -> np.ndarray:
         """ Read data from the buffer
 
         :param npts: number of points to be read
@@ -229,8 +232,11 @@ class RedPitayaScpi(SCPIMixin, Instrument):
                               set_process=lambda date: date.strftime('%Y,%m,%d'),
                               )
 
-    board_name = Instrument.measurement("SYST:BRD:Name?",
-                                        """Get the RedPitaya board name""")
+    board_name = Instrument.measurement(
+        "SYST:BRD:Name?",
+        """Get the RedPitaya board name""",
+        cast=str,
+    )
 
     def digital_reset(self):
         """Reset the state of all digital lines"""
@@ -272,6 +278,7 @@ class RedPitayaScpi(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         map_values=True,
         values={True: 'ON', False: 'OFF'},
+        cast=str,
     )
 
     acq_units = Instrument.control(
@@ -279,6 +286,7 @@ class RedPitayaScpi(SCPIMixin, Instrument):
         """Control the output data units (str), either 'RAW', or 'VOLTS' (default)""",
         validator=strict_discrete_set,
         values=['RAW', 'VOLTS'],
+        cast=str,
     )
 
     buffer_length = Instrument.measurement(
@@ -310,6 +318,7 @@ class RedPitayaScpi(SCPIMixin, Instrument):
         """Get the trigger status (bool), if True the trigger as been fired (or is disabled)""",
         map_values=True,
         values={True: 'TD', False: 'WAIT'},
+        cast=str,
     )
 
     acq_trigger_position = Instrument.measurement(

--- a/pymeasure/instruments/rigol/rigol_dg800.py
+++ b/pymeasure/instruments/rigol/rigol_dg800.py
@@ -23,6 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument, Channel, SCPIMixin
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import truncated_discrete_set
 
 
@@ -37,6 +38,7 @@ class VoltageChannel(Channel):
         validator=truncated_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     load = Channel.control(
@@ -56,6 +58,7 @@ class VoltageChannel(Channel):
         validator=truncated_discrete_set,
         values={True: "INF", False: "50"},
         map_values=True,
+        cast=str,
     )
 
     frequency = Channel.control(
@@ -70,6 +73,7 @@ class VoltageChannel(Channel):
         validator=truncated_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     sine = Channel.setting(
@@ -148,12 +152,14 @@ class VoltageChannel(Channel):
 
     shape = Channel.control(
         ":SOUR{ch}:FUNC?",
-        ":SOUR1:FUNC %s",
+        ":SOUR{ch}:FUNC %s",
         """Control the waveform type of the specified channel.""",
+        cast=str,
     )
 
     waveform = Channel.measurement(
-        ":SOUR{ch}:APPL?", """Get a descriptor of the waveform applied."""
+        ":SOUR{ch}:APPL?", """Get a descriptor of the waveform applied.""",
+        cast=cast_or_str(float),
     )
 
 

--- a/pymeasure/instruments/rohdeschwarz/fsseries.py
+++ b/pymeasure/instruments/rohdeschwarz/fsseries.py
@@ -36,7 +36,7 @@ log.addHandler(logging.NullHandler())
 
 def _number_or_auto(value):
     """
-    Evaluates wether input for bandwidth settings and sweep time is a number (requires space) or
+    Evaluates whether input for bandwidth settings and sweep time is a number (requires space) or
     AUTO (requires no space).
     """
     if isinstance(value, str) and value.upper() == "AUTO":
@@ -142,6 +142,7 @@ class FSSeries(SCPIMixin, Instrument):
         """,
         validator=strict_discrete_set,
         values=["WRIT", "MAXH", "MINH", "AVER", "VIEW"],
+        cast=str,
     )
 
     # Markers --------------------------------------------------------------------------------------
@@ -337,7 +338,8 @@ class FSW(FSSeries):
         strict_discrete_set(channel_name, list((self.available_channels).keys()))
         self.write(f"INST:DEL '{channel_name}'")
 
-    def _channel_list_to_dict(raw):
+    @staticmethod
+    def _channel_list_to_dict(raw: list[str]) -> dict[str, str]:
         """
         Convert a list of available channels to a dictionary of form {channel_name: channel_type}.
 
@@ -355,8 +357,9 @@ class FSW(FSSeries):
 
     available_channels = Instrument.measurement(
         "INST:LIST?",
-        "Measure open channel names and corresponding types",
+        "Get open channel names and corresponding types",
         get_process_list=_channel_list_to_dict,
+        cast=str,
     )
 
     def select_channel(self, channel_name):
@@ -383,7 +386,7 @@ class FSW(FSSeries):
         :return: active channel name
         :rtype: string
         """
-        name = self.values("INST?")[0]
+        name = self.values("INST?", cast=str)[0]
         if name == "SAN":
             name = "Spectrum"
         elif name == "PNO":
@@ -402,6 +405,7 @@ class FSW(FSSeries):
         "Control the viewmode of the device: True for split view or False for single channel view",
         values={True: "SPL", False: "SING"},
         map_values=True,
+        cast=str,
     )
 
     # Overview -------------------------------------------------------------------------------------

--- a/pymeasure/instruments/siglenttechnologies/siglent_sds1000xhd.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_sds1000xhd.py
@@ -25,6 +25,7 @@
 import struct
 import math
 from pymeasure.instruments import Channel, Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.generic_types import SCPIMixin
 from pymeasure.instruments.validators import (
     strict_range, strict_discrete_set
@@ -49,6 +50,7 @@ class AnalogChannel(Channel):
         "Control the channel coupling mode (str): 'DC', 'AC', or 'GND'.",
         validator=strict_discrete_set,
         values=["DC", "AC", "GND"],
+        cast=str,
     )
 
     probe = Channel.control(
@@ -75,6 +77,7 @@ class AnalogChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     display_enabled = Channel.control(
@@ -86,6 +89,7 @@ class AnalogChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     bandwidth_limit_enabled = Channel.control(
@@ -95,6 +99,7 @@ class AnalogChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     invert = Channel.control(
@@ -104,6 +109,7 @@ class AnalogChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     label = Channel.control(
@@ -111,6 +117,7 @@ class AnalogChannel(Channel):
         ":CHANnel{ch}:LABel:TEXT '%s'",
         "Control the channel label text (str).",
         preprocess_reply=lambda v: v.strip('\r\n\t \'"'),
+        cast=str,
     )
 
     unit = Channel.control(
@@ -119,6 +126,7 @@ class AnalogChannel(Channel):
         "Control the channel unit (str): 'V' or 'A'.",
         validator=strict_discrete_set,
         values=["V", "A"],
+        cast=str,
     )
 
 
@@ -140,6 +148,7 @@ class WaveformChannel(Channel):
         values=["C1", "C2", "C3", "C4", "F1", "F2", "F3", "F4",
                 "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
                 "D8", "D9", "D10", "D11", "D12", "D13", "D14", "D15"],
+        cast=str,
     )
 
     start_point = Channel.control(
@@ -202,6 +211,7 @@ class WaveformChannel(Channel):
         """,
         validator=strict_discrete_set,
         values=["BYTE", "WORD"],
+        cast=str,
     )
 
     def _parse_preamble_descriptor(self, raw_data):
@@ -376,6 +386,7 @@ class AdvancedMeasurementItem(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     source1 = Channel.control(
@@ -386,6 +397,7 @@ class AdvancedMeasurementItem(Channel):
         values=["C1", "C2", "C3", "C4", "F1", "F2", "F3", "F4",
                 "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
                 "D8", "D9", "D10", "D11", "D12", "D13", "D14", "D15"],
+        cast=str,
     )
 
     source2 = Channel.control(
@@ -398,6 +410,7 @@ class AdvancedMeasurementItem(Channel):
         values=["C1", "C2", "C3", "C4", "F1", "F2", "F3", "F4",
                 "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
                 "D8", "D9", "D10", "D11", "D12", "D13", "D14", "D15"],
+        cast=str,
     )
 
     statistics_all = Channel.measurement(
@@ -407,30 +420,35 @@ class AdvancedMeasurementItem(Channel):
         """,
         preprocess_reply=lambda v: v.strip(),
         separator=None,
+        cast=cast_or_str(str),
     )
 
     statistics_current = Channel.measurement(
         ":MEASure:ADVanced:P{ch}:STATistics? CURRent",
         """Get the current statistical value in NR3 format (scientific notation, e.g., 1.23E+2).""",
         get_process=lambda v: float(v) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     statistics_mean = Channel.measurement(
         ":MEASure:ADVanced:P{ch}:STATistics? MEAN",
         """Get the mean statistical value in NR3 format (scientific notation, e.g., 1.23E+2).""",
         get_process=lambda v: float(v) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     statistics_maximum = Channel.measurement(
         ":MEASure:ADVanced:P{ch}:STATistics? MAXimum",
         """Get the maximum statistical value in NR3 format (scientific notation, e.g., 1.23E+2).""",
         get_process=lambda v: float(v) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     statistics_minimum = Channel.measurement(
         ":MEASure:ADVanced:P{ch}:STATistics? MINimum",
         """Get the minimum statistical value in NR3 format (scientific notation, e.g., 1.23E+2).""",
         get_process=lambda v: float(v) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     statistics_stddev = Channel.measurement(
@@ -439,12 +457,14 @@ class AdvancedMeasurementItem(Channel):
         Returns the standard deviation in NR3 format (e.g., 1.23E+2).
         """,
         get_process=lambda v: float(v) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     statistics_count = Channel.measurement(
         ":MEASure:ADVanced:P{ch}:STATistics? COUNt",
         """Get the count of measurements used for statistics calculation.""",
         get_process=lambda v: int(float(v)) if str(v).strip() != "OFF" else str(v).strip(),
+        cast=cast_or_str(float),
     )
 
     type = Channel.control(
@@ -462,6 +482,7 @@ class AdvancedMeasurementItem(Channel):
                 "REDGES", "FEDGES", "EDGES", "PPULSES", "NPULSES", "PHA", "SKEW",
                 "FRR", "FRF", "FFR", "FFF", "LRR", "LRF", "LFR", "LFF", "PACArea",
                 "NACArea", "ACArea", "ABSACArea", "PSLOPE", "NSLOPE", "TSR", "TSF", "THR", "THF"],
+        cast=str,
     )
 
     value = Channel.control(
@@ -494,6 +515,7 @@ class MeasureChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     advanced_mode_enabled = Channel.control(
@@ -503,6 +525,7 @@ class MeasureChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ADVanced", False: "SIMPle"},
         map_values=True,
+        cast=str,
     )
 
     advanced_line_number = Channel.control(
@@ -522,6 +545,7 @@ class MeasureChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     # Simple measurement properties
@@ -532,6 +556,7 @@ class MeasureChannel(Channel):
         validator=strict_discrete_set,
         values=["CHANnel1", "CHANnel2", "CHANnel3", "CHANnel4",
                 "FUNCtion1", "FUNCtion2", "FUNCtion3", "FUNCtion4"],
+        cast=str,
     )
 
     def get_simple_value(self, measurement_type):
@@ -561,6 +586,7 @@ class MeasureChannel(Channel):
         except for delay measurements.""",
         preprocess_reply=lambda v: v.strip(),
         separator=None,
+        cast=str,
     )
 
     simple_item = Channel.setting(
@@ -613,6 +639,7 @@ class AcquisitionChannel(Channel):
         validator=strict_discrete_set,
         values={True: "FAST", False: "SLOW"},
         map_values=True,
+        cast=str,
     )
 
     interpolation_enabled = Channel.control(
@@ -623,6 +650,7 @@ class AcquisitionChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     memory_management = Channel.control(
@@ -639,6 +667,7 @@ class AcquisitionChannel(Channel):
                      according to storage depth and time base.""",
         validator=strict_discrete_set,
         values=["AUTO", "FSRate", "FMDepth"],
+        cast=str,
     )
 
     plot_mode = Channel.control(
@@ -653,6 +682,7 @@ class AcquisitionChannel(Channel):
         "strip chart" recording and is ideal for low-frequency signals.""",
         validator=strict_discrete_set,
         values=["YT", "XY", "ROLL"],
+        cast=str,
     )
 
     memory_depth = Channel.control(
@@ -664,6 +694,7 @@ class AcquisitionChannel(Channel):
         common options but should be validated for your specific instrument.""",
         validator=strict_discrete_set,
         values=["AUTO", "10K", "100K", "1M", "10M", "50M"],
+        cast=str,
     )
 
     count = Channel.control(
@@ -690,6 +721,7 @@ class AcquisitionChannel(Channel):
         validator=strict_discrete_set,
         values={True: "10Bits", False: "8Bits"},
         map_values=True,
+        cast=str,
     )
 
     sequence_mode = Channel.control(
@@ -699,6 +731,7 @@ class AcquisitionChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     sequence_count = Channel.control(
@@ -728,7 +761,8 @@ class AcquisitionChannel(Channel):
         - 'ERES': Enhanced resolution mode""",
         validator=strict_discrete_set,
         values=["NORMal", "PEAK", "AVERage", "ERES"],
-        get_process=lambda v: v.strip().split(',')[0],  # Extract base type from response
+        get_process=lambda v: v.strip().split(',')[0],
+        cast=str,
     )
 
 
@@ -756,6 +790,7 @@ class TimebaseChannel(Channel):
                   around the position of the horizontal display.""",
         validator=strict_discrete_set,
         values=["DELay", "POSition"],
+        cast=str,
     )
 
     reference_position = Channel.control(
@@ -791,6 +826,7 @@ class TimebaseChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     window_delay = Channel.control(
@@ -855,11 +891,13 @@ class TriggerChannel(Channel):
         """,
         validator=strict_discrete_set,
         values=["AUTO", "NORMal", "SINGle", "FTRIG"],
+        cast=str,
     )
 
     status = Channel.measurement(
         ":TRIGger:STATus?",
         docs="""Get the current trigger status, such as STOP, READY, ARM, TD, WAIT, etc.""",
+        cast=str,
     )
 
     type = Channel.measurement(
@@ -868,6 +906,7 @@ class TriggerChannel(Channel):
         - "type": trigger type (EDGE, SLOPe, PULSe, VIDeo, WINDow, INTerval, DROPout,
         RUNT, PATTern, QUALified, DELay, NEDGe, SHOLd, IIC, SPI, UART, CAN, LIN, etc.)
         """,
+        cast=str,
     )
 
     # EDGE trigger specific measurements
@@ -877,6 +916,7 @@ class TriggerChannel(Channel):
         """Control the coupling mode of the edge trigger.""",
         validator=strict_discrete_set,
         values=["DC", "AC", "LFREJect", "HFREJect"],
+        cast=str,
     )
 
     edge_hld_event = Channel.control(
@@ -916,6 +956,7 @@ class TriggerChannel(Channel):
         validator=strict_discrete_set,
         values=["OFF", "EVENTS", "TIME"],
         get_process=lambda v: v.upper(),
+        cast=str,
     )
 
     edge_hld_start = Channel.control(
@@ -924,6 +965,7 @@ class TriggerChannel(Channel):
         """Control the initial position of the edge trigger holdoff.""",
         validator=strict_discrete_set,
         values=["LAST_TRIG", "ACQ_START"],
+        cast=str,
     )
 
     edge_high_impedance = Channel.control(
@@ -936,6 +978,7 @@ class TriggerChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ONEMeg", False: "FIFTy"},
         map_values=True,
+        cast=str,
     )
 
     edge_level = Channel.control(
@@ -956,6 +999,7 @@ class TriggerChannel(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     edge_slope = Channel.control(
@@ -964,6 +1008,7 @@ class TriggerChannel(Channel):
         """Control the slope of the edge trigger.""",
         validator=strict_discrete_set,
         values=["RISing", "FALLing", "ALTernate"],
+        cast=str,
     )
 
     edge_source = Channel.control(
@@ -973,6 +1018,7 @@ class TriggerChannel(Channel):
         validator=strict_discrete_set,
         values=["C1", "C2", "C3", "C4", "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7",
                 "D8", "D9", "D10", "D11", "D12", "D13", "D14", "D15", "EX", "EX5", "LINE"],
+        cast=str,
     )
 
     def force_trigger(self):

--- a/pymeasure/instruments/siglenttechnologies/siglent_sds1072cml.py
+++ b/pymeasure/instruments/siglenttechnologies/siglent_sds1072cml.py
@@ -25,6 +25,7 @@
 import struct
 
 from pymeasure.instruments import Channel, Instrument
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.generic_types import SCPIMixin
 from pymeasure.instruments.validators import truncated_discrete_set, truncated_range
 
@@ -53,6 +54,7 @@ class VoltageChannel(Channel):
         values={"DC": "D", "AC": "A"},
         map_values=True,
         get_process=lambda v: v.split(" ", 1)[-1][0],
+        cast=str,
     )
 
     def get_waveform(self):
@@ -194,6 +196,7 @@ class TriggerChannel(Channel):
             "hold_type": v[4],
             "hold_value1": v[6],
         },
+        cast=cast_or_str(float),
     )
 
     trigger_level = Channel.measurement(
@@ -207,6 +210,7 @@ class TriggerChannel(Channel):
             "source": v.split(":", 1)[0],
             "level": float(v.split(" ", 1)[-1][:-2]),
         },
+        cast=str,
     )
 
     trigger_slope = Channel.measurement(
@@ -220,6 +224,7 @@ class TriggerChannel(Channel):
             "source": v.split(":", 1)[0],
             "slope": v.split(" ", 1)[-1],
         },
+        cast=str,
     )
 
     trigger_mode = Channel.measurement(
@@ -230,6 +235,7 @@ class TriggerChannel(Channel):
 
         """,
         get_process=lambda v: {"mode": v.split(" ", 1)[-1]},
+        cast=str,
     )
 
     trigger_coupling = Channel.measurement(
@@ -243,6 +249,7 @@ class TriggerChannel(Channel):
             "source": v.split(":", 1)[0],
             "coupling": v.split(" ", 1)[-1],
         },
+        cast=str,
     )
 
     def set_trigger_config(self, **kwargs):
@@ -332,18 +339,21 @@ class SDS1072CML(SCPIMixin, Instrument):
         "SAST?",
         "Get the sampling status of the scope (Stop, Ready, Trig'd, Armed)",
         get_process=lambda v: v.split(" ", 1)[-1],
+        cast=str,
     )
 
     internal_state = Instrument.measurement(
         "INR?",
         "Get the scope's Internal state change register and clears it.",
         get_process=lambda v: v.split(" ", 1)[-1],
+        cast=str,
     )
 
     is_ready = Instrument.measurement(
         "SAST?",
         "Get whether the scope is ready for the next acquisition (bool)",
         get_process=lambda v: v.split(" ", 1)[-1] in ["Stop", "Ready", "Armed"],
+        cast=str,
     )
 
     def wait(self, time):
@@ -380,6 +390,7 @@ class SDS1072CML(SCPIMixin, Instrument):
             dict_in.get("number"),
             dict_in.get("first"),
         ),
+        cast=cast_or_str(float),
     )
 
     template = Instrument.measurement(

--- a/pymeasure/instruments/spellmanhv/spellmanXRV.py
+++ b/pymeasure/instruments/spellmanhv/spellmanXRV.py
@@ -29,6 +29,7 @@ from pyvisa.constants import InterfaceType
 
 from pymeasure.instruments import Channel, Instrument
 from pymeasure.adapters import Adapter
+from pymeasure.instruments.common_base import cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 # https://www.spellmanhv.com/en/high-voltage-power-supplies/XRV
@@ -479,7 +480,8 @@ class SpellmanXRV(Instrument):
     dsp = Instrument.measurement(
         "23",
         """Get the DSP part number and version (list).""",
-        )
+        cast=cast_or_str(float),
+    )
 
     configuration = Instrument.measurement(
         "27",
@@ -560,7 +562,8 @@ class SpellmanXRV(Instrument):
     fpga = Instrument.measurement(
         "43",
         """Get the FPGA part number and version (list).""",
-        )
+        cast=cast_or_str(float),
+    )
 
     errors = Instrument.measurement(
         "68",

--- a/pymeasure/instruments/srs/ldc500series.py
+++ b/pymeasure/instruments/srs/ldc500series.py
@@ -63,6 +63,7 @@ class LDC500SeriesLD(Channel):
         Laser will only operate with a closed interlock.""",
         values={True: "CLOSED", False: "OPEN"},
         map_values=True,
+        cast=str,
     )
 
     enabled = Instrument.control(
@@ -72,6 +73,7 @@ class LDC500SeriesLD(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     mode = Instrument.control(
@@ -93,6 +95,7 @@ class LDC500SeriesLD(Channel):
         validator=strict_discrete_set,
         values=["CC", "CP"],
         check_set_errors=True,
+        cast=str,
     )
 
     # --- direct ld current control ---
@@ -136,6 +139,7 @@ class LDC500SeriesLD(Channel):
         """,
         validator=strict_discrete_set,
         values=("HIGH", "LOW"),
+        cast=str,
     )
 
     # --- ld voltage control ---
@@ -163,6 +167,7 @@ class LDC500SeriesLD(Channel):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     modulation_bandwidth = Instrument.control(
@@ -181,6 +186,7 @@ class LDC500SeriesLD(Channel):
         """,
         validator=strict_discrete_set,
         values=("HIGH", "LOW"),
+        cast=str,
     )
 
 
@@ -194,6 +200,7 @@ class LDC500SeriesPD(Channel):
         validator=strict_discrete_set,
         values={"mW": "ON", "uA": "OFF"},
         map_values=True,
+        cast=str,
     )
 
     bias = Instrument.control(
@@ -304,6 +311,7 @@ class LDC500SeriesTEC(Channel):
         If ``mode`` is changed from "CC" to "CT", the present value of the temperature sensor
         is measured, and the CT setpoint is set to this measurement.
         """,
+        cast=str,
     )
 
     thermometer_type = Instrument.control(

--- a/pymeasure/instruments/tdk/tdk_base.py
+++ b/pymeasure/instruments/tdk/tdk_base.py
@@ -110,7 +110,8 @@ class TDK_Lambda_Base(Instrument):
         """,
         check_set_errors=True,
         validator=strict_discrete_set,
-        values=["LOC", "REM", "LLO"]
+        values=["LOC", "REM", "LLO"],
+        cast=str
     )
 
     multidrop_capability = Instrument.measurement(
@@ -147,7 +148,8 @@ class TDK_Lambda_Base(Instrument):
         """Get the identity of the instrument.
 
         Returns a list of instrument manufacturer and model in the format: ``["LAMBDA", "GENX-Y"]``
-        """
+        """,
+        cast=str
     )
 
     version = Instrument.measurement(
@@ -155,7 +157,8 @@ class TDK_Lambda_Base(Instrument):
         """Get the software version on instrument.
 
         Returns the software version as an ASCII string.
-        """
+        """,
+        cast=str
     )
 
     serial = Instrument.measurement(
@@ -163,7 +166,8 @@ class TDK_Lambda_Base(Instrument):
         """Get the serial number of the instrument.
 
         Returns the serial number of of the instrument as an ASCII string.
-        """
+        """,
+        cast=str
     )
 
     last_test_date = Instrument.measurement(
@@ -171,7 +175,8 @@ class TDK_Lambda_Base(Instrument):
         """Get the date of the last test, possibly calibration date.
 
         Returns a string in the format: yyyy/mm/dd.
-        """
+        """,
+        cast=str
     )
 
     voltage_setpoint = Instrument.control(
@@ -212,7 +217,8 @@ class TDK_Lambda_Base(Instrument):
         When power supply is on, the returned value will be either ``'CV'`` for
         control voltage or ``'CC'`` for or control current. If the power supply
         is off, the returned value will be ``'OFF'``.
-        """
+        """,
+        cast=str
     )
 
     display = Instrument.measurement(
@@ -258,7 +264,8 @@ class TDK_Lambda_Base(Instrument):
         check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     foldback_enabled = Instrument.control(
@@ -271,7 +278,8 @@ class TDK_Lambda_Base(Instrument):
         check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     foldback_delay = Instrument.control(
@@ -321,7 +329,8 @@ class TDK_Lambda_Base(Instrument):
         check_set_errors=True,
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
-        map_values=True
+        map_values=True,
+        cast=str
     )
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pymeasure/instruments/tektronix/afg3152c.py
+++ b/pymeasure/instruments/tektronix/afg3152c.py
@@ -62,6 +62,7 @@ class AFG3152CChannel(Channel):
         validator=strict_discrete_set,
         values=SHAPES,
         map_values=True,
+        cast=str,
     )
 
     unit = Instrument.control(
@@ -70,6 +71,7 @@ class AFG3152CChannel(Channel):
         """ Control the amplitude unit. (str)""",
         validator=strict_discrete_set,
         values=UNIT_LIMIT,
+        cast=str,
     )
 
     amp_vpp = Instrument.control(

--- a/pymeasure/instruments/teledyne/teledyneMAUI.py
+++ b/pymeasure/instruments/teledyne/teledyneMAUI.py
@@ -25,6 +25,7 @@
 from pymeasure.instruments import Instrument
 from pymeasure.instruments.teledyne.teledyne_oscilloscope import TeledyneOscilloscope, \
     TeledyneOscilloscopeChannel, _results_list_to_dict
+from pymeasure.instruments.common_base import cast_or_str
 
 
 class TeledyneMAUIChannel(TeledyneOscilloscopeChannel):
@@ -204,6 +205,7 @@ class TeledyneMAUI(TeledyneOscilloscope):
         "HCSU?",
         """Get current hardcopy config.""",
         get_process_list=_results_list_to_dict,
+        cast=cast_or_str(float),
     )
 
     def hardcopy_setup(self, **kwargs):

--- a/pymeasure/instruments/teledyne/teledyneT3AFG.py
+++ b/pymeasure/instruments/teledyne/teledyneT3AFG.py
@@ -23,6 +23,8 @@
 #
 
 import logging
+from typing import TypeVar
+from collections.abc import Callable
 
 from pymeasure.instruments import Instrument, Channel, SCPIMixin
 from pymeasure.instruments.validators import strict_range, strict_discrete_set
@@ -30,11 +32,15 @@ from pymeasure.instruments.validators import strict_range, strict_discrete_set
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+T = TypeVar("T")
 
-def get_process_generator_search(keyword, unit, type):
+
+def get_process_generator_search(
+    keyword: str, unit: str, type: Callable[[str], T]
+) -> Callable[[list[str]], T | None]:
     """Generate a get_process method searching for keyword, stripping unit"""
 
-    def selector(values):
+    def selector(values: list[str]) -> T | None:
         if keyword in values:
             try:
                 return type(values[values.index(keyword) + 1].strip(unit))
@@ -56,8 +62,8 @@ class SignalChannel(Channel):
         validator=strict_discrete_set,
         map_values=True,
         values={True: 'ON', False: 'OFF'},
-        # Replace ON and OFF with True and False in both get and set
-        get_process_list=lambda x: True if x[0].split(' ')[1] == 'ON' else False,
+        get_process_list=lambda x: x[0].split(' ')[1] == 'ON',
+        cast=str,
     )
 
     wavetype = Channel.control(
@@ -69,6 +75,7 @@ class SignalChannel(Channel):
         validator=strict_discrete_set,
         values=['SINE', 'SQUARE', 'RAMP', 'PULSE', 'NOISE', 'ARB', 'DC', 'PRBS', 'IQ'],
         get_process_list=lambda x: x[1],
+        cast=str,
     )
 
     frequency = Channel.control(
@@ -81,6 +88,7 @@ class SignalChannel(Channel):
         get_process_list=get_process_generator_search('FRQ', 'HZ', float),
         dynamic=True,
         check_set_errors=True,
+        cast=str,
     )
 
     amplitude = Channel.control(
@@ -95,6 +103,7 @@ class SignalChannel(Channel):
         get_process_list=get_process_generator_search('AMP', 'V', float),
         dynamic=True,
         check_set_errors=True,
+        cast=str,
     )
 
     offset = Channel.control(
@@ -109,6 +118,7 @@ class SignalChannel(Channel):
         get_process_list=get_process_generator_search('OFST', 'V', float),
         dynamic=True,
         check_set_errors=True,
+        cast=str,
     )
 
     max_output_amplitude = Channel.control(
@@ -119,6 +129,7 @@ class SignalChannel(Channel):
         values=[0, 20],
         get_process_list=get_process_generator_search('MAX_OUTPUT_AMP', 'V', float),
         dynamic=True,
+        cast=str,
     )
 
 

--- a/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
+++ b/pymeasure/instruments/teledyne/teledyne_oscilloscope.py
@@ -29,7 +29,7 @@ import time
 from decimal import Decimal
 import numpy as np
 
-from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin
+from pymeasure.instruments import Instrument, Channel, SCPIUnknownMixin, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range, \
     strict_discrete_range
 
@@ -104,7 +104,7 @@ def _trigger_select_validator(value, values, num_pars_finder=_trigger_select_num
     return value
 
 
-def _trigger_select_get_process(value):
+def _trigger_select_get_process(value: list[str]) -> list[str | float]:
     """Process the output of the trigger_select property.
 
     The format of the input list is
@@ -131,7 +131,7 @@ def _trigger_select_get_process(value):
     return output
 
 
-def _results_list_to_dict(results):
+def _results_list_to_dict(results: list[str]) -> dict[str, str]:
     """Turn a list into a dict, using the uneven indices as keys.
 
     E.g. turn ['C1', 'OFF', 'C2', 'OFF'] into {'C1': 'OFF', 'C2': 'OFF'}
@@ -228,6 +228,7 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         values=BANDWIDTH_LIMITS,
         get_process_list=_results_list_to_dict,
         dynamic=True,
+        cast=str,
     )
 
     coupling = Instrument.control(
@@ -235,7 +236,8 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         """Control the coupling with a string parameter ("ac 1M", "dc 1M", "ground").""",
         validator=strict_discrete_set,
         values={"ac 1M": "A1M", "dc 1M": "D1M", "ground": "GND"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     display = Instrument.control(
@@ -243,7 +245,8 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         """Control the display enabled state. (strict bool)""",
         validator=strict_discrete_set,
         values=_BOOLS,
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     offset = Instrument.control(
@@ -281,7 +284,8 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         """,
         validator=strict_discrete_set,
         values={"ac": "AC", "dc": "DC", "lowpass": "HFREJ", "highpass": "LFREJ"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     trigger_level = Instrument.control(
@@ -321,6 +325,7 @@ class TeledyneOscilloscopeChannel(Channel, metaclass=ABCMeta):
         values=TRIGGER_SLOPES,
         map_values=True,
         dynamic=True,
+        cast=str,
     )
 
     _measurable_parameters = ["PKPK", "MAX", "MIN", "AMPL", "TOP", "BASE", "CMEAN", "MEAN", "RMS",
@@ -561,6 +566,7 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         • OFF — header is omitted from the response and units in numbers are suppressed.""",
         validator=strict_discrete_set,
         values=["OFF", "SHORT", "LONG"],
+        cast=str,
     )
 
     ###########
@@ -574,6 +580,7 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         values=TeledyneOscilloscopeChannel.BANDWIDTH_LIMITS,
         get_process_list=_results_list_to_dict,
         dynamic=True,
+        cast=str,
     )
 
     ##################
@@ -657,7 +664,8 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         """,
         validator=strict_range,
         get_process_list=lambda vals: vals[vals.index("NP") + 1],
-        values=[0, sys.maxsize]
+        values=[0, sys.maxsize],
+        cast=cast_or_str(float),
     )
 
     waveform_sparsing = Instrument.control(
@@ -669,7 +677,8 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         """,
         validator=strict_range,
         get_process_list=lambda vals: vals[vals.index("SP") + 1],
-        values=[0, sys.maxsize]
+        values=[0, sys.maxsize],
+        cast=cast_or_str(float),
     )
 
     waveform_first_point = Instrument.control(
@@ -679,7 +688,8 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         given segment. The first data point starts at zero and is strictly positive.""",
         validator=strict_range,
         get_process_list=lambda vals: vals[vals.index("FP") + 1],
-        values=[0, sys.maxsize]
+        values=[0, sys.maxsize],
+        cast=cast_or_str(float),
     )
 
     ##################
@@ -692,7 +702,7 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         Assign for example 500, 100e6, "100K", "25MA".
 
         The reply will always be a float.
-        """
+        """,
     )
 
     @property
@@ -714,7 +724,7 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         - "yoffset": value that is represented at center of screen in Volts
 
         """
-        vals = self.values("WFSU?")
+        vals = self.values("WFSU?", cast=cast_or_str(float))
         preamble = {
             "sparsing": vals[vals.index("SP") + 1],
             "requested_points": vals[vals.index("NP") + 1],
@@ -946,7 +956,8 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         """,
         validator=strict_discrete_set,
         values={"stopped": "STOP", "normal": "NORM", "single": "SINGLE", "auto": "AUTO"},
-        map_values=True
+        map_values=True,
+        cast=str,
     )
 
     _trigger_select_vals = {
@@ -968,7 +979,8 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         get_process_list=_trigger_select_get_process,
         validator=_trigger_select_validator,
         values=_trigger_select_vals,
-        dynamic=True
+        dynamic=True,
+        cast=cast_or_str(float),
     )
 
     def center_trigger(self):
@@ -1131,5 +1143,6 @@ class TeledyneOscilloscope(SCPIUnknownMixin, Instrument, metaclass=ABCMeta):
         """Set the intensity level of the grid or the trace in percent """,
         validator=_intensity_validator,
         values=[[0, 100], [0, 100]],
-        get_process_list=lambda v: {v[0]: v[1], v[2]: v[3]}
+        cast=cast_or_str(float),
+        get_process_list=lambda v: {v[0]: v[1], v[2]: v[3]},
     )

--- a/pymeasure/instruments/thorlabs/thorlabspm100usb.py
+++ b/pymeasure/instruments/thorlabs/thorlabspm100usb.py
@@ -93,7 +93,7 @@ class ThorlabsPM100USB(SCPIUnknownMixin, Instrument):
 
     def _set_flags(self):
         """Get sensor info and write flags."""
-        response = self.values("SYST:SENSOR:IDN?")
+        response = self.values("SYST:SENSOR:IDN?", cast=str)
         if response[0] == "no sensor":
             raise OSError("No sensor connected.")
         self.sensor_name = response[0]

--- a/pymeasure/instruments/thyracont/smartline_v2.py
+++ b/pymeasure/instruments/thyracont/smartline_v2.py
@@ -336,6 +336,7 @@ class SmartlineV2(Instrument):
         docs="""Control the unit shown in the display. ('mbar', 'Torr', 'hPa')""",
         values=['mbar', 'Torr', 'hPa'],
         validator=validators.strict_discrete_set,
+        cast=str,
         set_process=compose_data,
         check_set_errors=True,
     )

--- a/pymeasure/instruments/toptica/ibeamsmart.py
+++ b/pymeasure/instruments/toptica/ibeamsmart.py
@@ -53,9 +53,10 @@ class DriverChannel(Channel):
         """Control the enabled state of the driver channel.""",
         validator=strict_discrete_set,
         values=[True, False],
-        get_process=lambda s: True if s == 'ON' else False,
+        get_process=lambda s: s == 'ON',
         set_process=lambda v: "en" if v else "di",
         check_set_errors=True,
+        cast=str,
     )
 
 
@@ -170,10 +171,12 @@ class IBeamSmart(Instrument):
 
     version = Instrument.measurement(
         "ver", """Get Firmware version number.""",
+        cast=str,
     )
 
     serial = Instrument.measurement(
         "serial", """Get Serial number of the laser system.""",
+        cast=str,
     )
 
     temp = Instrument.measurement(
@@ -196,9 +199,10 @@ class IBeamSmart(Instrument):
         """Control emission status of the laser diode driver (bool).""",
         validator=strict_discrete_set,
         values=[True, False],
-        get_process=lambda s: True if s == 'ON' else False,
+        get_process=lambda s: s == 'ON',
         set_process=lambda v: "on" if v else "off",
         check_set_errors=True,
+        cast=str,
     )
 
     power = Instrument.control(

--- a/pymeasure/instruments/yokogawa/aq6370series.py
+++ b/pymeasure/instruments/yokogawa/aq6370series.py
@@ -267,6 +267,7 @@ class AQ6370Series(SCPIMixin, Instrument):
         validator=strict_discrete_set,
         values={True: "ON", False: "OFF"},
         map_values=True,
+        cast=str,
     )
 
     resolution_bandwidth = Instrument.control(
@@ -285,6 +286,7 @@ class AQ6370Series(SCPIMixin, Instrument):
         ":TRACe:ACTive?",
         ":TRACe:ACTive %d",
         "Control the active trace (str 'A', 'B', 'C', ...).",
+        cast=str,
     )
 
     def copy_trace(self, source, destination):
@@ -353,6 +355,7 @@ class AQ6370Series(SCPIMixin, Instrument):
         ":FORMat:DATA %s",
         """Control the data transfer format. It returns to default ASCII at reset.""",
         values=["ASCII", "REAL,32", "REAL,64"],
+        cast=str,
     )
 
     def get_binary_data(self, bitness=64):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,11 @@ extend-select = ["E", "E9", "F63", "F7", "F82", "W", "UP", "FURB"]
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error:Cannot cast.*In a future version:FutureWarning",
+]
+
 [tool.pyright.defineConstant]
 PYQT5 = true
 PYSIDE2 = false

--- a/tests/instruments/test_channel.py
+++ b/tests/instruments/test_channel.py
@@ -79,8 +79,8 @@ class ChannelInstrument(Instrument):
         self.add_child(GenericChannel, "A")
         self.add_child(GenericChannel, "B")
 
-    def check_errors(self):
-        err = self.values("SYST:ERR?")
+    def check_errors(self) -> list[str]:
+        err = self.values("SYST:ERR?", cast=str)
         if err:
             self.errors.append(err)
         return err

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -28,7 +28,7 @@ import pytest
 
 from pymeasure.units import ureg
 from pymeasure.test import expected_protocol
-from pymeasure.instruments.common_base import DynamicProperty, CommonBase
+from pymeasure.instruments.common_base import DynamicProperty, CommonBase, cast_or_str
 from pymeasure.adapters import FakeAdapter, ProtocolAdapter
 from pymeasure.instruments.validators import strict_discrete_set, strict_range, truncated_range
 
@@ -48,11 +48,11 @@ class CommonBaseTesting(CommonBase):
     def wait_for(self, query_delay=0):
         pass
 
-    def write(self, command):
-        self.parent.write(command)
+    def write(self, command, **kwargs):
+        self.parent.write(command, **kwargs)
 
-    def read(self):
-        return self.parent.read()
+    def read(self, **kwargs):
+        return self.parent.read(**kwargs)
 
 
 class GenericBase(CommonBaseTesting):
@@ -80,11 +80,6 @@ class GenericBase(CommonBaseTesting):
         """A special control with different channel specifiers for get and set.""",
         cast=str,
     )
-
-
-@pytest.fixture()
-def generic():
-    return GenericBase()
 
 
 class FakeBase(CommonBaseTesting):
@@ -115,7 +110,8 @@ class FakeBase(CommonBaseTesting):
         values=(1, 10),
         dynamic=True,
         check_get_errors=True,
-        check_set_errors=True
+        check_set_errors=True,
+        cast=str,
     )
 
 
@@ -430,19 +426,28 @@ def test_ask_writes_and_reads():
 
 @pytest.mark.parametrize("value, kwargs, result",
                          (("5,6,7", {}, [5, 6, 7]),
+                          ("5.1,6,x", {"cast": cast_or_str(float)}, [5.1, 6, "x"]),
+                          ("5,6,x", {"cast": cast_or_str(int)}, [5, 6, "x"]),
                           ("5.6.7", {'separator': '.'}, [5, 6, 7]),
                           ("5,6,7", {'cast': str}, ['5', '6', '7']),
-                          ("X,Y,Z", {}, ['X', 'Y', 'Z']),
+                          ("X,Y,Z", {"cast": str}, ['X', 'Y', 'Z']),
                           ("X,Y,Z", {'cast': str}, ['X', 'Y', 'Z']),
-                          ("X.Y.Z", {'separator': '.'}, ['X', 'Y', 'Z']),
+                          ("X.Y.Z", {"separator": ".", "cast":str}, ["X", "Y", "Z"]),
                           ("0,5,7.1", {'cast': bool}, [False, True, True]),
                           ("x5x", {'preprocess_reply': lambda v: v.strip("x")}, [5]),
-                          ("X,Y,Z", {'maxsplit': 1}, ["X", "Y,Z"]),
-                          ("X,Y,Z", {'maxsplit': 0}, ["X,Y,Z"]),
+                          ("X,Y,Z", {'maxsplit': 1, "cast": str}, ["X", "Y,Z"]),
+                          ("X,Y,Z", {'maxsplit': 0, "cast": str}, ["X,Y,Z"]),
                           ))
 def test_values(value, kwargs, result):
     cb = CommonBaseTesting(FakeAdapter(), "test")
     assert cb.values(value, **kwargs) == result
+
+
+def test_values_fallback_emits_futurewarning():
+    cb = CommonBaseTesting(FakeAdapter(), "test")
+    with pytest.warns(FutureWarning, match=r"Cannot cast.*In a future version"):
+        result = cb.values("X,Y,Z")
+    assert result == ["X", "Y", "Z"]
 
 
 def test_binary_values(fake):
@@ -648,7 +653,7 @@ def test_control_invalid_values_get():
     class Fake(FakeBase):
         x = CommonBase.control(
             "", "%d", "",
-            values=b"abasdfe", map_values=True)
+            values=b"abasdfe", map_values=True, cast=str)
 
     with pytest.raises(ValueError, match="Values of type"):
         Fake().x
@@ -700,6 +705,7 @@ def test_control_get_process(dynamic):
             values=[0, 10],
             get_process=lambda v: int(v.replace('JUNK', '')),
             dynamic=dynamic,
+            cast=str,
         )
 
     fake = Fake()
@@ -785,7 +791,7 @@ def test_measurement_parameters_for_values():
             "JUNK%d",
             "",
             preprocess_reply=lambda v: v.replace('JUNK', ''),
-            cast=int,
+            cast=cast_or_str(int),
             values_kwargs={'testing': True},
         )
 

--- a/tests/instruments/test_common_base.py
+++ b/tests/instruments/test_common_base.py
@@ -449,6 +449,12 @@ def test_values_fallback_emits_futurewarning():
         result = cb.values("X,Y,Z")
     assert result == ["X", "Y", "Z"]
 
+def test_values_fallback_raises_futurewarning_in_pymeasure():
+    cb = CommonBaseTesting(FakeAdapter(), "test")
+    # "match" should match pyproject.toml error raising
+    with pytest.raises(FutureWarning, match=r"Cannot cast.*In a future version"):
+        cb.values("X,Y,Z")
+
 
 def test_binary_values(fake):
     fake.read_binary_values = fake.read


### PR DESCRIPTION
For instruments: Properties are adjusted to use `cast_or_str` or `cast=str` where applicable such that tests pass.

Tests (also for new instruments) will fail if they use the fallback mechanism (everyone else will just get a warning).