### PR TITLE
Fix amplitude unit conversion of HP856Xx trace data

### DIFF
--- a/pymeasure/instruments/hp/hp856Xx.py
+++ b/pymeasure/instruments/hp/hp856Xx.py
@@ -2618,16 +2618,16 @@ class HP856Xx(Instrument):
 
         values = self.values(cmd_str, cast=int)
 
-        if amp_units is AmplitudeUnits.W:
+        if amp_units == AmplitudeUnits.W:
             # calculate dbm from watts
             ref_lvl = (10 * log10(ref_lvl)) + 30
-        elif amp_units is AmplitudeUnits.DBUV:
+        elif amp_units == AmplitudeUnits.DBUV:
             # calculate dbm from dbuv in 50 Ohm system
             ref_lvl = ref_lvl - 107
-        elif amp_units is AmplitudeUnits.V:
-            # calculate dbm from volts in 50 Ohm system
-            ref_lvl = 20 * log10((ref_lvl / 0.05) ** 0.5)
-        elif amp_units is AmplitudeUnits.DBMV:
+        elif amp_units == AmplitudeUnits.V:
+            # calculate dbm from volts in 50 Ohm system: P[mW] = V**2 / (50 Ohm * 1 mW)
+            ref_lvl = 10 * log10(ref_lvl ** 2 / 0.05)
+        elif amp_units == AmplitudeUnits.DBMV:
             # calculate dbm from dbmv
             ref_lvl = ref_lvl - 46.9897
 

--- a/tests/instruments/hp/test_hp856Xx.py
+++ b/tests/instruments/hp/test_hp856Xx.py
@@ -893,6 +893,33 @@ class TestHP856Xx:
         ) as instr:
             assert getattr(instr, function)() == expected_data
 
+    # The reference level is reported in the instrument's active amplitude unit, but the trace
+    # data is always returned in dBm. Expected values are derived from the 50 Ohm relations
+    # P[mW] = V**2 / (50 Ohm * 1 mW), i.e. 0 dBm = 0.2236 V = 46.9897 dBmV = 106.9897 dBuV.
+    @pytest.mark.parametrize("amplitude_unit, reference_level, reference_level_dbm", [
+        (AmplitudeUnits.DBM, "-10.0", -10.0),
+        (AmplitudeUnits.W, "10.0", 40.0),
+        (AmplitudeUnits.V, "0.1", -6.9897),
+        (AmplitudeUnits.DBMV, "50.0", 3.0103),
+        (AmplitudeUnits.DBUV, "107.0", 0.0103),
+    ])
+    def test_trace_data_amplitude_units(self, amplitude_unit, reference_level,
+                                        reference_level_dbm):
+        data = [600, 540, 0]
+        log_scale = 10.0
+        expected_data = [reference_level_dbm + log_scale * (value - 600) / 60 for value in data]
+        with expected_protocol(
+                HP856Xx,
+                [
+                    ("TDF M", None),
+                    ("AUNITS?", amplitude_unit),
+                    ("RL?", reference_level),
+                    ("LG?", str(log_scale)),
+                    ("TRA?", ','.join([str(i) for i in data]))
+                ]
+        ) as instr:
+            assert instr.get_trace_data_a() == pytest.approx(expected_data, abs=0.02)
+
     def test_fft_trace_window(self):
         with expected_protocol(
                 HP856Xx,


### PR DESCRIPTION
`HP856Xx._get_trace_data` reads the instrument's amplitude unit into a plain `str` (`hp856Xx.py:2609`, `amp_units = str(self.ask("AUNITS?"))`) and then compares it against `AmplitudeUnits` members with `is`. `AmplitudeUnits` is a `StrEnum`, so its members are `str` *subclass instances* and a plain `str` is never the same object:

```
DBUV   value='DBUV'  ('DBUV' is member) -> False   ('DBUV' == member) -> True
```

All four conversion branches at `:2621-2632` are therefore unreachable and the reference level is used as dBm whatever unit the analyzer is set to. With `AUNITS DBUV` the whole trace comes back offset by ~107 dB.

Switching to `==` uncovers a second error in the branch that was dead. The volts conversion is written `20 * log10((ref_lvl / 0.05) ** 0.5)`, which is `10 * log10(V / 0.05)`, not `10 * log10(V**2 / 0.05)`. For a 50 Ω system P[mW] = V²/(50 Ω · 1 mW), so the exponent belongs on V. The two forms agree only at V = 1 V:

```
V=1.0     buggy=  13.0103   correct=  13.0103
V=0.1     buggy=   3.0103   correct=  -6.9897
V=0.001   buggy= -16.9897   correct= -46.9897
```

The oracle is the neighbouring branch in the same function: 0 dBmV is 1 mV, and the dBmV branch already carries `-46.9897`, which is exactly `10*log10((1e-3)**2/0.05)`. Only the corrected expression reproduces it. Both are in one PR because fixing only the comparison ships the wrong volts conversion — the second mutant below.

**Why this survived:** `test_trace_data` is the only test of this path and its fixture answers `("AUNITS?", "DBM")` — the one unit for which the function is a no-op. Every other `AUNITS?` in `test_hp856Xx.py` also answers `"DBM"`. The new parametrized test derives its expected values from the 50 Ω relations rather than from the implementation.

**Measured** (Python 3.14, `pytest tests/instruments/hp/`): fix in tree → 189 passed. Reverting only `hp856Xx.py` and keeping the new test → 4 failed (W, V, dBmV, dBµV) / 185 passed; e.g. `obtained 107.0, expected 0.0103`. Applying only `is`→`==` and keeping the original volts expression → 1 failed, the V case, off by 10 dB. Full suite: 2 failed / 9286 passed / 3459 skipped, and both failures (`test_formfactorVelox.py::test_expected_error`, `test_common_base.py::test_values_fallback_raises_futurewarning_in_pymeasure`) reproduce identically on `68bd427` without this change — pre-existing here, unrelated. `ruff check`, `flake8`, and `pyright` on the changed files are clean.

**Not tested:** no HP 8560A/8561B was available; everything is `expected_protocol`. I did not consult HP's programming manual, so I have not confirmed that `AUNITS?` replies carry no trailing whitespace on real hardware — if they do, `==` still fails and the branches stay dead, but `str(self.ask(...))` has no `.strip()` today and I did not add one. I also left `ref_lvl - 107` for dBµV alone; the exact offset is `-106.9897`, a 0.0103 dB inconsistency against the dBmV branch's full precision, so the new test uses `abs=0.02` and neither asserts nor blesses it. `AUTO` still falls through with no conversion, as before.

Found by a hunt for identity-vs-equality comparisons against `StrEnum` values, not from a bug encountered on an instrument. Written with AI assistance (Claude).
