### PR TITLE
Added support for the Keysight E364xA series of power supplies

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -110,3 +110,4 @@ Sung-Chieh Chiu
 Przemysław Piróg
 Haotian Zhang
 Maduka Ariyasiri
+Jonas Grage

--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -19,3 +19,4 @@ If the instrument you are looking for is not here, also check :doc:`Agilent<../a
    keysight81160A
    keysight33250A
    keysightPNA
+   keysightE364xA

--- a/docs/api/instruments/keysight/keysightE364xA.rst
+++ b/docs/api/instruments/keysight/keysightE364xA.rst
@@ -1,0 +1,45 @@
+##########################################
+Keysight E364xA Series of Power Supplies
+##########################################
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3640A
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3641A
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3642A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3643A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3644A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3645A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3646A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3647A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3648A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3649A    
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE364XASingleOutput
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE364XADualOutput
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE364XAChannel
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/keysight/keysightE364xA.rst
+++ b/docs/api/instruments/keysight/keysightE364xA.rst
@@ -1,6 +1,6 @@
-##########################################
+########################################
 Keysight E364xA Series of Power Supplies
-##########################################
+########################################
 
 .. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3640A
     :show-inheritance:

--- a/docs/api/instruments/keysight/keysightE364xA.rst
+++ b/docs/api/instruments/keysight/keysightE364xA.rst
@@ -8,28 +8,28 @@ Keysight E364xA Series of Power Supplies
 .. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3641A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3642A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3642A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3643A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3643A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3644A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3644A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3645A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3645A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3646A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3646A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3647A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3647A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3648A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3648A
     :show-inheritance:
 
-.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3649A    
+.. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE3649A
     :show-inheritance:
 
 .. autoclass:: pymeasure.instruments.keysight.keysightE364xA.KeysightE364XASingleOutput

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -30,3 +30,15 @@ from .keysightE36312A import KeysightE36312A
 from .keysightN5767A import KeysightN5767A
 from .keysightN7776C import KeysightN7776C
 from .keysightPNA import KeysightPNA
+from .keysightE364xA import (
+    KeysightE3640A,
+    KeysightE3641A,
+    KeysightE3642A,
+    KeysightE3643A,
+    KeysightE3644A,
+    KeysightE3645A,
+    KeysightE3646A,
+    KeysightE3647A,
+    KeysightE3648A,
+    KeysightE3649A,
+)

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -25,11 +25,6 @@
 from .keysight33250A import Keysight33250A
 from .keysight81160A import Keysight81160A
 from .keysightDSOX1102G import KeysightDSOX1102G
-from .keysightE3631A import KeysightE3631A
-from .keysightE36312A import KeysightE36312A
-from .keysightN5767A import KeysightN5767A
-from .keysightN7776C import KeysightN7776C
-from .keysightPNA import KeysightPNA
 from .keysightE364xA import (
     KeysightE3640A,
     KeysightE3641A,
@@ -42,3 +37,8 @@ from .keysightE364xA import (
     KeysightE3648A,
     KeysightE3649A,
 )
+from .keysightE3631A import KeysightE3631A
+from .keysightE36312A import KeysightE36312A
+from .keysightN5767A import KeysightN5767A
+from .keysightN7776C import KeysightN7776C
+from .keysightPNA import KeysightPNA

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -115,18 +115,11 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """Dynamically set 'update_validator_range' as a set process for the range command.
-
-        This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
-        the range property is modified. The setpoint/limit values are class attributes of the
-        specific model of the device series.
-        During instantiation the range attribute is set to reflect the 'voltage_range' passed to the
-        constructor. This will initially setup said validator ranges and put the device in the
-        desired output range.
-        """
-
+        # Set 'update_validator_range' as a set process for the channels range command
         self.range_set_process = self.update_validator_range
+        # Set mapping of "HIGH" and "LOW" to device specific range keywords
         self.range_values = self._range_map
+        # Initialize device with desired output range modes
         self.range = voltage_range
 
     voltage_setpoint = Instrument.control(
@@ -219,19 +212,13 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """ Dynamically set 'update_validator_range' as a set process for the range command.
-
-        This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
-        the range property is modified. The setpoint/limit values are class attributes of the
-        specific model of the device series.
-        During instantiation the range attribute is set to reflect the 'voltage_range' passed to the
-        constructor. This will initially setup said validator ranges and put the channels in the
-        desired output ranges.
-        """
+        # Set 'update_validator_range' as a set process for the channels range command
         self.ch_1.range_set_process = self.ch_1.update_validator_range
         self.ch_2.range_set_process = self.ch_2.update_validator_range
+        # Set mapping of "HIGH" and "LOW" to device specific range keywords
         self.ch_1.range_values = self._range_map
         self.ch_2.range_values = self._range_map
+        # Initialize device with desired output range modes
         self.ch_1.range = voltage_range[0]
         self.ch_2.range = voltage_range[1]
 

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -105,9 +105,9 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
     """
 
     _default_name = "KeysightE364XASingleOutput"
-    _max_voltage = {}
-    _max_current = {}
-    _range_map = {}
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
 
     def __init__(self, adapter, name=None, voltage_range="LOW", **kwargs):
         super().__init__(
@@ -206,9 +206,9 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
     :type voltage_range: tuple(str, str) with any combination of "LOW" or "HIGH"
     """
     _default_name = "KeysightE364XADualOutput"
-    _max_voltage = {}
-    _max_current = {}
-    _range_map = {}
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
 
     ch_1 = Instrument.ChannelCreator(KeysightE364XAChannel, 1)
     ch_2 = Instrument.ChannelCreator(KeysightE364XAChannel, 2)

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -105,6 +105,9 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
     """
 
     _default_name = "KeysightE364XASingleOutput"
+    _max_voltage = {}
+    _max_current = {}
+    _range_map = {}
 
     def __init__(self, adapter, name=None, voltage_range="LOW", **kwargs):
         super().__init__(
@@ -203,6 +206,10 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
     :type voltage_range: tuple(str, str) with any combination of "LOW" or "HIGH"
     """
     _default_name = "KeysightE364XADualOutput"
+    _max_voltage = {}
+    _max_current = {}
+    _range_map = {}
+
     ch_1 = Instrument.ChannelCreator(KeysightE364XAChannel, 1)
     ch_2 = Instrument.ChannelCreator(KeysightE364XAChannel, 2)
 

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -213,15 +213,10 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        # Set 'update_validator_range' as a set process for the channels range command
-        self.ch_1.range_set_process = self.ch_1.update_validator_range
-        self.ch_2.range_set_process = self.ch_2.update_validator_range
-        # Set mapping of "HIGH" and "LOW" to device specific range keywords
-        self.ch_1.range_values = self._range_map
-        self.ch_2.range_values = self._range_map
-        # Initialize device with desired output range modes
-        self.ch_1.range = voltage_range[0]
-        self.ch_2.range = voltage_range[1]
+        for i, ch in enumerate(self.channels.values()):
+            ch.range_set_process = ch.update_validator_range
+            ch.range_values = self._range_map
+            ch.range = voltage_range[i]
 
     output_enabled = Instrument.control(
         "OUTP?",

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -42,7 +42,8 @@ class KeysightE364XAChannel(Channel):
     voltage_setpoint = Channel.control(
         "INST:NSEL {ch};:VOLT?",
         "INST:NSEL {ch};:VOLT %g",
-        """Control output voltage setpoint. Range depends on selected LOW or HIGH mode.""",
+        """Control output voltage setpoint in volts (float).
+        Range depends on selected LOW or HIGH mode.""",
         validator=strict_range,
         dynamic=True,
     )
@@ -50,19 +51,20 @@ class KeysightE364XAChannel(Channel):
     current_limit = Channel.control(
         "INST:NSEL {ch};:CURR?",
         "INST:NSEL {ch};:CURR %g",
-        """Control current limit of this channel. Range depends on selected LOW or HIGH mode.""",
+        """Control current limit of this channel in amps (float).
+        Range depends on selected LOW or HIGH mode.""",
         validator=strict_range,
         dynamic=True,
     )
 
     voltage = Channel.measurement(
         "INST:NSEL {ch};:MEAS:VOLT?",
-        """Measure voltage at the channel output.""",
+        """Measure voltage at the channel output in volts (float).""",
     )
 
     current = Channel.measurement(
         "INST:NSEL {ch};:MEAS:CURR?",
-        """Measure current at the channel output.""",
+        """Measure current at the channel output in amps (float).""",
     )
 
     range = Channel.control(
@@ -115,17 +117,15 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        # Set 'update_validator_range' as a set process for the channels range command
         self.range_set_process = self.update_validator_range
-        # Set mapping of "HIGH" and "LOW" to device specific range keywords
         self.range_values = self._range_map
-        # Initialize device with desired output range modes
         self.range = voltage_range
 
     voltage_setpoint = Instrument.control(
         "VOLT?",
         "VOLT %g",
-        """Control output voltage setpoint. Range depends on selected LOW or HIGH mode.""",
+        """Control output voltage setpoint in volts (float).
+        Range depends on selected LOW or HIGH mode.""",
         validator=strict_range,
         dynamic=True,
     )
@@ -133,19 +133,20 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
     current_limit = Instrument.control(
         "CURR?",
         "CURR %g",
-        """Control current limit of device. Range depends on selected LOW or HIGH mode.""",
+        """Control current limit of device in amps (float).
+        Range depends on selected LOW or HIGH mode.""",
         validator=strict_range,
         dynamic=True,
     )
 
     voltage = Instrument.measurement(
         "MEAS:VOLT?",
-        """Measure voltage at the device output.""",
+        """Measure voltage at the device output in volts (float).""",
     )
 
     current = Instrument.measurement(
         "MEAS:CURR?",
-        """Measure current at the device output.""",
+        """Measure current at the device output in amps (float).""",
     )
 
     output_enabled = Instrument.control(

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -104,13 +104,15 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
     :type voltage_range: str ("LOW") or str ("HIGH")
     """
 
+    _default_name = "KeysightE364XASingleOutput"
+
     def __init__(self, adapter, name=None, voltage_range="LOW", **kwargs):
         super().__init__(
             adapter,
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """Dynamically set 'update_validator_range' as a set process for the range selection command.
+        """Dynamically set 'update_validator_range' as a set process for the range command.
 
         This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
         the range property is modified. The setpoint/limit values are class attributes of the
@@ -200,6 +202,7 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
         initialization.
     :type voltage_range: tuple(str, str) with any combination of "LOW" or "HIGH"
     """
+    _default_name = "KeysightE364XADualOutput"
     ch_1 = Instrument.ChannelCreator(KeysightE364XAChannel, 1)
     ch_2 = Instrument.ChannelCreator(KeysightE364XAChannel, 2)
 
@@ -209,7 +212,7 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """ Dynamically set 'update_validator_range' as a set process for the range selection command.
+        """ Dynamically set 'update_validator_range' as a set process for the range command.
 
         This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
         the range property is modified. The setpoint/limit values are class attributes of the

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -75,7 +75,7 @@ class KeysightE364XAChannel(Channel):
         cast=str,
     )
 
-    def update_output_range(self, value):
+    def update_validator_range(self, value):
         """Update the validator ranges after switching the output range.
 
         When the output range is switched, the maximum values of `voltage_setpoint`
@@ -110,7 +110,7 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """Dynamically set 'update_output_range' as a set process for the range selection command.
+        """Dynamically set 'update_validator_range' as a set process for the range selection command.
 
         This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
         the range property is modified. The setpoint/limit values are class attributes of the
@@ -120,7 +120,7 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
         desired output range.
         """
 
-        self.range_set_process = self.update_output_range
+        self.range_set_process = self.update_validator_range
         self.range_values = self._range_map
         self.range = voltage_range
 
@@ -170,7 +170,7 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
         cast=str,
     )
 
-    def update_output_range(self, value):
+    def update_validator_range(self, value):
         """Update the validator ranges after switching the output range.
 
         When the output range is switched, the maximum values of `voltage_setpoint`
@@ -209,7 +209,7 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        """ Dynamically set 'update_output_range' as a set process for the range selection command.
+        """ Dynamically set 'update_validator_range' as a set process for the range selection command.
 
         This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
         the range property is modified. The setpoint/limit values are class attributes of the
@@ -218,8 +218,8 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
         constructor. This will initially setup said validator ranges and put the channels in the
         desired output ranges.
         """
-        self.ch_1.range_set_process = self.ch_1.update_output_range
-        self.ch_2.range_set_process = self.ch_2.update_output_range
+        self.ch_1.range_set_process = self.ch_1.update_validator_range
+        self.ch_2.range_set_process = self.ch_2.update_validator_range
         self.ch_1.range_values = self._range_map
         self.ch_2.range_values = self._range_map
         self.ch_1.range = voltage_range[0]

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -1,0 +1,355 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+from pymeasure.instruments import Instrument, Channel, SCPIMixin
+from pymeasure.instruments.validators import strict_range, strict_discrete_set
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class KeysightE364XAChannel(Channel):
+    """ Class representing a single channel of Keysights E364xA series dual output models.
+
+    The Channel supports `HIGH` and a `LOW` output range that can be changed during operation.
+    However switching to different range while the output is set to parameters that the newly
+    selected range does not support will automatically alter those to match the maximum
+    allowed values of the new range setting.
+    """
+    voltage_setpoint = Channel.control(
+        "INST:NSEL {ch};:VOLT?",
+        "INST:NSEL {ch};:VOLT %g",
+        """Control output voltage setpoint. Range depends on selected LOW or HIGH mode.""",
+        validator=strict_range,
+        dynamic=True,
+    )
+
+    current_limit = Channel.control(
+        "INST:NSEL {ch};:CURR?",
+        "INST:NSEL {ch};:CURR %g",
+        """Control current limit of this channel. Range depends on selected LOW or HIGH mode.""",
+        validator=strict_range,
+        dynamic=True,
+    )
+
+    voltage = Channel.measurement(
+        "INST:NSEL {ch};:MEAS:VOLT?",
+        """Measure voltage at the channel output.""",
+    )
+
+    current = Channel.measurement(
+        "INST:NSEL {ch};:MEAS:CURR?",
+        """Measure current at the channel output.""",
+    )
+
+    range = Channel.control(
+        "INST:NSEL {ch};:VOLT:RANG?",
+        "INST:NSEL {ch};:VOLT:RANG %s",
+        """Set channel in LOW or HIGH output voltage range.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        dynamic=True,
+        cast=str,
+    )
+
+    def update_output_range(self, value):
+        """Update the validator ranges after switching the output range.
+
+        When the output range is switched, the maximum values of `voltage_setpoint`
+        and `current_limit` have to be adjusted. So we use this callback to update
+        the dynamic `values` fields of `voltage_setpoint` resp. `current_limit`.
+        """
+        self.voltage_setpoint_values = [0, self.parent._max_voltage[value]]
+        self.current_limit_values = [0, self.parent._max_current[value]]
+        return value
+
+
+class KeysightE364XASingleOutput(SCPIMixin, Instrument):
+    """ Base class representing the single output channel PSUs of the Keysight E364xA series.
+
+    The single output channel models are E3640A, E3641A, E3642A, E3643A, E3644A and E3645A
+    which are represented in their respective classes (:class:`~.KeysightE3640A`,
+    :class:`~.KeysightE3641A`, :class:`~.KeysightE3642A`, :class:`~.KeysightE3643A`,
+    :class:`~.KeysightE3644A`, :class:`~.KeysightE3645A`), that vary in their output voltage
+    and current limit ranges.
+    The device has two output ranges: A `HIGH` and a `LOW` output range that can be changed
+    during operation. However switching to different range while the output is set to parameters
+    that the newly selected range does not support will automatically alter those to match the
+    maximum allowed values of the new range setting.
+
+    :param voltage_range: select the initial output range (default="LOW") during initialization.
+    :type voltage_range: str ("LOW") or str ("HIGH")
+    """
+
+    def __init__(self, adapter, name=None, voltage_range="LOW", **kwargs):
+        super().__init__(
+            adapter,
+            name if name is not None else self._default_name,
+            **kwargs,
+        )
+        """Dynamically set 'update_output_range' as a set process for the range selection command.
+
+        This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
+        the range property is modified. The setpoint/limit values are class attributes of the
+        specific model of the device series.
+        During instantiation the range attribute is set to reflect the 'voltage_range' passed to the
+        constructor. This will initially setup said validator ranges and put the device in the
+        desired output range.
+        """
+
+        self.range_set_process = self.update_output_range
+        self.range_values = self._range_map
+        self.range = voltage_range
+
+    voltage_setpoint = Instrument.control(
+        "VOLT?",
+        "VOLT %g",
+        """Control output voltage setpoint. Range depends on selected LOW or HIGH mode.""",
+        validator=strict_range,
+        dynamic=True,
+    )
+
+    current_limit = Instrument.control(
+        "CURR?",
+        "CURR %g",
+        """Control current limit of device. Range depends on selected LOW or HIGH mode.""",
+        validator=strict_range,
+        dynamic=True,
+    )
+
+    voltage = Instrument.measurement(
+        "MEAS:VOLT?",
+        """Measure voltage at the device output.""",
+    )
+
+    current = Instrument.measurement(
+        "MEAS:CURR?",
+        """Measure current at the device output.""",
+    )
+
+    output_enabled = Instrument.control(
+        "OUTP?",
+        "OUTP %d",
+        """Control outputs of the device (boolean).""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: 1, False: 0},
+        dynamic=True,
+    )
+
+    range = Instrument.control(
+        "VOLT:RANG?",
+        "VOLT:RANG %s",
+        """Set device in LOW or HIGH output voltage range.""",
+        validator=strict_discrete_set,
+        map_values=True,
+        dynamic=True,
+        cast=str,
+    )
+
+    def update_output_range(self, value):
+        """Update the validator ranges after switching the output range.
+
+        When the output range is switched, the maximum values of `voltage_setpoint`
+        and `current_limit` have to be adjusted. So we use this callback to update
+        the dynamic `values` fields of `voltage_setpoint` resp. `current_limit`.
+        """
+        self.voltage_setpoint_values = [0, self._max_voltage[value]]
+        self.current_limit_values = [0, self._max_current[value]]
+        return value
+
+
+class KeysightE364XADualOutput(SCPIMixin, Instrument):
+    """ Base class representing the dual output channel PSUs of the Keysight E364xA series.
+
+    The dual output channel models are E3646A, E3647A, E3648A and E3649A represented by
+    their respective classes (:class:`~.KeysightE3646A`, :class:`~.KeysightE3647A`,
+    :class:`~.KeysightE3648A`, :class:`~.KeysightE3649A`), that vary in their output
+    voltage and current limit ranges.
+    The device has two output channels of :class:`~.KeysightE364XAChannel` named
+    `ch_1` and `ch_2` that each support two output voltage ranges:
+    A `HIGH` and a `LOW` output range that can be changed during operation. However
+    switching to different range while the output is set to parameters that the newly
+    selected range does not support will automatically alter those to match the maximum
+    allowed values of the new range setting.
+
+    :param voltage_range: select the initial output range (default=("LOW", "LOW")) during
+        initialization.
+    :type voltage_range: tuple(str, str) with any combination of "LOW" or "HIGH"
+    """
+    ch_1 = Instrument.ChannelCreator(KeysightE364XAChannel, 1)
+    ch_2 = Instrument.ChannelCreator(KeysightE364XAChannel, 2)
+
+    def __init__(self, adapter, name=None, voltage_range=("LOW", "LOW"), **kwargs):
+        super().__init__(
+            adapter,
+            name if name is not None else self._default_name,
+            **kwargs,
+        )
+        """ Dynamically set 'update_output_range' as a set process for the range selection command.
+
+        This callback will update the 'voltage_setpoint_values' and 'current_limit_values' each time
+        the range property is modified. The setpoint/limit values are class attributes of the
+        specific model of the device series.
+        During instantiation the range attribute is set to reflect the 'voltage_range' passed to the
+        constructor. This will initially setup said validator ranges and put the channels in the
+        desired output ranges.
+        """
+        self.ch_1.range_set_process = self.ch_1.update_output_range
+        self.ch_2.range_set_process = self.ch_2.update_output_range
+        self.ch_1.range_values = self._range_map
+        self.ch_2.range_values = self._range_map
+        self.ch_1.range = voltage_range[0]
+        self.ch_2.range = voltage_range[1]
+
+    output_enabled = Instrument.control(
+        "OUTP?",
+        "OUTP %d",
+        """Control outputs of the device (boolean).""",
+        validator=strict_discrete_set,
+        map_values=True,
+        values={True: 1, False: 0},
+        dynamic=True,
+    )
+
+    tracking_enabled = Instrument.control(
+        ":OUTP:TRAC?",
+        ":OUTP:TRAC %d",
+        """Control whether the power supply operates in the track mode (boolean)""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+
+class KeysightE3640A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3640A 30W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3640A"
+    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current = {"LOW": 3.0, "HIGH": 1.5}
+    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+
+
+class KeysightE3641A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3641A 30W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3641A"
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 0.8, "HIGH": 0.5}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+
+
+class KeysightE3642A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3642A 50W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3642A"
+    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current = {"LOW": 5.0, "HIGH": 2.5}
+    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+
+
+class KeysightE3643A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3643A 50W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3643A"
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+
+
+class KeysightE3644A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3644A 80W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3644A"
+    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current = {"LOW": 8.0, "HIGH": 4.0}
+    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+
+
+class KeysightE3645A(KeysightE364XASingleOutput):
+    """ Class representing the single output Keysight E3645A 80W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
+    """
+    _default_name = "KeysightE3645A"
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 2.2, "HIGH": 1.3}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+
+
+class KeysightE3646A(KeysightE364XADualOutput):
+    """ Class representing the dual output Keysight E3646A 60W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
+    """
+    _default_name = "KeysightE3646A"
+    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current = {"LOW": 3.0, "HIGH": 1.5}
+    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+
+
+class KeysightE3647A(KeysightE364XADualOutput):
+    """ Class representing the dual output Keysight E3647A 60W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
+    """
+    _default_name = "KeysightE3647A"
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 0.8, "HIGH": 0.5}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+
+
+class KeysightE3648A(KeysightE364XADualOutput):
+    """ Class representing the dual output Keysight E3648A 100W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
+    """
+    _default_name = "KeysightE3648A"
+    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current = {"LOW": 5.0, "HIGH": 2.5}
+    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+
+
+class KeysightE3649A(KeysightE364XADualOutput):
+    """ Class representing the dual output Keysight E3649A 100W power supply.
+
+    For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
+    """
+    _default_name = "KeysightE3649A"
+    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map = {"LOW": "P35V", "HIGH": "P60V"}

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -23,9 +23,10 @@
 #
 
 import logging
+from typing import ClassVar
 
-from pymeasure.instruments import Instrument, Channel, SCPIMixin
-from pymeasure.instruments.validators import strict_range, strict_discrete_set
+from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -107,9 +108,9 @@ class KeysightE364XASingleOutput(SCPIMixin, Instrument):
     """
 
     _default_name = "KeysightE364XASingleOutput"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 1.4, "HIGH": 0.8}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
     def __init__(self, adapter, name=None, voltage_range="LOW", **kwargs):
         super().__init__(
@@ -200,9 +201,9 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
     :type voltage_range: tuple(str, str) with any combination of "LOW" or "HIGH"
     """
     _default_name = "KeysightE364XADualOutput"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 1.4, "HIGH": 0.8}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
     ch_1 = Instrument.ChannelCreator(KeysightE364XAChannel, 1)
     ch_2 = Instrument.ChannelCreator(KeysightE364XAChannel, 2)
@@ -244,9 +245,9 @@ class KeysightE3640A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3640A"
-    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
-    _max_current = {"LOW": 3.0, "HIGH": 1.5}
-    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 3.0, "HIGH": 1.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P8V", "HIGH": "P20V"}
 
 
 class KeysightE3641A(KeysightE364XASingleOutput):
@@ -255,9 +256,9 @@ class KeysightE3641A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3641A"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 0.8, "HIGH": 0.5}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 0.8, "HIGH": 0.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
 
 class KeysightE3642A(KeysightE364XASingleOutput):
@@ -266,9 +267,9 @@ class KeysightE3642A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3642A"
-    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
-    _max_current = {"LOW": 5.0, "HIGH": 2.5}
-    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 5.0, "HIGH": 2.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P8V", "HIGH": "P20V"}
 
 
 class KeysightE3643A(KeysightE364XASingleOutput):
@@ -277,9 +278,9 @@ class KeysightE3643A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3643A"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 1.4, "HIGH": 0.8}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
 
 class KeysightE3644A(KeysightE364XASingleOutput):
@@ -288,9 +289,9 @@ class KeysightE3644A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3644A"
-    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
-    _max_current = {"LOW": 8.0, "HIGH": 4.0}
-    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 4.0}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P8V", "HIGH": "P20V"}
 
 
 class KeysightE3645A(KeysightE364XASingleOutput):
@@ -299,9 +300,9 @@ class KeysightE3645A(KeysightE364XASingleOutput):
     For documentation refer to the :class:`~.KeysightE364XASingleOutput` base class.
     """
     _default_name = "KeysightE3645A"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 2.2, "HIGH": 1.3}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 2.2, "HIGH": 1.3}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
 
 class KeysightE3646A(KeysightE364XADualOutput):
@@ -310,9 +311,9 @@ class KeysightE3646A(KeysightE364XADualOutput):
     For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
     """
     _default_name = "KeysightE3646A"
-    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
-    _max_current = {"LOW": 3.0, "HIGH": 1.5}
-    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 3.0, "HIGH": 1.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P8V", "HIGH": "P20V"}
 
 
 class KeysightE3647A(KeysightE364XADualOutput):
@@ -321,9 +322,9 @@ class KeysightE3647A(KeysightE364XADualOutput):
     For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
     """
     _default_name = "KeysightE3647A"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 0.8, "HIGH": 0.5}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 0.8, "HIGH": 0.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}
 
 
 class KeysightE3648A(KeysightE364XADualOutput):
@@ -332,9 +333,9 @@ class KeysightE3648A(KeysightE364XADualOutput):
     For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
     """
     _default_name = "KeysightE3648A"
-    _max_voltage = {"LOW": 8.0, "HIGH": 20.0}
-    _max_current = {"LOW": 5.0, "HIGH": 2.5}
-    _range_map = {"LOW": "P8V", "HIGH": "P20V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 8.0, "HIGH": 20.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 5.0, "HIGH": 2.5}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P8V", "HIGH": "P20V"}
 
 
 class KeysightE3649A(KeysightE364XADualOutput):
@@ -343,6 +344,6 @@ class KeysightE3649A(KeysightE364XADualOutput):
     For documentation refer to the :class:`~.KeysightE364XADualOutput` base class.
     """
     _default_name = "KeysightE3649A"
-    _max_voltage = {"LOW": 35.0, "HIGH": 60.0}
-    _max_current = {"LOW": 1.4, "HIGH": 0.8}
-    _range_map = {"LOW": "P35V", "HIGH": "P60V"}
+    _max_voltage: ClassVar[dict[str, float]] = {"LOW": 35.0, "HIGH": 60.0}
+    _max_current: ClassVar[dict[str, float]] = {"LOW": 1.4, "HIGH": 0.8}
+    _range_map: ClassVar[dict[str, str]] = {"LOW": "P35V", "HIGH": "P60V"}

--- a/pymeasure/instruments/keysight/keysightE364xA.py
+++ b/pymeasure/instruments/keysight/keysightE364xA.py
@@ -213,10 +213,10 @@ class KeysightE364XADualOutput(SCPIMixin, Instrument):
             name if name is not None else self._default_name,
             **kwargs,
         )
-        for i, ch in enumerate(self.channels.values()):
+        for ident, ch in self.channels.items():
             ch.range_set_process = ch.update_validator_range
             ch.range_values = self._range_map
-            ch.range = voltage_range[i]
+            ch.range = voltage_range[ident-1]
 
     output_enabled = Instrument.control(
         "OUTP?",

--- a/tests/instruments/keysight/test_keysightE364xA.py
+++ b/tests/instruments/keysight/test_keysightE364xA.py
@@ -1,0 +1,411 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.keysight import KeysightE3640A, KeysightE3643A, KeysightE3649A
+
+
+# Protocol tests for single channel devices
+def test_single_init():
+    with expected_protocol(
+            KeysightE3643A,
+            [(b'VOLT:RANG P35V', None)],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_current_limit_setter():
+    with expected_protocol(
+            KeysightE3643A,
+            [(b'VOLT:RANG P35V', None),
+             (b'CURR 0.6', None)],
+    ) as inst:
+        inst.current_limit = 0.6
+
+
+def test_current_limit_getter():
+    with expected_protocol(
+            KeysightE3643A,
+            [(b'VOLT:RANG P35V', None),
+             (b'CURR?', b'+6.00000000E-01\n')],
+    ) as inst:
+        assert inst.current_limit == 0.6
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P35V', None),
+      (b'OUTP 1', None)],
+     True),
+    ([(b'VOLT:RANG P35V', None),
+      (b'OUTP 0', None)],
+     False),
+))
+def test_single_output_enabled_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3643A,
+            comm_pairs,
+    ) as inst:
+        inst.output_enabled = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P35V', None),
+      (b'OUTP?', b'1\n')],
+     True),
+    ([(b'VOLT:RANG P35V', None),
+      (b'OUTP?', b'0\n')],
+     False),
+))
+def test_single_output_enabled_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3643A,
+            comm_pairs,
+    ) as inst:
+        assert inst.output_enabled == value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P35V', None),
+      (b'VOLT:RANG P35V', None)],
+     'LOW'),
+    ([(b'VOLT:RANG P35V', None),
+      (b'VOLT:RANG P60V', None)],
+     'HIGH'),
+))
+def test_range_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3643A,
+            comm_pairs,
+    ) as inst:
+        inst.range = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P35V', None),
+      (b'VOLT:RANG?', b'P35V\n')],
+     'LOW'),
+    ([(b'VOLT:RANG P35V', None),
+      (b'VOLT:RANG?', b'P60V\n')],
+     'HIGH'),
+))
+def test_range_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3643A,
+            comm_pairs,
+    ) as inst:
+        assert inst.range == value
+
+
+def test_voltage_setpoint_setter():
+    with expected_protocol(
+            KeysightE3643A,
+            [(b'VOLT:RANG P35V', None),
+             (b'VOLT 15', None)],
+    ) as inst:
+        inst.voltage_setpoint = 15.0
+
+
+def test_voltage_setpoint_getter():
+    with expected_protocol(
+            KeysightE3643A,
+            [(b'VOLT:RANG P35V', None),
+             (b'VOLT?', b'+1.50000000E+01\n')],
+    ) as inst:
+        assert inst.voltage_setpoint == 15.0
+
+
+# Protocol tests for dual channel devices
+def test_dual_init():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None)],
+    ):
+        pass  # Verify the expected communication.
+
+
+def test_ch_1_current_limit_setter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 1;:CURR 0.6', None)],
+    ) as inst:
+        inst.ch_1.current_limit = 0.6
+
+
+def test_ch_1_current_limit_getter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 1;:CURR?', b'+6.00000000E-01\n')],
+    ) as inst:
+        assert inst.ch_1.current_limit == 0.6
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 1;:VOLT:RANG P35V', None)],
+     'LOW'),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 1;:VOLT:RANG P60V', None)],
+     'HIGH'),
+))
+def test_ch_1_range_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        inst.ch_1.range = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 1;:VOLT:RANG?', b'P35V\n')],
+     'LOW'),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 1;:VOLT:RANG?', b'P60V\n')],
+     'HIGH'),
+))
+def test_ch_1_range_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        assert inst.ch_1.range == value
+
+
+def test_ch_1_voltage_setpoint_setter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 1;:VOLT 15', None)],
+    ) as inst:
+        inst.ch_1.voltage_setpoint = 15.0
+
+
+def test_ch_1_voltage_setpoint_getter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 1;:VOLT?', b'+1.50000000E+01\n')],
+    ) as inst:
+        assert inst.ch_1.voltage_setpoint == 15.0
+
+
+def test_ch_2_current_limit_setter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:CURR 0.6', None)],
+    ) as inst:
+        inst.ch_2.current_limit = 0.6
+
+
+def test_ch_2_current_limit_getter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:CURR?', b'+6.00000000E-01\n')],
+    ) as inst:
+        assert inst.ch_2.current_limit == 0.6
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None)],
+     'LOW'),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P60V', None)],
+     'HIGH'),
+))
+def test_ch_2_range_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        inst.ch_2.range = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG?', b'P35V\n')],
+     'LOW'),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG?', b'P60V\n')],
+     'HIGH'),
+))
+def test_ch_2_range_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        assert inst.ch_2.range == value
+
+
+def test_ch_2_voltage_setpoint_setter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT 15', None)],
+    ) as inst:
+        inst.ch_2.voltage_setpoint = 15.0
+
+
+def test_ch_2_voltage_setpoint_getter():
+    with expected_protocol(
+            KeysightE3649A,
+            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+             (b'INST:NSEL 2;:VOLT?', b'+1.50000000E+01\n')],
+    ) as inst:
+        assert inst.ch_2.voltage_setpoint == 15.0
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'OUTP 1', None)],
+     True),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'OUTP 0', None)],
+     False),
+))
+def test_dual_output_enabled_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        inst.output_enabled = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'OUTP?', b'1\n')],
+     True),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b'OUTP?', b'0\n')],
+     False),
+))
+def test_dual_output_enabled_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        assert inst.output_enabled == value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b':OUTP:TRAC 1', None)],
+     True),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b':OUTP:TRAC 0', None)],
+     False),
+))
+def test_tracking_enabled_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        inst.tracking_enabled = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b':OUTP:TRAC?', b'1\n')],
+     True),
+    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
+      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
+      (b':OUTP:TRAC?', b'0\n')],
+     False),
+))
+def test_tracking_enabled_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3649A,
+            comm_pairs,
+    ) as inst:
+        assert inst.tracking_enabled == value
+
+
+# Protocol tests for range mapping of low voltage devices
+def test_low_voltage_init():
+    with expected_protocol(
+            KeysightE3640A,
+            [(b'VOLT:RANG P8V', None)],
+    ):
+        pass  # Verify the expected communication.
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P8V', None),
+      (b'VOLT:RANG P8V', None)],
+     'LOW'),
+    ([(b'VOLT:RANG P8V', None),
+      (b'VOLT:RANG P20V', None)],
+     'HIGH'),
+))
+def test_low_voltage_range_setter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3640A,
+            comm_pairs,
+    ) as inst:
+        inst.range = value
+
+
+@pytest.mark.parametrize("comm_pairs, value", (
+    ([(b'VOLT:RANG P8V', None),
+      (b'VOLT:RANG?', b'P8V\n')],
+     'LOW'),
+    ([(b'VOLT:RANG P8V', None),
+      (b'VOLT:RANG?', b'P20V\n')],
+     'HIGH'),
+))
+def test_low_voltage_range_getter(comm_pairs, value):
+    with expected_protocol(
+            KeysightE3640A,
+            comm_pairs,
+    ) as inst:
+        assert inst.range == value

--- a/tests/instruments/keysight/test_keysightE364xA.py
+++ b/tests/instruments/keysight/test_keysightE364xA.py
@@ -36,7 +36,7 @@ def test_single_init():
         pass  # Verify the expected communication.
 
 
-def test_current_limit_setter():
+def test_single_current_limit_setter():
     with expected_protocol(
             KeysightE3643A,
             [(b'VOLT:RANG P35V', None),
@@ -45,7 +45,7 @@ def test_current_limit_setter():
         inst.current_limit = 0.6
 
 
-def test_current_limit_getter():
+def test_single_current_limit_getter():
     with expected_protocol(
             KeysightE3643A,
             [(b'VOLT:RANG P35V', None),
@@ -94,7 +94,7 @@ def test_single_output_enabled_getter(comm_pairs, value):
       (b'VOLT:RANG P60V', None)],
      'HIGH'),
 ))
-def test_range_setter(comm_pairs, value):
+def test_single_range_setter(comm_pairs, value):
     with expected_protocol(
             KeysightE3643A,
             comm_pairs,
@@ -110,7 +110,7 @@ def test_range_setter(comm_pairs, value):
       (b'VOLT:RANG?', b'P60V\n')],
      'HIGH'),
 ))
-def test_range_getter(comm_pairs, value):
+def test_single_range_getter(comm_pairs, value):
     with expected_protocol(
             KeysightE3643A,
             comm_pairs,
@@ -118,7 +118,7 @@ def test_range_getter(comm_pairs, value):
         assert inst.range == value
 
 
-def test_voltage_setpoint_setter():
+def test_single_voltage_setpoint_setter():
     with expected_protocol(
             KeysightE3643A,
             [(b'VOLT:RANG P35V', None),
@@ -127,7 +127,7 @@ def test_voltage_setpoint_setter():
         inst.voltage_setpoint = 15.0
 
 
-def test_voltage_setpoint_getter():
+def test_single_voltage_setpoint_getter():
     with expected_protocol(
             KeysightE3643A,
             [(b'VOLT:RANG P35V', None),
@@ -146,26 +146,6 @@ def test_dual_init():
         pass  # Verify the expected communication.
 
 
-def test_ch_1_current_limit_setter():
-    with expected_protocol(
-            KeysightE3649A,
-            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 1;:CURR 0.6', None)],
-    ) as inst:
-        inst.ch_1.current_limit = 0.6
-
-
-def test_ch_1_current_limit_getter():
-    with expected_protocol(
-            KeysightE3649A,
-            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 1;:CURR?', b'+6.00000000E-01\n')],
-    ) as inst:
-        assert inst.ch_1.current_limit == 0.6
-
-
 @pytest.mark.parametrize("comm_pairs, value", (
     ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
       (b'INST:NSEL 2;:VOLT:RANG P35V', None),
@@ -176,7 +156,7 @@ def test_ch_1_current_limit_getter():
       (b'INST:NSEL 1;:VOLT:RANG P60V', None)],
      'HIGH'),
 ))
-def test_ch_1_range_setter(comm_pairs, value):
+def test_dual_range_setter(comm_pairs, value):
     with expected_protocol(
             KeysightE3649A,
             comm_pairs,
@@ -194,7 +174,7 @@ def test_ch_1_range_setter(comm_pairs, value):
       (b'INST:NSEL 1;:VOLT:RANG?', b'P60V\n')],
      'HIGH'),
 ))
-def test_ch_1_range_getter(comm_pairs, value):
+def test_dual_range_getter(comm_pairs, value):
     with expected_protocol(
             KeysightE3649A,
             comm_pairs,
@@ -202,7 +182,7 @@ def test_ch_1_range_getter(comm_pairs, value):
         assert inst.ch_1.range == value
 
 
-def test_ch_1_voltage_setpoint_setter():
+def test_dual_voltage_setpoint_setter():
     with expected_protocol(
             KeysightE3649A,
             [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
@@ -212,7 +192,7 @@ def test_ch_1_voltage_setpoint_setter():
         inst.ch_1.voltage_setpoint = 15.0
 
 
-def test_ch_1_voltage_setpoint_getter():
+def test_dual_voltage_setpoint_getter():
     with expected_protocol(
             KeysightE3649A,
             [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
@@ -222,7 +202,7 @@ def test_ch_1_voltage_setpoint_getter():
         assert inst.ch_1.voltage_setpoint == 15.0
 
 
-def test_ch_2_current_limit_setter():
+def test_dual_current_limit_setter():
     with expected_protocol(
             KeysightE3649A,
             [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
@@ -232,7 +212,7 @@ def test_ch_2_current_limit_setter():
         inst.ch_2.current_limit = 0.6
 
 
-def test_ch_2_current_limit_getter():
+def test_dual_current_limit_getter():
     with expected_protocol(
             KeysightE3649A,
             [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
@@ -240,62 +220,6 @@ def test_ch_2_current_limit_getter():
              (b'INST:NSEL 2;:CURR?', b'+6.00000000E-01\n')],
     ) as inst:
         assert inst.ch_2.current_limit == 0.6
-
-
-@pytest.mark.parametrize("comm_pairs, value", (
-    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P35V', None)],
-     'LOW'),
-    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P60V', None)],
-     'HIGH'),
-))
-def test_ch_2_range_setter(comm_pairs, value):
-    with expected_protocol(
-            KeysightE3649A,
-            comm_pairs,
-    ) as inst:
-        inst.ch_2.range = value
-
-
-@pytest.mark.parametrize("comm_pairs, value", (
-    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG?', b'P35V\n')],
-     'LOW'),
-    ([(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-      (b'INST:NSEL 2;:VOLT:RANG?', b'P60V\n')],
-     'HIGH'),
-))
-def test_ch_2_range_getter(comm_pairs, value):
-    with expected_protocol(
-            KeysightE3649A,
-            comm_pairs,
-    ) as inst:
-        assert inst.ch_2.range == value
-
-
-def test_ch_2_voltage_setpoint_setter():
-    with expected_protocol(
-            KeysightE3649A,
-            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT 15', None)],
-    ) as inst:
-        inst.ch_2.voltage_setpoint = 15.0
-
-
-def test_ch_2_voltage_setpoint_getter():
-    with expected_protocol(
-            KeysightE3649A,
-            [(b'INST:NSEL 1;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT:RANG P35V', None),
-             (b'INST:NSEL 2;:VOLT?', b'+1.50000000E+01\n')],
-    ) as inst:
-        assert inst.ch_2.voltage_setpoint == 15.0
 
 
 @pytest.mark.parametrize("comm_pairs, value", (

--- a/tests/instruments/keysight/test_keysightE364xA.py
+++ b/tests/instruments/keysight/test_keysightE364xA.py
@@ -23,8 +23,9 @@
 #
 
 import pytest
-from pymeasure.test import expected_protocol
+
 from pymeasure.instruments.keysight import KeysightE3640A, KeysightE3643A, KeysightE3649A
+from pymeasure.test import expected_protocol
 
 
 # Protocol tests for single channel devices


### PR DESCRIPTION
I added support for the Keysight E364xA power supply series. The series has six single channel versions (E3640A to E3645A) and four dual output channel versions (E3646A to E3649A), so I created two base classes ```KeysightE364XASingleOutput``` and ```KeysightE364XADualOutput``` together with ```KeysightE364XAChannel``` for the individual device classes. The individual devices inherit their behavior from the base classes and provide their own maximum voltage and maximum current capabilities via class attributes.

One special feature of the device series is that each channel can be set into either "LOW" or "HIGH" output voltage mode via the ```VOLT:RANG``` SCPI command. I therefore declared the ```voltage_setpoint``` and ```current_limit``` of the device/channel as dynamic properties to be able to change the allowed validator range on the fly.
To update the validator range each time the user changes the output range, I registered an ```update_validator_range``` method as a set_process for the channels ```range``` property.

I tested correct operation on hardware with a E3643A (single output) and a E3649A (dual output) device connected with a [USBGpib v2](https://github.com/xyphro/UsbGpib) dongle, autogenerated the protocol tests and combined them into a single file under ```tests/instruments/keysight/test_keysightE364xA.py```.