### PR TITLE
Agilent E5270B add auto ranging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Changed
   ``Procedure.refresh_parameters`` is now a deprecated no-op (retained for API compatibility).
   ``UnknownProcedure`` now returns empty ``parameter_objects``/``metadata_objects`` dicts so loading an unimportable procedure no longer raises.
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
+- Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
 Version 0.16.0 (2026-05-20)
 ===========================

--- a/pymeasure/instruments/agilent/agilentE5270B.py
+++ b/pymeasure/instruments/agilent/agilentE5270B.py
@@ -162,8 +162,11 @@ class SMUChannel(Channel):
     )
 
     current = Channel.measurement(
-        "TI{ch}",
-        """Measure the current in Amps (float).""",
+        "TI{ch},11",
+        """Measure the current in Amps (float).
+
+        The measurement is performed with 1nA limited auto ranging.
+        """,
         get_process=lambda v: float(v[3:]),
         cast=str,
     )
@@ -193,8 +196,11 @@ class SMUChannel(Channel):
     )
 
     voltage = Instrument.measurement(
-        "TV{ch}",
-        """Measure the voltage in Volts (float).""",
+        "TV{ch},0",
+        """Measure the voltage in Volts (float).
+
+        The measurement is performed with auto ranging.
+        """,
         get_process=lambda v: float(v[3:]),
         cast=str,
     )

--- a/tests/instruments/agilent/test_agilentE5270B.py
+++ b/tests/instruments/agilent/test_agilentE5270B.py
@@ -112,7 +112,7 @@ class TestSMU:
         with expected_protocol(
             AgilentE5270B,
             [INITIALIZATION,
-             ("TI1", "NAI+1.234e-6"),
+             ("TI1,11", "NAI+1.234e-6"),
              ]
         ) as inst:
             assert 1.234e-6 == inst.smu1.current
@@ -131,7 +131,7 @@ class TestSMU:
         with expected_protocol(
             AgilentE5270B,
             [INITIALIZATION,
-             ("TV1", "NAV-1.234e-6"),
+             ("TV1,0", "NAV-1.234e-6"),
              ]
         ) as inst:
             assert -1.234e-6 == inst.smu1.voltage


### PR DESCRIPTION
- Add limited auto ranging to the current measurement. This improves the resolution for small currents if the SMU channel has a high current compliance set. The auto ranging does not go below the 1nA range to keep the measurement time at a reasonable level.
- Add auto ranging for voltage measurement. This improves the resolution for small voltages if the SMU channel has a high voltage compliance set.
- Adapt protocol test to auto ranging