### PR TITLE
Add get_device_info / check_is_dev_supported / open / close to SCPIMixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ settings.json
 
 # uv lock file
 uv.lock
+
+# Local developer / machine-specific scripts (not part of the package)
+enter_prj_win.ps1

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -117,3 +117,5 @@ Jonas Grage
 Max Tweedale
 Muralidhar M Shenoy
 Vincent Gao
+Peter Nußreiner
+Peter Mueller

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Deprecated
 
 Changed
 -------
+- Allow passing a caller-owned :class:`pyvisa.ResourceManager` as the ``visa_library`` argument of
+  :class:`.VISAAdapter`; the adapter does not close the supplied manager on :meth:`~.VISAAdapter.close`.
+  This enables multiple adapters to share one manager without lifecycle conflicts (replaces #1432).
+- Add :meth:`.Adapter.open` (no-op stub) and :meth:`.VISAAdapter.open` to reopen a VISA connection
+  after :meth:`~.VISAAdapter.close` or a network dropout, without reinstantiating the instrument.
+  Instrument-specific settings (e.g. termination characters) must be reapplied by the caller.
 - For property creators :code:`Instrument.control`... the conversion parameters (:code:`cast` etc.) are keyword only, now.
 - Refactored :class:`.Parameter` and :class:`.Metadata` to share a common descriptor base (``_InstanceValueDescriptor``).
   Values are now eagerly converted at assignment time via :meth:`~Parameter.convert` (identity for ``Metadata``).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Changed
 - Add :meth:`.Adapter.open` (no-op stub) and :meth:`.VISAAdapter.open` to reopen a VISA connection
   after :meth:`~.VISAAdapter.close` or a network dropout, without reinstantiating the instrument.
   Instrument-specific settings (e.g. termination characters) must be reapplied by the caller.
+- Add :meth:`~.SCPIMixin.get_device_info`, :meth:`~.SCPIMixin.check_is_dev_supported`,
+  :meth:`~.SCPIMixin.close`, and :meth:`~.SCPIMixin.open` to :class:`.SCPIMixin` for structured
+  ``*IDN?`` parsing, model validation, and connection lifecycle management (replaces #1433).
 - For property creators :code:`Instrument.control`... the conversion parameters (:code:`cast` etc.) are keyword only, now.
 - Refactored :class:`.Parameter` and :class:`.Metadata` to share a common descriptor base (``_InstanceValueDescriptor``).
   Values are now eagerly converted at assignment time via :meth:`~Parameter.convert` (identity for ``Metadata``).

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -76,6 +76,9 @@ class Adapter:
         if connection is not None:
             self.connection.close()
 
+    def open(self) -> None:
+        """Reopen the connection. No-op in the base class; override in subclasses."""
+
     # Directly called methods, which ensure proper logging of the communication
     # without the termination characters added by the particular adapters.
     # DO NOT OVERRIDE IN SUBCLASS!

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -30,21 +30,26 @@ import pyvisa
 from .adapter import Adapter
 from .protocol import ProtocolAdapter
 
+resource_manager_or_str = str | pyvisa.ResourceManager
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
-    """ Adapter class for the VISA library, using PyVISA to communicate with instruments.
+    """Adapter class for the VISA library, using PyVISA to communicate with instruments.
 
     The workhorse of our library, used by most instruments.
 
     :param resource_name: A
         `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
         or GPIB address integer that identifies the target of the connection
-    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library or VisaLibrary spec
-        string (``@py`` or ``@ivi``). If not given, the default for the platform will be used.
+    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library, VisaLibrary spec
+        string (``@py`` or ``@ivi``), or a caller-owned :class:`pyvisa.ResourceManager` instance.
+        When a :class:`pyvisa.ResourceManager` is supplied the adapter does **not** take ownership:
+        it will not be closed when :meth:`close` is called.
+        If not given, a new :class:`pyvisa.ResourceManager` is created and owned by the adapter.
     :param log: Parent logger of the 'Adapter' logger.
     :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
 
@@ -76,11 +81,12 @@ class VISAAdapter(Adapter):
     def __init__(
         self,
         resource_name: Union[ProtocolAdapter, "VISAAdapter", int, str],
-        visa_library: str = "",
+        visa_library: resource_manager_or_str = "",
         log: logging.Logger | None = None,
         **kwargs,
     ):
         super().__init__(log=log)
+        self._manager_owned = False
         if isinstance(resource_name, ProtocolAdapter):
             self.connection = resource_name
             self.connection.write_raw = self.connection.write_bytes  # type: ignore[assignment]
@@ -96,7 +102,11 @@ class VISAAdapter(Adapter):
             resource_name = f"GPIB0::{resource_name}::INSTR"
 
         self.resource_name = resource_name
-        self.manager = pyvisa.ResourceManager(visa_library)
+        if isinstance(visa_library, pyvisa.ResourceManager):
+            self.manager = visa_library
+        else:
+            self.manager = pyvisa.ResourceManager(visa_library)
+            self._manager_owned = True
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type
@@ -111,10 +121,39 @@ class VISAAdapter(Adapter):
                         kwargs.setdefault(k, v)
                 del kwargs[key]
 
-        self.connection = cast(pyvisa.resources.MessageBasedResource, self.manager.open_resource(
-            resource_name,
-            **kwargs
-        ))
+        self.connection = cast(
+            pyvisa.resources.MessageBasedResource,
+            self.manager.open_resource(resource_name, **kwargs),
+        )
+
+    def open(self) -> None:
+        """Reopen the VISA connection after a close or network dropout.
+
+        Re-uses the stored :attr:`resource_name` and :attr:`manager`.
+        Any instrument-specific settings (e.g. termination characters) must
+        be restored by the caller after this method returns.
+        Raises :exc:`AttributeError` if called on an adapter without a
+        stored resource name (e.g. one created from a ProtocolAdapter).
+        """
+        if not hasattr(self, "resource_name") or not hasattr(self, "manager"):
+            raise AttributeError(
+                "open() requires resource_name and manager (not available for "
+                "ProtocolAdapter-backed instances)"
+            )
+
+        try:
+            self.connection.close()
+        except Exception:
+            self.log.debug(
+                "Ignoring error while closing the VISA connection during reopen",
+                exc_info=True,
+            )
+
+        resource_name: str = self.resource_name  # type: ignore[assignment]
+        self.connection = cast(
+            pyvisa.resources.MessageBasedResource,
+            self.manager.open_resource(resource_name),
+        )
 
     def close(self) -> None:
         """Close the connection.
@@ -123,8 +162,12 @@ class VISAAdapter(Adapter):
 
             This closes the connection to the resource for all adapters using
             it currently (e.g. different adapters using the same GPIB line).
+            A :class:`pyvisa.ResourceManager` that was supplied by the caller is **not** closed;
+            only managers created internally by this adapter are closed.
         """
         super().close()
+        if not self._manager_owned:
+            return
         try:
             if self.manager.visalib.library_path == "unset":
                 # if using the pyvisa-sim library the manager has to be also closed.
@@ -186,7 +229,7 @@ class VISAAdapter(Adapter):
                     raise
 
     def wait_for_srq(self, timeout: float = 25, delay: float = 0.1) -> None:
-        """ Block until a SRQ, and leave the bit high
+        """Block until a SRQ, and leave the bit high.
 
         :param timeout: Timeout duration in seconds
         :param delay: Time delay between checking SRQ in seconds
@@ -194,7 +237,7 @@ class VISAAdapter(Adapter):
         self.connection.wait_for_srq(int(timeout * 1000))
 
     def flush_read_buffer(self) -> None:
-        """ Flush and discard the input buffer
+        """Flush and discard the input buffer.
 
         As detailed by pyvisa, discard the read and receivee buffer contents
         and if data was present in the read buffer and no END-indicator was present,

--- a/pymeasure/instruments/generic_types.py
+++ b/pymeasure/instruments/generic_types.py
@@ -70,7 +70,6 @@ class IEEE4882Mixin(CommonBase):
         maxsplit=0,
     )
 
-    # IEEE 488.2 default method
     def clear(self) -> None:
         """Clear the instrument status byte."""
         self.write("*CLS")
@@ -108,6 +107,49 @@ class SCPIMixin(IEEE4882Mixin):
             else:
                 break
         return errors
+
+    def close(self) -> None:
+        """Close the VISA connection."""
+        self.adapter.close()
+
+    def open(self) -> None:
+        """Reopen the VISA connection after a close or network dropout."""
+        self.adapter.open()
+
+    def get_device_info(self) -> None:
+        """Query ``*IDN?`` and populate identification attributes on this instance.
+
+        Sets the following attributes from the parsed ``*IDN?`` response:
+
+        * ``self.name`` — model designation (e.g. ``"NGP804"``)
+        * ``self.vendor`` — manufacturer string
+        * ``self.serial_number`` — serial number string
+        * ``self.firmware_ref`` — firmware / software version string
+        """
+        resp_str = self.id
+        vendor, name, serial_number, firmware_ref = resp_str.split(",")
+        self.vendor = vendor
+        self.name = name
+        self.serial_number = serial_number
+        self.firmware_ref = firmware_ref
+
+    def check_is_dev_supported(self, instr_list: list[str], err_msg: str = "") -> None:
+        """Check that ``self.name`` (the model from ``*IDN?``) is in *instr_list*.
+
+        Call :meth:`get_device_info` first to populate ``self.name``.
+        Closes the connection and raises :class:`AssertionError` if the model
+        is not in *instr_list*.
+
+        :param instr_list: List of supported model name strings.
+        :param err_msg: Message suffix appended to the model name in the error.
+        :raises AssertionError: If ``self.name`` is ``None`` or not found in *instr_list*.
+        """
+        if self.name is None:
+            raise AssertionError("Instrument connection not opened!")
+
+        if instr_list is not None and not any(self.name in instr for instr in instr_list):
+            self.close()
+            raise AssertionError(self.name + err_msg)
 
 
 class SCPIUnknownMixin(SCPIMixin):

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -37,6 +37,13 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+try:
+    import pyvisa as _pyvisa
+    _ResourceManager = _pyvisa.ResourceManager
+except ImportError:  # pragma: no cover
+    _pyvisa = None  # type: ignore[assignment]
+    _ResourceManager = None  # type: ignore[assignment]
+
 AdapterType = Adapter | str | int
 
 
@@ -58,14 +65,23 @@ class Instrument(CommonBase):
     resource name.
     Keyword arguments can be used to further configure the connection.
 
+    When ``adapter`` is a :class:`pyvisa.ResourceManager`, ``name`` is interpreted as
+    the VISA resource string and the ``ResourceManager`` is reused (not closed on
+    :meth:`shutdown`).
+    This is the preferred pattern when multiple instruments share a single
+    ``ResourceManager`` opened with a specific VISA library.
+
     Otherwise, the passed :py:class:`~pymeasure.adapters.Adapter` object is used and any keyword
     arguments are discarded.
 
-    :param adapter: A string, integer, or :py:class:`~pymeasure.adapters.Adapter` subclass object
-    :param string name: The name of the instrument. Often the model designation by default.
-
-    :param \\**kwargs: In case ``adapter`` is a string or integer, additional arguments passed on
-        to :py:class:`~pymeasure.adapters.VISAAdapter` (check there for details).
+    :param adapter: A string, integer, :class:`pyvisa.ResourceManager`, or
+        :py:class:`~pymeasure.adapters.Adapter` subclass object.
+    :param string name: The name of the instrument.
+        When ``adapter`` is a :class:`pyvisa.ResourceManager`, ``name`` is used as the
+        VISA resource string (e.g. ``"TCPIP0::192.168.1.10::INSTR"``).
+    :param \\**kwargs: In case ``adapter`` is a string, integer, or
+        :class:`pyvisa.ResourceManager`, additional arguments passed on to
+        :py:class:`~pymeasure.adapters.VISAAdapter`.
         Discarded otherwise.
     """
     adapter: Adapter
@@ -82,7 +98,16 @@ class Instrument(CommonBase):
                  "the `SCPIMixin` class instead if it supports SCPI.", FutureWarning)
             kwargs.pop("includeSCPI")
         # Setup communication before possible children require the adapter.
-        if isinstance(adapter, (int, str)):
+        if _ResourceManager is not None and isinstance(adapter, _ResourceManager):
+            # adapter is a shared ResourceManager; name is the VISA resource string.
+            # VISAAdapter will set _manager_owned=False so the RM is not closed on shutdown.
+            try:
+                adapter = VISAAdapter(name, visa_library=adapter, **kwargs)
+            except ImportError:
+                raise TypeError(
+                    "Invalid Adapter provided for Instrument since PyVISA is not present"
+                )
+        elif isinstance(adapter, (int, str)):
             try:
                 adapter = VISAAdapter(adapter, **kwargs)
             except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,10 @@ reportIncompatibleMethodOverride = "warning"
 reportOperatorIssue = "warning"
 reportPrivateImportUsage = "none"
 defineConstant = { PYQT6 = true, PYSIDE2 = false, PYQT5 = false, PYSIDE6 = false }
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "pyvisa-sim>=0.7.1",
+]

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -106,6 +106,71 @@ class TestClose:
             _ = adapterC.manager.session
 
 
+class TestSharedResourceManager:
+    """Tests for passing a caller-owned ResourceManager via visa_library."""
+
+    @pytest.fixture
+    def shared_rm(self):
+        """Provide a pyvisa-sim ResourceManager and close it after the test."""
+        rm = pyvisa.ResourceManager('@sim')
+        yield rm
+        rm.close()
+
+    def test_shared_rm_is_used(self, shared_rm):
+        """Adapter opened with a caller-supplied RM uses that exact manager instance."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert a.manager is shared_rm
+        a.close()
+
+    def test_shared_rm_not_owned(self, shared_rm):
+        """Adapter does not own a caller-supplied RM."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert a._manager_owned is False
+        a.close()
+
+    def test_shared_rm_not_closed_on_adapter_close(self, shared_rm):
+        """Closing the adapter does not close a caller-supplied ResourceManager."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert shared_rm.session is not None
+        a.close()
+        assert shared_rm.session is not None
+
+    def test_second_adapter_still_works_after_first_closes(self, shared_rm):
+        """A second adapter sharing the same RM continues to operate after the first closes."""
+        a1 = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm, read_termination="\n")
+        a2 = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm, read_termination="\n")
+        a1.close()
+        a2.write("*IDN?")
+        assert a2.read() == "SCPI,MOCK,VERSION_1.0"
+        a2.close()
+
+    def test_owned_manager_is_closed_on_adapter_close(self):
+        """Adapter that created its own RM closes it on close() (pyvisa-sim workaround)."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library='@sim')
+        assert a._manager_owned is True
+        rm = a.manager
+        assert rm.session is not None
+        a.close()
+        with pytest.raises(pyvisa.errors.InvalidSession, match="Invalid session"):
+            _ = rm.session
+
+    def test_instrument_init_accepts_resource_manager(self, shared_rm):
+        """Instrument(rm, resource_string) reuses the shared RM without closing it."""
+        from pymeasure.instruments import Instrument, SCPIMixin
+
+        class SimpleInstrument(SCPIMixin, Instrument):
+            """Minimal instrument used to verify shared ResourceManager handling."""
+
+        inst = SimpleInstrument(shared_rm, SIM_RESOURCE, read_termination="\n")
+        assert inst.adapter.manager is shared_rm
+        assert inst.adapter._manager_owned is False
+        inst.shutdown()
+        assert shared_rm.session is not None
+
+
 def test_write_read(adapter):
     adapter.write(":VOLT:IMM:AMPL?")
     assert float(adapter.read()) == 1
@@ -150,3 +215,32 @@ class TestReadBytes:
         adapter.write("*IDN?")
         # `break_on_termchar=False` is default value
         assert adapter.read_bytes(-1) == b"SCPI,MOCK,VERSION_1.0\nSCPI,MOCK,VERSION_1.0\n"
+
+
+class TestOpen:
+    """Tests for VISAAdapter.open() connection-lifecycle behaviour."""
+
+    def test_open_after_close_restores_connection(self):
+        """open() after close() re-establishes a working VISA connection.
+
+        The caller is responsible for re-applying connection settings
+        (e.g. read_termination) after open(), as open() does not restore them.
+        """
+        rm = pyvisa.ResourceManager('@sim')
+        try:
+            a = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+            a.close()
+            a.open()
+            a.connection.read_termination = "\n"
+            a.write("*IDN?")
+            assert a.read() == "SCPI,MOCK,VERSION_1.0"
+            a.close()
+        finally:
+            rm.close()
+
+    def test_open_raises_for_protocol_adapter(self):
+        """open() raises AttributeError when backed by a ProtocolAdapter."""
+        with expected_protocol(VISAAdapter, []) as a, pytest.raises(  # type: ignore
+            AttributeError, match="resource_name"
+        ):
+            a.open()

--- a/tests/instruments/test_generic_types.py
+++ b/tests/instruments/test_generic_types.py
@@ -103,6 +103,88 @@ class Test_SCPIMixin:
             assert inst.check_errors() == [[-100, '"Command error"'],
                                            [-222, '"Data out of range"']]
 
+    def test_close_does_not_raise(self):
+        with expected_protocol(self.SCPIInstrument, [], name="test") as inst:
+            inst.close()  # Adapter.close() is a no-op for ProtocolAdapter — must not raise
+
 
 def test_SCPIMixin_inherits_IEEE4882Mixin():
     assert issubclass(SCPIMixin, IEEE4882Mixin)
+
+
+class Test_GetDeviceInfo:
+    """Tests for SCPIMixin.get_device_info()."""
+
+    class SCPIInstrument(SCPIMixin, Instrument):
+        """Minimal SCPI instrument used in get_device_info tests."""
+
+    def test_sets_name_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.name == "NGP804"
+
+    def test_sets_vendor_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.vendor == "Rohde&Schwarz"
+
+    def test_sets_serial_number_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.serial_number == "12345"
+
+    def test_sets_firmware_ref_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.firmware_ref == "V1.0"
+
+
+class Test_CheckIsDevSupported:
+    """Tests for SCPIMixin.check_is_dev_supported()."""
+
+    class SCPIInstrument(SCPIMixin, Instrument):
+        """Minimal SCPI instrument used in check_is_dev_supported tests."""
+
+    def test_supported_model_does_not_raise(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            inst.check_is_dev_supported(["NGP804", "NGP814"], ": not supported")
+
+    def test_unsupported_model_raises_assertion_error(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP402,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            with pytest.raises(AssertionError, match="NGP402"):
+                inst.check_is_dev_supported(["NGP804", "NGP814"], ": not supported")
+
+    def test_error_includes_custom_message(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,UNKNOWN,SN,FW")],
+                name="test") as inst:
+            inst.get_device_info()
+            with pytest.raises(AssertionError, match="Instrument not supported"):
+                inst.check_is_dev_supported(["NGP804"], ": Instrument not supported")
+
+    def test_none_name_raises_assertion_error(self):
+        with expected_protocol(self.SCPIInstrument, [], name="test") as inst:
+            inst.name = None
+            with pytest.raises(AssertionError, match="not opened"):
+                inst.check_is_dev_supported(["NGP804"], "")


### PR DESCRIPTION
## Summary

Adds device identification and connection lifecycle helpers directly to `SCPIMixin`:

- `get_device_info()` — queries `*IDN?` and populates `self.vendor`, `self.name`, `self.serial_number`, `self.firmware_ref`
- `check_is_dev_supported(instr_list, errMsg)` — validates the detected model; calls `close()` and raises `AssertionError` on mismatch
- `close()` — delegates to `self.adapter.close()`
- `open()` — delegates to `self.adapter.open()` (pairs with `VISAAdapter.open()` from #1534)

Intended usage in instrument constructors:
```python
self.get_device_info()
self.check_is_dev_supported(["NGP804", "NGP814"], ": Instrument not supported!")
```

Replaces #1433.

## Test plan
- [ ] `tests/instruments/test_generic_types.py::Test_GetDeviceInfo`
- [ ] `tests/instruments/test_generic_types.py::Test_CheckIsDevSupported`
- [ ] `tests/instruments/test_generic_types.py::Test_SCPIMixin::test_close_does_not_raise`
