### PR TITLE
Add SRS DC205 precision DC voltage source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Changed
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
+Instruments
+-----------
+- Add Stanford Research Systems DC205 precision DC voltage source.
+
 Version 0.16.0 (2026-05-20)
 ===========================
 

--- a/docs/api/instruments/srs/dc205.rst
+++ b/docs/api/instruments/srs/dc205.rst
@@ -1,0 +1,7 @@
+##################################
+DC205 Precision DC Voltage Source
+##################################
+
+.. autoclass:: pymeasure.instruments.srs.dc205.DC205
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/srs/index.rst
+++ b/docs/api/instruments/srs/index.rst
@@ -9,6 +9,7 @@ This section contains specific documentation on the Stanford Research Systems (S
 .. toctree::
    :maxdepth: 2
 
+   dc205
    ldc500series
    sr510
    sr570

--- a/pymeasure/instruments/srs/__init__.py
+++ b/pymeasure/instruments/srs/__init__.py
@@ -22,6 +22,7 @@
 # THE SOFTWARE.
 #
 
+from .dc205 import DC205
 from .ldc500series import LDC500Series
 from .sg380 import SG380
 from .sr510 import SR510

--- a/pymeasure/instruments/srs/dc205.py
+++ b/pymeasure/instruments/srs/dc205.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument, IEEE4882Mixin
+from pymeasure.instruments import IEEE4882Mixin, Instrument
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 BOOL_MAP = {True: 1, False: 0}
@@ -53,6 +53,9 @@ class DC205(IEEE4882Mixin, Instrument):
         )
         # Ensure token-type queries answer with numbers, not text tokens.
         self.write("TOKN 0")
+        # Sync the voltage/scan validators with the instrument's active ranges.
+        self._read_voltage_range()
+        self._read_scan_range()
 
     voltage = Instrument.control(
         "VOLT?", "VOLT %.6f",
@@ -69,22 +72,27 @@ class DC205(IEEE4882Mixin, Instrument):
 
         Setting the range also updates the allowed :attr:`voltage` range, so an
         out-of-range voltage raises a :class:`ValueError` until the range is set.
+        The value is read back from the instrument, which may refuse the change
+        (for example while a scan is armed or running).
         """
-        code = int(self.ask("RNGE?"))
-        value = {v: k for k, v in RANGE_CODES.items()}[code]
-        self._sync_voltage_range(value)
-        return value
+        return self._read_voltage_range()
 
     @voltage_range.setter
     def voltage_range(self, value):
         value = strict_discrete_set(value, list(RANGE_CODES))
         self.write(f"RNGE {RANGE_CODES[value]}")
-        self._sync_voltage_range(value)
+        actual = self._read_voltage_range()
+        if actual != value:
+            raise ValueError(
+                f"DC205 did not switch to the {value} V range (now {actual} V); "
+                "check that no scan is armed or running."
+            )
 
-    def _sync_voltage_range(self, value):
-        """Update the :attr:`voltage` validator to match the given range in V."""
-        limit = RANGE_LIMITS[value]
-        self.voltage_values = [-limit, limit]
+    def _read_voltage_range(self):
+        """Read the active range in V, syncing the :attr:`voltage` validator to it."""
+        value = {v: k for k, v in RANGE_CODES.items()}[int(self.ask("RNGE?"))]
+        self.voltage_values = [-RANGE_LIMITS[value], RANGE_LIMITS[value]]
+        return value
 
     output_enabled = Instrument.control(
         "SOUT?", "SOUT %d",
@@ -128,32 +136,58 @@ class DC205(IEEE4882Mixin, Instrument):
     token_mode_enabled = Instrument.control(
         "TOKN?", "TOKN %d",
         """Control whether token-type queries answer with text tokens instead of
-        numbers (bool). The driver relies on numeric responses, so leave this off.""",
+        numbers (bool). The driver relies on numeric responses, so only ``False``
+        is accepted; setting ``True`` raises a :class:`ValueError`.""",
         validator=strict_discrete_set,
-        values=BOOL_MAP,
+        values={False: 0},
         map_values=True,
     )
 
     # Scan configuration ---------------------------------------------------------------------------
 
-    scan_range = Instrument.control(
-        "SCAR?", "SCAR %d",
-        """Control the scan range in V (int 1, 10 or 100). It can be set
-        independently of :attr:`voltage_range`, but must match it to arm a scan.
-        Changing it resets :attr:`scan_begin` and :attr:`scan_end` to 0 V.""",
-        validator=strict_discrete_set,
-        values=RANGE_CODES,
-        map_values=True,
-    )
+    @property
+    def scan_range(self):
+        """Control the scan range in V (int 1, 10 or 100).
+
+        It can be set independently of :attr:`voltage_range` but must match it to
+        arm a scan. Setting it also updates the allowed :attr:`scan_begin` and
+        :attr:`scan_end` range and, on the instrument, resets both to 0 V. The
+        value is read back, which may be refused while a scan is armed or running.
+        """
+        return self._read_scan_range()
+
+    @scan_range.setter
+    def scan_range(self, value):
+        value = strict_discrete_set(value, list(RANGE_CODES))
+        self.write(f"SCAR {RANGE_CODES[value]}")
+        actual = self._read_scan_range()
+        if actual != value:
+            raise ValueError(
+                f"DC205 did not switch to the {value} V scan range (now {actual} V); "
+                "check that no scan is armed or running."
+            )
+
+    def _read_scan_range(self):
+        """Read the scan range in V, syncing the scan endpoint validators to it."""
+        value = {v: k for k, v in RANGE_CODES.items()}[int(self.ask("SCAR?"))]
+        self.scan_begin_values = [-RANGE_LIMITS[value], RANGE_LIMITS[value]]
+        self.scan_end_values = [-RANGE_LIMITS[value], RANGE_LIMITS[value]]
+        return value
 
     scan_begin = Instrument.control(
         "SCAB?", "SCAB %.6f",
-        """Control the scan start voltage in V (float, within the :attr:`scan_range`).""",
+        """Control the scan start voltage in V (float, within :attr:`scan_range`).""",
+        validator=strict_range,
+        values=[-RANGE_LIMITS[1], RANGE_LIMITS[1]],
+        dynamic=True,
     )
 
     scan_end = Instrument.control(
         "SCAE?", "SCAE %.6f",
-        """Control the scan stop voltage in V (float, within the :attr:`scan_range`).""",
+        """Control the scan stop voltage in V (float, within :attr:`scan_range`).""",
+        validator=strict_range,
+        values=[-RANGE_LIMITS[1], RANGE_LIMITS[1]],
+        dynamic=True,
     )
 
     scan_time = Instrument.control(

--- a/pymeasure/instruments/srs/dc205.py
+++ b/pymeasure/instruments/srs/dc205.py
@@ -1,0 +1,224 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument, IEEE4882Mixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+BOOL_MAP = {True: 1, False: 0}
+
+# Range setting -> maximum settable magnitude in V (see the VOLT command in the
+# manual; e.g. the 10 V range allows up to 10.1 V).
+RANGE_LIMITS = {1: 1.010, 10: 10.10, 100: 101.0}
+RANGE_CODES = {1: 0, 10: 1, 100: 2}
+
+
+class DC205(IEEE4882Mixin, Instrument):
+    """Stanford Research Systems DC205 precision DC voltage source.
+
+    The allowed :attr:`voltage` range follows the selected :attr:`voltage_range`:
+    the instrument does not auto-range, so a voltage outside the active range is
+    rejected until the range is changed. The driver forces numeric response mode
+    (``TOKN OFF``) on connection so the mapped properties parse reliably.
+    """
+
+    def __init__(self, adapter, name="Stanford Research Systems DC205", **kwargs):
+        super().__init__(
+            adapter,
+            name,
+            asrl={"baud_rate": 115200},
+            write_termination="\r\n",
+            read_termination="\r\n",
+            **kwargs,
+        )
+        # Ensure token-type queries answer with numbers, not text tokens.
+        self.write("TOKN 0")
+
+    voltage = Instrument.control(
+        "VOLT?", "VOLT %.6f",
+        """Control the output voltage in V (float). The valid range follows
+        :attr:`voltage_range` (up to +-1.01, +-10.1 or +-101 V).""",
+        validator=strict_range,
+        values=[-RANGE_LIMITS[1], RANGE_LIMITS[1]],
+        dynamic=True,
+    )
+
+    @property
+    def voltage_range(self):
+        """Control the output range in V (int 1, 10 or 100).
+
+        Setting the range also updates the allowed :attr:`voltage` range, so an
+        out-of-range voltage raises a :class:`ValueError` until the range is set.
+        """
+        code = int(self.ask("RNGE?"))
+        value = {v: k for k, v in RANGE_CODES.items()}[code]
+        self._sync_voltage_range(value)
+        return value
+
+    @voltage_range.setter
+    def voltage_range(self, value):
+        value = strict_discrete_set(value, list(RANGE_CODES))
+        self.write(f"RNGE {RANGE_CODES[value]}")
+        self._sync_voltage_range(value)
+
+    def _sync_voltage_range(self, value):
+        """Update the :attr:`voltage` validator to match the given range in V."""
+        limit = RANGE_LIMITS[value]
+        self.voltage_values = [-limit, limit]
+
+    output_enabled = Instrument.control(
+        "SOUT?", "SOUT %d",
+        """Control whether the output is switched on (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    isolation = Instrument.control(
+        "ISOL?", "ISOL %d",
+        """Control the output common, either 'ground' or 'float' (str).""",
+        validator=strict_discrete_set,
+        values={"ground": 0, "float": 1},
+        map_values=True,
+    )
+
+    sensing = Instrument.control(
+        "SENS?", "SENS %d",
+        """Control the sensing mode, either 'two-wire' or 'four-wire' (str).""",
+        validator=strict_discrete_set,
+        values={"two-wire": 0, "four-wire": 1},
+        map_values=True,
+    )
+
+    overloaded = Instrument.measurement(
+        "OVLD?",
+        """Get whether the output is in current limit (bool).""",
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    alarm_enabled = Instrument.control(
+        "ALRM?", "ALRM %d",
+        """Control the audible alarm (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    token_mode_enabled = Instrument.control(
+        "TOKN?", "TOKN %d",
+        """Control whether token-type queries answer with text tokens instead of
+        numbers (bool). The driver relies on numeric responses, so leave this off.""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    # Scan configuration ---------------------------------------------------------------------------
+
+    scan_range = Instrument.control(
+        "SCAR?", "SCAR %d",
+        """Control the scan range in V (int 1, 10 or 100). It can be set
+        independently of :attr:`voltage_range`, but must match it to arm a scan.
+        Changing it resets :attr:`scan_begin` and :attr:`scan_end` to 0 V.""",
+        validator=strict_discrete_set,
+        values=RANGE_CODES,
+        map_values=True,
+    )
+
+    scan_begin = Instrument.control(
+        "SCAB?", "SCAB %.6f",
+        """Control the scan start voltage in V (float, within the :attr:`scan_range`).""",
+    )
+
+    scan_end = Instrument.control(
+        "SCAE?", "SCAE %.6f",
+        """Control the scan stop voltage in V (float, within the :attr:`scan_range`).""",
+    )
+
+    scan_time = Instrument.control(
+        "SCAT?", "SCAT %.1f",
+        """Control the scan duration in s (float from 0.1 to 9999.9).""",
+        validator=strict_range,
+        values=[0.1, 9999.9],
+    )
+
+    scan_shape = Instrument.control(
+        "SCAS?", "SCAS %d",
+        """Control the scan shape, either 'one-direction' or 'up-down' (str).""",
+        validator=strict_discrete_set,
+        values={"one-direction": 0, "up-down": 1},
+        map_values=True,
+    )
+
+    scan_cycle = Instrument.control(
+        "SCAC?", "SCAC %d",
+        """Control the scan cycling mode, either 'once' or 'repeat' (str).""",
+        validator=strict_discrete_set,
+        values={"once": 0, "repeat": 1},
+        map_values=True,
+    )
+
+    scan_display = Instrument.control(
+        "SCAD?", "SCAD %d",
+        """Control whether the display updates during a scan (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    scan_state = Instrument.measurement(
+        "SCAA?",
+        """Get the scan state, one of 'idle', 'armed' or 'scanning' (str).""",
+        values={"idle": 0, "armed": 1, "scanning": 2},
+        map_values=True,
+    )
+
+    def arm_scan(self):
+        """Arm the scan.
+
+        Requires the output to be enabled, :attr:`scan_range` to match
+        :attr:`voltage_range`, and :attr:`scan_begin` and :attr:`scan_end` to
+        differ. Start the armed scan with :meth:`start_scan`.
+        """
+        self.write("SCAA ARMED")
+
+    def disarm_scan(self):
+        """Disarm an armed scan or cancel a running scan."""
+        self.write("SCAA IDLE")
+
+    def start_scan(self):
+        """Start a previously armed scan (equivalent to a trigger)."""
+        self.write("*TRG")
+
+    last_execution_error = Instrument.measurement(
+        "LEXE?",
+        """Get the last execution error code (int).""",
+        cast=int,
+    )
+
+    last_command_error = Instrument.measurement(
+        "LCME?",
+        """Get the last command error code (int).""",
+        cast=int,
+    )

--- a/tests/instruments/srs/test_dc205.py
+++ b/tests/instruments/srs/test_dc205.py
@@ -1,0 +1,136 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.instruments.srs.dc205 import DC205
+from pymeasure.test import expected_protocol
+
+# Every connection forces numeric token mode first.
+INIT = ("TOKN 0", None)
+
+
+def test_init():
+    with expected_protocol(DC205, [INIT]):
+        pass
+
+
+def test_voltage_setter():
+    with expected_protocol(DC205, [INIT, ("VOLT 0.500000", None)]) as inst:
+        inst.voltage = 0.5
+
+
+def test_voltage_getter():
+    with expected_protocol(DC205, [INIT, ("VOLT?", "0.500000")]) as inst:
+        assert inst.voltage == 0.5
+
+
+def test_voltage_range_setter():
+    with expected_protocol(DC205, [INIT, ("RNGE 2", None)]) as inst:
+        inst.voltage_range = 100
+
+
+def test_voltage_range_getter():
+    with expected_protocol(DC205, [INIT, ("RNGE?", "1")]) as inst:
+        assert inst.voltage_range == 10
+
+
+def test_voltage_range_setter_updates_voltage_limit():
+    # After selecting the 100 V range, a 50 V setpoint must be accepted.
+    with expected_protocol(
+        DC205, [INIT, ("RNGE 2", None), ("VOLT 50.000000", None)]
+    ) as inst:
+        inst.voltage_range = 100
+        inst.voltage = 50
+
+
+def test_voltage_out_of_range_raises():
+    # In the default 1 V range, 50 V is rejected before anything is written.
+    with expected_protocol(DC205, [INIT]) as inst, pytest.raises(ValueError):
+        inst.voltage = 50
+
+
+def test_output_enabled_setter():
+    with expected_protocol(DC205, [INIT, ("SOUT 1", None)]) as inst:
+        inst.output_enabled = True
+
+
+def test_isolation_setter():
+    with expected_protocol(DC205, [INIT, ("ISOL 1", None)]) as inst:
+        inst.isolation = "float"
+
+
+def test_sensing_setter():
+    with expected_protocol(DC205, [INIT, ("SENS 1", None)]) as inst:
+        inst.sensing = "four-wire"
+
+
+def test_overloaded_getter():
+    with expected_protocol(DC205, [INIT, ("OVLD?", "1")]) as inst:
+        assert inst.overloaded is True
+
+
+def test_scan_range_setter():
+    with expected_protocol(DC205, [INIT, ("SCAR 1", None)]) as inst:
+        inst.scan_range = 10
+
+
+def test_scan_time_setter():
+    with expected_protocol(DC205, [INIT, ("SCAT 3600.0", None)]) as inst:
+        inst.scan_time = 3600
+
+
+def test_scan_shape_getter():
+    with expected_protocol(DC205, [INIT, ("SCAS?", "1")]) as inst:
+        assert inst.scan_shape == "up-down"
+
+
+def test_scan_cycle_setter():
+    with expected_protocol(DC205, [INIT, ("SCAC 1", None)]) as inst:
+        inst.scan_cycle = "repeat"
+
+
+def test_scan_state_getter():
+    with expected_protocol(DC205, [INIT, ("SCAA?", "2")]) as inst:
+        assert inst.scan_state == "scanning"
+
+
+def test_arm_scan():
+    with expected_protocol(DC205, [INIT, ("SCAA ARMED", None)]) as inst:
+        inst.arm_scan()
+
+
+def test_disarm_scan():
+    with expected_protocol(DC205, [INIT, ("SCAA IDLE", None)]) as inst:
+        inst.disarm_scan()
+
+
+def test_start_scan():
+    with expected_protocol(DC205, [INIT, ("*TRG", None)]) as inst:
+        inst.start_scan()
+
+
+def test_last_execution_error_getter():
+    with expected_protocol(DC205, [INIT, ("LEXE?", "0")]) as inst:
+        assert inst.last_execution_error == 0

--- a/tests/instruments/srs/test_dc205.py
+++ b/tests/instruments/srs/test_dc205.py
@@ -27,110 +27,163 @@ import pytest
 from pymeasure.instruments.srs.dc205 import DC205
 from pymeasure.test import expected_protocol
 
-# Every connection forces numeric token mode first.
-INIT = ("TOKN 0", None)
+# On connection the driver forces numeric token mode and reads the active output
+# and scan ranges (reported here as code 0 = 1 V range).
+INIT = [("TOKN 0", None), ("RNGE?", "0"), ("SCAR?", "0")]
 
 
 def test_init():
-    with expected_protocol(DC205, [INIT]):
+    with expected_protocol(DC205, INIT):
         pass
 
 
 def test_voltage_setter():
-    with expected_protocol(DC205, [INIT, ("VOLT 0.500000", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("VOLT 0.500000", None)]) as inst:
         inst.voltage = 0.5
 
 
 def test_voltage_getter():
-    with expected_protocol(DC205, [INIT, ("VOLT?", "0.500000")]) as inst:
+    with expected_protocol(DC205, INIT + [("VOLT?", "0.500000")]) as inst:
         assert inst.voltage == 0.5
 
 
 def test_voltage_range_setter():
-    with expected_protocol(DC205, [INIT, ("RNGE 2", None)]) as inst:
+    # Set writes RNGE, then reads back to confirm the range changed.
+    with expected_protocol(
+        DC205, INIT + [("RNGE 2", None), ("RNGE?", "2")]
+    ) as inst:
         inst.voltage_range = 100
 
 
 def test_voltage_range_getter():
-    with expected_protocol(DC205, [INIT, ("RNGE?", "1")]) as inst:
+    with expected_protocol(DC205, INIT + [("RNGE?", "1")]) as inst:
         assert inst.voltage_range == 10
 
 
 def test_voltage_range_setter_updates_voltage_limit():
     # After selecting the 100 V range, a 50 V setpoint must be accepted.
     with expected_protocol(
-        DC205, [INIT, ("RNGE 2", None), ("VOLT 50.000000", None)]
+        DC205, INIT + [("RNGE 2", None), ("RNGE?", "2"), ("VOLT 50.000000", None)]
     ) as inst:
         inst.voltage_range = 100
         inst.voltage = 50
 
 
+def test_voltage_range_refused_raises():
+    # The instrument reports it stayed in the 1 V range, so the setter raises.
+    with expected_protocol(
+        DC205, INIT + [("RNGE 2", None), ("RNGE?", "0")]
+    ) as inst, pytest.raises(ValueError):
+        inst.voltage_range = 100
+
+
 def test_voltage_out_of_range_raises():
-    # In the default 1 V range, 50 V is rejected before anything is written.
-    with expected_protocol(DC205, [INIT]) as inst, pytest.raises(ValueError):
+    # In the 1 V range (from init), 50 V is rejected before anything is written.
+    with expected_protocol(DC205, INIT) as inst, pytest.raises(ValueError):
         inst.voltage = 50
 
 
 def test_output_enabled_setter():
-    with expected_protocol(DC205, [INIT, ("SOUT 1", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SOUT 1", None)]) as inst:
         inst.output_enabled = True
 
 
 def test_isolation_setter():
-    with expected_protocol(DC205, [INIT, ("ISOL 1", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("ISOL 1", None)]) as inst:
         inst.isolation = "float"
 
 
 def test_sensing_setter():
-    with expected_protocol(DC205, [INIT, ("SENS 1", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SENS 1", None)]) as inst:
         inst.sensing = "four-wire"
 
 
 def test_overloaded_getter():
-    with expected_protocol(DC205, [INIT, ("OVLD?", "1")]) as inst:
+    with expected_protocol(DC205, INIT + [("OVLD?", "1")]) as inst:
         assert inst.overloaded is True
 
 
+def test_token_mode_getter():
+    with expected_protocol(DC205, INIT + [("TOKN?", "0")]) as inst:
+        assert inst.token_mode_enabled is False
+
+
+def test_token_mode_cannot_be_enabled():
+    # Enabling token mode would break the numeric getters, so it is rejected.
+    with expected_protocol(DC205, INIT) as inst, pytest.raises(ValueError):
+        inst.token_mode_enabled = True
+
+
 def test_scan_range_setter():
-    with expected_protocol(DC205, [INIT, ("SCAR 1", None)]) as inst:
+    # Set writes SCAR, then reads back to confirm the scan range changed.
+    with expected_protocol(
+        DC205, INIT + [("SCAR 1", None), ("SCAR?", "1")]
+    ) as inst:
         inst.scan_range = 10
 
 
+def test_scan_range_getter():
+    with expected_protocol(DC205, INIT + [("SCAR?", "2")]) as inst:
+        assert inst.scan_range == 100
+
+
+def test_scan_range_refused_raises():
+    with expected_protocol(
+        DC205, INIT + [("SCAR 2", None), ("SCAR?", "0")]
+    ) as inst, pytest.raises(ValueError):
+        inst.scan_range = 100
+
+
+def test_scan_begin_out_of_range_raises():
+    # In the 1 V scan range (from init), a 5 V endpoint is rejected.
+    with expected_protocol(DC205, INIT) as inst, pytest.raises(ValueError):
+        inst.scan_begin = 5
+
+
+def test_scan_range_updates_endpoint_limit():
+    # After selecting the 100 V scan range, a 50 V endpoint must be accepted.
+    with expected_protocol(
+        DC205, INIT + [("SCAR 2", None), ("SCAR?", "2"), ("SCAE 50.000000", None)]
+    ) as inst:
+        inst.scan_range = 100
+        inst.scan_end = 50
+
+
 def test_scan_time_setter():
-    with expected_protocol(DC205, [INIT, ("SCAT 3600.0", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAT 3600.0", None)]) as inst:
         inst.scan_time = 3600
 
 
 def test_scan_shape_getter():
-    with expected_protocol(DC205, [INIT, ("SCAS?", "1")]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAS?", "1")]) as inst:
         assert inst.scan_shape == "up-down"
 
 
 def test_scan_cycle_setter():
-    with expected_protocol(DC205, [INIT, ("SCAC 1", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAC 1", None)]) as inst:
         inst.scan_cycle = "repeat"
 
 
 def test_scan_state_getter():
-    with expected_protocol(DC205, [INIT, ("SCAA?", "2")]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAA?", "2")]) as inst:
         assert inst.scan_state == "scanning"
 
 
 def test_arm_scan():
-    with expected_protocol(DC205, [INIT, ("SCAA ARMED", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAA ARMED", None)]) as inst:
         inst.arm_scan()
 
 
 def test_disarm_scan():
-    with expected_protocol(DC205, [INIT, ("SCAA IDLE", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("SCAA IDLE", None)]) as inst:
         inst.disarm_scan()
 
 
 def test_start_scan():
-    with expected_protocol(DC205, [INIT, ("*TRG", None)]) as inst:
+    with expected_protocol(DC205, INIT + [("*TRG", None)]) as inst:
         inst.start_scan()
 
 
 def test_last_execution_error_getter():
-    with expected_protocol(DC205, [INIT, ("LEXE?", "0")]) as inst:
+    with expected_protocol(DC205, INIT + [("LEXE?", "0")]) as inst:
         assert inst.last_execution_error == 0


### PR DESCRIPTION
### Description

Adds a driver for the Stanford Research Systems DC205 precision DC voltage source (`srs/dc205.py`).

### Highlights

- `voltage` uses a dynamic validator that follows `voltage_range` (±1.01/±10.1/±101 V). The DC205 does not auto-range, so an out-of-range voltage raises `ValueError` until the range is changed.
- Full scan configuration (range, begin/end, time, shape, cycle, display) plus `scan_state` and `arm_scan()` / `disarm_scan()` / `start_scan()` (`*TRG`).
- Numeric response mode is forced on connection (`TOKN 0`) so the mapped properties parse reliably.
- 20 protocol tests; docs and CHANGES added.