### PR TITLE
Fix DSPBase.auto_gain and .gain returning list instead of scalar

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -112,3 +112,4 @@ Niklas Schulz
 Haotian Zhang
 Maduka Ariyasiri
 Max Tweedale
+Muralidhar M Shenoy

--- a/pymeasure/instruments/signalrecovery/dsp_base.py
+++ b/pymeasure/instruments/signalrecovery/dsp_base.py
@@ -258,7 +258,7 @@ class DSPBase(Instrument):
     @property
     def gain(self):
         """Control the AC gain of signal channel amplifier."""
-        return self.values("ACGAIN")
+        return self.values("ACGAIN")[0]
 
     @gain.setter
     def gain(self, value):
@@ -297,7 +297,7 @@ class DSPBase(Instrument):
     @property
     def auto_gain(self):
         """Control lock-in amplifier for automatic AC gain."""
-        return int(self.values("AUTOMATIC")) == 1
+        return int(self.values("AUTOMATIC")[0]) == 1
 
     @auto_gain.setter
     def auto_gain(self, value):

--- a/tests/instruments/signalrecovery/test_dspbase.py
+++ b/tests/instruments/signalrecovery/test_dspbase.py
@@ -69,3 +69,37 @@ def test_x(reading, value):
             [('X.', reading)],
     ) as instr:
         assert instr.x == value
+
+
+@pytest.mark.parametrize("reading, value", [(b"0\r\n", 0), (b"5\r\n", 5), (b"9\r\n", 9)])
+def test_gain_getter(reading, value):
+    with expected_protocol(
+            DSPBase,
+            [("ACGAIN", reading)],
+    ) as instr:
+        assert instr.gain == value
+
+
+@pytest.mark.parametrize("reading, value", [(b"0\r\n", False), (b"1\r\n", True)])
+def test_auto_gain_getter(reading, value):
+    with expected_protocol(
+            DSPBase,
+            [("AUTOMATIC", reading)],
+    ) as instr:
+        assert instr.auto_gain == value
+
+
+def test_auto_gain_setter_enable():
+    with expected_protocol(
+            DSPBase,
+            [("AUTOMATIC 1", None)],
+    ) as instr:
+        instr.auto_gain = True
+
+
+def test_auto_gain_setter_disable():
+    with expected_protocol(
+            DSPBase,
+            [("AUTOMATIC 0", None)],
+    ) as instr:
+        instr.auto_gain = False


### PR DESCRIPTION
## Summary

`DSPBase.auto_gain` (`pymeasure/instruments/signalrecovery/dsp_base.py`) called `int(self.values("AUTOMATIC")) == 1`, but `Instrument.values()` always returns a `list`, so reading `auto_gain` raises `TypeError` instead of returning a bool.

While fixing that, I found the same anti-pattern in the neighboring `gain` getter: it returned the raw single-element list from `self.values("ACGAIN")` instead of a scalar.

Both are fixed by indexing into the result, matching the existing `sensitivity` property a few lines above (`self.values("SEN.")[0]`).

Fixes #1478

## Test plan

- Added `test_gain_getter`, `test_auto_gain_getter`, `test_auto_gain_setter_enable`, `test_auto_gain_setter_disable` to `tests/instruments/signalrecovery/test_dspbase.py`, following the existing `expected_protocol` pattern in that file.
- `pytest tests/instruments/signalrecovery/` — 31/31 passed.
- `ruff check` on both changed files — clean.