### PR TITLE
Fix AQ6370 wavelength_start upper bound typo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Changed
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
+Instruments
+-----------
+- Fix Yokogawa AQ6370 ``wavelength_start`` upper bound, which was 1691 m due to a ``1700 - 9`` typo (now ``1700e-9``).
+
 Version 0.16.0 (2026-05-20)
 ===========================
 

--- a/pymeasure/instruments/yokogawa/aq6370series.py
+++ b/pymeasure/instruments/yokogawa/aq6370series.py
@@ -255,9 +255,9 @@ class AQ6370Series(SCPIMixin, Instrument):
     wavelength_start = Instrument.control(
         ":SENSe:WAVelength:STARt?",
         ":SENSe:WAVelength:STARt %g",
-        "Control the measurement start wavelength (float from 50e-9 to 2250e-9 in m).",
+        "Control the measurement start wavelength (float from 50e-9 to 1700e-9 in m).",
         validator=strict_range,
-        values=[50e-9, 1700 - 9],
+        values=[50e-9, 1700e-9],
         dynamic=True,
     )
 

--- a/tests/instruments/yokogawa/test_aq6370d.py
+++ b/tests/instruments/yokogawa/test_aq6370d.py
@@ -178,6 +178,14 @@ def test_wavelength_start_setter():
         inst.wavelength_start = 8e-07
 
 
+def test_wavelength_start_upper_bound():
+    # Regression: the upper bound was 1691 m (typo "1700 - 9"), an absurdly large
+    # limit that never rejected anything. Per the manual the start wavelength is
+    # 50 to 1700 nm, so a value above 1700 nm must now be rejected.
+    with expected_protocol(AQ6370D, []) as inst, pytest.raises(ValueError):
+        inst.wavelength_start = 1800e-9
+
+
 def test_wavelength_stop_setter():
     with expected_protocol(
         AQ6370D,


### PR DESCRIPTION
### Description

`AQ6370Series.wavelength_start` had an upper validator bound written as `1700 - 9`, which evaluates to **1691** (metres) instead of `1700e-9`. The limit was therefore effectively unbounded for any real wavelength, so out-of-range start wavelengths were never rejected.

### Changes

- Fix the `wavelength_start` upper bound to `1700e-9` (manual: START WL **50–1700 nm** for AQ6370C/D).
- Correct the docstring, which wrongly stated `2250e-9` — that is the **STOP** range (`wavelength_stop`: 600–2250 nm), not the start range.
- Add a regression test asserting that a start wavelength above 1700 nm now raises `ValueError`.