### PR TITLE
Replace deprecated tempfile.mktemp() with mkstemp()

### DIFF
--- a/examples/Basic/console.py
+++ b/examples/Basic/console.py
@@ -38,6 +38,7 @@ python console.py --seed 12345 #Console version
 """
 
 import logging
+import os
 import random
 import sys
 import tempfile
@@ -95,7 +96,9 @@ class MainWindow(ManagedWindow):
         self.setWindowTitle('GUI Example')
 
     def queue(self):
-        filename = tempfile.mktemp()
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        os.unlink(filename)
 
         procedure = self.make_procedure()
         results = Results(procedure, filename)

--- a/examples/Basic/script.py
+++ b/examples/Basic/script.py
@@ -34,6 +34,7 @@ python script.py
 """
 
 import logging
+import os
 import random
 import tempfile
 from time import sleep
@@ -88,7 +89,9 @@ if __name__ == "__main__":
     scribe = console_log(log, level=logging.DEBUG)
     scribe.start()
 
-    filename = tempfile.mktemp()
+    fd, filename = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(filename)
     log.info(f"Using data file: {filename}")
 
     procedure = TestProcedure()

--- a/examples/Basic/script_plotter.py
+++ b/examples/Basic/script_plotter.py
@@ -34,6 +34,7 @@ python script_plotter.py
 """
 
 import logging
+import os
 import random
 import tempfile
 from time import sleep
@@ -89,7 +90,9 @@ if __name__ == "__main__":
     scribe = console_log(log, level=logging.DEBUG)
     scribe.start()
 
-    filename = tempfile.mktemp()
+    fd, filename = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(filename)
     log.info(f"Using data file: {filename}")
 
     procedure = TestProcedure()

--- a/pymeasure/display/windows/managed_window.py
+++ b/pymeasure/display/windows/managed_window.py
@@ -635,7 +635,9 @@ class ManagedWindowBase(QtWidgets.QMainWindow):
                 log.error(f"Invalid filename provided: {E.args[0]}")
                 return
         else:
-            filename = tempfile.mktemp(prefix='TempFile_', suffix='.csv')
+            fd, filename = tempfile.mkstemp(prefix='TempFile_', suffix='.csv')
+            os.close(fd)
+            os.unlink(filename)
 
         results = Results(procedure, filename)
 

--- a/pymeasure/experiment/experiment.py
+++ b/pymeasure/experiment/experiment.py
@@ -24,6 +24,7 @@
 
 import gc
 import logging
+import os
 import tempfile
 import time
 
@@ -70,7 +71,9 @@ def create_filename(title):
     if 'Filename' in config._sections:
         filename = unique_filename(suffix=f'_{title}', **config._sections['Filename'])
     else:
-        filename = tempfile.mktemp()
+        fd, filename = tempfile.mkstemp()
+        os.close(fd)
+        os.unlink(filename)
     return filename
 
 

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -107,7 +107,9 @@ def test_procedure_filestorage():
     assert RandomProcedure.iterations.value == 100
     procedure = RandomProcedure()
     procedure.iterations = 101
-    resultfile = tempfile.mktemp()
+    fd, resultfile = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(resultfile)
     results = Results(procedure, resultfile)
 
     new_results = pickle.loads(pickle.dumps(results))

--- a/tests/experiment/test_workers.py
+++ b/tests/experiment/test_workers.py
@@ -41,7 +41,9 @@ tcp_libs_available = bool(importlib.util.find_spec('cloudpickle')
 
 def test_worker_stop():
     procedure = RandomProcedure()
-    file = tempfile.mktemp()
+    fd, file = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(file)
     results = Results(procedure, file)
     worker = Worker(results)
     worker.start()
@@ -54,7 +56,9 @@ def test_worker_finish():
     procedure = RandomProcedure()
     procedure.iterations = 100
     procedure.delay = 0.001
-    file = tempfile.mktemp()
+    fd, file = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(file)
     results = Results(procedure, file)
     worker = Worker(results)
     worker.start()
@@ -71,7 +75,9 @@ def test_worker_closes_file_after_finishing():
     procedure = RandomProcedure()
     procedure.iterations = 100
     procedure.delay = 0.001
-    file = tempfile.mktemp()
+    fd, file = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(file)
     results = Results(procedure, file)
     worker = Worker(results)
     worker.start()
@@ -89,7 +95,9 @@ def test_zmq_does_not_crash_worker(caplog):
     See https://github.com/ralph-group/pymeasure/issues/168
     """
     procedure = RandomProcedure()
-    file = tempfile.mktemp()
+    fd, file = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(file)
     results = Results(procedure, file)
     # If we define a port here we get ZMQ communication
     # if cloudpickle is installed
@@ -115,7 +123,9 @@ def test_zmq_topic_filtering_works(caplog):
             self.emit('progress', 99)
 
     procedure = ThreeEmitsProcedure()
-    file = tempfile.mktemp()
+    fd, file = tempfile.mkstemp()
+    os.close(fd)
+    os.unlink(file)
     results = Results(procedure, file)
     received = []
     worker = Worker(results, port=5888, log_level=logging.DEBUG)


### PR DESCRIPTION
mktemp() is deprecated since Python 2.3. Replace with mkstemp() followed by close+unlink to get a temp path without a file on disk, preserving the same behavior as mktemp().