### PR TITLE
Fix AMI430.has_persistent_switch_enabled always returning True

### DIFF
--- a/pymeasure/instruments/ami/ami430.py
+++ b/pymeasure/instruments/ami/ami430.py
@@ -50,7 +50,7 @@ class AMI430(SCPIMixin, Instrument):
         magnet.ramp_rate_field = 0.0422         # Sets the ramp rate in kGauss/s
         magnet.ramp                             # Initiates the ramping
         magnet.pause                            # Pauses the ramping
-        magnet.status                           # Returns the status of the magnet
+        magnet.magnet_status                    # Returns the status of the magnet
 
         magnet.ramp_to_current(5)             # Ramps the current to 5 A
 
@@ -141,7 +141,7 @@ class AMI430(SCPIMixin, Instrument):
 
     def has_persistent_switch_enabled(self):
         """ Returns a boolean if the persistent switch is enabled. """
-        return bool(self.ask("PSwitch?"))
+        return int(self.ask("PSwitch?")) == 1
 
     def enable_persistent_switch(self):
         """ Enables the persistent switch. """

--- a/tests/instruments/ami/test_ami430.py
+++ b/tests/instruments/ami/test_ami430.py
@@ -39,9 +39,6 @@ def test_has_persistent_switch_enabled_true():
 
 
 def test_has_persistent_switch_enabled_false():
-    # Regression test: bool(self.ask(...)) is always True for a non-empty
-    # string reply, so a "0" (switch disabled) reply was incorrectly
-    # reported as enabled. See github.com/pymeasure/pymeasure/issues/1205.
     with expected_protocol(
             AMI430,
             INIT + [(b"PSwitch?", b"0")],

--- a/tests/instruments/ami/test_ami430.py
+++ b/tests/instruments/ami/test_ami430.py
@@ -1,0 +1,65 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments.ami.ami430 import AMI430
+from pymeasure.test import expected_protocol
+
+# AMI430.__init__ reads (and discards) two welcome/connect message lines
+# before any other communication; their content is irrelevant here.
+INIT = [(None, b"welcome1"), (None, b"welcome2")]
+
+
+def test_has_persistent_switch_enabled_true():
+    with expected_protocol(
+            AMI430,
+            INIT + [(b"PSwitch?", b"1")],
+    ) as instr:
+        assert instr.has_persistent_switch_enabled() is True
+
+
+def test_has_persistent_switch_enabled_false():
+    # Regression test: bool(self.ask(...)) is always True for a non-empty
+    # string reply, so a "0" (switch disabled) reply was incorrectly
+    # reported as enabled. See github.com/pymeasure/pymeasure/issues/1205.
+    with expected_protocol(
+            AMI430,
+            INIT + [(b"PSwitch?", b"0")],
+    ) as instr:
+        assert instr.has_persistent_switch_enabled() is False
+
+
+def test_enable_persistent_switch():
+    with expected_protocol(
+            AMI430,
+            INIT + [(b"PSwitch 1", None)],
+    ) as instr:
+        instr.enable_persistent_switch()
+
+
+def test_disable_persistent_switch():
+    with expected_protocol(
+            AMI430,
+            INIT + [(b"PSwitch 0", None)],
+    ) as instr:
+        instr.disable_persistent_switch()


### PR DESCRIPTION
## Summary

`AMI430.has_persistent_switch_enabled()` (`pymeasure/instruments/ami/ami430.py`) did `return bool(self.ask("PSwitch?"))`. Since `ask()` returns a string and any non-empty string is truthy in Python, this always returned `True` regardless of the actual switch state.

Fixed by parsing the reply before comparing: `return int(self.ask("PSwitch?")) == 1`, matching the same int-string-to-bool idiom already used elsewhere in the codebase (`sr830.py`, `anritsuMG3692C.py`, `ametek7270.py`).

The issue also flagged the class docstring's usage example pointing at `magnet.status` for "Returns the status of the magnet" — `status` is the inherited `*STB?` GPIB status byte, not the magnet's actual status (`magnet_status`/`state` are). Fixed the example to `magnet.magnet_status`.

Fixes #1205

## Not addressed here

The issue's third comment (docstrings hardcoding kGauss units, e.g. on `coilconst`/`target_field`/`ramp_rate_field`, when the device's unit is actually configurable to kG or T) is left open, no concrete wording was proposed and it touches several unrelated docstrings. Happy to take it on separately if useful.

## Test plan

- Added `tests/instruments/ami/test_ami430.py` (previously no coverage existed for this driver at all), using the existing `expected_protocol` pattern: covers both `True`/`False` replies for `has_persistent_switch_enabled`, plus basic coverage for `enable_persistent_switch`/`disable_persistent_switch`.
- `pytest tests/instruments/ami/` — 4/4 passed. `pytest tests/instruments/test_all_instruments.py -k ami` — 25/25 passed, no regression.
- `ruff check` and `pyright` on both changed files — clean.
