### PR TITLE
Add Rohde and Schwarz NGPx power-supply driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ settings.json
 
 # uv lock file
 uv.lock
+
+# Local developer / machine-specific scripts (not part of the package)
+enter_prj_win.ps1

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -117,3 +117,5 @@ Jonas Grage
 Max Tweedale
 Muralidhar M Shenoy
 Vincent Gao
+Peter Nußreiner
+Peter Mueller

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ Deprecated
 
 Changed
 -------
+- Allow passing a caller-owned :class:`pyvisa.ResourceManager` as the ``visa_library`` argument of
+  :class:`.VISAAdapter`; the adapter does not close the supplied manager on :meth:`~.VISAAdapter.close`.
+  This enables multiple adapters to share one manager without lifecycle conflicts (replaces #1432).
+- Add :meth:`.Adapter.open` (no-op stub) and :meth:`.VISAAdapter.open` to reopen a VISA connection
+  after :meth:`~.VISAAdapter.close` or a network dropout, without reinstantiating the instrument.
+  Instrument-specific settings (e.g. termination characters) must be reapplied by the caller.
 - For property creators :code:`Instrument.control`... the conversion parameters (:code:`cast` etc.) are keyword only, now.
 - Refactored :class:`.Parameter` and :class:`.Metadata` to share a common descriptor base (``_InstanceValueDescriptor``).
   Values are now eagerly converted at assignment time via :meth:`~Parameter.convert` (identity for ``Metadata``).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Changed
 - Add :meth:`.Adapter.open` (no-op stub) and :meth:`.VISAAdapter.open` to reopen a VISA connection
   after :meth:`~.VISAAdapter.close` or a network dropout, without reinstantiating the instrument.
   Instrument-specific settings (e.g. termination characters) must be reapplied by the caller.
+- Add :meth:`~.SCPIMixin.get_device_info`, :meth:`~.SCPIMixin.check_is_dev_supported`,
+  :meth:`~.SCPIMixin.close`, and :meth:`~.SCPIMixin.open` to :class:`.SCPIMixin` for structured
+  ``*IDN?`` parsing, model validation, and connection lifecycle management (replaces #1433).
 - For property creators :code:`Instrument.control`... the conversion parameters (:code:`cast` etc.) are keyword only, now.
 - Refactored :class:`.Parameter` and :class:`.Metadata` to share a common descriptor base (``_InstanceValueDescriptor``).
   Values are now eagerly converted at assignment time via :meth:`~Parameter.convert` (identity for ``Metadata``).

--- a/docs/api/instruments/rohdeschwarz/index.rst
+++ b/docs/api/instruments/rohdeschwarz/index.rst
@@ -9,6 +9,7 @@ This section contains specific documentation on the Rohde & Schwarz instruments 
 .. toctree::
    :maxdepth: 3
 
+   ngpx
    sfm
    fsseries
    hmp

--- a/docs/api/instruments/rohdeschwarz/ngpx.rst
+++ b/docs/api/instruments/rohdeschwarz/ngpx.rst
@@ -1,0 +1,89 @@
+##############################
+R&S NGPx Power Supply Family
+##############################
+
+The :class:`~pymeasure.instruments.rohdeschwarz.ngpx.NGPx` class implements
+support for the Rohde & Schwarz NGPx programmable power-supply family
+(NGP802, NGP804, NGP812, NGP814).
+The model is detected automatically from the ``*IDN?`` response at construction
+time, and the correct number of channels is created dynamically.
+
+Basic usage
+===========
+
+.. code-block:: python
+
+    from pymeasure.instruments.rohdeschwarz import NGPx
+
+    psu = NGPx("TCPIP0::192.168.1.10::INSTR")
+
+    psu.ch1.voltage_setpoint = 5.0
+    psu.ch1.current_limit = 1.0
+    psu.ch1.sense = "EXT"          # remote sense
+    psu.ch1.output = True
+
+    print(psu.ch1.voltage, psu.ch1.current)
+
+    psu.ch1.output = False
+    psu.shutdown()
+
+Shared ResourceManager
+=======================
+
+When managing multiple instruments with a specific VISA library (e.g. NI-VISA
+vs RS-VISA), create one :class:`pyvisa.ResourceManager` up front and pass it
+as the ``adapter`` argument.
+The instrument will **not** close the shared manager when it shuts down.
+
+.. code-block:: python
+
+    import pyvisa
+    from pymeasure.instruments.rohdeschwarz import NGPx
+
+    rm = pyvisa.ResourceManager("C:/WINDOWS/system32/visa64.dll")
+
+    psu1 = NGPx(rm, "TCPIP0::192.168.1.10::INSTR")
+    psu2 = NGPx(rm, "TCPIP0::192.168.1.11::INSTR")
+
+    # ... use instruments ...
+
+    psu1.shutdown()
+    psu2.shutdown()
+    rm.close()          # close only once, after all instruments
+
+Reconnection after network dropout
+===================================
+
+Call :meth:`~pymeasure.instruments.rohdeschwarz.ngpx.NGPx.open` to reopen
+the connection without reinstantiating the instrument object.
+
+.. code-block:: python
+
+    psu.close()
+    # ... wait for network recovery ...
+    psu.open()
+    psu.ch1.voltage_setpoint = 5.0
+
+.. admonition:: Migration from the R&S internal fork
+
+    If you previously used the internal R&S fork of pymeasure, the API is
+    kept as close as possible to minimize migration effort.
+
+    All property and method names —
+    ``ch1`` … ``ch4``, ``sense``, ``output``, ``output_general``,
+    ``set2local``, ``set2remote``, ``get_device_info``,
+    ``check_is_dev_supported``, ``clear_reset`` — are identical.
+
+PwrChannel
+==========
+
+.. autoclass:: pymeasure.instruments.rohdeschwarz.ngpx.PwrChannel
+    :members:
+    :show-inheritance:
+
+NGPx
+====
+
+.. autoclass:: pymeasure.instruments.rohdeschwarz.ngpx.NGPx
+    :members:
+    :show-inheritance:

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -76,6 +76,9 @@ class Adapter:
         if connection is not None:
             self.connection.close()
 
+    def open(self) -> None:
+        """Reopen the connection. No-op in the base class; override in subclasses."""
+
     # Directly called methods, which ensure proper logging of the communication
     # without the termination characters added by the particular adapters.
     # DO NOT OVERRIDE IN SUBCLASS!

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -30,21 +30,26 @@ import pyvisa
 from .adapter import Adapter
 from .protocol import ProtocolAdapter
 
+resource_manager_or_str = str | pyvisa.ResourceManager
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
-    """ Adapter class for the VISA library, using PyVISA to communicate with instruments.
+    """Adapter class for the VISA library, using PyVISA to communicate with instruments.
 
     The workhorse of our library, used by most instruments.
 
     :param resource_name: A
         `VISA resource string <https://pyvisa.readthedocs.io/en/latest/introduction/names.html>`__
         or GPIB address integer that identifies the target of the connection
-    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library or VisaLibrary spec
-        string (``@py`` or ``@ivi``). If not given, the default for the platform will be used.
+    :param visa_library: PyVISA VisaLibrary Instance, path of the VISA library, VisaLibrary spec
+        string (``@py`` or ``@ivi``), or a caller-owned :class:`pyvisa.ResourceManager` instance.
+        When a :class:`pyvisa.ResourceManager` is supplied the adapter does **not** take ownership:
+        it will not be closed when :meth:`close` is called.
+        If not given, a new :class:`pyvisa.ResourceManager` is created and owned by the adapter.
     :param log: Parent logger of the 'Adapter' logger.
     :param \\**kwargs: Keyword arguments for configuring the PyVISA connection.
 
@@ -76,11 +81,12 @@ class VISAAdapter(Adapter):
     def __init__(
         self,
         resource_name: Union[ProtocolAdapter, "VISAAdapter", int, str],
-        visa_library: str = "",
+        visa_library: resource_manager_or_str = "",
         log: logging.Logger | None = None,
         **kwargs,
     ):
         super().__init__(log=log)
+        self._manager_owned = False
         if isinstance(resource_name, ProtocolAdapter):
             self.connection = resource_name
             self.connection.write_raw = self.connection.write_bytes  # type: ignore[assignment]
@@ -96,7 +102,11 @@ class VISAAdapter(Adapter):
             resource_name = f"GPIB0::{resource_name}::INSTR"
 
         self.resource_name = resource_name
-        self.manager = pyvisa.ResourceManager(visa_library)
+        if isinstance(visa_library, pyvisa.ResourceManager):
+            self.manager = visa_library
+        else:
+            self.manager = pyvisa.ResourceManager(visa_library)
+            self._manager_owned = True
 
         # Clean up kwargs considering the interface type matching resource_name
         if_type = self.manager.resource_info(self.resource_name).interface_type
@@ -111,10 +121,39 @@ class VISAAdapter(Adapter):
                         kwargs.setdefault(k, v)
                 del kwargs[key]
 
-        self.connection = cast(pyvisa.resources.MessageBasedResource, self.manager.open_resource(
-            resource_name,
-            **kwargs
-        ))
+        self.connection = cast(
+            pyvisa.resources.MessageBasedResource,
+            self.manager.open_resource(resource_name, **kwargs),
+        )
+
+    def open(self) -> None:
+        """Reopen the VISA connection after a close or network dropout.
+
+        Re-uses the stored :attr:`resource_name` and :attr:`manager`.
+        Any instrument-specific settings (e.g. termination characters) must
+        be restored by the caller after this method returns.
+        Raises :exc:`AttributeError` if called on an adapter without a
+        stored resource name (e.g. one created from a ProtocolAdapter).
+        """
+        if not hasattr(self, "resource_name") or not hasattr(self, "manager"):
+            raise AttributeError(
+                "open() requires resource_name and manager (not available for "
+                "ProtocolAdapter-backed instances)"
+            )
+
+        try:
+            self.connection.close()
+        except Exception:
+            self.log.debug(
+                "Ignoring error while closing the VISA connection during reopen",
+                exc_info=True,
+            )
+
+        resource_name: str = self.resource_name  # type: ignore[assignment]
+        self.connection = cast(
+            pyvisa.resources.MessageBasedResource,
+            self.manager.open_resource(resource_name),
+        )
 
     def close(self) -> None:
         """Close the connection.
@@ -123,8 +162,12 @@ class VISAAdapter(Adapter):
 
             This closes the connection to the resource for all adapters using
             it currently (e.g. different adapters using the same GPIB line).
+            A :class:`pyvisa.ResourceManager` that was supplied by the caller is **not** closed;
+            only managers created internally by this adapter are closed.
         """
         super().close()
+        if not self._manager_owned:
+            return
         try:
             if self.manager.visalib.library_path == "unset":
                 # if using the pyvisa-sim library the manager has to be also closed.
@@ -186,7 +229,7 @@ class VISAAdapter(Adapter):
                     raise
 
     def wait_for_srq(self, timeout: float = 25, delay: float = 0.1) -> None:
-        """ Block until a SRQ, and leave the bit high
+        """Block until a SRQ, and leave the bit high.
 
         :param timeout: Timeout duration in seconds
         :param delay: Time delay between checking SRQ in seconds
@@ -194,7 +237,7 @@ class VISAAdapter(Adapter):
         self.connection.wait_for_srq(int(timeout * 1000))
 
     def flush_read_buffer(self) -> None:
-        """ Flush and discard the input buffer
+        """Flush and discard the input buffer.
 
         As detailed by pyvisa, discard the read and receivee buffer contents
         and if data was present in the read buffer and no END-indicator was present,

--- a/pymeasure/instruments/generic_types.py
+++ b/pymeasure/instruments/generic_types.py
@@ -70,7 +70,6 @@ class IEEE4882Mixin(CommonBase):
         maxsplit=0,
     )
 
-    # IEEE 488.2 default method
     def clear(self) -> None:
         """Clear the instrument status byte."""
         self.write("*CLS")
@@ -108,6 +107,49 @@ class SCPIMixin(IEEE4882Mixin):
             else:
                 break
         return errors
+
+    def close(self) -> None:
+        """Close the VISA connection."""
+        self.adapter.close()
+
+    def open(self) -> None:
+        """Reopen the VISA connection after a close or network dropout."""
+        self.adapter.open()
+
+    def get_device_info(self) -> None:
+        """Query ``*IDN?`` and populate identification attributes on this instance.
+
+        Sets the following attributes from the parsed ``*IDN?`` response:
+
+        * ``self.name`` — model designation (e.g. ``"NGP804"``)
+        * ``self.vendor`` — manufacturer string
+        * ``self.serial_number`` — serial number string
+        * ``self.firmware_ref`` — firmware / software version string
+        """
+        resp_str = self.id
+        vendor, name, serial_number, firmware_ref = resp_str.split(",")
+        self.vendor = vendor
+        self.name = name
+        self.serial_number = serial_number
+        self.firmware_ref = firmware_ref
+
+    def check_is_dev_supported(self, instr_list: list[str], err_msg: str = "") -> None:
+        """Check that ``self.name`` (the model from ``*IDN?``) is in *instr_list*.
+
+        Call :meth:`get_device_info` first to populate ``self.name``.
+        Closes the connection and raises :class:`AssertionError` if the model
+        is not in *instr_list*.
+
+        :param instr_list: List of supported model name strings.
+        :param err_msg: Message suffix appended to the model name in the error.
+        :raises AssertionError: If ``self.name`` is ``None`` or not found in *instr_list*.
+        """
+        if self.name is None:
+            raise AssertionError("Instrument connection not opened!")
+
+        if instr_list is not None and not any(self.name in instr for instr in instr_list):
+            self.close()
+            raise AssertionError(self.name + err_msg)
 
 
 class SCPIUnknownMixin(SCPIMixin):

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -37,6 +37,13 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
+try:
+    import pyvisa as _pyvisa
+    _ResourceManager = _pyvisa.ResourceManager
+except ImportError:  # pragma: no cover
+    _pyvisa = None  # type: ignore[assignment]
+    _ResourceManager = None  # type: ignore[assignment]
+
 AdapterType = Adapter | str | int
 
 
@@ -58,14 +65,23 @@ class Instrument(CommonBase):
     resource name.
     Keyword arguments can be used to further configure the connection.
 
+    When ``adapter`` is a :class:`pyvisa.ResourceManager`, ``name`` is interpreted as
+    the VISA resource string and the ``ResourceManager`` is reused (not closed on
+    :meth:`shutdown`).
+    This is the preferred pattern when multiple instruments share a single
+    ``ResourceManager`` opened with a specific VISA library.
+
     Otherwise, the passed :py:class:`~pymeasure.adapters.Adapter` object is used and any keyword
     arguments are discarded.
 
-    :param adapter: A string, integer, or :py:class:`~pymeasure.adapters.Adapter` subclass object
-    :param string name: The name of the instrument. Often the model designation by default.
-
-    :param \\**kwargs: In case ``adapter`` is a string or integer, additional arguments passed on
-        to :py:class:`~pymeasure.adapters.VISAAdapter` (check there for details).
+    :param adapter: A string, integer, :class:`pyvisa.ResourceManager`, or
+        :py:class:`~pymeasure.adapters.Adapter` subclass object.
+    :param string name: The name of the instrument.
+        When ``adapter`` is a :class:`pyvisa.ResourceManager`, ``name`` is used as the
+        VISA resource string (e.g. ``"TCPIP0::192.168.1.10::INSTR"``).
+    :param \\**kwargs: In case ``adapter`` is a string, integer, or
+        :class:`pyvisa.ResourceManager`, additional arguments passed on to
+        :py:class:`~pymeasure.adapters.VISAAdapter`.
         Discarded otherwise.
     """
     adapter: Adapter
@@ -82,7 +98,16 @@ class Instrument(CommonBase):
                  "the `SCPIMixin` class instead if it supports SCPI.", FutureWarning)
             kwargs.pop("includeSCPI")
         # Setup communication before possible children require the adapter.
-        if isinstance(adapter, (int, str)):
+        if _ResourceManager is not None and isinstance(adapter, _ResourceManager):
+            # adapter is a shared ResourceManager; name is the VISA resource string.
+            # VISAAdapter will set _manager_owned=False so the RM is not closed on shutdown.
+            try:
+                adapter = VISAAdapter(name, visa_library=adapter, **kwargs)
+            except ImportError:
+                raise TypeError(
+                    "Invalid Adapter provided for Instrument since PyVISA is not present"
+                )
+        elif isinstance(adapter, (int, str)):
             try:
                 adapter = VISAAdapter(adapter, **kwargs)
             except ImportError:

--- a/pymeasure/instruments/rohdeschwarz/__init__.py
+++ b/pymeasure/instruments/rohdeschwarz/__init__.py
@@ -24,4 +24,5 @@
 
 from .fsseries import FSL, FSW
 from .hmp import HMP4040
+from .ngpx import NGPx, PwrChannel
 from .sfm import SFM

--- a/pymeasure/instruments/rohdeschwarz/ngpx.py
+++ b/pymeasure/instruments/rohdeschwarz/ngpx.py
@@ -1,0 +1,577 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2025 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""Rohde & Schwarz NGPx programmable power-supply family driver.
+
+Supports NGP802 / NGP812 (2-channel) and NGP804 / NGP814 (4-channel) models.
+
+Minimal usage example::
+
+    from pymeasure.instruments.rohdeschwarz.ngpx import NGPx
+
+    psu = NGPx("TCPIP::192.168.1.10::INSTR")   # or pass a shared ResourceManager
+
+    psu.ch1.voltage_setpoint = 5.0
+    psu.ch1.current_limit = 1.0
+    psu.ch1.output = True
+    print(psu.ch1.voltage, psu.ch1.current)
+    psu.ch1.output = False
+
+See https://www.rohde-schwarz.com/webhelp/NGP800_HTML_UserManual_en for the
+full SCPI command reference.
+"""
+
+import logging
+from time import sleep
+
+from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, truncated_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+class PwrChannel(Channel):
+    """One output channel of an NGPx power supply.
+
+    Channels are created dynamically by :class:`NGPx.__init__` based on the
+    detected model, and exposed as ``inst.ch1``, ``inst.ch2``, etc.
+    """
+
+    _selection_status: bool = False
+    _output_status: bool = False
+    _tracking_status: bool = False
+
+    _select = Instrument.control(
+        "OUTP:SEL? (@{ch})",
+        "OUTP:SEL %d,(@{ch})",
+        """Control whether this channel is selected for bulk output control (bool).
+        True = selected (included in master output toggle), False = not selected.
+        Also updates internal _selection_status flag.""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    _tracking_select = Instrument.control(
+        "TRAC:SEL:CH{ch}?",
+        "TRAC:SEL:CH{ch} %d",
+        """Control whether this channel is selected for tracking configuration (bool).
+        True = channel is selected for master tracking enable/disable.
+        False = channel excluded from master tracking control.
+        Also updates internal _tracking_select flag.""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    _output = Instrument.control(
+        "OUTP? (@{ch})",
+        "OUTP %d,(@{ch})",
+        "Control the individual per-channel output state (bool). True = ON, False = OFF.",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    @property
+    def select(self) -> bool:
+        """Control whether this channel is selected for bulk output control (bool)."""
+        self._selection_status = self._select  # type: ignore
+        return self._selection_status
+
+    @select.setter
+    def select(self, v: bool) -> None:
+        self._select = v
+        self._selection_status = v
+
+    @property
+    def tracking_select(self) -> bool:
+        """Control whether this channel is selected for tracking configuration (bool)."""
+        self._tracking_status = self._tracking_select  # type: ignore
+        return self._tracking_status
+
+    @tracking_select.setter
+    def tracking_select(self, v: bool) -> None:
+        self._tracking_select = v
+        self._tracking_status = v
+
+    @property
+    def output(self) -> bool:
+        """Control the per-channel output state (bool). True = ON, False = OFF."""
+        self._output_status = self._output  # type: ignore
+        return self._output_status
+
+    @output.setter
+    def output(self, v: bool) -> None:
+        self._output = v
+        self._output_status = v
+
+    voltage = Instrument.measurement(
+        "MEAS:VOLT? (@{ch})",
+        "Measure the actual output voltage (V).",
+        get_process=float,
+    )
+
+    current = Instrument.measurement(
+        "MEAS:CURR? (@{ch})",
+        "Measure the actual output current (A).",
+        get_process=float,
+    )
+
+    safety_limits_ena = Instrument.control(
+        "ALIM? (@{ch})",
+        "ALIM %d,(@{ch})",
+        "Control the safety limit state (bool). True = enabled, False = disabled.",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    voltage_upper_limit = Instrument.control(
+        "VOLT:ALIM:UPP? (@{ch})",
+        "VOLT:ALIM:UPP %.3f,(@{ch})",
+        "Control the upper voltage safety limit (V). "
+        "This limits the maximum allowable voltage setpoint. "
+        "Range: 0.000 to 64.050 V (for 64 V models) or 0.000 to 32.050 V (for 32 V models). "
+        r"Increment: 0.001 V. \*RST: model-dependent (64.050 or 32.050 V)",
+        validator=truncated_range,
+        values=[0.000, 64.050],  # use widest range; hardware rejects invalid values
+    )
+
+    current_upper_limit = Instrument.control(
+        "CURR:ALIM:UPP? (@{ch})",
+        "CURR:ALIM:UPP %.3f,(@{ch})",
+        "Control the upper current safety limit (A). "
+        "Range depends on model: up to 20.010 A (32V models) or 10.010 A (64V models).",
+        validator=truncated_range,
+        values=[0.001, 20.010],  # widest range — hardware will reject invalid values
+    )
+
+    voltage_setpoint = Instrument.control(
+        "VOLT? (@{ch})",
+        "VOLT %.3f,(@{ch})",
+        "Control the output voltage setpoint in voltage source mode (V). "
+        "This is the target voltage the channel regulates to. "
+        "Range: 0.000 to 64.050 V (clamped by voltage_upper_limit if safety limits are enabled).",
+        validator=truncated_range,
+        values=[0.000, 64.050],
+    )
+
+    current_limit = Instrument.control(
+        "CURR? (@{ch})",
+        "CURR %.3f,(@{ch})",
+        "Control the current limit in voltage source mode (A). "
+        "Maximum current the channel will supply before switching to CC mode. "
+        "Range: 0.001 to 20.010 A (32 V models) or 0.001 to 10.010 A (64 V models). "
+        "Hardware limits max based on current voltage range.",
+        validator=truncated_range,
+        values=[0.001, 20.010],  # widest possible range — instrument will reject invalid values
+    )
+
+    sense = Instrument.control(
+        "VOLT:SENS? (@{ch})",
+        "VOLT:SENS %s,(@{ch})",
+        "Control the remote sense state: 'INT' (internal), 'EXT' (external/remote).",
+        validator=strict_discrete_set,
+        values=["INT", "EXT"],
+        cast=str,
+        get_process=lambda v: v.strip(),
+    )
+
+    # Overvoltage Protection (OVP / VOLT:PROT)
+    ovp_enabled = Instrument.control(
+        "VOLT:PROT? (@{ch})",
+        "VOLT:PROT %d,(@{ch})",
+        """Control the Overvoltage Protection (OVP) state (bool).
+        True = OVP enabled (active), False = disabled.
+
+        When remote sense (EXT) is active, it is strongly recommended to enable OVP
+        to protect the load from overvoltage in case of sense wire disconnection.""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    ovp_level = Instrument.control(
+        "VOLT:PROT:LEV? (@{ch})",
+        "VOLT:PROT:LEV %.3f,(@{ch})",
+        r"""Control the overvoltage protection trip level (V).
+        If the output voltage exceeds this value, the channel shuts down.
+        Range: 0.000 to 64.050 V (64 V models) or 32.050 V (32 V models).
+        \*RST: model maximum (64.050 or 32.050 V)
+
+        Recommended setting in remote sense mode: slightly above your voltage_setpoint
+        (e.g., voltage_setpoint + 2-5 V).""",
+        validator=truncated_range,
+        values=[0.000, 64.050],
+    )
+
+    ovp_tripped = Instrument.measurement(
+        "VOLT:PROT:TRIP? (@{ch})",
+        """Measure whether OVP has tripped (bool). True = tripped, the output is shut down.
+        Use ovp_clear() to reset after fixing the cause.""",
+        get_process=bool,
+    )
+
+    def ovp_clear(self):
+        """Clear the OVP tripped state and re-enable output if possible."""
+        self.write("VOLT:PROT:CLE (@{ch})")
+
+    # Overcurrent Protection (OCP / Fuse)
+    ocp_enabled = Instrument.control(
+        "FUSE? (@{ch})",
+        "FUSE %d,(@{ch})",
+        "Control the Overcurrent Protection (OCP/Fuse) state (bool)."
+        " True = enabled, False = disabled.",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    ocp_delay_initial = Instrument.control(
+        "FUSE:DEL:INIT? (@{ch})",
+        "FUSE:DEL:INIT %.3f,(@{ch})",
+        r"Control the initial fuse delay after output ON (s). Range: 0-60 s. \*RST: 0",
+        validator=truncated_range,
+        values=[0.0, 60.0],
+    )
+
+    ocp_delay = Instrument.control(
+        "FUSE:DEL? (@{ch})",
+        "FUSE:DEL %.3f,(@{ch})",
+        r"Control the ongoing fuse delay during operation (s). Range: 0-10 s. \*RST: 0",
+        validator=truncated_range,
+        values=[0.0, 10.0],
+    )
+
+    ocp_tripped = Instrument.measurement(
+        "FUSE:TRIP? (@{ch})",
+        "Measure whether OCP (fuse) has tripped due to overcurrent (bool). True = tripped.",
+        get_process=bool,
+    )
+
+    def ocp_clear(self):
+        """Reset the OCP (fuse) tripped state after fixing overcurrent."""
+        self.write("FUSE:TRIP:CLE (@{ch})")
+
+
+class NGPx(SCPIMixin, Instrument):
+    """Represent a Rohde & Schwarz NGPx programmable power supply.
+
+    The constructor queries ``*IDN?`` to detect the connected model, populates
+    :attr:`name`, :attr:`vendor`, :attr:`serial_number`, and
+    :attr:`firmware_ref`, and creates channel objects (``ch1``, ``ch2``, …)
+    based on the detected model.
+
+    :param adapter: VISA resource string or a :class:`pyvisa.ResourceManager`
+        (when a ``ResourceManager`` is passed, ``name`` is the VISA resource
+        string and the manager is *not* closed on exit).
+    :param name: VISA resource string when ``adapter`` is a
+        ``ResourceManager``, otherwise an optional label.
+    :param \\**kwargs: Forwarded to :class:`.Instrument`.
+    """
+
+    def __init__(self, adapter, name="Rohde Schwarz NGPx", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
+        resource = getattr(self, "resource_name", None) or ""
+        if "TCPIP" in resource.upper():
+            self.adapter.connection.write_termination = "\n"  # type: ignore
+            self.adapter.connection.read_termination = "\n"  # type: ignore
+
+        ids = []
+
+        self.get_device_info()
+        self.check_is_dev_supported(
+            ["NGP804", "NGP814", "NGP802", "NGP812"], ": Instrument not supported!"
+        )
+
+        if self.name in ("NGP804", "NGP814"):
+            ids = [1, 2, 3, 4]
+        elif self.name in ("NGP802", "NGP812"):
+            ids = [1, 2]
+        else:
+            pass
+
+        self.channels = {ch_id: PwrChannel(self, ch_id) for ch_id in ids}
+        for ch_id, channel in self.channels.items():
+            setattr(self, f"ch{ch_id}", channel)
+
+    def open(self):
+        self.adapter.open()
+
+        if "TCPIP" in self.adapter.resource_name.upper():
+            self.adapter.connection.write_termination = "\n"  # type: ignore
+            self.adapter.connection.read_termination = "\n"  # type: ignore
+
+    def set2local(self):
+        self.write("SYST:LOC")
+
+    def set2remote(self):
+        self.write("SYST:REM")
+
+    def __del__(self):
+        try:
+            self.set2local()
+        except Exception:  # noqa: BLE001
+            log.info(self.name + " already disconnected.")
+
+        try:
+            self.close()
+        except Exception:  # noqa: BLE001
+            log.info(self.name + " already disconnected.")
+
+    def clear_reset(self):
+        """Clear instrument status and reset to factory defaults."""
+        resource = getattr(self, "resource_name", None) or ""
+        if "ASRL" in resource:
+            self.write("*CLS;*RST;")
+            sleep(0.7)
+        else:
+            self.write("*CLS;*RST;*OPC?")
+            sleep(0.5)
+            self.read().strip()
+
+    def _get_selected_channel_list(self):
+        """Return SCPI channel list string like '(@1,2,4)' or empty string if none selected."""
+        selected: list[int] = [
+            ch.id
+            for ch in self.channels.values()
+            if isinstance(ch.id, int) and getattr(ch, "_selection_status", False)
+        ]
+        if not selected:
+            return ""
+        return "(@" + ",".join(map(str, sorted(selected))) + ")"
+
+    def _parse_outp_response(self, response: str) -> list[int]:
+        """Parse a comma-separated ``OUTP?`` response into a list of integers."""
+        if response is None:
+            return []
+        s = response.strip()
+        if not s:
+            return []
+        return [int(p.strip()) for p in s.split(",")]
+
+    @property
+    def output(self) -> bool:
+        """Control the master output state for all selected channels (bool).
+
+        True  -> all selected channels are ON (all 1)
+        False -> all selected channels are OFF (all 0) OR no channels selected
+        False + warning -> mixed/undefined state (not identical)
+        """
+        ch_list = self._get_selected_channel_list()
+        if not ch_list:
+            log.info("No channels selected; output=False")
+            return False
+
+        try:
+            response = self.ask(f"OUTP? {ch_list}")
+            vals = self._parse_outp_response(response)
+
+            if not vals:
+                log.warning("OUTP? returned empty response for %s: %r", ch_list, response)
+                return False
+
+            # normalize: some devices might respond with more than 0/1; treat nonzero as 1?
+            # If you want strict 0/1 only, keep the check below.
+            if any(v not in (0, 1) for v in vals):
+                log.warning(
+                    "OUTP? returned non-binary values for %s: %r (parsed=%s)",
+                    ch_list,
+                    response,
+                    vals,
+                )
+                return False
+
+            if all(v == 1 for v in vals):
+                return True
+            if all(v == 0 for v in vals):
+                return False
+
+            # Mixed state
+            log.warning(
+                "Undefined output state for %s: %r (parsed=%s). Returning False.",
+                ch_list,
+                response,
+                vals,
+            )
+            return False
+
+        except Exception:
+            log.exception("Failed to query master output state for %s", ch_list)
+            return False
+
+    @output.setter
+    def output(self, value: bool) -> None:
+        ch_list = self._get_selected_channel_list()
+        if not ch_list:
+            log.warning("No channels selected; master output command ignored.")
+            return
+
+        state = 1 if bool(value) else 0
+
+        try:
+            self.write(f"OUTP {state},{ch_list}")
+        except Exception:
+            log.exception("Failed to set master output state for %s", ch_list)
+            raise
+
+    output_general = Instrument.control(
+        "OUTP:GEN?",
+        "OUTP:GEN %d",
+        "Control the primary output state (bool). True = on, False = off.",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        get_process=bool,
+    )
+
+    def get_ocp_linked_channels(self, master_channel) -> list[int]:
+        """Query channels linked to *master_channel* for synchronized OCP tripping.
+
+        When an OCP event occurs on any channel in a linked group, all channels
+        in that group shut down to prevent back-feeding.
+
+        :param master_channel: Channel number (int) or :class:`PwrChannel`.
+        :returns: List of channel numbers linked to the master (excluding the
+            master itself). Empty list when nothing is linked.
+        """
+        ch_id = master_channel.id if isinstance(master_channel, PwrChannel) else int(master_channel)
+        response = self.ask(f"INST (@{ch_id});FUSE:LINK?")
+        if not response.strip() or response.strip() == "0":
+            return []
+        return [int(x) for x in response.split(",") if x.strip().isdigit()]
+
+    def link_ocp(self, master_channel, *linked_channels) -> None:
+        """Link channels to *master_channel* for synchronized OCP protection.
+
+        When OCP trips on any channel in the group all channels shut down
+        simultaneously, preventing back-current in parallel/series setups.
+
+        :param master_channel: Reference channel (int or :class:`PwrChannel`).
+        :param linked_channels: One or more channels to link (int or
+            :class:`PwrChannel`). Self-links are silently ignored.
+        """
+        master_id = (
+            master_channel.id if isinstance(master_channel, PwrChannel) else int(master_channel)
+        )
+        links = []
+        for ch in linked_channels:
+            ch_id = ch.id if isinstance(ch, PwrChannel) else int(ch)
+            if ch_id == master_id:
+                continue  # avoid self-linking
+            links.append(str(ch_id))
+
+        if not links:
+            log.info("No valid channels to link — command skipped.")
+            return
+
+        self.write(f"INST (@{master_id});FUSE:LINK {','.join(links)}")
+
+    def unlink_ocp(self, master_channel, target_channel=None) -> None:
+        """Remove OCP linking from channels linked to *master_channel*.
+
+        :param master_channel: Master channel (int or :class:`PwrChannel`).
+        :param target_channel: Specific channel to unlink (int or
+            :class:`PwrChannel`). When ``None`` (default) all links from the
+            master are removed.
+        """
+        master_id = (
+            master_channel.id if isinstance(master_channel, PwrChannel) else int(master_channel)
+        )
+
+        if target_channel is None:
+            self.write(f"INST (@{master_id});FUSE:UNL 0")
+        else:
+            target_id = (
+                target_channel.id if isinstance(target_channel, PwrChannel) else int(target_channel)
+            )
+            self.write(f"INST (@{master_id});FUSE:UNL {target_id}")
+
+    def _get_tracking_selected_list(self):
+        """Return SCPI channel list like '(@1,2,4)' for tracking-selected channels."""
+        selected: list[int] = [
+            ch.id
+            for ch in self.channels.values()
+            if isinstance(ch.id, int) and getattr(ch, "_tracking_status", False)
+        ]
+        if not selected:
+            return ""
+        return "(@" + ",".join(map(str, sorted(selected))) + ")"
+
+    @property
+    def tracking_enabled(self):
+        """Control the tracking state of all tracking-selected channels (boolean).
+
+        Getter returns ``True`` only when every tracking-selected channel has
+        tracking enabled; ``False`` when none are selected.
+        Setter enables or disables tracking on all channels marked via
+        :attr:`PwrChannel.tracking_select`.
+        """
+        ch_list = self._get_tracking_selected_list()
+        if not ch_list:
+            return False
+        try:
+            response = self.ask(f"TRAC? {ch_list}")
+            return bool(int(response.strip()))
+        except Exception:
+            log.exception("Failed to query tracking state for %s", ch_list)
+            return False
+
+    @tracking_enabled.setter
+    def tracking_enabled(self, value):
+        ch_list = self._get_tracking_selected_list()
+        if not ch_list:
+            log.warning("No channels tracking-selected — tracking command ignored.")
+            return
+
+        state = 1 if bool(value) else 0
+        try:
+            self.write(f"TRAC {state},{ch_list}")
+        except Exception:
+            log.exception("Failed to set tracking state for %s", ch_list)
+            raise
+
+    @property
+    def tracking_general_enabled(self):
+        """Control the global (primary) tracking master switch (bool).
+
+        This corresponds to TRACking:GENeral.
+        Must be True for any per-channel tracking to be active.
+        """
+        return bool(int(self.ask("TRAC:GEN?").strip()))
+
+    @tracking_general_enabled.setter
+    def tracking_general_enabled(self, value):
+        """Enable or disable the primary tracking function globally."""
+        state = 1 if bool(value) else 0
+        self.write(f"TRAC:GEN {state}")

--- a/pymeasure/instruments/rohdeschwarz/ngpx_sim.yaml
+++ b/pymeasure/instruments/rohdeschwarz/ngpx_sim.yaml
@@ -1,0 +1,91 @@
+spec: "1.0"
+devices:
+  ngp804:
+    eom:
+      TCPIP INSTR:
+        q: "\n"
+        r: "\n"
+      USB INSTR:
+        q: "\n"
+        r: "\n"
+      ASRL INSTR:
+        q: "\r\n"
+        r: "\n"
+    dialogues:
+      - q: "*IDN?"
+        r: "Rohde&Schwarz,NGP804,123456/001,1.00"
+      - q: "*CLS;*RST;*OPC?"
+        r: "1"
+      - q: "*CLS;*RST;"
+      - q: "SYST:REM"
+      - q: "SYST:LOC"
+      # --- Channel 1 ---
+      - q: "INST (@1);VOLT 5.000000E+00"
+      - q: "INST (@1);VOLT?"
+        r: "5.000000E+00"
+      - q: "INST (@1);CURR 1.000000E+00"
+      - q: "INST (@1);CURR?"
+        r: "1.000000E+00"
+      - q: "INST (@1);MEAS:VOLT?"
+        r: "4.999100E+00"
+      - q: "INST (@1);MEAS:CURR?"
+        r: "9.998000E-01"
+      - q: "INST (@1);OUTP 1"
+      - q: "OUTP? (@1)"
+        r: "1"
+      - q: "INST (@1);OUTP 0"
+      - q: "OUTP? (@1)"
+        r: "0"
+      # --- Channel 2 ---
+      - q: "INST (@2);VOLT 0.000000E+00"
+      - q: "INST (@2);VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@2);CURR 0.000000E+00"
+      - q: "INST (@2);CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@2);MEAS:VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@2);MEAS:CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@2);OUTP 0"
+      - q: "OUTP? (@2)"
+        r: "0"
+      # --- Channel 3 ---
+      - q: "INST (@3);VOLT 0.000000E+00"
+      - q: "INST (@3);VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@3);CURR 0.000000E+00"
+      - q: "INST (@3);CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@3);MEAS:VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@3);MEAS:CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@3);OUTP 0"
+      - q: "OUTP? (@3)"
+        r: "0"
+      # --- Channel 4 ---
+      - q: "INST (@4);VOLT 0.000000E+00"
+      - q: "INST (@4);VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@4);CURR 0.000000E+00"
+      - q: "INST (@4);CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@4);MEAS:VOLT?"
+        r: "0.000000E+00"
+      - q: "INST (@4);MEAS:CURR?"
+        r: "0.000000E+00"
+      - q: "INST (@4);OUTP 0"
+      - q: "OUTP? (@4)"
+        r: "0"
+      # --- Global output ---
+      - q: "OUTP:GEN 1"
+      - q: "OUTP:GEN?"
+        r: "1"
+      - q: "OUTP:GEN 0"
+
+resources:
+  TCPIP::localhost::9000::SOCKET:
+    device: ngp804
+  USB::0x0AAD::0x01FF::123456::INSTR:
+    device: ngp804

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,10 @@ reportIncompatibleMethodOverride = "warning"
 reportOperatorIssue = "warning"
 reportPrivateImportUsage = "none"
 defineConstant = { PYQT6 = true, PYSIDE2 = false, PYQT5 = false, PYSIDE6 = false }
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "pyvisa-sim>=0.7.1",
+]

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -106,6 +106,71 @@ class TestClose:
             _ = adapterC.manager.session
 
 
+class TestSharedResourceManager:
+    """Tests for passing a caller-owned ResourceManager via visa_library."""
+
+    @pytest.fixture
+    def shared_rm(self):
+        """Provide a pyvisa-sim ResourceManager and close it after the test."""
+        rm = pyvisa.ResourceManager('@sim')
+        yield rm
+        rm.close()
+
+    def test_shared_rm_is_used(self, shared_rm):
+        """Adapter opened with a caller-supplied RM uses that exact manager instance."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert a.manager is shared_rm
+        a.close()
+
+    def test_shared_rm_not_owned(self, shared_rm):
+        """Adapter does not own a caller-supplied RM."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert a._manager_owned is False
+        a.close()
+
+    def test_shared_rm_not_closed_on_adapter_close(self, shared_rm):
+        """Closing the adapter does not close a caller-supplied ResourceManager."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm,
+                        read_termination="\n")
+        assert shared_rm.session is not None
+        a.close()
+        assert shared_rm.session is not None
+
+    def test_second_adapter_still_works_after_first_closes(self, shared_rm):
+        """A second adapter sharing the same RM continues to operate after the first closes."""
+        a1 = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm, read_termination="\n")
+        a2 = VISAAdapter(SIM_RESOURCE, visa_library=shared_rm, read_termination="\n")
+        a1.close()
+        a2.write("*IDN?")
+        assert a2.read() == "SCPI,MOCK,VERSION_1.0"
+        a2.close()
+
+    def test_owned_manager_is_closed_on_adapter_close(self):
+        """Adapter that created its own RM closes it on close() (pyvisa-sim workaround)."""
+        a = VISAAdapter(SIM_RESOURCE, visa_library='@sim')
+        assert a._manager_owned is True
+        rm = a.manager
+        assert rm.session is not None
+        a.close()
+        with pytest.raises(pyvisa.errors.InvalidSession, match="Invalid session"):
+            _ = rm.session
+
+    def test_instrument_init_accepts_resource_manager(self, shared_rm):
+        """Instrument(rm, resource_string) reuses the shared RM without closing it."""
+        from pymeasure.instruments import Instrument, SCPIMixin
+
+        class SimpleInstrument(SCPIMixin, Instrument):
+            """Minimal instrument used to verify shared ResourceManager handling."""
+
+        inst = SimpleInstrument(shared_rm, SIM_RESOURCE, read_termination="\n")
+        assert inst.adapter.manager is shared_rm
+        assert inst.adapter._manager_owned is False
+        inst.shutdown()
+        assert shared_rm.session is not None
+
+
 def test_write_read(adapter):
     adapter.write(":VOLT:IMM:AMPL?")
     assert float(adapter.read()) == 1
@@ -150,3 +215,32 @@ class TestReadBytes:
         adapter.write("*IDN?")
         # `break_on_termchar=False` is default value
         assert adapter.read_bytes(-1) == b"SCPI,MOCK,VERSION_1.0\nSCPI,MOCK,VERSION_1.0\n"
+
+
+class TestOpen:
+    """Tests for VISAAdapter.open() connection-lifecycle behaviour."""
+
+    def test_open_after_close_restores_connection(self):
+        """open() after close() re-establishes a working VISA connection.
+
+        The caller is responsible for re-applying connection settings
+        (e.g. read_termination) after open(), as open() does not restore them.
+        """
+        rm = pyvisa.ResourceManager('@sim')
+        try:
+            a = VISAAdapter(SIM_RESOURCE, visa_library=rm, read_termination="\n")
+            a.close()
+            a.open()
+            a.connection.read_termination = "\n"
+            a.write("*IDN?")
+            assert a.read() == "SCPI,MOCK,VERSION_1.0"
+            a.close()
+        finally:
+            rm.close()
+
+    def test_open_raises_for_protocol_adapter(self):
+        """open() raises AttributeError when backed by a ProtocolAdapter."""
+        with expected_protocol(VISAAdapter, []) as a, pytest.raises(  # type: ignore
+            AttributeError, match="resource_name"
+        ):
+            a.open()

--- a/tests/instruments/rohdeschwarz/test_ngpx.py
+++ b/tests/instruments/rohdeschwarz/test_ngpx.py
@@ -1,0 +1,510 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.instruments.rohdeschwarz.ngpx import NGPx, PwrChannel
+from pymeasure.test import expected_protocol
+
+# ---------------------------------------------------------------------------
+# Test subclasses — suppress the constructor's *IDN? query so individual
+# protocol tests can focus on the commands under test without prepending an
+# IDN exchange to every expected_protocol list.
+# ---------------------------------------------------------------------------
+
+
+class _NGP4(NGPx):
+    """4-channel test stand-in (NGP804 identity, no IDN query)."""
+
+    def get_device_info(self) -> None:
+        self.name = "NGP804"
+
+    def check_is_dev_supported(self, *args, **kwargs) -> None:
+        pass
+
+
+class _NGP2(NGPx):
+    """2-channel test stand-in (NGP802 identity, no IDN query)."""
+
+    def get_device_info(self) -> None:
+        self.name = "NGP802"
+
+    def check_is_dev_supported(self, *args, **kwargs) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Channel creation
+# ---------------------------------------------------------------------------
+
+class TestChannelCreation:
+    def test_four_channels_for_ngp804(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            assert inst.ch1.id == 1
+            assert inst.ch2.id == 2
+            assert inst.ch3.id == 3
+            assert inst.ch4.id == 4
+
+    def test_channels_are_pwrchannel_instances(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            assert isinstance(inst.ch1, PwrChannel)
+
+    def test_channels_dict_has_four_entries(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            assert set(inst.channels.keys()) == {1, 2, 3, 4}
+
+    def test_two_channels_for_ngp802(self):
+        with expected_protocol(_NGP2, [], name="NGP802") as inst:
+            assert inst.ch1.id == 1
+            assert inst.ch2.id == 2
+            assert not hasattr(inst, "ch3")
+
+    def test_channels_dict_has_two_entries(self):
+        with expected_protocol(_NGP2, [], name="NGP802") as inst:
+            assert set(inst.channels.keys()) == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Voltage / current setpoints
+# ---------------------------------------------------------------------------
+
+class TestChannelSetpoints:
+    def test_voltage_setpoint_get(self):
+        with expected_protocol(_NGP4, [("VOLT? (@1)", "5.000")], name="NGP804") as inst:
+            assert inst.ch1.voltage_setpoint == pytest.approx(5.0)
+
+    def test_voltage_setpoint_set(self):
+        with expected_protocol(_NGP4, [("VOLT 5.000,(@2)", None)], name="NGP804") as inst:
+            inst.ch2.voltage_setpoint = 5.0
+
+    def test_current_limit_get(self):
+        with expected_protocol(_NGP4, [("CURR? (@3)", "1.500")], name="NGP804") as inst:
+            assert inst.ch3.current_limit == pytest.approx(1.5)
+
+    def test_current_limit_set(self):
+        with expected_protocol(_NGP4, [("CURR 2.000,(@4)", None)], name="NGP804") as inst:
+            inst.ch4.current_limit = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Measurements
+# ---------------------------------------------------------------------------
+
+class TestChannelMeasurements:
+    def test_voltage_measurement(self):
+        with expected_protocol(_NGP4, [("MEAS:VOLT? (@1)", "4.987")], name="NGP804") as inst:
+            assert inst.ch1.voltage == pytest.approx(4.987)
+
+    def test_current_measurement(self):
+        with expected_protocol(_NGP4, [("MEAS:CURR? (@2)", "0.250")], name="NGP804") as inst:
+            assert inst.ch2.current == pytest.approx(0.25)
+
+
+# ---------------------------------------------------------------------------
+# Safety limits
+# ---------------------------------------------------------------------------
+
+class TestChannelSafetyLimits:
+    def test_safety_limits_ena_get_true(self):
+        with expected_protocol(_NGP4, [("ALIM? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.safety_limits_ena is True
+
+    def test_safety_limits_ena_get_false(self):
+        with expected_protocol(_NGP4, [("ALIM? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.safety_limits_ena is False
+
+    def test_safety_limits_ena_set(self):
+        with expected_protocol(_NGP4, [("ALIM 1,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.safety_limits_ena = True
+
+    def test_voltage_upper_limit(self):
+        with expected_protocol(_NGP4,
+                               [("VOLT:ALIM:UPP? (@1)", "6.000"),
+                                ("VOLT:ALIM:UPP 6.000,(@1)", None)],
+                               name="NGP804") as inst:
+            assert inst.ch1.voltage_upper_limit == pytest.approx(6.0)
+            inst.ch1.voltage_upper_limit = 6.0
+
+    def test_current_upper_limit(self):
+        with expected_protocol(_NGP4,
+                               [("CURR:ALIM:UPP? (@1)", "5.000"),
+                                ("CURR:ALIM:UPP 5.000,(@1)", None)],
+                               name="NGP804") as inst:
+            assert inst.ch1.current_upper_limit == pytest.approx(5.0)
+            inst.ch1.current_upper_limit = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Remote sense
+# ---------------------------------------------------------------------------
+
+class TestChannelSense:
+    def test_sense_get_int(self):
+        with expected_protocol(_NGP4, [("VOLT:SENS? (@1)", "INT")], name="NGP804") as inst:
+            assert inst.ch1.sense == "INT"
+
+    def test_sense_get_ext(self):
+        with expected_protocol(_NGP4, [("VOLT:SENS? (@1)", "EXT")], name="NGP804") as inst:
+            assert inst.ch1.sense == "EXT"
+
+    def test_sense_set(self):
+        with expected_protocol(_NGP4, [("VOLT:SENS EXT,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.sense = "EXT"
+
+    def test_sense_invalid_raises(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst, pytest.raises(ValueError):
+            inst.ch1.sense = "INVALID"
+
+
+# ---------------------------------------------------------------------------
+# Overvoltage protection
+# ---------------------------------------------------------------------------
+
+class TestChannelOVP:
+    def test_ovp_enabled_get_true(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.ovp_enabled is True
+
+    def test_ovp_enabled_get_false(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.ovp_enabled is False
+
+    def test_ovp_level_get(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT:LEV? (@1)", "6.500")], name="NGP804") as inst:
+            assert inst.ch1.ovp_level == pytest.approx(6.5)
+
+    def test_ovp_level_set(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT:LEV 6.500,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.ovp_level = 6.5
+
+    def test_ovp_tripped_false(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT:TRIP? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.ovp_tripped is False
+
+    def test_ovp_tripped_true(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT:TRIP? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.ovp_tripped is True
+
+    def test_ovp_clear(self):
+        with expected_protocol(_NGP4, [("VOLT:PROT:CLE (@1)", None)], name="NGP804") as inst:
+            inst.ch1.ovp_clear()
+
+
+# ---------------------------------------------------------------------------
+# Overcurrent protection
+# ---------------------------------------------------------------------------
+
+class TestChannelOCP:
+    def test_ocp_enabled_get_true(self):
+        with expected_protocol(_NGP4, [("FUSE? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.ocp_enabled is True
+
+    def test_ocp_enabled_get_false(self):
+        with expected_protocol(_NGP4, [("FUSE? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.ocp_enabled is False
+
+    def test_ocp_delay_initial(self):
+        with expected_protocol(_NGP4,
+                               [("FUSE:DEL:INIT? (@1)", "0.500"),
+                                ("FUSE:DEL:INIT 0.500,(@1)", None)],
+                               name="NGP804") as inst:
+            assert inst.ch1.ocp_delay_initial == pytest.approx(0.5)
+            inst.ch1.ocp_delay_initial = 0.5
+
+    def test_ocp_delay(self):
+        with expected_protocol(_NGP4,
+                               [("FUSE:DEL? (@1)", "1.000"),
+                                ("FUSE:DEL 1.000,(@1)", None)],
+                               name="NGP804") as inst:
+            assert inst.ch1.ocp_delay == pytest.approx(1.0)
+            inst.ch1.ocp_delay = 1.0
+
+    def test_ocp_tripped_false(self):
+        with expected_protocol(_NGP4, [("FUSE:TRIP? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.ocp_tripped is False
+
+    def test_ocp_tripped_true(self):
+        with expected_protocol(_NGP4, [("FUSE:TRIP? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.ocp_tripped is True
+
+    def test_ocp_clear(self):
+        with expected_protocol(_NGP4, [("FUSE:TRIP:CLE (@1)", None)], name="NGP804") as inst:
+            inst.ch1.ocp_clear()
+
+
+# ---------------------------------------------------------------------------
+# Per-channel output
+# ---------------------------------------------------------------------------
+
+class TestChannelOutput:
+    def test_output_get_true(self):
+        with expected_protocol(_NGP4, [("OUTP? (@1)", "1")], name="NGP804") as inst:
+            assert inst.ch1.output is True
+
+    def test_output_get_false(self):
+        with expected_protocol(_NGP4, [("OUTP? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.output is False
+
+    def test_output_set_on(self):
+        with expected_protocol(_NGP4, [("OUTP 1,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.output = True
+
+    def test_output_set_off(self):
+        with expected_protocol(_NGP4, [("OUTP 0,(@2)", None)], name="NGP804") as inst:
+            inst.ch2.output = False
+
+
+# ---------------------------------------------------------------------------
+# Channel selection (for bulk output control)
+# ---------------------------------------------------------------------------
+
+class TestChannelSelection:
+    def test_select_get_false(self):
+        with expected_protocol(_NGP4, [("OUTP:SEL? (@1)", "0")], name="NGP804") as inst:
+            assert inst.ch1.select is False
+
+    def test_select_get_true(self):
+        with expected_protocol(_NGP4, [("OUTP:SEL? (@2)", "1")], name="NGP804") as inst:
+            assert inst.ch2.select is True
+
+    def test_select_set_updates_status(self):
+        with expected_protocol(_NGP4, [("OUTP:SEL 1,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.select = True
+            assert inst.ch1._selection_status is True
+
+    def test_select_clear_updates_status(self):
+        with expected_protocol(_NGP4, [("OUTP:SEL 0,(@1)", None)], name="NGP804") as inst:
+            inst.ch1.select = False
+            assert inst.ch1._selection_status is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk output (master output over selected channels)
+# ---------------------------------------------------------------------------
+
+class TestBulkOutput:
+    def test_output_setter_sends_correct_scpi(self):
+        with expected_protocol(_NGP4,
+                               [("OUTP:SEL 1,(@1)", None),
+                                ("OUTP:SEL 1,(@3)", None),
+                                ("OUTP 1,(@1,3)", None)],
+                               name="NGP804") as inst:
+            inst.ch1.select = True
+            inst.ch3.select = True
+            inst.output = True
+
+    def test_output_getter_all_on_returns_true(self):
+        with expected_protocol(_NGP4,
+                               [("OUTP:SEL 1,(@1)", None),
+                                ("OUTP:SEL 1,(@2)", None),
+                                ("OUTP? (@1,2)", "1,1")],
+                               name="NGP804") as inst:
+            inst.ch1.select = True
+            inst.ch2.select = True
+            assert inst.output is True
+
+    def test_output_getter_mixed_returns_false(self):
+        with expected_protocol(_NGP4,
+                               [("OUTP:SEL 1,(@1)", None),
+                                ("OUTP:SEL 1,(@2)", None),
+                                ("OUTP? (@1,2)", "1,0")],
+                               name="NGP804") as inst:
+            inst.ch1.select = True
+            inst.ch2.select = True
+            assert inst.output is False
+
+    def test_output_setter_no_channels_warns(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            inst.output = True  # no channels selected — should warn, do nothing
+
+    def test_output_getter_no_channels_returns_false(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            assert inst.output is False
+
+    def test_output_general_get_false(self):
+        with expected_protocol(_NGP4, [("OUTP:GEN?", "0")], name="NGP804") as inst:
+            assert inst.output_general is False
+
+    def test_output_general_get_true(self):
+        with expected_protocol(_NGP4, [("OUTP:GEN?", "1")], name="NGP804") as inst:
+            assert inst.output_general is True
+
+    def test_output_general_set_on(self):
+        with expected_protocol(_NGP4, [("OUTP:GEN 1", None)], name="NGP804") as inst:
+            inst.output_general = True
+
+    def test_output_general_set_off(self):
+        with expected_protocol(_NGP4, [("OUTP:GEN 0", None)], name="NGP804") as inst:
+            inst.output_general = False
+
+
+# ---------------------------------------------------------------------------
+# Tracking
+# ---------------------------------------------------------------------------
+
+class TestTracking:
+    def test_tracking_select_get_false(self):
+        with expected_protocol(_NGP4, [("TRAC:SEL:CH1?", "0")], name="NGP804") as inst:
+            assert inst.ch1.tracking_select is False
+
+    def test_tracking_select_get_true(self):
+        with expected_protocol(_NGP4, [("TRAC:SEL:CH2?", "1")], name="NGP804") as inst:
+            assert inst.ch2.tracking_select is True
+
+    def test_tracking_select_set_updates_status(self):
+        with expected_protocol(_NGP4, [("TRAC:SEL:CH1 1", None)], name="NGP804") as inst:
+            inst.ch1.tracking_select = True
+            assert inst.ch1._tracking_status is True
+
+    def test_tracking_enabled_set_uses_comma_separator(self):
+        """TRAC command must have a comma between state and channel list."""
+        with expected_protocol(_NGP4,
+                               [("TRAC:SEL:CH1 1", None),
+                                ("TRAC:SEL:CH2 1", None),
+                                ("TRAC 1,(@1,2)", None)],
+                               name="NGP804") as inst:
+            inst.ch1.tracking_select = True
+            inst.ch2.tracking_select = True
+            inst.tracking_enabled = True
+
+    def test_tracking_enabled_get_true(self):
+        with expected_protocol(_NGP4,
+                               [("TRAC:SEL:CH1 1", None),
+                                ("TRAC? (@1)", "1")],
+                               name="NGP804") as inst:
+            inst.ch1.tracking_select = True
+            assert inst.tracking_enabled is True
+
+    def test_tracking_enabled_no_channels_returns_false(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            assert inst.tracking_enabled is False
+
+    def test_tracking_enabled_set_no_channels_warns(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            inst.tracking_enabled = True  # no channels — warn, do nothing
+
+    def test_tracking_general_enabled_get_false(self):
+        with expected_protocol(_NGP4, [("TRAC:GEN?", "0")], name="NGP804") as inst:
+            assert inst.tracking_general_enabled is False
+
+    def test_tracking_general_enabled_set_true(self):
+        with expected_protocol(_NGP4, [("TRAC:GEN 1", None)], name="NGP804") as inst:
+            inst.tracking_general_enabled = True
+
+
+# ---------------------------------------------------------------------------
+# OCP linking
+# ---------------------------------------------------------------------------
+
+class TestOCPLinking:
+    def test_link_ocp(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:LINK 2,3", None)], name="NGP804") as inst:
+            inst.link_ocp(1, 2, 3)
+
+    def test_link_ocp_ignores_self_link(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:LINK 2", None)], name="NGP804") as inst:
+            inst.link_ocp(1, 1, 2)
+
+    def test_link_ocp_no_valid_targets_skips(self):
+        with expected_protocol(_NGP4, [], name="NGP804") as inst:
+            inst.link_ocp(1, 1)
+
+    def test_unlink_ocp_all(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:UNL 0", None)], name="NGP804") as inst:
+            inst.unlink_ocp(1)
+
+    def test_unlink_ocp_specific(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:UNL 2", None)], name="NGP804") as inst:
+            inst.unlink_ocp(1, 2)
+
+    def test_get_ocp_linked_channels_empty(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:LINK?", "0")], name="NGP804") as inst:
+            assert inst.get_ocp_linked_channels(1) == []
+
+    def test_get_ocp_linked_channels(self):
+        with expected_protocol(_NGP4, [("INST (@1);FUSE:LINK?", "2,3")], name="NGP804") as inst:
+            assert inst.get_ocp_linked_channels(1) == [2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Local / remote control
+# ---------------------------------------------------------------------------
+
+class TestLocalRemote:
+    def test_set2local(self):
+        with expected_protocol(_NGP4, [("SYST:LOC", None)], name="NGP804") as inst:
+            inst.set2local()
+
+    def test_set2remote(self):
+        with expected_protocol(_NGP4, [("SYST:REM", None)], name="NGP804") as inst:
+            inst.set2remote()
+
+
+# ---------------------------------------------------------------------------
+# Constructor — identity query (uses real NGPx so the full init runs)
+# ---------------------------------------------------------------------------
+
+class TestNGPxConstructorIdentity:
+    """Verify *IDN? query, attribute population, and dynamic channels.
+
+    These tests use the real NGPx class so the full constructor path is
+    exercised.  The expected_protocol list must include the IDN exchange.
+    The context-manager calls shutdown() on exit which sends SYST:LOC.
+    """
+
+    def test_constructor_sets_name_from_idn(self):
+        with expected_protocol(NGPx,
+                               [("*IDN?", "Rohde&Schwarz,NGP804,123456,V1.00")],
+                               name="NGP804") as inst:
+            assert inst.name == "NGP804"
+
+    def test_constructor_sets_vendor_serial_firmware(self):
+        with expected_protocol(NGPx,
+                               [("*IDN?", "Rohde&Schwarz,NGP804,123456,V1.00")],
+                               name="NGP804") as inst:
+            assert inst.vendor == "Rohde&Schwarz"
+            assert inst.serial_number == "123456"
+            assert inst.firmware_ref == "V1.00"
+
+    def test_constructor_creates_ch1_to_ch4_for_ngp804(self):
+        with expected_protocol(NGPx,
+                               [("*IDN?", "Rohde&Schwarz,NGP804,123456,V1.00")],
+                               name="NGP804") as inst:
+            for i in (1, 2, 3, 4):
+                assert hasattr(inst, f"ch{i}")
+                assert isinstance(getattr(inst, f"ch{i}"), PwrChannel)
+
+    def test_constructor_creates_ch1_to_ch2_for_ngp802(self):
+        with expected_protocol(NGPx,
+                               [("*IDN?", "Rohde&Schwarz,NGP802,999,V2.00")],
+                               name="NGP802") as inst:
+            assert hasattr(inst, "ch1")
+            assert hasattr(inst, "ch2")
+            assert not hasattr(inst, "ch3")
+
+    def test_constructor_rejects_unsupported_model(self):
+        with pytest.raises(AssertionError), expected_protocol(NGPx,
+                               [("*IDN?", "Rohde&Schwarz,NGP999,123456,V1.00")],
+                               name="NGP999"):
+            pass

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -114,6 +114,7 @@ need_init_communication = [
     "Keithley2281S",
     "SpellmanXRV",
     "YAR",
+    "NGPx",
 ]
 # Instruments whose property docstrings are not YET in accordance with the style (Get, Set, Control)
 grandfathered_docstring_instruments = [

--- a/tests/instruments/test_generic_types.py
+++ b/tests/instruments/test_generic_types.py
@@ -103,6 +103,88 @@ class Test_SCPIMixin:
             assert inst.check_errors() == [[-100, '"Command error"'],
                                            [-222, '"Data out of range"']]
 
+    def test_close_does_not_raise(self):
+        with expected_protocol(self.SCPIInstrument, [], name="test") as inst:
+            inst.close()  # Adapter.close() is a no-op for ProtocolAdapter — must not raise
+
 
 def test_SCPIMixin_inherits_IEEE4882Mixin():
     assert issubclass(SCPIMixin, IEEE4882Mixin)
+
+
+class Test_GetDeviceInfo:
+    """Tests for SCPIMixin.get_device_info()."""
+
+    class SCPIInstrument(SCPIMixin, Instrument):
+        """Minimal SCPI instrument used in get_device_info tests."""
+
+    def test_sets_name_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.name == "NGP804"
+
+    def test_sets_vendor_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.vendor == "Rohde&Schwarz"
+
+    def test_sets_serial_number_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.serial_number == "12345"
+
+    def test_sets_firmware_ref_from_idn(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            assert inst.firmware_ref == "V1.0"
+
+
+class Test_CheckIsDevSupported:
+    """Tests for SCPIMixin.check_is_dev_supported()."""
+
+    class SCPIInstrument(SCPIMixin, Instrument):
+        """Minimal SCPI instrument used in check_is_dev_supported tests."""
+
+    def test_supported_model_does_not_raise(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP804,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            inst.check_is_dev_supported(["NGP804", "NGP814"], ": not supported")
+
+    def test_unsupported_model_raises_assertion_error(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,NGP402,12345,V1.0")],
+                name="test") as inst:
+            inst.get_device_info()
+            with pytest.raises(AssertionError, match="NGP402"):
+                inst.check_is_dev_supported(["NGP804", "NGP814"], ": not supported")
+
+    def test_error_includes_custom_message(self):
+        with expected_protocol(
+                self.SCPIInstrument,
+                [("*IDN?", "Rohde&Schwarz,UNKNOWN,SN,FW")],
+                name="test") as inst:
+            inst.get_device_info()
+            with pytest.raises(AssertionError, match="Instrument not supported"):
+                inst.check_is_dev_supported(["NGP804"], ": Instrument not supported")
+
+    def test_none_name_raises_assertion_error(self):
+        with expected_protocol(self.SCPIInstrument, [], name="test") as inst:
+            inst.name = None
+            with pytest.raises(AssertionError, match="not opened"):
+                inst.check_is_dev_supported(["NGP804"], "")


### PR DESCRIPTION
## Summary

Adds a complete Rohde & Schwarz NGPx (NGP802/804/812/814) power-supply driver:

- Single `NGPx` class; model detection via `*IDN?` at construction time
- Dynamic channel creation: 4-channel for NGP804/NGP814, 2-channel for NGP802/NGP812
- Channel access as `inst.ch1` … `inst.ch4` with full per-channel control (voltage, current, OVP, OCP, fuse, tracking, selection)
- Instrument-level `output_general`, `tracking_enabled`, `output` (all-channel toggle)
- `clear_reset()` with connection-type-aware timing (ASRL vs TCPIP/GPIB)
- `open()` for reconnection after network dropout (restores TCPIP termination settings)
- `set2local()` / `set2remote()` for panel lock management
- `__del__` returns to local mode and closes the connection safely
- Supports caller-owned `pyvisa.ResourceManager` (from #1534) for multi-instrument setups
- `pyvisa-sim` YAML fixture for offline testing
- Full protocol test suite (NGP804 and NGP802 configurations)
- RST documentation page

Depends on #1534 and #1535.
Replaces #1434.

## Test plan
- [ ] `tests/instruments/rohdeschwarz/test_ngpx.py` — all protocol tests (no hardware required)
- [ ] Hardware test with real NGP804 via TCPIP
