### PR TITLE
Fix AQ6370 ethernet authentication case sensitivity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Changed
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
+Instruments
+-----------
+- Fix Yokogawa AQ6370 :code:`authenticate_ethernet` to compare responses case-insensitively (older firmware such as the AQ6370B answers in lower case) and raise :code:`ConnectionError` instead of asserting.
+
 Version 0.16.0 (2026-05-20)
 ===========================
 

--- a/pymeasure/instruments/yokogawa/aq6370series.py
+++ b/pymeasure/instruments/yokogawa/aq6370series.py
@@ -106,7 +106,13 @@ class AQ6370Series(SCPIMixin, Instrument):
     TRG = Instrument.ChannelCreator(Trace, "TRG")
 
     def authenticate_ethernet(self, username: str, password: str = "") -> None:
-        """Authenticate for an ethernet connection."""
+        """Authenticate for an ethernet connection.
+
+        :param username: User name to log in with.
+        :param password: Password to log in with (empty by default).
+        :raises ConnectionError: If the instrument does not return the expected
+            handshake responses.
+        """
         # Open the connection. It has to be closed at the end.
         # The comparison is case-insensitive because older firmware (e.g. the
         # AQ6370B) answers in lower case.

--- a/pymeasure/instruments/yokogawa/aq6370series.py
+++ b/pymeasure/instruments/yokogawa/aq6370series.py
@@ -108,9 +108,15 @@ class AQ6370Series(SCPIMixin, Instrument):
     def authenticate_ethernet(self, username: str, password: str = "") -> None:
         """Authenticate for an ethernet connection."""
         # Open the connection. It has to be closed at the end.
-        assert self.ask(f'OPEN "{username}"') == "AUTHENTICATE CRAM-MD5."
+        # The comparison is case-insensitive because older firmware (e.g. the
+        # AQ6370B) answers in lower case.
+        response = self.ask(f'OPEN "{username}"').strip()
+        if response.upper() != "AUTHENTICATE CRAM-MD5.":
+            raise ConnectionError(f"Unexpected response to OPEN: {response!r}")
         # Encrypted password transfer is possible.
-        assert self.ask(password) == "READY"
+        response = self.ask(password).strip()
+        if response.upper() != "READY":
+            raise ConnectionError(f"Authentication failed: {response!r}")
 
     # Control sweep status -------------------------------------------------------------------------
 

--- a/tests/instruments/yokogawa/test_aq6370d.py
+++ b/tests/instruments/yokogawa/test_aq6370d.py
@@ -618,3 +618,28 @@ def test_trace_get_y_data_of_area():
             1.55001e-6,
             1.55002e-6,
         ]
+
+
+def test_authenticate_ethernet_lowercase_response():
+    # Older firmware (e.g. the AQ6370B) answers in lower case, which must
+    # still be accepted (case-insensitive comparison).
+    with expected_protocol(
+        AQ6370D,
+        [
+            ('OPEN "user"', "authenticate cram-md5."),
+            ("password", "ready"),
+        ],
+    ) as inst:
+        inst.authenticate_ethernet("user", "password")
+
+
+def test_authenticate_ethernet_failure_raises():
+    with expected_protocol(
+        AQ6370D,
+        [
+            ('OPEN "user"', "AUTHENTICATE CRAM-MD5."),
+            ("wrong", "error"),
+        ],
+    ) as inst:
+        with pytest.raises(ConnectionError):
+            inst.authenticate_ethernet("user", "wrong")

--- a/tests/instruments/yokogawa/test_aq6370d.py
+++ b/tests/instruments/yokogawa/test_aq6370d.py
@@ -633,13 +633,24 @@ def test_authenticate_ethernet_lowercase_response():
         inst.authenticate_ethernet("user", "password")
 
 
-def test_authenticate_ethernet_failure_raises():
+def test_authenticate_ethernet_open_failure_raises():
+    # An unexpected response to OPEN aborts before the password is sent, and
+    # the raised error reports the received response.
+    with expected_protocol(
+        AQ6370D,
+        [('OPEN "user"', "denied")],
+    ) as inst, pytest.raises(ConnectionError, match="denied"):
+        inst.authenticate_ethernet("user", "password")
+
+
+def test_authenticate_ethernet_password_failure_raises():
+    # A wrong password is rejected after OPEN succeeded, and the raised error
+    # reports the received response.
     with expected_protocol(
         AQ6370D,
         [
             ('OPEN "user"', "AUTHENTICATE CRAM-MD5."),
             ("wrong", "error"),
         ],
-    ) as inst:
-        with pytest.raises(ConnectionError):
-            inst.authenticate_ethernet("user", "wrong")
+    ) as inst, pytest.raises(ConnectionError, match="error"):
+        inst.authenticate_ethernet("user", "wrong")


### PR DESCRIPTION
# Description

`AQ6370Series.authenticate_ethernet()` compared the instrument's handshake responses (`AUTHENTICATE CRAM-MD5.` and `READY`) with a case-sensitive, exact assert. This fails on hardware whose firmware replies in lower case: an AQ6370B (firmware 01.01) answers `ready`, so the login actually succeeds but the assert raises and aborts the connection.

Found while connecting to a real AQ6370B over Ethernet.

# Changes

- Compare the responses case-insensitively (`.strip().upper()`), so lower-case firmware replies are accepted.
- Replace the two assert statements with an explicit `raise ConnectionError(...)` — asserts are stripped under python -O and are not appropriate for library control flow; the exception also reports the unexpected response.
- Add protocol tests covering the lower-case handshake and the failure case.