### PR TITLE
Fix plotter class throwing warning

### DIFF
--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -96,7 +96,7 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         # Setup blinking
         if self._blink_qtimer is None:
             self._blink_qtimer = QtCore.QTimer()
-            
+
         self._blink_qtimer.timeout.connect(self._blink)
         self.handler.connect(self._blinking_start)
 

--- a/pymeasure/display/widgets/log_widget.py
+++ b/pymeasure/display/widgets/log_widget.py
@@ -79,7 +79,7 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
     tab_widget = None
     tab_index = None
 
-    _blink_qtimer = QtCore.QTimer()
+    _blink_qtimer = None
     _blink_color = None
     _blink_state = False
 
@@ -94,6 +94,9 @@ class LogWidget(TabWidget, QtWidgets.QWidget):
         self._layout()
 
         # Setup blinking
+        if self._blink_qtimer is None:
+            self._blink_qtimer = QtCore.QTimer()
+            
         self._blink_qtimer.timeout.connect(self._blink)
         self.handler.connect(self._blinking_start)
 


### PR DESCRIPTION
Fix for plotter class throwing the warning: `WARNING: QApplication was not created in the main() thread.` (Closes #268)

The problem is that LogWidget calls QTimer() when importing the module, which starts the Qt event loop in the initial thread. 