### PR TITLE
Add UNI-T UDP6933B power supply

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -117,3 +117,4 @@ Jonas Grage
 Max Tweedale
 Muralidhar M Shenoy
 Vincent Gao
+Andrew Everson

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -86,5 +86,6 @@ Instruments by manufacturer:
    thorlabs/index
    thyracont/index
    toptica/index
+   unit/index
    velleman/index
    yokogawa/index

--- a/docs/api/instruments/unit/index.rst
+++ b/docs/api/instruments/unit/index.rst
@@ -1,0 +1,13 @@
+.. module:: pymeasure.instruments.unit
+
+#####
+UNI-T
+#####
+
+This section contains documentation for the implemented UNI-T instruments.
+
+.. toctree::
+   :maxdepth: 2
+
+   udp6933b
+

--- a/docs/api/instruments/unit/udp6933b.rst
+++ b/docs/api/instruments/unit/udp6933b.rst
@@ -1,0 +1,7 @@
+UNI-T UDP6933B DC Power Supply
+==============================
+
+.. autoclass:: pymeasure.instruments.unit.UNITUDP6933B
+    :members:
+    :show-inheritance:
+

--- a/pymeasure/instruments/unit/__init__.py
+++ b/pymeasure/instruments/unit/__init__.py
@@ -1,0 +1,26 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .udp6933b import UNITUDP6933B
+

--- a/pymeasure/instruments/unit/udp6933b.py
+++ b/pymeasure/instruments/unit/udp6933b.py
@@ -1,0 +1,101 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import AdapterType, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+
+class UNITUDP6933B(SCPIMixin, Instrument):
+    """Control the UNI-T UDP6933B programmable DC power supply.
+
+    The supply supports SCPI communication over USB, LAN, RS-232, and RS-485.
+    """
+
+    def __init__(
+        self,
+        adapter: AdapterType,
+        name: str = "UNI-T UDP6933B DC power supply",
+        **kwargs,
+    ):
+        super().__init__(adapter, name, **kwargs)
+
+    voltage = Instrument.measurement(
+        "MEAS:VOLT?",
+        """Measure the actual output voltage in volts.""",
+    )
+
+    current = Instrument.measurement(
+        "MEAS:CURR?",
+        """Measure the actual output current in amperes.""",
+    )
+
+    # Use the full keyword because hardware testing showed that the shorter MEAS:POW? form is
+    # rejected by firmware 1.01.0301, even though the other measurement abbreviations work.
+    power = Instrument.measurement(
+        "MEASure:POWer?",
+        """Measure the actual output power in watts.""",
+    )
+
+    voltage_setpoint = Instrument.control(
+        "VOLT?",
+        "VOLT %g",
+        """Control the output voltage setpoint in volts (float strictly from 0 to 150).""",
+        validator=strict_range,
+        values=(0, 150),
+    )
+
+    current_limit = Instrument.control(
+        "CURR?",
+        "CURR %g",
+        """Control the output current limit in amperes (float strictly from 0 to 5).""",
+        validator=strict_range,
+        values=(0, 5),
+    )
+
+    # Hardware returns ON/OFF strings, so cast=str prevents numeric response parsing.
+    output_enabled = Instrument.control(
+        "OUTP?",
+        "OUTP %s",
+        """Control whether the power output is enabled (boolean).""",
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True,
+        cast=str,
+    )
+
+    def apply(self, voltage: float, current_limit: float) -> None:
+        """Set the output voltage and current limit.
+
+        :param voltage: Output voltage setpoint in volts.
+        :param current_limit: Output current limit in amperes.
+        """
+        # Validate both values first to avoid applying only part of the requested configuration.
+        strict_range(voltage, (0, 150))
+        strict_range(current_limit, (0, 5))
+
+        # Unlike the GW Instek example, the UDP6933B has no general two-argument APPLy command. Its
+        # documented APPLy command recalls stored presets, so voltage and current are sent
+        # separately.
+        self.voltage_setpoint = voltage
+        self.current_limit = current_limit

--- a/pymeasure/instruments/unit/udp6933b.py
+++ b/pymeasure/instruments/unit/udp6933b.py
@@ -94,8 +94,8 @@ class UNITUDP6933B(SCPIMixin, Instrument):
         strict_range(voltage, (0, 150))
         strict_range(current_limit, (0, 5))
 
-        # Unlike the GW Instek example, the UDP6933B has no general two-argument APPLy command. Its
-        # documented APPLy command recalls stored presets, so voltage and current are sent
-        # separately.
+        # Unlike the GW Instek example, the UDP6933B has no general two-argument APPLy
+        # command. Its documented APPLy command recalls stored presets, so voltage and
+        # current are sent separately.
         self.voltage_setpoint = voltage
         self.current_limit = current_limit

--- a/tests/instruments/unit/test_udp6933b.py
+++ b/tests/instruments/unit/test_udp6933b.py
@@ -1,0 +1,166 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.instruments.unit import UNITUDP6933B
+from pymeasure.test import expected_protocol
+
+
+def test_id():
+    with expected_protocol(
+        UNITUDP6933B,
+        [("*IDN?", "Uni-Trend,UDP6933B,0000000000000,1.00.0905")],
+    ) as instr:
+        assert instr.id == "Uni-Trend,UDP6933B,0000000000000,1.00.0905"
+
+
+def test_reset():
+    with expected_protocol(UNITUDP6933B, [("*RST", None)]) as instr:
+        instr.reset()
+
+
+def test_clear():
+    with expected_protocol(UNITUDP6933B, [("*CLS", None)]) as instr:
+        instr.clear()
+
+
+def test_next_error():
+    with expected_protocol(UNITUDP6933B, [("SYST:ERR?", '0,"No error"')]) as instr:
+        error = instr.next_error
+
+    assert error[0] == 0
+    assert isinstance(error[1], str)
+    assert "No error" in error[1]
+
+
+def test_check_errors_logs_errors(caplog):
+    with expected_protocol(
+        UNITUDP6933B,
+        [
+            ("SYST:ERR?", '-100,"Command error"'),
+            ("SYST:ERR?", '0,"No error"'),
+        ],
+    ) as instr:
+        instr.check_errors()
+
+    assert "Command error" in caplog.text
+
+
+def test_voltage_getter():
+    with expected_protocol(UNITUDP6933B, [("MEAS:VOLT?", "12.345")]) as instr:
+        assert instr.voltage == 12.345
+
+
+def test_current_getter():
+    with expected_protocol(UNITUDP6933B, [("MEAS:CURR?", "0.123")]) as instr:
+        assert instr.current == 0.123
+
+
+def test_power_getter():
+    with expected_protocol(UNITUDP6933B, [("MEASure:POWer?", "1.518")]) as instr:
+        assert instr.power == 1.518
+
+
+def test_voltage_setpoint_getter():
+    with expected_protocol(UNITUDP6933B, [("VOLT?", "24.000")]) as instr:
+        assert instr.voltage_setpoint == 24.0
+
+
+@pytest.mark.parametrize(
+    "voltage, command",
+    ((0, "VOLT 0"), (12, "VOLT 12"), (150, "VOLT 150")),
+)
+def test_voltage_setpoint_setter(voltage, command):
+    with expected_protocol(UNITUDP6933B, [(command, None)]) as instr:
+        instr.voltage_setpoint = voltage
+
+
+@pytest.mark.parametrize("voltage", (-0.1, 150.1))
+def test_voltage_setpoint_validator(voltage):
+    with expected_protocol(UNITUDP6933B, []) as instr, pytest.raises(ValueError):
+        instr.voltage_setpoint = voltage
+
+
+def test_current_limit_getter():
+    with expected_protocol(UNITUDP6933B, [("CURR?", "1.500")]) as instr:
+        assert instr.current_limit == 1.5
+
+
+@pytest.mark.parametrize(
+    "current_limit, command",
+    ((0, "CURR 0"), (0.5, "CURR 0.5"), (5, "CURR 5")),
+)
+def test_current_limit_setter(current_limit, command):
+    with expected_protocol(UNITUDP6933B, [(command, None)]) as instr:
+        instr.current_limit = current_limit
+
+
+@pytest.mark.parametrize("current_limit", (-0.1, 5.1))
+def test_current_limit_validator(current_limit):
+    with expected_protocol(UNITUDP6933B, []) as instr, pytest.raises(ValueError):
+        instr.current_limit = current_limit
+
+
+@pytest.mark.parametrize("state, command", ((True, "OUTP ON"), (False, "OUTP OFF")))
+def test_output_enabled_setter(state, command):
+    with expected_protocol(UNITUDP6933B, [(command, None)]) as instr:
+        instr.output_enabled = state
+
+
+@pytest.mark.parametrize("reply, state", (("ON", True), ("OFF", False)))
+def test_output_enabled_getter(reply, state):
+    with expected_protocol(UNITUDP6933B, [("OUTP?", reply)]) as instr:
+        assert instr.output_enabled is state
+
+
+@pytest.mark.parametrize("state", ("on", "off", 2, -1))
+def test_output_enabled_validator(state):
+    with expected_protocol(UNITUDP6933B, []) as instr, pytest.raises(ValueError):
+        instr.output_enabled = state
+
+
+@pytest.mark.parametrize(
+    "voltage, current_limit, commands",
+    (
+        (0, 0, [("VOLT 0", None), ("CURR 0", None)]),
+        (12, 0.5, [("VOLT 12", None), ("CURR 0.5", None)]),
+        (150, 5, [("VOLT 150", None), ("CURR 5", None)]),
+    ),
+)
+def test_apply(voltage, current_limit, commands):
+    with expected_protocol(UNITUDP6933B, commands) as instr:
+        instr.apply(voltage, current_limit)
+
+
+@pytest.mark.parametrize("voltage", (-0.1, 150.1))
+def test_apply_voltage_validator(voltage):
+    with expected_protocol(UNITUDP6933B, []) as instr, pytest.raises(ValueError):
+        instr.apply(voltage, 0.5)
+
+
+@pytest.mark.parametrize("current_limit", (-0.1, 5.1))
+def test_apply_current_limit_validator(current_limit):
+    with expected_protocol(UNITUDP6933B, []) as instr, pytest.raises(ValueError):
+        instr.apply(12, current_limit)


### PR DESCRIPTION
## Summary

Add a driver for the UNI-T UDP6933B programmable DC power supply.

The driver supports:

- Voltage, current, and power measurements
- Voltage-setpoint control
- Current-limit control
- Boolean output control
- Combined voltage and current configuration
- Standard SCPI identification, reset, clear, and error handling

## Testing

- Added 35 protocol tests using `expected_protocol`
- Verified against a physical UDP6933B over USB VISA
- Tested with firmware 1.01.0301
- Full test suite: 9,336 passed, 3,459 skipped, and 1 expected failure
- Ruff, Pyright, and whitespace checks passed

## Implementation notes

The full `MEASure:POWer?` command is used because firmware 1.01.0301 did not respond to the abbreviated `MEAS:POW?` command.

The UDP6933B `APPLy` command recalls stored presets rather than accepting arbitrary voltage and current arguments. Therefore, the `apply()` convenience method validates both arguments and sends separate voltage and current commands.