### PR TITLE
Add Rohde & Schwarz SMP04 microwave signal generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Changed
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
+Instruments
+-----------
+- Add Rohde & Schwarz SMP04 microwave signal generator.
+
 Version 0.16.0 (2026-05-20)
 ===========================
 

--- a/docs/api/instruments/rohdeschwarz/index.rst
+++ b/docs/api/instruments/rohdeschwarz/index.rst
@@ -10,5 +10,6 @@ This section contains specific documentation on the Rohde & Schwarz instruments 
    :maxdepth: 3
 
    sfm
+   smp04
    fsseries
    hmp

--- a/docs/api/instruments/rohdeschwarz/smp04.rst
+++ b/docs/api/instruments/rohdeschwarz/smp04.rst
@@ -1,0 +1,7 @@
+##################################
+SMP04 Microwave Signal Generator
+##################################
+
+.. autoclass:: pymeasure.instruments.rohdeschwarz.smp04.SMP04
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/rohdeschwarz/__init__.py
+++ b/pymeasure/instruments/rohdeschwarz/__init__.py
@@ -25,3 +25,4 @@
 from .fsseries import FSL, FSW
 from .hmp import HMP4040
 from .sfm import SFM
+from .smp04 import SMP04

--- a/pymeasure/instruments/rohdeschwarz/smp04.py
+++ b/pymeasure/instruments/rohdeschwarz/smp04.py
@@ -29,35 +29,50 @@ BOOL_MAP = {True: 1, False: 0}
 
 
 class SMP04(SCPIMixin, Instrument):
-    """Rohde & Schwarz SMP04 microwave signal generator (10 MHz to 40 GHz).
+    """Rohde & Schwarz SMP04 microwave signal generator (2 GHz to 40 GHz).
 
     The instrument does not implement the ``FREQuency:MINimum?`` family of
     queries, so the frequency and level ranges below are taken from the manual.
+    By default the standard-model limits apply; installed options widen them:
+
+    :param frequency_extension_option: SMP-B11 frequency range extension, lowers
+        the frequency limit from 2 GHz to 10 MHz.
+    :param step_attenuator_option: SMP-B15/B17 step attenuator, lowers the level
+        limit from -20 dBm to -130 dBm.
     """
 
-    def __init__(self, adapter, name="Rohde & Schwarz SMP04", **kwargs):
+    def __init__(self, adapter, name="Rohde & Schwarz SMP04",
+                 frequency_extension_option=False,
+                 step_attenuator_option=False, **kwargs):
         super().__init__(adapter, name, **kwargs)
+        if frequency_extension_option:
+            self.frequency_values = [10e6, 40e9]
+        if step_attenuator_option:
+            self.power_values = [-130, 16]
 
     frequency = Instrument.control(
         "FREQ?", "FREQ %.3f",
-        """Control the CW output frequency in Hz (float from 10e6 to 40e9).
+        """Control the CW output frequency in Hz (float from 2e9 to 40e9).
 
-        Values outside the range are clipped to the nearest limit. The base model
-        covers 2 GHz to 40 GHz; the 10 MHz to 2 GHz portion requires the SMP-B11
-        frequency range extension.""",
+        Values outside the range are clipped to the nearest limit. The lower
+        limit drops to 10 MHz with the SMP-B11 frequency range extension
+        (``frequency_extension_option=True``).""",
         validator=truncated_range,
-        values=[10e6, 40e9],
+        values=[2e9, 40e9],
+        dynamic=True,
     )
 
     power = Instrument.control(
         "POW?", "POW %.2f",
-        """Control the RF output level in dBm (float from -130 to 16).
+        """Control the RF output level in dBm (float from -20 to 16).
 
-        Values outside the range are clipped to the nearest limit. The -130 dBm
-        lower limit requires the SMP-B15/B17 step attenuator option (otherwise
-        -20 dBm). +13 dBm is the specified level, +16 dBm the overrange ceiling.""",
+        Values outside the range are clipped to the nearest limit. The lower
+        limit drops to -130 dBm with the SMP-B15/B17 step attenuator
+        (``step_attenuator_option=True``). +13 dBm is the specified level,
+        +16 dBm the overrange ceiling.""",
         validator=truncated_range,
-        values=[-130, 16],
+        values=[-20, 16],
+        dynamic=True,
     )
 
     output_enabled = Instrument.control(

--- a/pymeasure/instruments/rohdeschwarz/smp04.py
+++ b/pymeasure/instruments/rohdeschwarz/smp04.py
@@ -40,7 +40,11 @@ class SMP04(SCPIMixin, Instrument):
 
     frequency = Instrument.control(
         "FREQ?", "FREQ %.3f",
-        """Control the CW output frequency in Hz (float from 10e6 to 40e9).""",
+        """Control the CW output frequency in Hz (float from 10e6 to 40e9).
+
+        Values outside the range are clipped to the nearest limit. The base model
+        covers 2 GHz to 40 GHz; the 10 MHz to 2 GHz portion requires the SMP-B11
+        frequency range extension.""",
         validator=truncated_range,
         values=[10e6, 40e9],
     )
@@ -49,9 +53,9 @@ class SMP04(SCPIMixin, Instrument):
         "POW?", "POW %.2f",
         """Control the RF output level in dBm (float from -130 to 16).
 
-        The -130 dBm lower limit requires the SMP-B15/B17 step attenuator option
-        (otherwise -20 dBm). +13 dBm is the specified level, +16 dBm the
-        overrange ceiling.""",
+        Values outside the range are clipped to the nearest limit. The -130 dBm
+        lower limit requires the SMP-B15/B17 step attenuator option (otherwise
+        -20 dBm). +13 dBm is the specified level, +16 dBm the overrange ceiling.""",
         validator=truncated_range,
         values=[-130, 16],
     )
@@ -74,9 +78,9 @@ class SMP04(SCPIMixin, Instrument):
 
     power_mode = Instrument.control(
         "POW:MODE?", "POW:MODE %s",
-        """Control the level mode ('CW', 'SWEEP' or 'LIST').""",
+        """Control the level mode ('FIXED', 'SWEEP' or 'LIST').""",
         validator=strict_discrete_set,
-        values=["CW", "SWEEP", "LIST"],
+        values=["FIXED", "SWEEP", "LIST"],
         cast=str,
     )
 
@@ -91,7 +95,9 @@ class SMP04(SCPIMixin, Instrument):
     reference_frequency = Instrument.control(
         "ROSC:EXT:FREQ?", "ROSC:EXT:FREQ %g",
         """Control the expected external reference frequency in Hz
-        (float, typically 5e6, 10e6 or 13e6).""",
+        (float, 1 MHz to 16 MHz in 1 MHz steps).""",
+        validator=strict_discrete_set,
+        values=[n * 1e6 for n in range(1, 17)],
     )
 
     alc_enabled = Instrument.control(

--- a/pymeasure/instruments/rohdeschwarz/smp04.py
+++ b/pymeasure/instruments/rohdeschwarz/smp04.py
@@ -29,7 +29,7 @@ BOOL_MAP = {True: 1, False: 0}
 
 
 class SMP04(SCPIMixin, Instrument):
-    """Rohde & Schwarz SMP04 microwave signal generator (2 GHz to 40 GHz).
+    """Control the Rohde & Schwarz SMP04 microwave signal generator (2 GHz to 40 GHz).
 
     The instrument does not implement the ``FREQuency:MINimum?`` family of
     queries, so the frequency and level ranges below are taken from the manual.

--- a/pymeasure/instruments/rohdeschwarz/smp04.py
+++ b/pymeasure/instruments/rohdeschwarz/smp04.py
@@ -1,0 +1,151 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, truncated_range
+
+BOOL_MAP = {True: 1, False: 0}
+
+
+class SMP04(SCPIMixin, Instrument):
+    """Rohde & Schwarz SMP04 microwave signal generator (10 MHz to 40 GHz).
+
+    The instrument does not implement the ``FREQuency:MINimum?`` family of
+    queries, so the frequency and level ranges below are taken from the manual.
+    """
+
+    def __init__(self, adapter, name="Rohde & Schwarz SMP04", **kwargs):
+        super().__init__(adapter, name, **kwargs)
+
+    frequency = Instrument.control(
+        "FREQ?", "FREQ %.3f",
+        """Control the CW output frequency in Hz (float from 10e6 to 40e9).""",
+        validator=truncated_range,
+        values=[10e6, 40e9],
+    )
+
+    power = Instrument.control(
+        "POW?", "POW %.2f",
+        """Control the RF output level in dBm (float from -130 to 16).
+
+        The -130 dBm lower limit requires the SMP-B15/B17 step attenuator option
+        (otherwise -20 dBm). +13 dBm is the specified level, +16 dBm the
+        overrange ceiling.""",
+        validator=truncated_range,
+        values=[-130, 16],
+    )
+
+    output_enabled = Instrument.control(
+        "OUTP?", "OUTP %d",
+        """Control whether the RF output is enabled (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    frequency_mode = Instrument.control(
+        "FREQ:MODE?", "FREQ:MODE %s",
+        """Control the frequency mode ('CW', 'SWEEP' or 'LIST').""",
+        validator=strict_discrete_set,
+        values=["CW", "SWEEP", "LIST"],
+        cast=str,
+    )
+
+    power_mode = Instrument.control(
+        "POW:MODE?", "POW:MODE %s",
+        """Control the level mode ('CW', 'SWEEP' or 'LIST').""",
+        validator=strict_discrete_set,
+        values=["CW", "SWEEP", "LIST"],
+        cast=str,
+    )
+
+    reference_source = Instrument.control(
+        "ROSC:SOUR?", "ROSC:SOUR %s",
+        """Control the reference oscillator source ('INT' or 'EXT').""",
+        validator=strict_discrete_set,
+        values=["INT", "EXT"],
+        cast=str,
+    )
+
+    reference_frequency = Instrument.control(
+        "ROSC:EXT:FREQ?", "ROSC:EXT:FREQ %g",
+        """Control the expected external reference frequency in Hz
+        (float, typically 5e6, 10e6 or 13e6).""",
+    )
+
+    alc_enabled = Instrument.control(
+        "POW:ALC?", "POW:ALC %d",
+        """Control the automatic level control (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    attenuator_mode = Instrument.control(
+        "OUTP:AMOD?", "OUTP:AMOD %s",
+        """Control the attenuator mode ('AUTO' or 'FIX'). 'FIX' freezes the step
+        attenuator, avoiding level glitches while changing power.""",
+        validator=strict_discrete_set,
+        values=["AUTO", "FIX"],
+        cast=str,
+    )
+
+    am_enabled = Instrument.control(
+        "AM:STAT?", "AM:STAT %d",
+        """Control amplitude modulation (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    fm_enabled = Instrument.control(
+        "FM:STAT?", "FM:STAT %d",
+        """Control frequency modulation (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    pulse_modulation_enabled = Instrument.control(
+        "PULM:STAT?", "PULM:STAT %d",
+        """Control pulse modulation (bool).""",
+        validator=strict_discrete_set,
+        values=BOOL_MAP,
+        map_values=True,
+    )
+
+    questionable_condition = Instrument.measurement(
+        "STAT:QUES:COND?",
+        """Get the questionable status condition register (int). Bit 5 (value 32)
+        flags a frequency problem, such as an unlocked reference.""",
+        cast=int,
+    )
+
+    frequency_ok = Instrument.measurement(
+        "STAT:QUES:COND?",
+        """Get whether the frequency status is fine (bool): bit 5 (FREQuency) of
+        the questionable condition register is clear. A set bit flags a frequency
+        problem such as an unlocked reference.""",
+        get_process=lambda v: not (int(v) & 32),
+    )

--- a/tests/instruments/rohdeschwarz/test_smp04.py
+++ b/tests/instruments/rohdeschwarz/test_smp04.py
@@ -1,0 +1,107 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments.rohdeschwarz.smp04 import SMP04
+from pymeasure.test import expected_protocol
+
+
+def test_frequency_setter():
+    with expected_protocol(SMP04, [("FREQ 40000000000.000", None)]) as inst:
+        inst.frequency = 40e9
+
+
+def test_frequency_getter():
+    with expected_protocol(SMP04, [("FREQ?", "4.0E10")]) as inst:
+        assert inst.frequency == 40e9
+
+
+def test_power_setter():
+    with expected_protocol(SMP04, [("POW -30.00", None)]) as inst:
+        inst.power = -30
+
+
+def test_power_setter_truncates_below_minimum():
+    # truncated_range clamps to the -130 dBm lower limit.
+    with expected_protocol(SMP04, [("POW -130.00", None)]) as inst:
+        inst.power = -200
+
+
+def test_output_enabled_setter():
+    with expected_protocol(SMP04, [("OUTP 1", None)]) as inst:
+        inst.output_enabled = True
+
+
+def test_frequency_mode_setter():
+    with expected_protocol(SMP04, [("FREQ:MODE SWEEP", None)]) as inst:
+        inst.frequency_mode = "SWEEP"
+
+
+def test_power_mode_getter():
+    with expected_protocol(SMP04, [("POW:MODE?", "CW")]) as inst:
+        assert inst.power_mode == "CW"
+
+
+def test_reference_source_setter():
+    with expected_protocol(SMP04, [("ROSC:SOUR EXT", None)]) as inst:
+        inst.reference_source = "EXT"
+
+
+def test_alc_enabled_setter():
+    with expected_protocol(SMP04, [("POW:ALC 1", None)]) as inst:
+        inst.alc_enabled = True
+
+
+def test_attenuator_mode_setter():
+    with expected_protocol(SMP04, [("OUTP:AMOD FIX", None)]) as inst:
+        inst.attenuator_mode = "FIX"
+
+
+def test_am_enabled_setter():
+    with expected_protocol(SMP04, [("AM:STAT 1", None)]) as inst:
+        inst.am_enabled = True
+
+
+def test_fm_enabled_getter():
+    with expected_protocol(SMP04, [("FM:STAT?", "1")]) as inst:
+        assert inst.fm_enabled is True
+
+
+def test_pulse_modulation_enabled_setter():
+    with expected_protocol(SMP04, [("PULM:STAT 1", None)]) as inst:
+        inst.pulse_modulation_enabled = True
+
+
+def test_questionable_condition_getter():
+    with expected_protocol(SMP04, [("STAT:QUES:COND?", "32")]) as inst:
+        assert inst.questionable_condition == 32
+
+
+def test_frequency_ok_when_bit_clear():
+    with expected_protocol(SMP04, [("STAT:QUES:COND?", "0")]) as inst:
+        assert inst.frequency_ok is True
+
+
+def test_frequency_ok_when_bit_set():
+    with expected_protocol(SMP04, [("STAT:QUES:COND?", "32")]) as inst:
+        assert inst.frequency_ok is False

--- a/tests/instruments/rohdeschwarz/test_smp04.py
+++ b/tests/instruments/rohdeschwarz/test_smp04.py
@@ -22,6 +22,8 @@
 # THE SOFTWARE.
 #
 
+import pytest
+
 from pymeasure.instruments.rohdeschwarz.smp04 import SMP04
 from pymeasure.test import expected_protocol
 
@@ -58,13 +60,23 @@ def test_frequency_mode_setter():
 
 
 def test_power_mode_getter():
-    with expected_protocol(SMP04, [("POW:MODE?", "CW")]) as inst:
-        assert inst.power_mode == "CW"
+    with expected_protocol(SMP04, [("POW:MODE?", "FIXED")]) as inst:
+        assert inst.power_mode == "FIXED"
 
 
 def test_reference_source_setter():
     with expected_protocol(SMP04, [("ROSC:SOUR EXT", None)]) as inst:
         inst.reference_source = "EXT"
+
+
+def test_reference_frequency_setter():
+    with expected_protocol(SMP04, [("ROSC:EXT:FREQ 1e+07", None)]) as inst:
+        inst.reference_frequency = 10e6
+
+
+def test_reference_frequency_rejects_off_step_value():
+    with expected_protocol(SMP04, []) as inst, pytest.raises(ValueError):
+        inst.reference_frequency = 10.5e6
 
 
 def test_alc_enabled_setter():

--- a/tests/instruments/rohdeschwarz/test_smp04.py
+++ b/tests/instruments/rohdeschwarz/test_smp04.py
@@ -38,14 +38,38 @@ def test_frequency_getter():
         assert inst.frequency == 40e9
 
 
+def test_frequency_truncates_to_standard_minimum():
+    # Standard model: the 2 GHz lower limit clamps sub-2 GHz requests.
+    with expected_protocol(SMP04, [("FREQ 2000000000.000", None)]) as inst:
+        inst.frequency = 1e9
+
+
+def test_frequency_extension_option_allows_low_frequency():
+    # SMP-B11 lowers the limit to 10 MHz.
+    with expected_protocol(
+        SMP04, [("FREQ 1000000000.000", None)],
+        frequency_extension_option=True,
+    ) as inst:
+        inst.frequency = 1e9
+
+
 def test_power_setter():
-    with expected_protocol(SMP04, [("POW -30.00", None)]) as inst:
-        inst.power = -30
+    with expected_protocol(SMP04, [("POW -10.00", None)]) as inst:
+        inst.power = -10
 
 
-def test_power_setter_truncates_below_minimum():
-    # truncated_range clamps to the -130 dBm lower limit.
-    with expected_protocol(SMP04, [("POW -130.00", None)]) as inst:
+def test_power_truncates_to_standard_minimum():
+    # Standard model: truncated_range clamps to the -20 dBm lower limit.
+    with expected_protocol(SMP04, [("POW -20.00", None)]) as inst:
+        inst.power = -200
+
+
+def test_step_attenuator_option_allows_low_power():
+    # SMP-B15/B17 lowers the limit to -130 dBm.
+    with expected_protocol(
+        SMP04, [("POW -130.00", None)],
+        step_attenuator_option=True,
+    ) as inst:
         inst.power = -200
 
 


### PR DESCRIPTION
### Description

Adds a driver for the Rohde & Schwarz SMP04 microwave signal generator (10 MHz–40 GHz), verified against the SMP operating manual (IM 1035.5005).

### Features

- CW frequency and RF level (level range -130…+16 dBm; -130 dBm needs the SMP-B15/B17 attenuator).
- Output on/off, frequency/level mode (CW/SWEEP/LIST), reference oscillator source and external reference frequency.
- ALC, attenuator mode, and AM/FM/pulse modulation state.
- `questionable_condition` and `frequency_ok` (bit 5 of the questionable status register).

16 protocol tests; docs and CHANGES added.