### PR TITLE
Rewrite Thorlabs PRO8000 driver with per-slot module channels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Changed
   ``UnknownProcedure`` now returns empty ``parameter_objects``/``metadata_objects`` dicts so loading an unimportable procedure no longer raises.
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
-- Rewrite the Thorlabs PRO8000/PRO800 driver to use channels: one channel per populated slot is auto-detected (:code:`:CONFIG:PLUG?`) with LDC, TED and ITC module support, added measured read-backs (actual current, temperature, voltage, ...) and fixed the laser diode polarity command (now :code:`:LDPOL`). The former flat, slot-selecting properties (:code:`LDCCurrent`, :code:`LDCStatus`, ...) are replaced by the channel interfaces.
+- Rewrite the Thorlabs PRO8000/PRO800 driver to use channels: one channel per populated slot is auto-detected (:code:`:CONFIG:PLUG?`) with LDC, TED, ITC and PDA (:class:`PDAChannel`, whose ports are :class:`PDAPortChannel`) module support, added measured read-backs (actual current, temperature, voltage, ...) and fixed the laser diode polarity command (now :code:`:LDPOL`). The former flat, slot-selecting properties (:code:`LDCCurrent`, :code:`LDCStatus`, ...) are replaced by the channel interfaces.
 
 Version 0.16.0 (2026-05-20)
 ===========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Changed
   ``UnknownProcedure`` now returns empty ``parameter_objects``/``metadata_objects`` dicts so loading an unimportable procedure no longer raises.
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
+- Rewrite the Thorlabs PRO8000/PRO800 driver to use channels: one channel per populated slot is auto-detected (:code:`:CONFIG:PLUG?`) with LDC, TED and ITC module support, added measured read-backs (actual current, temperature, voltage, ...) and fixed the laser diode polarity command (now :code:`:LDPOL`). The former flat, slot-selecting properties (:code:`LDCCurrent`, :code:`LDCStatus`, ...) are replaced by the channel interfaces.
 
 Version 0.16.0 (2026-05-20)
 ===========================

--- a/docs/api/instruments/thorlabs/thorlabspro8000.rst
+++ b/docs/api/instruments/thorlabs/thorlabspro8000.rst
@@ -5,3 +5,27 @@ Thorlabs Pro 8000 modular laser driver
 .. autoclass:: pymeasure.instruments.thorlabs.ThorlabsPro8000
     :members:
     :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.Pro8Channel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.LDCChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.TEDChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.ITCChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.PDAChannel
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.thorlabs.thorlabspro8000.PDAPortChannel
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -24,6 +24,8 @@
 
 import logging
 
+from pyvisa.constants import ControlFlow
+
 from pymeasure.instruments import Channel, Instrument, SCPIMixin
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
@@ -312,10 +314,29 @@ class ThorlabsPro8000(SCPIMixin, Instrument):
     Supported modules are LDC8xxx (:class:`LDCChannel`), TED8xxx
     (:class:`TEDChannel`), ITC8xxx (:class:`ITCChannel`) and PDA8xxx
     (:class:`PDAChannel`, whose two ports are :class:`PDAPortChannel`).
+
+    Over the serial port the mainframe requires RTS/CTS hardware handshaking and
+    needs a short pause between a command and its response; both are configured by
+    default. The baud rate must match the setting of the mainframe's rear DIP
+    switches (factory default 19200).
     """
 
-    def __init__(self, adapter, name="Thorlabs Pro 8000", **kwargs):
-        super().__init__(adapter, name, **kwargs)
+    def __init__(self, adapter, name="Thorlabs Pro 8000", baud_rate=19200, **kwargs):
+        kwargs.setdefault("timeout", 5000)
+        super().__init__(
+            adapter,
+            name,
+            asrl={
+                "baud_rate": baud_rate,
+                # The mainframe only sends once the host asserts RTS, and it needs
+                # time to assemble the answer before it can be read back.
+                "flow_control": ControlFlow.rts_cts,
+                "query_delay": 0.05,
+                "read_termination": "\n",
+                "write_termination": "\n",
+            },
+            **kwargs,
+        )
         # Respond with bare values (without the command mnemonic) to simplify parsing.
         self.write(":SYST:ANSW VALUE")
         self._create_module_channels()

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -51,6 +51,7 @@ class Pro8Channel(Channel):
         ":TYPE:TXT?",
         """Get the module type of this slot as text, e.g. ``LDC8xxx`` (str).""",
         cast=str,
+        maxsplit=0,
     )
 
 
@@ -89,7 +90,7 @@ class LDCChannel(Pro8Channel):
     current_limit = Channel.control(
         ":LIMC:SET?", ":LIMC:SET %g",
         """Control the software laser diode current limit, in A
-        (float, must be below the hardware limit).""",
+        (float, must be below the hardware limit, see :attr:`current_hardware_limit`).""",
     )
 
     current_hardware_limit = Channel.measurement(
@@ -344,10 +345,11 @@ class ThorlabsPro8000(SCPIMixin, Instrument):
     def get_module_ids(self):
         """Get the list of module type ids for all slots (``:CONFIG:PLUG?``).
 
-        :return: List of 8 integer module ids, one per slot (see :data:`MODULE_NAMES`).
+        :return: List of integer module ids, one per slot (see
+            :data:`~pymeasure.instruments.thorlabs.thorlabspro8000.MODULE_NAMES`).
         """
         values = self.values(":CONFIG:PLUG?")
-        # 16 numbers are returned: (type, subtype) for each of the 8 slots.
+        # (type, subtype) pairs are returned, one pair per slot.
         return [int(v) for v in values[0::2]]
 
     def _create_module_channels(self):

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -230,10 +230,19 @@ class PDAPortChannel(Channel):
 
     measurement_range = Channel.control(
         ":RANGE?", ":RANGE %d",
-        """Control the measurement range as an index from 1 to 7, corresponding to
-        10 nA, 100 nA, 1 µA, 10 µA, 100 µA, 1 mA and 10 mA full scale (int).""",
+        """Control the measurement range as the full-scale photodiode current, in A.
+        One of 10e-9, 100e-9, 1e-6, 10e-6, 100e-6, 1e-3 or 10e-3 (float).""",
         validator=strict_discrete_set,
-        values=list(range(1, 8)),
+        values={
+            10e-9: 1,
+            100e-9: 2,
+            1e-6: 3,
+            10e-6: 4,
+            100e-6: 5,
+            1e-3: 6,
+            10e-3: 7,
+        },
+        map_values=True,
         cast=int,
     )
 

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -22,62 +22,308 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument, SCPIUnknownMixin
-from pymeasure.instruments.validators import strict_discrete_set
+import logging
+
+from pymeasure.instruments import Channel, Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
-class ThorlabsPro8000(SCPIUnknownMixin, Instrument):
-    """Represents Thorlabs Pro 8000 modular laser driver"""
-    SLOTS = range(1, 9)
-    LDC_POLARITIES = ['AG', 'CG']
-    STATUS = ['ON', 'OFF']
+class Pro8Channel(Channel):
+    """Base class for a plug-in module of a :class:`ThorlabsPro8000` mainframe.
+
+    The PRO8000 protocol is stateful: a slot is selected with ``:SLOT <n>`` and
+    all following module commands act on the selected slot. Each channel therefore
+    selects its own slot before every command ("select-then-send"), so that the
+    caller does not have to keep track of the active slot.
+    """
+
+    def write(self, command, **kwargs):
+        """Select this channel's slot, then write the module command."""
+        self.parent.write(f":SLOT {self.id}")
+        self.parent.write(command, **kwargs)
+
+    module_type = Channel.measurement(
+        ":TYPE:TXT?",
+        """Get the module type of this slot as text, e.g. ``LDC8xxx`` (str).""",
+        cast=str,
+    )
+
+
+class LDCChannel(Pro8Channel):
+    """A laser-diode current controller module (LDC8xxx)."""
+
+    laser_enabled = Channel.control(
+        ":LASER?", ":LASER %s",
+        """Control whether the laser output is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True,
+        cast=str,
+    )
+
+    current = Channel.measurement(
+        ":ILD:ACT?",
+        """Measure the actual laser diode current, in A (float).""",
+    )
+
+    current_setpoint = Channel.control(
+        ":ILD:SET?", ":ILD:SET %g",
+        """Control the laser diode current setpoint, in A (float).""",
+    )
+
+    current_min = Channel.measurement(
+        ":ILD:MIN?",
+        """Get the minimum allowed laser diode current, in A (float).""",
+    )
+
+    current_max = Channel.measurement(
+        ":ILD:MAX?",
+        """Get the maximum allowed laser diode current, in A (float).""",
+    )
+
+    current_limit = Channel.control(
+        ":LIMC:SET?", ":LIMC:SET %g",
+        """Control the software laser diode current limit, in A
+        (float, must be below the hardware limit).""",
+    )
+
+    current_hardware_limit = Channel.measurement(
+        ":LIMCP:ACT?",
+        """Get the hardware laser diode current limit, in A (float).""",
+    )
+
+    voltage = Channel.measurement(
+        ":VLD:ACT?",
+        """Measure the actual laser diode voltage, in V (float).""",
+    )
+
+    ld_polarity = Channel.control(
+        ":LDPOL?", ":LDPOL %s",
+        """Control the laser diode polarity, ``AG`` (anode grounded) or ``CG``
+        (cathode grounded) (str).""",
+        validator=strict_discrete_set,
+        values=["AG", "CG"],
+        cast=str,
+    )
+
+    pd_polarity = Channel.control(
+        ":PDPOL?", ":PDPOL %s",
+        """Control the monitor photodiode polarity, ``AG`` (anode grounded) or
+        ``CG`` (cathode grounded) (str).""",
+        validator=strict_discrete_set,
+        values=["AG", "CG"],
+        cast=str,
+    )
+
+    mode = Channel.control(
+        ":MODE?", ":MODE %s",
+        """Control the operation mode, ``CC`` (constant current) or ``CP``
+        (constant power) (str).""",
+        validator=strict_discrete_set,
+        values=["CC", "CP"],
+        cast=str,
+    )
+
+
+class TEDChannel(Pro8Channel):
+    """A thermo-electric temperature controller module (TED8xxx)."""
+
+    tec_enabled = Channel.control(
+        ":TEC?", ":TEC %s",
+        """Control whether the TEC (temperature control) output is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True,
+        cast=str,
+    )
+
+    temperature = Channel.measurement(
+        ":TEMP:ACT?",
+        """Measure the actual temperature, in °C (float).""",
+    )
+
+    temperature_setpoint = Channel.control(
+        ":TEMP:SET?", ":TEMP:SET %g",
+        """Control the temperature setpoint, in °C (float).""",
+    )
+
+    tec_current = Channel.measurement(
+        ":ITE:ACT?",
+        """Measure the actual TEC current, in A (float).""",
+    )
+
+    pid_p_share = Channel.control(
+        ":SHAREP:SET?", ":SHAREP:SET %g",
+        """Control the proportional (P) share of the temperature control loop,
+        in percent (float strictly in range 0 to 100).""",
+        validator=strict_range,
+        values=[0, 100],
+    )
+
+    pid_i_share = Channel.control(
+        ":SHAREI:SET?", ":SHAREI:SET %g",
+        """Control the integral (I) share of the temperature control loop,
+        in percent (float strictly in range 0 to 100).""",
+        validator=strict_range,
+        values=[0, 100],
+    )
+
+    pid_d_share = Channel.control(
+        ":SHARED:SET?", ":SHARED:SET %g",
+        """Control the derivative (D) share of the temperature control loop,
+        in percent (float strictly in range 0 to 100).""",
+        validator=strict_range,
+        values=[0, 100],
+    )
+
+
+class ITCChannel(LDCChannel, TEDChannel):
+    """A combined laser current and temperature controller module (ITC8xxx).
+
+    Exposes the union of the :class:`LDCChannel` (laser) and :class:`TEDChannel`
+    (temperature) interfaces.
+    """
+
+
+class PDAPortChannel(Channel):
+    """A single port of a PDA8xxx photodiode amplifier module.
+
+    A PDA module has two independent ports. Each command selects the module's
+    slot and the port (``:SLOT <slot>``, ``:PORT <port>``) before it is sent.
+    """
+
+    def write(self, command, **kwargs):
+        """Select the parent module's slot and this port, then write the command."""
+        frame = self.parent.parent
+        # The slot must be selected first: selecting a slot resets the port to 1.
+        frame.write(f":SLOT {self.parent.id}")
+        frame.write(f":PORT {self.id}")
+        frame.write(command, **kwargs)
+
+    current = Channel.measurement(
+        ":IPD:ACT?",
+        """Measure the photodiode current, in A (float).""",
+    )
+
+    optical_power = Channel.measurement(
+        ":POPT:ACT?",
+        """Measure the optical power, in W (float).""",
+    )
+
+    sensitivity = Channel.control(
+        ":CALPD:SET?", ":CALPD:SET %g",
+        """Control the photodiode sensitivity used to convert current to optical
+        power, in A/W (float).""",
+    )
+
+    pd_polarity = Channel.control(
+        ":PDPOL?", ":PDPOL %s",
+        """Control the photodiode polarity, ``AG`` (anode grounded) or ``CG``
+        (cathode grounded) (str).""",
+        validator=strict_discrete_set,
+        values=["AG", "CG"],
+        cast=str,
+    )
+
+    measurement_range = Channel.control(
+        ":RANGE?", ":RANGE %d",
+        """Control the measurement range as an index from 1 to 7, corresponding to
+        10 nA, 100 nA, 1 µA, 10 µA, 100 µA, 1 mA and 10 mA full scale (int).""",
+        validator=strict_discrete_set,
+        values=list(range(1, 8)),
+        cast=int,
+    )
+
+    bias_enabled = Channel.control(
+        ":PDBIA?", ":PDBIA %s",
+        """Control whether the photodiode bias voltage is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: "ON", False: "OFF"},
+        map_values=True,
+        cast=str,
+    )
+
+    bias_voltage = Channel.control(
+        ":VBIAS:SET?", ":VBIAS:SET %g",
+        """Control the photodiode bias voltage, in V (float).""",
+    )
+
+
+class PDAChannel(Pro8Channel):
+    """A photodiode amplifier module (PDA8xxx) with two independent ports.
+
+    The ports are accessible via the ``ports`` dictionary (keyed by port number
+    1 and 2) or the ``port_1`` / ``port_2`` attributes.
+    """
+
+    def __init__(self, parent, id, **kwargs):
+        super().__init__(parent, id, **kwargs)
+        for port in (1, 2):
+            self.add_child(PDAPortChannel, port, collection="ports", prefix="port_")
+
+
+# Module type ids reported by ``:CONFIG:PLUG?`` / ``:TYPE:ID?`` and the channel
+# class used to control them. Ids without a dedicated class (0 = empty slot,
+# 47 = MLC8xxx, 249 = WDM-B) do not create a channel.
+MODULE_CHANNELS = {
+    107: PDAChannel,
+    159: ITCChannel,
+    191: LDCChannel,
+    223: TEDChannel,
+}
+
+MODULE_NAMES = {
+    0: "empty",
+    47: "MLC8xxx",
+    107: "PDA8xxx",
+    159: "ITC8xxx",
+    191: "LDC8xxx",
+    223: "TED8xxx",
+    249: "WDM-B",
+}
+
+
+class ThorlabsPro8000(SCPIMixin, Instrument):
+    """Represents a Thorlabs PRO8000 / PRO800 modular laser driver mainframe.
+
+    On connection the mainframe is queried for its installed modules
+    (``:CONFIG:PLUG?``) and a :class:`Channel` is created for every populated slot
+    that holds a supported module. Channels are accessible through the ``channels``
+    dictionary (keyed by slot number) or the ``ch_<slot>`` attributes:
+
+    .. code-block:: python
+
+        pro8000 = ThorlabsPro8000("GPIB::10")
+        pro8000.channels[1].laser_enabled = True      # slot 1 holds an LDC module
+        print(pro8000.channels[2].temperature)        # slot 2 holds a TED module
+
+    Supported modules are LDC8xxx (:class:`LDCChannel`), TED8xxx
+    (:class:`TEDChannel`), ITC8xxx (:class:`ITCChannel`) and PDA8xxx
+    (:class:`PDAChannel`, whose two ports are :class:`PDAPortChannel`).
+    """
 
     def __init__(self, adapter, name="Thorlabs Pro 8000", **kwargs):
-        super().__init__(
-            adapter,
-            name,
-            **kwargs
-        )
-        self.write(':SYST:ANSW VALUE')
+        super().__init__(adapter, name, **kwargs)
+        # Respond with bare values (without the command mnemonic) to simplify parsing.
+        self.write(":SYST:ANSW VALUE")
+        self._create_module_channels()
 
-    # Code for general purpose commands (mother board related)
-    slot = Instrument.control(":SLOT?", ":SLOT %d",
-                              f"Control slot selection. Allowed values are: {SLOTS}",
-                              validator=strict_discrete_set,
-                              values=SLOTS,
-                              map_values=False)
+    def get_module_ids(self):
+        """Get the list of module type ids for all slots (``:CONFIG:PLUG?``).
 
-    # Code for LDC-xxxx daughter boards (laser driver)
-    LDCCurrent = Instrument.control(":ILD:SET?", ":ILD:SET %g",
-                                    """Control laser current.""")
+        :return: List of 8 integer module ids, one per slot (see :data:`MODULE_NAMES`).
+        """
+        values = self.values(":CONFIG:PLUG?")
+        # 16 numbers are returned: (type, subtype) for each of the 8 slots.
+        return [int(v) for v in values[0::2]]
 
-    LDCCurrentLimit = Instrument.control(
-        ":LIMC:SET?", ":LIMC:SET %g",
-        """Set Software current Limit (value must be lower than hardware current limit)."""
-    )
-
-    LDCPolarity = Instrument.control(
-        ":LIMC:SET?", ":LIMC:SET %s",
-        f"""Set laser diode polarity. Allowed values are: {LDC_POLARITIES}""",
-        validator=strict_discrete_set,
-        values=LDC_POLARITIES,
-        map_values=False
-    )
-
-    LDCStatus = Instrument.control(
-        ":LASER?", ":LASER %s",
-        f"""Set laser diode status. Allowed values are: {STATUS}""",
-        validator=strict_discrete_set,
-        values=STATUS,
-        map_values=False
-    )
-
-    # Code for TED-xxxx daughter boards (TEC driver)
-    TEDStatus = Instrument.control(":TEC?", ":TEC %s",
-                                   f"""Control TEC status. Allowed values are: {STATUS}""",
-                                   validator=strict_discrete_set,
-                                   values=STATUS,
-                                   map_values=False)
-
-    TEDSetTemperature = Instrument.control(":TEMP:SET?", ":TEMP:SET %g",
-                                           """Control TEC temperature""")
+    def _create_module_channels(self):
+        """Create a channel for every slot holding a supported module."""
+        self.channels = {}
+        for slot, module_id in enumerate(self.get_module_ids(), start=1):
+            channel_class = MODULE_CHANNELS.get(module_id)
+            if channel_class is not None:
+                self.add_child(channel_class, slot)

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -265,15 +265,17 @@ class PDAPortChannel(Channel):
 
 
 class PDAChannel(Pro8Channel):
-    """A photodiode amplifier module (PDA8xxx) with two independent ports.
+    """A photodiode amplifier module (PDA8xxx) with one or two independent ports.
 
-    The ports are accessible via the ``ports`` dictionary (keyed by port number
-    1 and 2) or the ``port_1`` / ``port_2`` attributes.
+    The number of ports depends on the module variant: the PDA8000-1 has a
+    single port, the PDA8000-2 has two. The ports are accessible via the
+    ``ports`` dictionary (keyed by port number) or the ``port_1`` / ``port_2``
+    attributes.
     """
 
-    def __init__(self, parent, id, **kwargs):
+    def __init__(self, parent, id, port_count=2, **kwargs):
         super().__init__(parent, id, **kwargs)
-        for port in (1, 2):
+        for port in range(1, port_count + 1):
             self.add_child(PDAPortChannel, port, collection="ports", prefix="port_")
 
 
@@ -314,7 +316,7 @@ class ThorlabsPro8000(SCPIMixin, Instrument):
 
     Supported modules are LDC8xxx (:class:`LDCChannel`), TED8xxx
     (:class:`TEDChannel`), ITC8xxx (:class:`ITCChannel`) and PDA8xxx
-    (:class:`PDAChannel`, whose two ports are :class:`PDAPortChannel`).
+    (:class:`PDAChannel`, whose one or two ports are :class:`PDAPortChannel`).
 
     Over the serial port the mainframe requires RTS/CTS hardware handshaking and
     needs a short pause between a command and its response; both are configured by
@@ -355,7 +357,18 @@ class ThorlabsPro8000(SCPIMixin, Instrument):
     def _create_module_channels(self):
         """Create a channel for every slot holding a supported module."""
         self.channels = {}
-        for slot, module_id in enumerate(self.get_module_ids(), start=1):
+        values = self.values(":CONFIG:PLUG?")
+        # (type, subtype) pairs are returned, one pair per slot.
+        module_ids = [int(v) for v in values[0::2]]
+        subtypes = [int(v) for v in values[1::2]]
+        for slot, (module_id, subtype) in enumerate(zip(module_ids, subtypes), start=1):
             channel_class = MODULE_CHANNELS.get(module_id)
-            if channel_class is not None:
+            if channel_class is None:
+                continue
+            if channel_class is PDAChannel:
+                # For the PDA the subtype is the model variant and equals the port
+                # count: the PDA8000-1 (subtype 1) has one port, the PDA8000-2
+                # (subtype 2) has two.
+                self.add_child(channel_class, slot, port_count=subtype)
+            else:
                 self.add_child(channel_class, slot)

--- a/tests/instruments/test_all_instruments.py
+++ b/tests/instruments/test_all_instruments.py
@@ -101,6 +101,7 @@ need_init_communication = [
     "SwissArmyFake",
     "FakeInstrument",
     "ThorlabsPM100USB",
+    "ThorlabsPro8000",
     "Keithley2400",
     "Keithley2700",
     "TC038",

--- a/tests/instruments/thorlabs/test_thorlabspro8000.py
+++ b/tests/instruments/thorlabs/test_thorlabspro8000.py
@@ -81,19 +81,21 @@ def test_pda_optical_power():
 
 
 def test_pda_range_setter():
+    # 100e-6 A full scale maps to range index 5.
     with expected_protocol(
         ThorlabsPro8000,
         INIT + [(":SLOT 4", None), (":PORT 1", None), (":RANGE 5", None)],
     ) as inst:
-        inst.channels[4].port_1.measurement_range = 5
+        inst.channels[4].port_1.measurement_range = 100e-6
 
 
 def test_pda_range_getter():
+    # Range index 3 maps to 1e-6 A full scale.
     with expected_protocol(
         ThorlabsPro8000,
         INIT + [(":SLOT 4", None), (":PORT 1", None), (":RANGE?", "3")],
     ) as inst:
-        assert inst.channels[4].port_1.measurement_range == 3
+        assert inst.channels[4].port_1.measurement_range == 1e-6
 
 
 def test_pda_bias_enabled_setter():

--- a/tests/instruments/thorlabs/test_thorlabspro8000.py
+++ b/tests/instruments/thorlabs/test_thorlabspro8000.py
@@ -1,0 +1,268 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pymeasure.test import expected_protocol
+from pymeasure.instruments.thorlabs.thorlabspro8000 import (
+    ThorlabsPro8000,
+    LDCChannel,
+    TEDChannel,
+    ITCChannel,
+    PDAChannel,
+    PDAPortChannel,
+)
+
+# Module map used for most tests: slot 1 = LDC, slot 2 = TED, slot 3 = ITC,
+# slot 4 = PDA, the remaining slots are empty.
+# ``:CONFIG:PLUG?`` returns (type, subtype) pairs.
+CONFIG = "191,0,223,0,159,0,107,0,0,0,0,0,0,0,0,0"
+
+# Communication that every connection performs in ``__init__``.
+INIT = [
+    (":SYST:ANSW VALUE", None),
+    (":CONFIG:PLUG?", CONFIG),
+]
+
+
+def test_init():
+    """The mainframe queries its modules and creates one channel per populated slot."""
+    with expected_protocol(ThorlabsPro8000, INIT) as inst:
+        assert set(inst.channels.keys()) == {1, 2, 3, 4}
+        assert isinstance(inst.channels[1], LDCChannel)
+        assert isinstance(inst.channels[2], TEDChannel)
+        assert isinstance(inst.channels[3], ITCChannel)
+        assert isinstance(inst.channels[4], PDAChannel)
+
+
+def test_pda_has_two_ports():
+    with expected_protocol(ThorlabsPro8000, INIT) as inst:
+        assert set(inst.channels[4].ports.keys()) == {1, 2}
+        assert isinstance(inst.channels[4].port_1, PDAPortChannel)
+        assert isinstance(inst.channels[4].port_2, PDAPortChannel)
+
+
+def test_pda_port_selects_slot_and_port():
+    """A PDA port command selects both slot and port before the command."""
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 2", None), (":IPD:ACT?", "1.5E-06")],
+    ) as inst:
+        assert inst.channels[4].port_2.current == pytest.approx(1.5e-6)
+
+
+def test_pda_optical_power():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 1", None), (":POPT:ACT?", "0.002")],
+    ) as inst:
+        assert inst.channels[4].port_1.optical_power == pytest.approx(0.002)
+
+
+def test_pda_range_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 1", None), (":RANGE 5", None)],
+    ) as inst:
+        inst.channels[4].port_1.measurement_range = 5
+
+
+def test_pda_range_getter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 1", None), (":RANGE?", "3")],
+    ) as inst:
+        assert inst.channels[4].port_1.measurement_range == 3
+
+
+def test_pda_bias_enabled_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 2", None), (":PDBIA ON", None)],
+    ) as inst:
+        inst.channels[4].port_2.bias_enabled = True
+
+
+def test_pda_bias_voltage_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 4", None), (":PORT 1", None), (":VBIAS:SET 5", None)],
+    ) as inst:
+        inst.channels[4].port_1.bias_voltage = 5
+
+
+def test_no_channel_for_empty_or_unsupported_slots():
+    """Empty (0) and unsupported (MLC=47, WDM-B=249) slots do not create a channel."""
+    config = "47,0,249,0,0,0,0,0,0,0,0,0,0,0,0,0"
+    with expected_protocol(
+        ThorlabsPro8000,
+        [(":SYST:ANSW VALUE", None), (":CONFIG:PLUG?", config)],
+    ) as inst:
+        assert inst.channels == {}
+
+
+def test_channel_selects_slot_before_command():
+    """Every channel command is prefixed by a separate ``:SLOT`` selection."""
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":ILD:SET 0.05", None)],
+    ) as inst:
+        inst.channels[1].current_setpoint = 0.05
+
+
+def test_ldc_laser_enabled_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":LASER ON", None)],
+    ) as inst:
+        inst.channels[1].laser_enabled = True
+
+
+def test_ldc_laser_enabled_getter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":LASER?", "OFF")],
+    ) as inst:
+        assert inst.channels[1].laser_enabled is False
+
+
+def test_ldc_current_measurement():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":ILD:ACT?", "5.1234E-02")],
+    ) as inst:
+        assert inst.channels[1].current == pytest.approx(0.051234)
+
+
+def test_ldc_voltage_measurement():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":VLD:ACT?", "1.85")],
+    ) as inst:
+        assert inst.channels[1].voltage == pytest.approx(1.85)
+
+
+def test_ldc_hardware_limit():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":LIMCP:ACT?", "0.2")],
+    ) as inst:
+        assert inst.channels[1].current_hardware_limit == pytest.approx(0.2)
+
+
+def test_ldc_polarity_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":LDPOL CG", None)],
+    ) as inst:
+        inst.channels[1].ld_polarity = "CG"
+
+
+def test_ldc_polarity_getter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":LDPOL?", "AG")],
+    ) as inst:
+        assert inst.channels[1].ld_polarity == "AG"
+
+
+def test_ldc_polarity_invalid():
+    with expected_protocol(ThorlabsPro8000, INIT) as inst:
+        with pytest.raises(ValueError):
+            inst.channels[1].ld_polarity = "XX"
+
+
+def test_ldc_mode_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":MODE CP", None)],
+    ) as inst:
+        inst.channels[1].mode = "CP"
+
+
+def test_ted_enabled_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 2", None), (":TEC OFF", None)],
+    ) as inst:
+        inst.channels[2].tec_enabled = False
+
+
+def test_ted_temperature_measurement():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 2", None), (":TEMP:ACT?", "25.3")],
+    ) as inst:
+        assert inst.channels[2].temperature == pytest.approx(25.3)
+
+
+def test_ted_temperature_setpoint():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 2", None), (":TEMP:SET 21", None)],
+    ) as inst:
+        inst.channels[2].temperature_setpoint = 21
+
+
+def test_ted_tec_current():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 2", None), (":ITE:ACT?", "0.42")],
+    ) as inst:
+        assert inst.channels[2].tec_current == pytest.approx(0.42)
+
+
+def test_ted_pid_share_setter():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 2", None), (":SHAREP:SET 30", None)],
+    ) as inst:
+        inst.channels[2].pid_p_share = 30
+
+
+def test_ted_pid_share_out_of_range():
+    with expected_protocol(ThorlabsPro8000, INIT) as inst:
+        with pytest.raises(ValueError):
+            inst.channels[2].pid_i_share = 150
+
+
+def test_itc_has_both_laser_and_tec():
+    """An ITC channel exposes both laser (LDC) and temperature (TED) commands."""
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [
+            (":SLOT 3", None), (":LASER ON", None),
+            (":SLOT 3", None), (":TEMP:ACT?", "20.0"),
+        ],
+    ) as inst:
+        inst.channels[3].laser_enabled = True
+        assert inst.channels[3].temperature == pytest.approx(20.0)
+
+
+def test_module_type_query():
+    with expected_protocol(
+        ThorlabsPro8000,
+        INIT + [(":SLOT 1", None), (":TYPE:TXT?", "LDC8xxx")],
+    ) as inst:
+        assert inst.channels[1].module_type == "LDC8xxx"

--- a/tests/instruments/thorlabs/test_thorlabspro8000.py
+++ b/tests/instruments/thorlabs/test_thorlabspro8000.py
@@ -204,9 +204,8 @@ def test_ldc_polarity_getter():
 
 
 def test_ldc_polarity_invalid():
-    with expected_protocol(ThorlabsPro8000, INIT) as inst:
-        with pytest.raises(ValueError):
-            inst.channels[1].ld_polarity = "XX"
+    with expected_protocol(ThorlabsPro8000, INIT) as inst, pytest.raises(ValueError):
+        inst.channels[1].ld_polarity = "XX"
 
 
 def test_ldc_mode_setter():
@@ -258,9 +257,8 @@ def test_ted_pid_share_setter():
 
 
 def test_ted_pid_share_out_of_range():
-    with expected_protocol(ThorlabsPro8000, INIT) as inst:
-        with pytest.raises(ValueError):
-            inst.channels[2].pid_i_share = 150
+    with expected_protocol(ThorlabsPro8000, INIT) as inst, pytest.raises(ValueError):
+        inst.channels[2].pid_i_share = 150
 
 
 def test_itc_has_both_laser_and_tec():

--- a/tests/instruments/thorlabs/test_thorlabspro8000.py
+++ b/tests/instruments/thorlabs/test_thorlabspro8000.py
@@ -35,9 +35,10 @@ from pymeasure.instruments.thorlabs.thorlabspro8000 import (
 )
 
 # Module map used for most tests: slot 1 = LDC, slot 2 = TED, slot 3 = ITC,
-# slot 4 = PDA, the remaining slots are empty.
-# ``:CONFIG:PLUG?`` returns (type, subtype) pairs.
-CONFIG = "191,0,223,0,159,0,107,0,0,0,0,0,0,0,0,0"
+# slot 4 = PDA8000-2 (two ports), the remaining slots are empty.
+# ``:CONFIG:PLUG?`` returns (type, subtype) pairs; for a PDA the subtype is the
+# model variant and equals the port count (1 = PDA8000-1, 2 = PDA8000-2).
+CONFIG = "191,0,223,0,159,0,107,2,0,0,0,0,0,0,0,0"
 
 # Communication that every connection performs in ``__init__``.
 INIT = [
@@ -56,11 +57,24 @@ def test_init():
         assert isinstance(inst.channels[4], PDAChannel)
 
 
-def test_pda_has_two_ports():
+def test_pda8000_2_has_two_ports():
+    """A PDA8000-2 (subtype 2) exposes two ports."""
     with expected_protocol(ThorlabsPro8000, INIT) as inst:
         assert set(inst.channels[4].ports.keys()) == {1, 2}
         assert isinstance(inst.channels[4].port_1, PDAPortChannel)
         assert isinstance(inst.channels[4].port_2, PDAPortChannel)
+
+
+def test_pda8000_1_has_one_port():
+    """A PDA8000-1 (subtype 1) exposes a single port and no second one."""
+    config = "107,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
+    with expected_protocol(
+        ThorlabsPro8000,
+        [(":SYST:ANSW VALUE", None), (":CONFIG:PLUG?", config)],
+    ) as inst:
+        assert set(inst.channels[1].ports.keys()) == {1}
+        assert isinstance(inst.channels[1].port_1, PDAPortChannel)
+        assert not hasattr(inst.channels[1], "port_2")
 
 
 def test_pda_port_selects_slot_and_port():

--- a/tests/instruments/thorlabs/test_thorlabspro8000.py
+++ b/tests/instruments/thorlabs/test_thorlabspro8000.py
@@ -24,15 +24,15 @@
 
 import pytest
 
-from pymeasure.test import expected_protocol
 from pymeasure.instruments.thorlabs.thorlabspro8000 import (
-    ThorlabsPro8000,
-    LDCChannel,
-    TEDChannel,
     ITCChannel,
+    LDCChannel,
     PDAChannel,
     PDAPortChannel,
+    TEDChannel,
+    ThorlabsPro8000,
 )
+from pymeasure.test import expected_protocol
 
 # Module map used for most tests: slot 1 = LDC, slot 2 = TED, slot 3 = ITC,
 # slot 4 = PDA8000-2 (two ports), the remaining slots are empty.


### PR DESCRIPTION
## Summary

The PRO8000/PRO800 is a modular mainframe whose protocol is stateful: a slot is selected with `:SLOT <n>` and all following commands act on it. The old driver exposed this directly (a global `slot` property plus flat `LDCCurrent`/`TEDStatus`-style attributes acting on whatever slot happened to be selected), which is error-prone with several modules installed.

This PR rewrites the driver as a channel-based interface:
- On connection the mainframe is queried for its installed modules  (`:CONFIG:PLUG?`) and one channel per populated slot is created automatically  (this also handles the 2-slot PRO800 transparently).
- Each channel selects its own slot before every command ("select-then-send"),  so no global slot state has to be tracked by the caller.
- Supported modules: `LDC8xxx` (laser current driver), `TED8xxx` (TEC controller),  `ITC8xxx` (combined, exposes the union of both interfaces), and `PDA8xxx`  (photodiode amplifier) with its ports as nested sub-channels (`:PORT` is  re-selected after every `:SLOT`, since slot selection resets the port).

```python
pro8000 = ThorlabsPro8000("ASRL3::INSTR")
pro8000.channels[1].laser_enabled = True     # slot 1: LDC module
print(pro8000.channels[2].temperature)       # slot 2: TED module
```

### Bug fix

The old `LDCPolarity` property wrote `:LIMC:SET` - the current-limit command - so setting the polarity silently overwrote the software current limit. The correct command is `:LDPOL`, used now.

### Further changes
- New measured read-backs: actual laser current/voltage, actual temperature,  TEC current, hardware current limit, PID shares, photodiode current/optical  power, module type.
- PDA measurement range is exposed as full-scale photodiode current in amps  (10 nA … 10 mA) instead of a raw range index.
- PDA port count is derived from the module subtype in `:CONFIG:PLUG?`: the  PDA8000-1 (subtype 1) exposes a single port, the PDA8000-2 (subtype 2) two,  so a single-port module no longer gets an invalid second port.
- Serial connection defaults configured for the mainframe's requirements  (RTS/CTS handshaking, query delay, terminations, 19200 baud default matching  the factory setting); GPIB connections are unaffected.
- Switched SCPIUnknownMixin → SCPIMixin (the mainframe supports the SCPI  common commands).

## Breaking change

The former flat, slot-selecting properties (`slot`, `LDCCurrent`, `LDCStatus`,…) are removed in favor of the channel interfaces (noted in CHANGES.rst).

## Tests

28 protocol tests covering channel auto-detection, slot/port selection ordering, all module types, one- and two-port PDA modules, and the empty-frame case. Driver was validated on PRO8000 hardware (laser and TEC control). Docs and CHANGES.rst updated.