### PR TITLE
Rework unit initialization in Agilent B1500

### DIFF
--- a/docs/api/instruments/agilent/agilentB1500.rst
+++ b/docs/api/instruments/agilent/agilentB1500.rst
@@ -90,10 +90,10 @@ Initialization of the Instrument
 
     # explicitly define r/w terminations; set sufficiently large timeout in milliseconds or None.
     b1500=AgilentB1500("GPIB0::17::INSTR", read_termination='\r\n', write_termination='\r\n', timeout=600000)
-    # query SMU config from instrument and initialize all SMU instances
-    b1500.initialize_all_smus()
+    # query module config from instrument and initialize all unit instances (SMU, SPGU, CMU)
+    b1500.initialize_all_units()
     # set data output format (required!)
-    b1500.data_format(21, mode=1) #call after SMUs are initialized to get names for the channels
+    b1500.data_format(21, mode=1) # call after units are initialized to get names for the channels
 
 
 IV measurement with 4 SMUs

--- a/docs/api/instruments/agilent/agilentB1500.rst
+++ b/docs/api/instruments/agilent/agilentB1500.rst
@@ -91,7 +91,7 @@ Initialization of the Instrument
     # explicitly define r/w terminations; set sufficiently large timeout in milliseconds or None.
     b1500=AgilentB1500("GPIB0::17::INSTR", read_termination='\r\n', write_termination='\r\n', timeout=600000)
     # query module config from instrument and initialize all unit instances (SMU, SPGU, CMU)
-    b1500.initialize_all_units()
+    b1500.initialize_units()
     # set data output format (required!)
     b1500.data_format(21, mode=1) # call after units are initialized to get names for the channels
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -154,7 +154,7 @@ class AgilentB1500(SCPIMixin, Instrument):
                     raise NotImplementedError(f"Module {module[0]} is not implemented yet!") from e
         return out
 
-    def initialize_all_units(self) -> None:
+    def initialize_units(self) -> None:
         """Initialize all supported units.
 
         Query available modules once and create a :class:`.SMU`, :class:`.SPGU`
@@ -197,10 +197,10 @@ class AgilentB1500(SCPIMixin, Instrument):
         SMUs are accessible via attributes such as ``.smu1``, etc.
 
         .. deprecated:: 0.17.0
-            Use :meth:`initialize_all_units` instead.
+            Use :meth:`initialize_units` instead.
         """
         warnings.warn(
-            "`initialize_all_smus` is deprecated, use `initialize_all_units` instead.",
+            "`initialize_all_smus` is deprecated, use `initialize_units` instead.",
             FutureWarning,
             stacklevel=2,
         )
@@ -226,10 +226,10 @@ class AgilentB1500(SCPIMixin, Instrument):
         SPGUs are accessible via attributes such as ``.spgu1``, etc.
 
         .. deprecated:: 0.17.0
-            Use :meth:`initialize_all_units` instead.
+            Use :meth:`initialize_units` instead.
         """
         warnings.warn(
-            "`initialize_all_spgus` is deprecated, use `initialize_all_units` instead.",
+            "`initialize_all_spgus` is deprecated, use `initialize_units` instead.",
             FutureWarning,
             stacklevel=2,
         )
@@ -253,10 +253,10 @@ class AgilentB1500(SCPIMixin, Instrument):
         CMU is accessible via attribute ``.cmu``.
 
         .. deprecated:: 0.17.0
-            Use :meth:`initialize_all_units` instead.
+            Use :meth:`initialize_units` instead.
         """
         warnings.warn(
-            "`initialize_cmu` is deprecated, use `initialize_all_units` instead.",
+            "`initialize_cmu` is deprecated, use `initialize_units` instead.",
             FutureWarning,
             stacklevel=2,
         )

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -182,9 +182,17 @@ class AgilentB1500(SCPIMixin, Instrument):
         SPGUs are accessible via attributes such as ``.spgu1``, etc.
         """
         modules = self.query_modules()
+        i = 1
         for channel, module_type in modules.items():
             if module_type == "SPGU":
-                self.add_child(SPGU, channel, collection="spgus", prefix="spgu")
+                self.add_child(
+                    SPGU,
+                    i,
+                    collection="spgus",
+                    prefix="spgu",
+                    slot=channel,
+                )
+                i += 1
 
     def initialize_cmu(self) -> None:
         """Initialize CMU.
@@ -1791,11 +1799,13 @@ class SPGU(Channel):
     """Provide specific methods for the SPGU module of the Agilent B1500 mainframe.
 
     :param parent: Instance of the B1500 mainframe class
-    :param channel: Channel number of the SPGU
+    :param index: Index of the SPGU
+    :param slot: Slot number of the SPGU
     """
 
-    def __init__(self, parent: AgilentB1500, channel: int, **kwargs):
-        super().__init__(parent, channel, **kwargs)
+    def __init__(self, parent: AgilentB1500, index: int, slot: int, **kwargs):
+        slot = strict_discrete_set(slot, range(1, 11))
+        super().__init__(parent, slot, **kwargs)
         self.ch1 = self.add_child(SPGUChannel, int(f"{self.id}01"), prefix="ch")
         self.ch2 = self.add_child(SPGUChannel, int(f"{self.id}02"), prefix="ch")
 

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -59,7 +59,10 @@ class AgilentB1500(SCPIMixin, Instrument):
     measurements.
     """
 
+    # Created dynamically by :meth:`initialize_units`
     smus: dict[int, SMU]
+    spgus: dict[int, SPGU]
+    cmu: CMU
 
     def __init__(
         self,

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -68,7 +68,6 @@ class AgilentB1500(SCPIMixin, Instrument):
         **kwargs,
     ):
         super().__init__(adapter, name, read_termination="\r\n", write_termination="\r\n", **kwargs)
-        self._smu_references: dict[int, SMU] = {}
         self._data_format: AgilentB1500._data_formatting_generic | None = None
 
     @property
@@ -121,7 +120,8 @@ class AgilentB1500(SCPIMixin, Instrument):
 
         :param query_type: Query type (number according to manual)
         """
-        return QueryLearn.query_learn_header(self.ask, query_type, self._smu_references, **kwargs)
+        smu_references = {cast(int, smu.id): smu for smu in getattr(self, "smus", {}).values()}
+        return QueryLearn.query_learn_header(self.ask, query_type, smu_references, **kwargs)
 
     def query_modules(self) -> dict[int, str]:
         """Query module models from the instrument.
@@ -176,7 +176,6 @@ class AgilentB1500(SCPIMixin, Instrument):
                     smu_type=module_type,
                     slot=channel,
                 )
-                self._smu_references[channel] = self.smus[smu_index]
                 smu_index += 1
             elif "CMU" in module_type:
                 self.add_child(CMU, id=channel, collection="cmu", prefix=None)
@@ -216,7 +215,6 @@ class AgilentB1500(SCPIMixin, Instrument):
                     smu_type=module_type,
                     slot=channel,
                 )
-                self._smu_references[channel] = self.smus[i]
                 i += 1
 
     def initialize_all_spgus(self) -> None:

--- a/pymeasure/instruments/agilent/agilentB1500.py
+++ b/pymeasure/instruments/agilent/agilentB1500.py
@@ -154,12 +154,56 @@ class AgilentB1500(SCPIMixin, Instrument):
                     raise NotImplementedError(f"Module {module[0]} is not implemented yet!") from e
         return out
 
+    def initialize_all_units(self) -> None:
+        """Initialize all supported units.
+
+        Query available modules once and create a :class:`.SMU`, :class:`.SPGU`
+        or :class:`.CMU` instance for every module that is supported by this driver.
+        The units are numbered consecutively per type and are accessible via
+        attributes such as ``.smu1``, ``.spgu1`` and ``.cmu``.
+        The slot a unit is installed in is available as its ``id``.
+        """
+        modules = self.query_modules()
+        smu_index = 1
+        spgu_index = 1
+        for channel, module_type in modules.items():
+            if "SMU" in module_type:
+                self.add_child(
+                    SMU,
+                    smu_index,
+                    collection="smus",
+                    prefix="smu",
+                    smu_type=module_type,
+                    slot=channel,
+                )
+                self._smu_references[channel] = self.smus[smu_index]
+                smu_index += 1
+            elif "CMU" in module_type:
+                self.add_child(CMU, id=channel, collection="cmu", prefix=None)
+            elif module_type == "SPGU":
+                self.add_child(
+                    SPGU,
+                    spgu_index,
+                    collection="spgus",
+                    prefix="spgu",
+                    slot=channel,
+                )
+                spgu_index += 1
+
     def initialize_all_smus(self) -> None:
         """Initialize all SMUs.
 
         Query available modules and create a :class:`.SMU` instance for each.
         SMUs are accessible via attributes such as ``.smu1``, etc.
+
+        .. deprecated:: 0.17.0
+            Use :meth:`initialize_all_units` instead.
         """
+        warnings.warn(
+            "`initialize_all_smus` is deprecated, use `initialize_all_units` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         modules = self.query_modules()
         i = 1
         for channel, module_type in modules.items():
@@ -180,7 +224,15 @@ class AgilentB1500(SCPIMixin, Instrument):
 
         Query available modules and create a :class:`.SPGU` instance for each.
         SPGUs are accessible via attributes such as ``.spgu1``, etc.
+
+        .. deprecated:: 0.17.0
+            Use :meth:`initialize_all_units` instead.
         """
+        warnings.warn(
+            "`initialize_all_spgus` is deprecated, use `initialize_all_units` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         modules = self.query_modules()
         i = 1
         for channel, module_type in modules.items():
@@ -199,7 +251,15 @@ class AgilentB1500(SCPIMixin, Instrument):
 
         Query available modules and create a :class:`.CMU` instance for the CMU.
         CMU is accessible via attribute ``.cmu``.
+
+        .. deprecated:: 0.17.0
+            Use :meth:`initialize_all_units` instead.
         """
+        warnings.warn(
+            "`initialize_cmu` is deprecated, use `initialize_all_units` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         modules = self.query_modules()
         for channel, module_type in modules.items():
             if "CMU" in module_type:

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -49,9 +49,9 @@ from pymeasure.instruments.agilent.agilentB1500 import (
 )
 from pymeasure.test import expected_protocol
 
-#: ``UNT?`` response of a mainframe with SMUs in slot 1 and 4, SPGUs in slot 3 and 5,
-#: a CMU in slot 6 and an empty slot 2.
-MODULES = "B1517A,0;0,0;B1525A,0;B1511A,0;B1525A,0;B1520A,0"
+#: ``UNT?`` response of a mainframe with SPGUs in slot 1, an unsupported WGFMU in slot 2,
+#: SMUs in slots 3, 5, 6 and 7, a CMU in slot 8 and empty slots 4 and 10.
+MODULES = "B1525A,0;B1530A,0;B1510A,0;0,0;B1517A,0;B1517A,0;B1511B,1;B1520A/N1301A,0;0,0;0,0"
 
 
 class TestB1500:
@@ -89,27 +89,33 @@ class TestB1500:
         """Test that all supported units are initialized with a single module query."""
         with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
             inst.initialize_units()
-            assert inst.unit_names == {1: "SMU1", 4: "SMU2", 3: "SPGU1", 5: "SPGU2", 6: "CMU"}
-            assert list(inst.smu_references) == [inst.smu1, inst.smu2]
+            assert inst.unit_names == {
+                3: "SMU1",
+                5: "SMU2",
+                6: "SMU3",
+                7: "SMU4",
+                1: "SPGU1",
+                8: "CMU",
+            }
+            assert list(inst.smu_references) == [inst.smu1, inst.smu2, inst.smu3, inst.smu4]
 
     def test_initialize_units_numbering(self):
         """Test that units are numbered consecutively while their id is the slot number."""
         with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
             inst.initialize_units()
-            assert inst.smus == {1: inst.smu1, 2: inst.smu2}
-            assert (inst.smu1.id, inst.smu2.id) == (1, 4)
-            assert inst.spgus == {1: inst.spgu1, 2: inst.spgu2}
-            assert (inst.spgu1.id, inst.spgu2.id) == (3, 5)
-            # SPGU channel numbers are derived from the slot, not from the SPGU number
-            assert (inst.spgu1.ch1.id, inst.spgu1.ch2.id) == (301, 302)
-            assert inst.cmu.id == 6
+            assert inst.smus == {1: inst.smu1, 2: inst.smu2, 3: inst.smu3, 4: inst.smu4}
+            assert (inst.smu1.id, inst.smu2.id, inst.smu3.id, inst.smu4.id) == (3, 5, 6, 7)
+            assert inst.spgus == {1: inst.spgu1}
+            assert (inst.spgu1.id) == (1)
+            assert (inst.spgu1.ch1.id, inst.spgu1.ch2.id) == (101, 102)
+            assert inst.cmu.id == 8
 
     @pytest.mark.parametrize(
         "method, unit_names",
         [
-            ("initialize_all_smus", {1: "SMU1", 4: "SMU2"}),
-            ("initialize_all_spgus", {3: "SPGU1", 5: "SPGU2"}),
-            ("initialize_cmu", {6: "CMU"}),
+            ("initialize_all_smus", {3: "SMU1", 5: "SMU2", 6: "SMU3", 7: "SMU4"}),
+            ("initialize_all_spgus", {1: "SPGU1"}),
+            ("initialize_cmu", {8: "CMU"}),
         ],
     )
     def test_deprecated_initialization(self, method, unit_names):

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -49,6 +49,10 @@ from pymeasure.instruments.agilent.agilentB1500 import (
 )
 from pymeasure.test import expected_protocol
 
+#: ``UNT?`` response of a mainframe with SMUs in slot 1 and 4, SPGUs in slot 3 and 5,
+#: a CMU in slot 6 and an empty slot 2.
+MODULES = "B1517A,0;0,0;B1525A,0;B1511A,0;B1525A,0;B1520A,0"
+
 
 class TestB1500:
     """Tests for B1500 functionality."""
@@ -81,6 +85,15 @@ class TestB1500:
         ) as inst:
             inst.set_port_connection(port, status)
 
+    def test_initialize_all_spgus_numbering(self):
+        """Test that SPGUs are numbered consecutively while their id is the slot number."""
+        with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
+            inst.initialize_all_spgus()
+            assert inst.spgus == {1: inst.spgu1, 2: inst.spgu2}
+            assert (inst.spgu1.id, inst.spgu2.id) == (3, 5)
+            # SPGU channel numbers are derived from the slot, not from the SPGU number
+            assert (inst.spgu1.ch1.id, inst.spgu1.ch2.id) == (301, 302)
+
     def test_unit_names(self):
         """Test that unit_names covers all initialized units."""
         with expected_protocol(AgilentB1500Mock, []) as inst:
@@ -101,7 +114,7 @@ class AgilentB1500Mock(AgilentB1500):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.add_child(SPGU, id=1, collection="spgus", prefix="spgu")
+        self.add_child(SPGU, id=1, collection="spgus", prefix="spgu", slot=1)
         self.add_child(CMU, id=2, collection="cmu", prefix=None)
         self.add_child(SMU, id=1, collection="smus", prefix="smu", smu_type="HRSMU", slot=3)
 

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -85,14 +85,39 @@ class TestB1500:
         ) as inst:
             inst.set_port_connection(port, status)
 
-    def test_initialize_all_spgus_numbering(self):
-        """Test that SPGUs are numbered consecutively while their id is the slot number."""
+    def test_initialize_all_units(self):
+        """Test that all supported units are initialized with a single module query."""
         with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
-            inst.initialize_all_spgus()
+            inst.initialize_all_units()
+            assert inst.unit_names == {1: "SMU1", 4: "SMU2", 3: "SPGU1", 5: "SPGU2", 6: "CMU"}
+            assert list(inst.smu_references) == [inst.smu1, inst.smu2]
+
+    def test_initialize_all_units_numbering(self):
+        """Test that units are numbered consecutively while their id is the slot number."""
+        with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
+            inst.initialize_all_units()
+            assert inst.smus == {1: inst.smu1, 2: inst.smu2}
+            assert (inst.smu1.id, inst.smu2.id) == (1, 4)
             assert inst.spgus == {1: inst.spgu1, 2: inst.spgu2}
             assert (inst.spgu1.id, inst.spgu2.id) == (3, 5)
             # SPGU channel numbers are derived from the slot, not from the SPGU number
             assert (inst.spgu1.ch1.id, inst.spgu1.ch2.id) == (301, 302)
+            assert inst.cmu.id == 6
+
+    @pytest.mark.parametrize(
+        "method, unit_names",
+        [
+            ("initialize_all_smus", {1: "SMU1", 4: "SMU2"}),
+            ("initialize_all_spgus", {3: "SPGU1", 5: "SPGU2"}),
+            ("initialize_cmu", {6: "CMU"}),
+        ],
+    )
+    def test_deprecated_initialization(self, method, unit_names):
+        """Test that the deprecated per-type initialization methods warn but still work."""
+        with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
+            with pytest.warns(FutureWarning, match=f"`{method}` is deprecated"):
+                getattr(inst, method)()
+            assert inst.unit_names == unit_names
 
     def test_unit_names(self):
         """Test that unit_names covers all initialized units."""

--- a/tests/instruments/agilent/test_agilentB1500.py
+++ b/tests/instruments/agilent/test_agilentB1500.py
@@ -85,17 +85,17 @@ class TestB1500:
         ) as inst:
             inst.set_port_connection(port, status)
 
-    def test_initialize_all_units(self):
+    def test_initialize_units(self):
         """Test that all supported units are initialized with a single module query."""
         with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
-            inst.initialize_all_units()
+            inst.initialize_units()
             assert inst.unit_names == {1: "SMU1", 4: "SMU2", 3: "SPGU1", 5: "SPGU2", 6: "CMU"}
             assert list(inst.smu_references) == [inst.smu1, inst.smu2]
 
-    def test_initialize_all_units_numbering(self):
+    def test_initialize_units_numbering(self):
         """Test that units are numbered consecutively while their id is the slot number."""
         with expected_protocol(AgilentB1500, [("UNT?", MODULES)]) as inst:
-            inst.initialize_all_units()
+            inst.initialize_units()
             assert inst.smus == {1: inst.smu1, 2: inst.smu2}
             assert (inst.smu1.id, inst.smu2.id) == (1, 4)
             assert inst.spgus == {1: inst.spgu1, 2: inst.spgu2}


### PR DESCRIPTION
Introduces new `initialize_units` method that combines `initialize_all_smus`, `initialize_cmu`, `initialize_all_spgus` that are now deprecated.

Also fixes existing bug that I accidentally introduced in the initial [PR](https://github.com/pymeasure/pymeasure/pull/1344) with SPGU implementation while [reworking](https://github.com/pymeasure/pymeasure/pull/1344/changes/10b7968de7c2bc1c3eec72832db7890cb96d4dd9#diff-0a9f5185d06142806c6c4dfc46f4133c909f59f90ff3a8c8dc7292f018460e33L180-L182) SPGU class into Channel subclass. As was previously [discussed](https://github.com/pymeasure/pymeasure/pull/1344#discussion_r2301380809), in this instrument the dynamically initialized units are available by their ordinal numbers (`.smu1`, `.smu2`, etc.), while the actual slot number that is used when sending commands is present as `.id` attribute. The same logic should exist for SPGU units. I accidentally broke that while reworking and didn't notice that since in our setup SPGU is installed in slot 1, so it is accessible as `.spgu1` even with current realization.

According to the manual, 
> If the SPGUs are installed, the SPGUs must be installed in the slots from the slot number 1

So, this change should not have an effect for most cases anyway.