### PR TITLE
Add APE PulseCheck autocorrelator (RS232 and USB/pulseLink)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ Changed
 - Procedure use :class:`ProcedureStatus` enum instead of status and status message dicts.
 - Added auto ranging to Agilent E5270B ``voltage`` and ``current``. It improves measurement resolution but might slightly increase the measurement time.
 
+Instruments
+-----------
+- Add APE PulseCheck autocorrelator with RS232 (:class:`PulseCheck`) and USB/PulseLink (:class:`PulseCheckUSB`) interfaces (@niklasschulz99)
+
 Version 0.16.0 (2026-05-20)
 ===========================
 

--- a/docs/api/instruments/ape/index.rst
+++ b/docs/api/instruments/ape/index.rst
@@ -1,0 +1,13 @@
+.. module:: pymeasure.instruments.ape
+
+###
+APE
+###
+
+This section contains specific documentation on the APE instruments that are implemented.
+If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments/index>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   pulsecheck

--- a/docs/api/instruments/ape/index.rst
+++ b/docs/api/instruments/ape/index.rst
@@ -11,3 +11,4 @@ If you are interested in an instrument not included, please consider :doc:`addin
    :maxdepth: 2
 
    pulsecheck
+   pulsecheck_usb

--- a/docs/api/instruments/ape/pulsecheck.rst
+++ b/docs/api/instruments/ape/pulsecheck.rst
@@ -1,0 +1,7 @@
+##############
+APE PulseCheck
+##############
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck.PulseCheck
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/ape/pulsecheck_usb.rst
+++ b/docs/api/instruments/ape/pulsecheck_usb.rst
@@ -1,0 +1,22 @@
+##################
+APE PulseCheck USB
+##################
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.PulseCheckUSB
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.OperationStatus
+    :members:
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.InitializationStatus
+    :members:
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.BusyStatus
+    :members:
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.DataError
+    :members:
+
+.. autoclass:: pymeasure.instruments.ape.pulsecheck_usb.FirmwareError
+    :members:

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -32,6 +32,7 @@ Instruments by manufacturer:
    anapico/index
    andeenhagerling/index
    anritsu/index
+   ape/index
    attocube/index
    bkprecision/index
    danfysik/index

--- a/pymeasure/instruments/ape/__init__.py
+++ b/pymeasure/instruments/ape/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .pulsecheck import PulseCheck

--- a/pymeasure/instruments/ape/__init__.py
+++ b/pymeasure/instruments/ape/__init__.py
@@ -23,3 +23,4 @@
 #
 
 from .pulsecheck import PulseCheck
+from .pulsecheck_usb import PulseCheckUSB

--- a/pymeasure/instruments/ape/pulsecheck.py
+++ b/pymeasure/instruments/ape/pulsecheck.py
@@ -49,7 +49,17 @@ class PulseCheck(Instrument):
 
     The instrument silently discards a setting if the next command follows too
     closely, and occasionally even then. Leave at least 0.3 s after writing a
-    property, and read the property back to confirm the setting arrived.
+    property, and read the property back to confirm the setting arrived::
+
+        def set_and_read(instrument, name, value, timeout=10):
+            # write the property until the setting arrives, and return what it reads back
+            deadline = time.monotonic() + timeout
+            while True:
+                setattr(instrument, name, value)
+                time.sleep(0.3)
+                read = getattr(instrument, name)
+                if read == value or time.monotonic() > deadline:
+                    return read
 
     :param adapter: pyvisa resource name of the instrument or an adapter instance.
     :param name: name of the instrument.
@@ -59,13 +69,9 @@ class PulseCheck(Instrument):
 
     def __init__(self, adapter, name="APE PulseCheck", baud_rate=38400, **kwargs):
         self._last_command = ""
-        super().__init__(
-            adapter,
-            name,
-            write_termination="\r",
-            asrl=dict(baud_rate=baud_rate),
-            **kwargs,
-        )
+        kwargs.setdefault("write_termination", "\r")
+        kwargs.setdefault("asrl", {}).setdefault("baud_rate", baud_rate)
+        super().__init__(adapter, name, **kwargs)
 
     def write(self, command):
         """Write a command to the instrument, terminated by a carriage return.
@@ -133,7 +139,7 @@ class PulseCheck(Instrument):
         cast=int,
     )
 
-    running = Instrument.control(
+    measurement_running = Instrument.control(
         "GRS", "RS%d",
         """Control whether the instrument is currently running/scanning (bool).""",
         validator=strict_discrete_set,
@@ -192,7 +198,7 @@ class PulseCheck(Instrument):
         values=list(TRIGGER_MODES),
         # get and set use different (bit-coded vs. index) encodings, so map manually
         # instead of via `map_values`, which assumes a single shared encoding.
-        get_process=lambda code: TRIGGER_MODE_CODES[code],
+        get_process=lambda code: TRIGGER_MODE_CODES.get(code, f"unknown ({code})"),
         set_process=lambda mode: TRIGGER_MODES[mode],
         cast=int,
     )
@@ -219,7 +225,7 @@ class PulseCheck(Instrument):
         """
         self.write(f"TU{int(delta)}")
 
-    def set_alpha(self, alpha, retries=1):
+    def set_alpha(self, alpha, retries=1, timeout=60):
         """Move the turning angle/phase-modulation position to an absolute target.
 
         The instrument only accepts relative tuning steps via :meth:`tune`, so
@@ -230,9 +236,13 @@ class PulseCheck(Instrument):
 
         :param alpha: target turning angle/phase-modulation position (int).
         :param retries: number of additional attempts if tuning gets stuck.
-        :raises TimeoutError: if the target is not reached within the allowed
-            number of attempts.
+        :param timeout: how long to keep tuning altogether, in s.
+        :raises TimeoutError: if the target is not reached within `timeout`, or
+            within the allowed number of attempts.
         """
+        if retries < 0:
+            raise ValueError(f"retries has to be zero or more, not {retries}.")
+        deadline = time.monotonic() + timeout
         total_attempts = retries + 1
         for attempt in range(1, total_attempts + 1):
             self.tune(alpha - self.alpha)
@@ -242,6 +252,10 @@ class PulseCheck(Instrument):
             stuck = False
             while current != alpha:
                 log.debug("alpha = %d", current)
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
+                    )
                 time.sleep(0.5)
                 if self.alpha == current:
                     time.sleep(0.5)
@@ -257,7 +271,7 @@ class PulseCheck(Instrument):
             f"Tuning alpha to {alpha} got stuck after {total_attempts} attempt(s)."
         )
 
-    def acf(self):
+    def raw_acf(self):
         """Measure one autocorrelation trace as raw (unscaled) detector counts.
 
         The number of samples returned equals :attr:`resolution`.
@@ -272,13 +286,17 @@ class PulseCheck(Instrument):
         raw = self.read_bytes(2 * n_samples)
         return [value >> 6 for value in struct.unpack(f">{n_samples}H", raw)]
 
-    def get_autocorrelation(self):
-        """Measure one autocorrelation trace together with its delay axis.
+    @property
+    def acf(self):
+        """Get one autocorrelation trace together with its delay axis, as a tuple
+        ``(delay, acf)`` of numpy arrays; the delay axis is in seconds, the
+        autocorrelation is in raw detector counts.
 
-        :returns: a tuple ``(delay, acf)`` of numpy arrays; the delay axis is
-            in seconds, the autocorrelation is in raw detector counts.
+        With :attr:`scan_range` set to 0 the delay drive is parked, so every sample
+        is taken at zero delay and the delay axis is all zeros; use :meth:`raw_acf`
+        for the samples themselves.
         """
-        acf = np.array(self.acf())
+        acf = np.array(self.raw_acf())
         scan_range = self.scan_range
         delay = np.linspace(-scan_range / 2, scan_range / 2, len(acf))
         return delay, acf

--- a/pymeasure/instruments/ape/pulsecheck.py
+++ b/pymeasure/instruments/ape/pulsecheck.py
@@ -34,9 +34,11 @@ from pymeasure.instruments.validators import strict_discrete_set, strict_range
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-#: Trigger modes, in the order used by the ``GTF`` get-command (0-indexed);
-#: the ``TF`` set-command expects the 1-indexed position instead.
-TRIGGER_MODES = ("freerun", "trigger", "fringe", "slow")
+#: Trigger modes and the index the ``TF`` set-command expects for each.
+TRIGGER_MODES = {"freerun": 0, "trigger": 1, "fringe": 2, "slow": 3}
+
+#: The ``GTF`` get-command reports the mode bit-coded rather than by its index.
+TRIGGER_MODE_CODES = {0: "freerun", 1: "trigger", 2: "fringe", 4: "slow"}
 
 
 class PulseCheck(Instrument):
@@ -44,6 +46,10 @@ class PulseCheck(Instrument):
 
     Connection is made through an RS232 serial connection, 8 data bits, no
     parity, 1 stop bit, with commands terminated by a carriage return.
+
+    The instrument silently discards a setting if the next command follows too
+    closely, and occasionally even then. Leave at least 0.3 s after writing a
+    property, and read the property back to confirm the setting arrived.
 
     :param adapter: pyvisa resource name of the instrument or an adapter instance.
     :param name: name of the instrument.
@@ -177,13 +183,17 @@ class PulseCheck(Instrument):
 
     trigger_mode = Instrument.control(
         "GTF", "TF%d",
-        """Control the trigger mode (str, one of 'freerun', 'trigger', 'fringe', 'slow').""",
+        """Control the trigger mode (str, one of 'freerun', 'trigger', 'fringe', 'slow').
+
+        Selecting 'trigger' forces :attr:`filter` to 'low', and leaves it there when
+        another mode is selected again.
+        """,
         validator=strict_discrete_set,
-        values=TRIGGER_MODES,
-        # get and set use different (0- vs 1-indexed) encodings, so map manually
+        values=list(TRIGGER_MODES),
+        # get and set use different (bit-coded vs. index) encodings, so map manually
         # instead of via `map_values`, which assumes a single shared encoding.
-        get_process=lambda index: TRIGGER_MODES[index],
-        set_process=lambda mode: TRIGGER_MODES.index(mode) + 1,
+        get_process=lambda code: TRIGGER_MODE_CODES[code],
+        set_process=lambda mode: TRIGGER_MODES[mode],
         cast=int,
     )
 

--- a/pymeasure/instruments/ape/pulsecheck.py
+++ b/pymeasure/instruments/ape/pulsecheck.py
@@ -1,0 +1,274 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+import struct
+import time
+
+import numpy as np
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+#: Trigger modes, in the order used by the ``GTF`` get-command (0-indexed);
+#: the ``TF`` set-command expects the 1-indexed position instead.
+TRIGGER_MODES = ("freerun", "trigger", "fringe", "slow")
+
+
+class PulseCheck(Instrument):
+    """APE PulseCheck autocorrelator.
+
+    Connection is made through an RS232 serial connection, 8 data bits, no
+    parity, 1 stop bit, with commands terminated by a carriage return.
+
+    :param adapter: pyvisa resource name of the instrument or an adapter instance.
+    :param name: name of the instrument.
+    :param baud_rate: baud rate of the serial connection.
+    :param kwargs: any valid key-word argument for :class:`~pymeasure.instruments.Instrument`.
+    """
+
+    def __init__(self, adapter, name="APE PulseCheck", baud_rate=38400, **kwargs):
+        self._last_command = ""
+        super().__init__(
+            adapter,
+            name,
+            write_termination="\r",
+            asrl=dict(baud_rate=baud_rate),
+            **kwargs,
+        )
+
+    def write(self, command):
+        """Write a command to the instrument, terminated by a carriage return.
+
+        The device's replies are raw bytes without any framing that would
+        identify their type or length, so the command is remembered for
+        :meth:`read` to know how to decode the reply.
+
+        :param command: command string, e.g. ``"GG"`` or ``"F2"``.
+        """
+        self._last_command = command
+        super().write(command)
+
+    def read(self):
+        """Read the raw binary reply belonging to the most recently written command."""
+        if self._last_command in ("GG", "GPM"):
+            return str(struct.unpack(">H", self.read_bytes(2))[0])
+        if self._last_command == "GRE":
+            # the resolution is transmitted as its base-2 exponent
+            return str(2 ** self.read_bytes(1)[0])
+        return str(self.read_bytes(1)[0])
+
+    resolution = Instrument.measurement(
+        "GRE",
+        """Get the number of samples per autocorrelation trace
+        (int, one of 4, 8, 16, 32, 64, 128, 256).
+
+        The instrument firmware does not support changing this remotely yet.
+        """,
+        cast=int,
+    )
+
+    gain = Instrument.control(
+        "GG", "GN%d",
+        """Control the detector gain (int strictly from 0 to 999).""",
+        validator=strict_range,
+        values=(0, 999),
+        cast=int,
+    )
+
+    averages = Instrument.control(
+        "GAV", "A%d",
+        """Control the number of averages per autocorrelation trace
+        (int, one of 1, 2, 4, 8, 16).""",
+        validator=strict_discrete_set,
+        values=[1, 2, 4, 8, 16],
+        cast=int,
+    )
+
+    filter = Instrument.control(
+        "GF", "F%d",
+        """Control the low-pass filter setting (str, one of 'low', 'medium', 'high').""",
+        validator=strict_discrete_set,
+        values={"low": 1, "medium": 2, "high": 3},
+        map_values=True,
+        cast=int,
+    )
+
+    math_enabled = Instrument.control(
+        "GM", "M%d",
+        """Control whether the instrument's math/normalization function is enabled (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        cast=int,
+    )
+
+    running = Instrument.control(
+        "GRS", "RS%d",
+        """Control whether the instrument is currently running/scanning (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+        cast=int,
+    )
+
+    scan_range = Instrument.control(
+        "GSR", "SR%d",
+        """Control the scan range in seconds
+        (float, one of 0, 1.5e-12, 5e-12, 15e-12, 50e-12, 150e-12).""",
+        validator=strict_discrete_set,
+        values={0: 0, 1.5e-12: 1, 5e-12: 2, 15e-12: 3, 50e-12: 4, 150e-12: 5},
+        map_values=True,
+        cast=int,
+    )
+
+    alpha = Instrument.measurement(
+        "GPM",
+        """Get the current turning angle/phase-modulation position (int).
+
+        Use :meth:`set_alpha` to move to an absolute position, since the
+        instrument only accepts relative tuning steps.
+        """,
+        cast=int,
+    )
+
+    tau_register = Instrument.measurement(
+        "GTA",
+        """Get the raw value of the device's undocumented ``GTA`` register (int).
+
+        Its meaning is not documented by the manufacturer; this mirrors the
+        ``getTau`` method of the original MATLAB driver.
+        """,
+        cast=int,
+    )
+
+    sensitivity = Instrument.control(
+        "GSY", "SY%d",
+        """Control the (unit-free) input sensitivity (int, one of 1, 3, 10, 30, 100, 300).""",
+        validator=strict_discrete_set,
+        values={1: 1, 3: 2, 10: 3, 30: 4, 100: 5, 300: 6},
+        map_values=True,
+        cast=int,
+    )
+
+    trigger_mode = Instrument.control(
+        "GTF", "TF%d",
+        """Control the trigger mode (str, one of 'freerun', 'trigger', 'fringe', 'slow').""",
+        validator=strict_discrete_set,
+        values=TRIGGER_MODES,
+        # get and set use different (0- vs 1-indexed) encodings, so map manually
+        # instead of via `map_values`, which assumes a single shared encoding.
+        get_process=lambda index: TRIGGER_MODES[index],
+        set_process=lambda mode: TRIGGER_MODES.index(mode) + 1,
+        cast=int,
+    )
+
+    @property
+    def settings(self):
+        """Get a dictionary of the instrument's current settings."""
+        return dict(
+            sensitivity=self.sensitivity,
+            gain=self.gain,
+            scan_range=self.scan_range,
+            filter=self.filter,
+            averages=self.averages,
+            resolution=self.resolution,
+            alpha=self.alpha,
+            math_enabled=self.math_enabled,
+            trigger_mode=self.trigger_mode,
+        )
+
+    def tune(self, delta):
+        """Adjust the turning angle/phase-modulation position by a relative amount.
+
+        :param delta: relative tuning step (int).
+        """
+        self.write(f"TU{int(delta)}")
+
+    def set_alpha(self, alpha, retries=1):
+        """Move the turning angle/phase-modulation position to an absolute target.
+
+        The instrument only accepts relative tuning steps via :meth:`tune`, so
+        this polls :attr:`alpha` and nudges the position repeatedly until the
+        target is reached. If the position does not change for two consecutive
+        polls, tuning is retried up to `retries` times, mirroring the original
+        MATLAB driver's stuck-detection.
+
+        :param alpha: target turning angle/phase-modulation position (int).
+        :param retries: number of additional attempts if tuning gets stuck.
+        :raises TimeoutError: if the target is not reached within the allowed
+            number of attempts.
+        """
+        total_attempts = retries + 1
+        for attempt in range(1, total_attempts + 1):
+            self.tune(alpha - self.alpha)
+
+            time.sleep(1)
+            current = self.alpha
+            stuck = False
+            while current != alpha:
+                log.debug("alpha = %d", current)
+                time.sleep(0.5)
+                if self.alpha == current:
+                    time.sleep(0.5)
+                    if self.alpha == current:
+                        stuck = True
+                        break
+                current = self.alpha
+            if not stuck:
+                return
+            log.warning("Tuning got stuck at alpha = %d (attempt %d/%d).",
+                        current, attempt, total_attempts)
+        raise TimeoutError(
+            f"Tuning alpha to {alpha} got stuck after {total_attempts} attempt(s)."
+        )
+
+    def acf(self):
+        """Measure one autocorrelation trace as raw (unscaled) detector counts.
+
+        The number of samples returned equals :attr:`resolution`.
+
+        :returns: list of int, the raw detector counts.
+        """
+        n_samples = self.resolution
+        # No other command may be written between write() and read_bytes() below
+        # (e.g. from another thread), since the device sends the raw trace
+        # immediately after "GAC" with no framing to identify it.
+        self.write("GAC")
+        raw = self.read_bytes(2 * n_samples)
+        return [value >> 6 for value in struct.unpack(f">{n_samples}H", raw)]
+
+    def get_autocorrelation(self):
+        """Measure one autocorrelation trace together with its delay axis.
+
+        :returns: a tuple ``(delay, acf)`` of numpy arrays; the delay axis is
+            in seconds, the autocorrelation is in raw detector counts.
+        """
+        acf = np.array(self.acf())
+        scan_range = self.scan_range
+        delay = np.linspace(-scan_range / 2, scan_range / 2, len(acf))
+        return delay, acf

--- a/pymeasure/instruments/ape/pulsecheck.py
+++ b/pymeasure/instruments/ape/pulsecheck.py
@@ -243,23 +243,27 @@ class PulseCheck(Instrument):
         if retries < 0:
             raise ValueError(f"retries has to be zero or more, not {retries}.")
         deadline = time.monotonic() + timeout
+
+        def raise_if_timed_out(position):
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"Tuning alpha to {alpha} timed out at {position} after {timeout} s."
+                )
+
         total_attempts = retries + 1
         for attempt in range(1, total_attempts + 1):
-            self.tune(alpha - self.alpha)
+            current = self.alpha
+            # don't send a tuning command once the deadline has passed
+            raise_if_timed_out(current)
+            self.tune(alpha - current)
 
             time.sleep(1)
             current = self.alpha
-            if time.monotonic() > deadline:
-                raise TimeoutError(
-                    f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
-                )
+            raise_if_timed_out(current)
             stuck = False
             while current != alpha:
                 log.debug("alpha = %d", current)
-                if time.monotonic() > deadline:
-                    raise TimeoutError(
-                        f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
-                    )
+                raise_if_timed_out(current)
                 time.sleep(0.5)
                 if self.alpha == current:
                     time.sleep(0.5)
@@ -268,10 +272,7 @@ class PulseCheck(Instrument):
                         break
                 current = self.alpha
             if not stuck:
-                if time.monotonic() > deadline:
-                    raise TimeoutError(
-                        f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
-                    )
+                raise_if_timed_out(current)
                 return
             log.warning("Tuning got stuck at alpha = %d (attempt %d/%d).",
                         current, attempt, total_attempts)

--- a/pymeasure/instruments/ape/pulsecheck.py
+++ b/pymeasure/instruments/ape/pulsecheck.py
@@ -206,17 +206,17 @@ class PulseCheck(Instrument):
     @property
     def settings(self):
         """Get a dictionary of the instrument's current settings."""
-        return dict(
-            sensitivity=self.sensitivity,
-            gain=self.gain,
-            scan_range=self.scan_range,
-            filter=self.filter,
-            averages=self.averages,
-            resolution=self.resolution,
-            alpha=self.alpha,
-            math_enabled=self.math_enabled,
-            trigger_mode=self.trigger_mode,
-        )
+        return {
+            "sensitivity": self.sensitivity,
+            "gain": self.gain,
+            "scan_range": self.scan_range,
+            "filter": self.filter,
+            "averages": self.averages,
+            "resolution": self.resolution,
+            "alpha": self.alpha,
+            "math_enabled": self.math_enabled,
+            "trigger_mode": self.trigger_mode,
+        }
 
     def tune(self, delta):
         """Adjust the turning angle/phase-modulation position by a relative amount.
@@ -249,6 +249,10 @@ class PulseCheck(Instrument):
 
             time.sleep(1)
             current = self.alpha
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
+                )
             stuck = False
             while current != alpha:
                 log.debug("alpha = %d", current)
@@ -264,6 +268,10 @@ class PulseCheck(Instrument):
                         break
                 current = self.alpha
             if not stuck:
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"Tuning alpha to {alpha} timed out at {current} after {timeout} s."
+                    )
                 return
             log.warning("Tuning got stuck at alpha = %d (attempt %d/%d).",
                         current, attempt, total_attempts)

--- a/pymeasure/instruments/ape/pulsecheck_usb.py
+++ b/pymeasure/instruments/ape/pulsecheck_usb.py
@@ -1,0 +1,471 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from enum import IntFlag
+
+import numpy as np
+
+from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+#: Numbers of samples per trace, in the order the ``STATUS:RESOLUTION`` command indexes them.
+RESOLUTIONS = (200, 500, 1000, 1500, 2000)
+
+#: Resolution names, in the same order; the software accepts them instead of the index.
+RESOLUTION_NAMES = ("very low", "low", "medium", "high", "very high")
+
+
+def parse_resolution(reply):
+    """Convert a ``STATUS:RESOLUTION?`` reply into a number of samples per trace.
+
+    The manual lists the index, the number of samples and a name as equivalent notations,
+    without stating which one the software answers with, so all three are accepted here.
+
+    :param reply: the reply of the instrument (str).
+    :returns: number of samples per trace (int).
+    """
+    reply = reply.strip().lower()
+    if reply in RESOLUTION_NAMES:
+        return RESOLUTIONS[RESOLUTION_NAMES.index(reply)]
+    value = int(reply)
+    return RESOLUTIONS[value] if value < len(RESOLUTIONS) else value
+
+
+class OperationStatus(IntFlag):
+    """Operation status of the software, as returned by ``*OPER?``."""
+
+    DISCONNECTED = 1 << 0
+    VISA_CONNECTED = 1 << 1
+    DEVICE_INITIALIZED = 1 << 2
+    DEVICE_READY = 1 << 3
+    DEVICE_BUSY = 1 << 4
+    STANDBY = 1 << 5  #: delay motor switched off
+    DATA_ERROR = 1 << 6  #: ACF not valid, see :attr:`PulseCheckUSB.data_errors`
+    SOFTWARE_ERROR = 1 << 7
+    FIRMWARE_ERROR = 1 << 8  #: see :attr:`PulseCheckUSB.firmware_errors`
+    SHUTDOWN = 1 << 9
+    SERVICE_MODE = 1 << 10
+
+
+class InitializationStatus(IntFlag):
+    """Initialization status of the device, as returned by ``*INIT?``."""
+
+    LINK_OK = 1 << 2
+    OPTIC_OK = 1 << 3
+
+
+class BusyStatus(IntFlag):
+    """Busy status of the device, as returned by ``*BUSY?``."""
+
+    IDLE = 1 << 0
+    NEW_DATA = 1 << 1
+    MEASUREMENT_RUNNING = 1 << 2
+    FIT_RUNNING = 1 << 3
+
+
+class DataError(IntFlag):
+    """Quality problems of the measured autocorrelation, as returned by ``*ERR?``."""
+
+    SIGNAL_TOO_LOW = 1 << 0
+    SIGNAL_TOO_HIGH = 1 << 1
+    NO_PEAK_FOUND = 1 << 2
+    ASYMMETRIC_ACF = 1 << 3
+    DYNAMIC_RANGE_TOO_LOW = 1 << 4
+    SCAN_RANGE_TOO_LOW = 1 << 5
+    NEGATIVE_OFFSET = 1 << 6
+
+
+class FirmwareError(IntFlag):
+    """Firmware errors of the controller, as returned by ``*FRMW?``."""
+
+    PARSER_ERROR = 1 << 0
+    PARAMETER_ERROR = 1 << 1
+    FRAM_ERROR = 1 << 2
+    # the manual names both bit 3 and bit 4 "I2C-0 Error"
+    I2C_0_ERROR = 1 << 3
+    I2C_1_ERROR = 1 << 4
+    I2C_LOCKED = 1 << 5
+    CONFIGURATION_ERROR = 1 << 6
+    OPTICS_ERROR = 1 << 7
+    BUFFER_OVERFLOW = 1 << 8
+    DMA_ERROR = 1 << 9
+    USB_ERROR = 1 << 10
+    DATA_TIMEOUT = 1 << 11
+
+
+class PulseCheckUSB(SCPIMixin, Instrument):
+    """APE pulseCheck USB autocorrelator.
+
+    The autocorrelator is attached via USB to a Windows PC running the APE pulseLink control
+    software, and that software provides the remote interface: it has to be running, and its
+    TCP/IP port has to be enabled under ``Extras`` → ``TCP`` (APE recommends a port number
+    between 50000 and 64000). This driver connects to that port, either on the local machine or
+    over the network::
+
+        from pymeasure.instruments.ape import PulseCheckUSB
+
+        pulse_check = PulseCheckUSB("TCPIP::192.168.0.10::51123::SOCKET")
+        print(pulse_check.id)
+        delay, intensity = pulse_check.acf
+
+    Do not send these commands to the controller over USB directly, and note that the older
+    pulseCheck models with an RS232 port use a different command set, see
+    :class:`~pymeasure.instruments.ape.pulsecheck.PulseCheck`.
+
+    :param adapter: pyvisa resource name of the PC running the pulseLink software, or an
+        adapter instance.
+    :param name: name of the instrument.
+    :param kwargs: any valid key-word argument for :class:`~pymeasure.instruments.Instrument`.
+    """
+
+    def __init__(self, adapter, name="APE pulseCheck USB", **kwargs):
+        kwargs.setdefault("write_termination", "\r\n")
+        kwargs.setdefault("read_termination", "\n")
+        kwargs.setdefault("timeout", 5000)
+        super().__init__(adapter, name, **kwargs)
+
+    def read(self):
+        """Read a reply, discarding the padding null bytes the software may add."""
+        return super().read().replace("\x00", "").strip()
+
+    def _read_block(self):
+        """Read a definite length block, as the software sends it in reply to data queries.
+
+        :returns: the payload of the block (bytes).
+        """
+        start = self.read_bytes(1)
+        if start != b"#":
+            raise ValueError(f"Expected a block starting with '#', but got {start!r}.")
+        digits = int(self.read_bytes(1))
+        return self.read_bytes(int(self.read_bytes(digits)))
+
+    def _read_trace(self, command):
+        """Read a trace transferred as a block of interleaved intensity and delay values.
+
+        :param command: query returning the trace.
+        :returns: a tuple ``(delay, intensity)`` of numpy arrays, with the delay in s.
+        """
+        self.write(command)
+        # the block holds little-endian doubles as [y0, x0, y1, x1, ...] with x the delay in ps
+        values = np.frombuffer(self._read_block(), dtype="<f8")
+        return values[1::2] * 1e-12, values[0::2]
+
+    device_name = Instrument.measurement(
+        "SYSTEM:DEVICE?",
+        """Get the device name (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    serial_number = Instrument.measurement(
+        "SYSTEM:SNUMBER?",
+        """Get the serial number of the device (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    software_version = Instrument.measurement(
+        "SYSTEM:SOFTWARE?",
+        """Get the version of the pulseLink control software (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    hardware_version = Instrument.measurement(
+        "SYSTEM:HARDWARE?",
+        """Get the hardware version of the device (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    firmware_version = Instrument.measurement(
+        "SYSTEM:FIRMWARE?",
+        """Get the firmware version of the controller (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    motor_type = Instrument.measurement(
+        "SYSTEM:MOTOR?",
+        """Get the type of the delay motor (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    operation_status = Instrument.measurement(
+        "*OPER?",
+        """Get the operation status of the software (:class:`OperationStatus`).""",
+        cast=int,
+        get_process=OperationStatus,
+    )
+
+    initialization_status = Instrument.measurement(
+        "*INIT?",
+        """Get the initialization status of the device (:class:`InitializationStatus`).""",
+        cast=int,
+        # the upper four bits are documented as always being "1"
+        get_process=lambda value: InitializationStatus(value & 0x0F),
+    )
+
+    busy_status = Instrument.measurement(
+        "*BUSY?",
+        """Get the busy status of the device (:class:`BusyStatus`).""",
+        cast=int,
+        get_process=BusyStatus,
+    )
+
+    data_errors = Instrument.measurement(
+        "*ERR?",
+        """Get the quality problems of the measured autocorrelation (:class:`DataError`).""",
+        cast=int,
+        get_process=DataError,
+    )
+
+    firmware_errors = Instrument.measurement(
+        "*FRMW?",
+        """Get the errors reported by the controller firmware (:class:`FirmwareError`).""",
+        cast=int,
+        get_process=FirmwareError,
+    )
+
+    measurement_running = Instrument.measurement(
+        "STATUS:START?",
+        """Get whether a measurement is running (bool).
+
+        The remote command set does not include starting or stopping the measurement, this has
+        to be done with the "Start" button of the pulseLink software.
+        """,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    averages = Instrument.control(
+        "STATUS:AVERAGE?", "STATUS:AVERAGE=%d",
+        """Control the number of measurements averaged into one trace
+        (int, one of 1, 2, 4, 8, 16).""",
+        validator=strict_discrete_set,
+        values={1: 0, 2: 1, 4: 2, 8: 3, 16: 4},
+        map_values=True,
+    )
+
+    resolution = Instrument.control(
+        "STATUS:RESOLUTION?", "STATUS:RESOLUTION=%d",
+        """Control the number of samples per trace
+        (int, one of 200, 500, 1000, 1500, 2000).""",
+        validator=strict_discrete_set,
+        values=RESOLUTIONS,
+        set_process=RESOLUTIONS.index,
+        cast=str,
+        get_process=parse_resolution,
+    )
+
+    fit_type = Instrument.control(
+        "STATUS:FITTYPE?", "STATUS:FITTYPE=%d",
+        """Control the model fitted to the autocorrelation
+        (str, one of 'none', 'gaussian', 'sech2', 'lorentz').""",
+        validator=strict_discrete_set,
+        values={"none": 0, "gaussian": 1, "sech2": 2, "lorentz": 3},
+        map_values=True,
+    )
+
+    filter_enabled = Instrument.control(
+        "STATUS:FILTER?", "STATUS:FILTER=%d",
+        """Control whether the autocorrelation is filtered (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    scan_range = Instrument.control(
+        "MOTOR:SCANRANGE?", "MOTOR:SCANRANGE=%d",
+        """Control the scan range in s (float, one of 0, 150e-15, 500e-15, 1.5e-12, 5e-12,
+        15e-12, 50e-12, 150e-12).
+
+        A scan range of 0 stops the delay drive at the zero position. Which of the ranges are
+        available depends on the configuration of the device.
+        """,
+        validator=strict_discrete_set,
+        values={0: 0, 150e-15: 150, 500e-15: 500, 1.5e-12: 1500, 5e-12: 5000,
+                15e-12: 15000, 50e-12: 50000, 150e-12: 150000},
+        map_values=True,
+    )
+
+    gain = Instrument.control(
+        "DETECTOR:GAIN?", "DETECTOR:GAIN=%d",
+        """Control the detector gain (int strictly from 300 to 1000).""",
+        validator=strict_range,
+        values=(300, 1000),
+        cast=int,
+    )
+
+    autogain_enabled = Instrument.control(
+        "DETECTOR:AUTOGAIN?", "DETECTOR:AUTOGAIN=%d",
+        """Control whether the gain is adjusted automatically (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    sensitivity = Instrument.control(
+        "DETECTOR:SENSITIVITY?", "DETECTOR:SENSITIVITY=%d",
+        """Control the detector sensitivity (int, 1 for low or 10 for high sensitivity, 100
+        with the optional "HighSen" feature).""",
+        validator=strict_discrete_set,
+        values=(1, 10, 100),
+        cast=int,
+    )
+
+    trigger_level = Instrument.measurement(
+        "TRIGGER:LEVEL?",
+        """Get the trigger level in V (float from 0.2 to 5).""",
+        get_process=lambda value: value * 1e-3,
+    )
+
+    trigger_delay = Instrument.measurement(
+        "TRIGGER:DELAY?",
+        """Get the trigger delay in s (float from 1e-6 to 50e-6).""",
+        get_process=lambda value: value * 1e-6,
+    )
+
+    trigger_frequency = Instrument.measurement(
+        "TRIGGER:FREQUENCY?",
+        """Get the trigger frequency in Hz (float).""",
+    )
+
+    trigger_impedance = Instrument.measurement(
+        "TRIGGER:IMPEDANCE?",
+        """Get the trigger impedance in Ohm (float).""",
+    )
+
+    @property
+    def acf(self):
+        """Get the raw autocorrelation as a tuple ``(delay, intensity)`` of numpy arrays, with
+        the delay in s and the intensity in arbitrary units.
+
+        The measurement has to be running for the data to be valid.
+        """
+        return self._read_trace("ACF:DATA?")
+
+    @property
+    def displayed_acf(self):
+        """Get the autocorrelation as displayed by the software, i.e. with filtering and
+        averaging applied, as a tuple ``(delay, intensity)`` of numpy arrays, with the delay in
+        s and the intensity in arbitrary units.
+        """
+        return self._read_trace("ACF:DISPLAYED_ACF?")
+
+    acf_mean_data = Instrument.measurement(
+        "ACF:MEANDATA?",
+        """Get the mean values of the autocorrelation as a dict with the keys 'average',
+        'delay_max', 'delay_min' (in s), 'intensity_max' and 'intensity_min'.""",
+        separator=";",
+        get_process_list=lambda values: {
+            "average": values[0],
+            "delay_max": values[1] * 1e-12,
+            "delay_min": values[2] * 1e-12,
+            "intensity_max": values[3],
+            "intensity_min": values[4],
+        },
+    )
+
+    fwhm = Instrument.measurement(
+        "ACF:FWHM?",
+        """Get the FWHM of the measured autocorrelation in s (float).""",
+        get_process=lambda value: value * 1e-12,
+    )
+
+    fit_fwhm = Instrument.measurement(
+        "ACF:FITFWHM?",
+        """Get the FWHM of the fitted autocorrelation in s (float).
+
+        Use :attr:`fit_type` to select the model that is fitted.
+        """,
+        get_process=lambda value: value * 1e-12,
+    )
+
+    fix_shutter_open = Instrument.control(
+        "SHUTTER:FIX?", "SHUTTER:FIX=%d",
+        """Control whether the shutter of the fixed arm is open (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    scan_shutter_open = Instrument.control(
+        "SHUTTER:SCAN?", "SHUTTER:SCAN=%d",
+        """Control whether the shutter of the scanning arm is open (bool).""",
+        validator=strict_discrete_set,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    crystal_position = Instrument.control(
+        "XTAL:TUNING?", "XTAL:TUNING=%d",
+        """Control the position of the phase matching crystal
+        (int strictly from 500 to 11000).""",
+        validator=strict_range,
+        values=(500, 11000),
+        cast=int,
+    )
+
+    crystal_wavelength = Instrument.control(
+        "XTAL:LAMBDATUNE?", "XTAL:LAMBDATUNE=%d",
+        """Control the phase matching crystal position in terms of the laser wavelength in nm
+        (int).""",
+        cast=int,
+    )
+
+    crystal_moving = Instrument.measurement(
+        "XTAL:MOVE?",
+        """Get whether the crystal motor is moving (bool).""",
+        values={True: 1, False: 0},
+        map_values=True,
+    )
+
+    crystal_type = Instrument.measurement(
+        "XTAL:SETXTAL?",
+        """Get the type of the phase matching crystal (str).""",
+        cast=str,
+        maxsplit=0,
+    )
+
+    def check_errors(self):
+        """Read the errors the controller firmware reports.
+
+        The software does not implement the SCPI error queue, the firmware error register is
+        read instead. Problems with the measured autocorrelation itself are not errors in this
+        sense, see :attr:`data_errors` for those.
+
+        :returns: list of the firmware errors, empty if there are none.
+        """
+        errors = self.firmware_errors
+        if not errors:
+            return []
+        log.error("%s: %s", self.name, errors)
+        return [errors]

--- a/pymeasure/instruments/ape/pulsecheck_usb.py
+++ b/pymeasure/instruments/ape/pulsecheck_usb.py
@@ -53,29 +53,42 @@ def parse_resolution(reply):
 
     :param reply: the reply of the instrument (str).
     :returns: number of samples per trace (int).
+    :raises ValueError: if the reply is none of the three notations.
     """
     reply = reply.strip().lower()
     if reply in RESOLUTION_NAMES:
         return RESOLUTIONS[RESOLUTION_NAMES.index(reply)]
     value = int(reply)
-    return RESOLUTIONS[value] if value < len(RESOLUTIONS) else value
+    if value in RESOLUTIONS:
+        return value
+    if 0 <= value < len(RESOLUTIONS):
+        return RESOLUTIONS[value]
+    raise ValueError(f"Cannot interpret '{reply}' as a resolution.")
 
 
 def parse_averages(reply):
     """Convert a ``STATUS:AVERAGE?`` reply into a number of averaged measurements.
 
     The software answers with a name followed by the number in brackets, e.g. ``'Off'`` or
-    ``'Low (2)'``, while the manual documents the index the set command expects.
+    ``'Low (2)'``, while the manual documents the index the set command expects. A bare number
+    is read as the number of measurements where that is possible, and as the index otherwise,
+    so the indices 1, 2 and 4 cannot be told apart from the counts of the same name.
 
     :param reply: the reply of the instrument (str).
     :returns: number of measurements averaged into one trace (int).
+    :raises ValueError: if the reply is neither a name nor a count nor an index.
     """
     reply = reply.strip().lower()
     if "(" in reply:
         return int(reply[reply.index("(") + 1:reply.index(")")])
     if reply.startswith("off"):
         return 1
-    return AVERAGES[int(reply)]
+    value = int(reply)
+    if value in AVERAGES:
+        return value
+    if 0 <= value < len(AVERAGES):
+        return AVERAGES[value]
+    raise ValueError(f"Cannot interpret '{reply}' as a number of averages.")
 
 
 class OperationStatus(IntFlag):
@@ -168,17 +181,20 @@ class PulseCheckUSB(SCPIMixin, Instrument):
     :param adapter: pyvisa resource name of the PC running the pulseLink software, or an
         adapter instance.
     :param name: name of the instrument.
+    :param connection_delay: how long to wait after opening the connection, in s. Only applies
+        if this call opened it; wait yourself when handing in a ready-made adapter.
     :param kwargs: any valid key-word argument for :class:`~pymeasure.instruments.Instrument`.
     """
 
-    def __init__(self, adapter, name="APE pulseCheck USB", **kwargs):
+    def __init__(self, adapter, name="APE pulseCheck USB", connection_delay=1, **kwargs):
         kwargs.setdefault("write_termination", "\r\n")
         kwargs.setdefault("read_termination", "\n")
         kwargs.setdefault("timeout", 5000)
         super().__init__(adapter, name, **kwargs)
         if isinstance(adapter, (int, str)):
-            # the software silently drops commands sent right after opening the connection
-            time.sleep(1)
+            # only when this call opened the connection: the software silently drops commands
+            # sent right after. A ready-made adapter is assumed to be connected already.
+            time.sleep(connection_delay)
 
     def read(self):
         """Read a reply, discarding the padding null bytes the software may add.
@@ -208,7 +224,7 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         start = self.read_bytes(1)
         if start != b"#":
             raise ValueError(f"Expected a data block in reply to '{command}', but got "
-                             f"'{start.decode() + self.read()}'.")
+                             f"'{start.decode(errors='replace') + self.read()}'.")
         payload = self._read_block()
         if not payload or len(payload) % 16:
             # without valid data the software sends a message instead, e.g. "Time out"
@@ -216,7 +232,8 @@ class PulseCheckUSB(SCPIMixin, Instrument):
                              f"trace data, check whether the measurement is running.")
         # the block holds little-endian doubles as [y0, x0, y1, x1, ...] with x the delay in ps
         values = np.frombuffer(payload, dtype="<f8")
-        return values[1::2] * 1e-12, values[0::2]
+        # `values` is a read-only view of the reply, so copy what is not built anew anyway
+        return values[1::2] * 1e-12, values[0::2].copy()
 
     device_name = Instrument.measurement(
         "SYSTEM:DEVICE?",
@@ -446,7 +463,10 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         # the software sends this reply as a plain line, but falls back to a block holding a
         # message, e.g. "Time out", whenever it has no valid data
         reply = self._read_block().decode(errors="replace") if start == b"#" \
-            else start.decode() + self.read()
+            else start.decode(errors="replace") + self.read()
+        # read() cannot spot this itself, since the first character was consumed above
+        if reply == "Parser error":
+            raise ValueError(f"{self.name} did not understand the command.")
         values = reply.split(";")
         if len(values) != 5:
             raise ValueError(f"{self.name} sent '{reply}' instead of the mean values, check "
@@ -510,6 +530,9 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         """Set the phase matching crystal to the position calibrated for a laser wavelength in
         nm (int).
 
+        The manual documents no limits, since the range that makes sense depends on the optics
+        set installed, e.g. 700 to 1100 nm for NIR or 1000 to 1600 nm for IR.
+
         There is no counterpart to read the wavelength back: ``XTAL:LAMBDATUNE?`` answers with
         the crystal position, just like :attr:`crystal_position`.
         """,
@@ -542,4 +565,5 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         if not errors:
             return []
         log.error("%s: %s", self.name, errors)
-        return [errors]
+        # iterating the flag itself would need Python 3.11
+        return [error for error in FirmwareError if error in errors]

--- a/pymeasure/instruments/ape/pulsecheck_usb.py
+++ b/pymeasure/instruments/ape/pulsecheck_usb.py
@@ -163,7 +163,7 @@ class PulseCheckUSB(SCPIMixin, Instrument):
     The software implements only part of the SCPI standard commands, :attr:`options` and
     :attr:`next_error` are not among them. It also applies a new setting asynchronously, so
     reading a property back right after writing it may still yield the previous value; allow
-    for about a second.
+    for about a second, and see :attr:`gain` for the detector settings.
 
     :param adapter: pyvisa resource name of the PC running the pulseLink software, or an
         adapter instance.
@@ -363,7 +363,13 @@ class PulseCheckUSB(SCPIMixin, Instrument):
 
     gain = Instrument.control(
         "DETECTOR:GAIN?", "DETECTOR:GAIN=%d",
-        """Control the detector gain (int strictly from 300 to 1000).""",
+        """Control the detector gain (int strictly from 300 to 1000).
+
+        The software passes the detector settings on to the controller only once a further
+        command reaches it, and answers with the previous value until then. Reading in a loop
+        does not help, since queries do not trigger the update either; write the value twice
+        if the read back has to agree immediately.
+        """,
         validator=strict_range,
         values=(300, 1000),
         cast=int,
@@ -380,7 +386,12 @@ class PulseCheckUSB(SCPIMixin, Instrument):
     sensitivity = Instrument.control(
         "DETECTOR:SENSITIVITY?", "DETECTOR:SENSITIVITY=%d",
         """Control the detector sensitivity (int, 1 for low or 10 for high sensitivity, 100
-        with the optional "HighSen" feature).""",
+        with the optional "HighSen" feature).
+
+        The read back lags behind a change in the same way as the one of :attr:`gain`, and the
+        software passes a new sensitivity on only while the measurement is running, taking up
+        to several seconds to do so.
+        """,
         validator=strict_discrete_set,
         values=(1, 10, 100),
         cast=int,

--- a/pymeasure/instruments/ape/pulsecheck_usb.py
+++ b/pymeasure/instruments/ape/pulsecheck_usb.py
@@ -23,11 +23,12 @@
 #
 
 import logging
+import time
 from enum import IntFlag
 
 import numpy as np
 
-from pymeasure.instruments import Instrument, SCPIMixin
+from pymeasure.instruments import Instrument, SCPIMixin, cast_or_str
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
 log = logging.getLogger(__name__)
@@ -40,12 +41,15 @@ RESOLUTIONS = (200, 500, 1000, 1500, 2000)
 #: Resolution names, in the same order; the software accepts them instead of the index.
 RESOLUTION_NAMES = ("very low", "low", "medium", "high", "very high")
 
+#: Numbers of averaged measurements, in the order the ``STATUS:AVERAGE`` command indexes them.
+AVERAGES = (1, 2, 4, 8, 16)
+
 
 def parse_resolution(reply):
     """Convert a ``STATUS:RESOLUTION?`` reply into a number of samples per trace.
 
-    The manual lists the index, the number of samples and a name as equivalent notations,
-    without stating which one the software answers with, so all three are accepted here.
+    The software answers with the number of samples, while the manual documents the index,
+    the number of samples and a name as equivalent notations, so all three are accepted here.
 
     :param reply: the reply of the instrument (str).
     :returns: number of samples per trace (int).
@@ -55,6 +59,23 @@ def parse_resolution(reply):
         return RESOLUTIONS[RESOLUTION_NAMES.index(reply)]
     value = int(reply)
     return RESOLUTIONS[value] if value < len(RESOLUTIONS) else value
+
+
+def parse_averages(reply):
+    """Convert a ``STATUS:AVERAGE?`` reply into a number of averaged measurements.
+
+    The software answers with a name followed by the number in brackets, e.g. ``'Off'`` or
+    ``'Low (2)'``, while the manual documents the index the set command expects.
+
+    :param reply: the reply of the instrument (str).
+    :returns: number of measurements averaged into one trace (int).
+    """
+    reply = reply.strip().lower()
+    if "(" in reply:
+        return int(reply[reply.index("(") + 1:reply.index(")")])
+    if reply.startswith("off"):
+        return 1
+    return AVERAGES[int(reply)]
 
 
 class OperationStatus(IntFlag):
@@ -132,11 +153,17 @@ class PulseCheckUSB(SCPIMixin, Instrument):
 
         pulse_check = PulseCheckUSB("TCPIP::192.168.0.10::51123::SOCKET")
         print(pulse_check.id)
+        pulse_check.measurement_running = True
         delay, intensity = pulse_check.acf
 
     Do not send these commands to the controller over USB directly, and note that the older
     pulseCheck models with an RS232 port use a different command set, see
     :class:`~pymeasure.instruments.ape.pulsecheck.PulseCheck`.
+
+    The software implements only part of the SCPI standard commands, :attr:`options` and
+    :attr:`next_error` are not among them. It also applies a new setting asynchronously, so
+    reading a property back right after writing it may still yield the previous value; allow
+    for about a second.
 
     :param adapter: pyvisa resource name of the PC running the pulseLink software, or an
         adapter instance.
@@ -149,19 +176,25 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         kwargs.setdefault("read_termination", "\n")
         kwargs.setdefault("timeout", 5000)
         super().__init__(adapter, name, **kwargs)
+        if isinstance(adapter, (int, str)):
+            # the software silently drops commands sent right after opening the connection
+            time.sleep(1)
 
     def read(self):
-        """Read a reply, discarding the padding null bytes the software may add."""
-        return super().read().replace("\x00", "").strip()
+        """Read a reply, discarding the padding null bytes the software may add.
+
+        :raises ValueError: if the software did not understand the command.
+        """
+        reply = super().read().replace("\x00", "").strip()
+        if reply == "Parser error":
+            raise ValueError(f"{self.name} did not understand the command.")
+        return reply
 
     def _read_block(self):
-        """Read a definite length block, as the software sends it in reply to data queries.
+        """Read the payload of a definite length block, whose ``#`` is already consumed.
 
         :returns: the payload of the block (bytes).
         """
-        start = self.read_bytes(1)
-        if start != b"#":
-            raise ValueError(f"Expected a block starting with '#', but got {start!r}.")
         digits = int(self.read_bytes(1))
         return self.read_bytes(int(self.read_bytes(digits)))
 
@@ -172,8 +205,17 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         :returns: a tuple ``(delay, intensity)`` of numpy arrays, with the delay in s.
         """
         self.write(command)
+        start = self.read_bytes(1)
+        if start != b"#":
+            raise ValueError(f"Expected a data block in reply to '{command}', but got "
+                             f"'{start.decode() + self.read()}'.")
+        payload = self._read_block()
+        if not payload or len(payload) % 16:
+            # without valid data the software sends a message instead, e.g. "Time out"
+            raise ValueError(f"{self.name} sent '{payload.decode(errors='replace')}' instead of "
+                             f"trace data, check whether the measurement is running.")
         # the block holds little-endian doubles as [y0, x0, y1, x1, ...] with x the delay in ps
-        values = np.frombuffer(self._read_block(), dtype="<f8")
+        values = np.frombuffer(payload, dtype="<f8")
         return values[1::2] * 1e-12, values[0::2]
 
     device_name = Instrument.measurement(
@@ -254,13 +296,14 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         get_process=FirmwareError,
     )
 
-    measurement_running = Instrument.measurement(
-        "STATUS:START?",
-        """Get whether a measurement is running (bool).
+    measurement_running = Instrument.control(
+        "STATUS:START?", "STATUS:START=%d",
+        """Control whether the measurement is running (bool).
 
-        The remote command set does not include starting or stopping the measurement, this has
-        to be done with the "Start" button of the pulseLink software.
+        Setting this is equivalent to the "Start" button of the pulseLink software. The manual
+        documents the query only, but the set command works as well (pulseLink 1.9.3.12).
         """,
+        validator=strict_discrete_set,
         values={True: 1, False: 0},
         map_values=True,
     )
@@ -270,8 +313,10 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         """Control the number of measurements averaged into one trace
         (int, one of 1, 2, 4, 8, 16).""",
         validator=strict_discrete_set,
-        values={1: 0, 2: 1, 4: 2, 8: 3, 16: 4},
-        map_values=True,
+        values=AVERAGES,
+        set_process=AVERAGES.index,
+        cast=str,
+        get_process=parse_averages,
     )
 
     resolution = Instrument.control(
@@ -380,33 +425,48 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         """
         return self._read_trace("ACF:DISPLAYED_ACF?")
 
-    acf_mean_data = Instrument.measurement(
-        "ACF:MEANDATA?",
+    @property
+    def acf_mean_data(self):
         """Get the mean values of the autocorrelation as a dict with the keys 'average',
-        'delay_max', 'delay_min' (in s), 'intensity_max' and 'intensity_min'.""",
-        separator=";",
-        get_process_list=lambda values: {
-            "average": values[0],
-            "delay_max": values[1] * 1e-12,
-            "delay_min": values[2] * 1e-12,
-            "intensity_max": values[3],
-            "intensity_min": values[4],
-        },
-    )
+        'delay_max', 'delay_min' (in s), 'intensity_max' and 'intensity_min'.
+        """
+        self.write("ACF:MEANDATA?")
+        start = self.read_bytes(1)
+        # the software sends this reply as a plain line, but falls back to a block holding a
+        # message, e.g. "Time out", whenever it has no valid data
+        reply = self._read_block().decode(errors="replace") if start == b"#" \
+            else start.decode() + self.read()
+        values = reply.split(";")
+        if len(values) != 5:
+            raise ValueError(f"{self.name} sent '{reply}' instead of the mean values, check "
+                             f"whether the measurement is running.")
+        average, delay_max, delay_min, intensity_max, intensity_min = map(float, values)
+        return {
+            "average": average,
+            "delay_max": delay_max * 1e-12,
+            "delay_min": delay_min * 1e-12,
+            "intensity_max": intensity_max,
+            "intensity_min": intensity_min,
+        }
 
     fwhm = Instrument.measurement(
         "ACF:FWHM?",
         """Get the FWHM of the measured autocorrelation in s (float).""",
-        get_process=lambda value: value * 1e-12,
+        cast=cast_or_str(float),
+        # float() raises with a helpful message if the software reports a problem instead
+        get_process=lambda value: float(value) * 1e-12,
     )
 
     fit_fwhm = Instrument.measurement(
         "ACF:FITFWHM?",
         """Get the FWHM of the fitted autocorrelation in s (float).
 
-        Use :attr:`fit_type` to select the model that is fitted.
+        Use :attr:`fit_type` to select the model that is fitted; without a fit the software
+        answers with "No fit data" instead of a value.
         """,
-        get_process=lambda value: value * 1e-12,
+        cast=cast_or_str(float),
+        # float() raises with a helpful message if the software has no fit to report
+        get_process=lambda value: float(value) * 1e-12,
     )
 
     fix_shutter_open = Instrument.control(
@@ -434,11 +494,14 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         cast=int,
     )
 
-    crystal_wavelength = Instrument.control(
-        "XTAL:LAMBDATUNE?", "XTAL:LAMBDATUNE=%d",
-        """Control the phase matching crystal position in terms of the laser wavelength in nm
-        (int).""",
-        cast=int,
+    crystal_wavelength = Instrument.setting(
+        "XTAL:LAMBDATUNE=%d",
+        """Set the phase matching crystal to the position calibrated for a laser wavelength in
+        nm (int).
+
+        There is no counterpart to read the wavelength back: ``XTAL:LAMBDATUNE?`` answers with
+        the crystal position, just like :attr:`crystal_position`.
+        """,
     )
 
     crystal_moving = Instrument.measurement(

--- a/pymeasure/instruments/ape/pulsecheck_usb.py
+++ b/pymeasure/instruments/ape/pulsecheck_usb.py
@@ -92,7 +92,7 @@ def parse_averages(reply):
 
 
 class OperationStatus(IntFlag):
-    """Operation status of the software, as returned by ``*OPER?``."""
+    """Represent the operation status of the software, as returned by ``*OPER?``."""
 
     DISCONNECTED = 1 << 0
     VISA_CONNECTED = 1 << 1
@@ -108,14 +108,14 @@ class OperationStatus(IntFlag):
 
 
 class InitializationStatus(IntFlag):
-    """Initialization status of the device, as returned by ``*INIT?``."""
+    """Represent the initialization status of the device, as returned by ``*INIT?``."""
 
     LINK_OK = 1 << 2
     OPTIC_OK = 1 << 3
 
 
 class BusyStatus(IntFlag):
-    """Busy status of the device, as returned by ``*BUSY?``."""
+    """Represent the busy status of the device, as returned by ``*BUSY?``."""
 
     IDLE = 1 << 0
     NEW_DATA = 1 << 1
@@ -124,7 +124,7 @@ class BusyStatus(IntFlag):
 
 
 class DataError(IntFlag):
-    """Quality problems of the measured autocorrelation, as returned by ``*ERR?``."""
+    """Represent quality problems of the measured autocorrelation, as returned by ``*ERR?``."""
 
     SIGNAL_TOO_LOW = 1 << 0
     SIGNAL_TOO_HIGH = 1 << 1
@@ -136,7 +136,7 @@ class DataError(IntFlag):
 
 
 class FirmwareError(IntFlag):
-    """Firmware errors of the controller, as returned by ``*FRMW?``."""
+    """Represent the firmware errors of the controller, as returned by ``*FRMW?``."""
 
     PARSER_ERROR = 1 << 0
     PARAMETER_ERROR = 1 << 1
@@ -154,7 +154,7 @@ class FirmwareError(IntFlag):
 
 
 class PulseCheckUSB(SCPIMixin, Instrument):
-    """APE pulseCheck USB autocorrelator.
+    """Represent the APE pulseCheck USB autocorrelator.
 
     The autocorrelator is attached via USB to a Windows PC running the APE pulseLink control
     software, and that software provides the remote interface: it has to be running, and its
@@ -565,5 +565,5 @@ class PulseCheckUSB(SCPIMixin, Instrument):
         if not errors:
             return []
         log.error("%s: %s", self.name, errors)
-        # iterating the flag itself would need Python 3.11
-        return [error for error in FirmwareError if error in errors]
+        # test each flag bit with a bitwise AND; iterating `errors` itself would need Python 3.11
+        return [error for error in FirmwareError if error & errors]

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+import itertools
 import struct
 
 import pytest
@@ -28,6 +29,17 @@ import pytest
 from pymeasure.instruments.ape import pulsecheck as pulsecheck_module
 from pymeasure.instruments.ape import PulseCheck
 from pymeasure.test import expected_protocol
+
+
+def test_connection_settings_can_be_overridden():
+    """The defaults must not clash with connection settings passed by the user."""
+    with expected_protocol(
+        PulseCheck,
+        [("GTA", b"\x07")],
+        write_termination="\r",
+        asrl={"baud_rate": 9600},
+    ) as inst:
+        assert inst.tau_register == 7
 
 
 def test_gain_get():
@@ -73,13 +85,13 @@ def test_math_enabled():
         inst.math_enabled = False
 
 
-def test_running():
+def test_measurement_running():
     with expected_protocol(
         PulseCheck,
         [("GRS", b"\x01"), ("RS0", None)],
     ) as inst:
-        assert inst.running is True
-        inst.running = False
+        assert inst.measurement_running is True
+        inst.measurement_running = False
 
 
 def test_scan_range():
@@ -144,15 +156,24 @@ def test_trigger_mode_set(mode, index):
         inst.trigger_mode = mode
 
 
-def test_acf():
+def test_trigger_mode_get_unknown_code():
+    """An undocumented code has to be readable, since `settings` reads the mode as well."""
+    with expected_protocol(
+        PulseCheck,
+        [("GTF", b"\x03")],
+    ) as inst:
+        assert inst.trigger_mode == "unknown (3)"
+
+
+def test_raw_acf():
     with expected_protocol(
         PulseCheck,
         [("GRE", b"\x02"), ("GAC", struct.pack(">4H", 64, 128, 192, 256))],
     ) as inst:
-        assert inst.acf() == [1, 2, 3, 4]
+        assert inst.raw_acf() == [1, 2, 3, 4]
 
 
-def test_get_autocorrelation():
+def test_acf():
     with expected_protocol(
         PulseCheck,
         [
@@ -161,7 +182,7 @@ def test_get_autocorrelation():
             ("GSR", b"\x02"),
         ],
     ) as inst:
-        delay, acf = inst.get_autocorrelation()
+        delay, acf = inst.acf
         assert list(acf) == [1, 2, 3, 4]
         assert delay[0] == pytest.approx(-2.5e-12)
         assert delay[-1] == pytest.approx(2.5e-12)
@@ -214,6 +235,29 @@ def test_set_alpha_raises_timeout_error_when_stuck(monkeypatch):
     ) as inst:
         with pytest.raises(TimeoutError):
             inst.set_alpha(100, retries=0)
+
+
+def test_set_alpha_rejects_negative_retries():
+    with expected_protocol(PulseCheck, []) as inst:
+        with pytest.raises(ValueError, match="retries"):
+            inst.set_alpha(100, retries=-1)
+
+
+def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
+    """Verify that a position which keeps moving without arriving does not loop forever."""
+    monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
+    clock = itertools.count(step=100)
+    monkeypatch.setattr(pulsecheck_module.time, "monotonic", lambda: next(clock))
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GPM", struct.pack(">H", 90)),  # tune(): current position
+            ("TU10", None),
+            ("GPM", struct.pack(">H", 90)),  # current, after the initial 1 s wait
+        ],
+    ) as inst:
+        with pytest.raises(TimeoutError, match="timed out"):
+            inst.set_alpha(100)
 
 
 def test_tune():

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -1,0 +1,248 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+import struct
+
+import pytest
+
+from pymeasure.instruments.ape import pulsecheck as pulsecheck_module
+from pymeasure.instruments.ape import PulseCheck
+from pymeasure.test import expected_protocol
+
+
+def test_gain_get():
+    with expected_protocol(
+        PulseCheck,
+        [("GG", struct.pack(">H", 250))],
+    ) as inst:
+        assert inst.gain == 250
+
+
+def test_gain_set():
+    with expected_protocol(
+        PulseCheck,
+        [("GN500", None)],
+    ) as inst:
+        inst.gain = 500
+
+
+def test_averages():
+    with expected_protocol(
+        PulseCheck,
+        [("GAV", b"\x04"), ("A8", None)],
+    ) as inst:
+        assert inst.averages == 4
+        inst.averages = 8
+
+
+def test_filter():
+    with expected_protocol(
+        PulseCheck,
+        [("GF", b"\x02"), ("F3", None)],
+    ) as inst:
+        assert inst.filter == "medium"
+        inst.filter = "high"
+
+
+def test_math_enabled():
+    with expected_protocol(
+        PulseCheck,
+        [("GM", b"\x01"), ("M0", None)],
+    ) as inst:
+        assert inst.math_enabled is True
+        inst.math_enabled = False
+
+
+def test_running():
+    with expected_protocol(
+        PulseCheck,
+        [("GRS", b"\x01"), ("RS0", None)],
+    ) as inst:
+        assert inst.running is True
+        inst.running = False
+
+
+def test_scan_range():
+    with expected_protocol(
+        PulseCheck,
+        [("GSR", b"\x03"), ("SR2", None)],
+    ) as inst:
+        assert inst.scan_range == pytest.approx(15e-12)
+        inst.scan_range = 5e-12
+
+
+def test_resolution():
+    with expected_protocol(
+        PulseCheck,
+        [("GRE", b"\x05")],
+    ) as inst:
+        assert inst.resolution == 32
+
+
+def test_alpha():
+    with expected_protocol(
+        PulseCheck,
+        [("GPM", struct.pack(">H", 1000))],
+    ) as inst:
+        assert inst.alpha == 1000
+
+
+def test_tau_register():
+    with expected_protocol(
+        PulseCheck,
+        [("GTA", b"\x07")],
+    ) as inst:
+        assert inst.tau_register == 7
+
+
+def test_sensitivity():
+    with expected_protocol(
+        PulseCheck,
+        [("GSY", b"\x05"), ("SY6", None)],
+    ) as inst:
+        assert inst.sensitivity == 100
+        inst.sensitivity = 300
+
+
+def test_trigger_mode_get():
+    with expected_protocol(
+        PulseCheck,
+        [("GTF", b"\x02")],
+    ) as inst:
+        assert inst.trigger_mode == "fringe"
+
+
+def test_trigger_mode_set():
+    with expected_protocol(
+        PulseCheck,
+        [("TF1", None)],
+    ) as inst:
+        inst.trigger_mode = "freerun"
+
+
+def test_acf():
+    with expected_protocol(
+        PulseCheck,
+        [("GRE", b"\x02"), ("GAC", struct.pack(">4H", 64, 128, 192, 256))],
+    ) as inst:
+        assert inst.acf() == [1, 2, 3, 4]
+
+
+def test_get_autocorrelation():
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GRE", b"\x02"),
+            ("GAC", struct.pack(">4H", 64, 128, 192, 256)),
+            ("GSR", b"\x02"),
+        ],
+    ) as inst:
+        delay, acf = inst.get_autocorrelation()
+        assert list(acf) == [1, 2, 3, 4]
+        assert delay[0] == pytest.approx(-2.5e-12)
+        assert delay[-1] == pytest.approx(2.5e-12)
+
+
+def test_set_alpha_reaches_target_immediately(monkeypatch):
+    monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GPM", struct.pack(">H", 90)),
+            ("TU10", None),
+            ("GPM", struct.pack(">H", 100)),
+        ],
+    ) as inst:
+        inst.set_alpha(100)
+
+
+def test_set_alpha_retries_after_getting_stuck(monkeypatch):
+    """Verify that a stuck first attempt is retried and can still succeed."""
+    monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GPM", struct.pack(">H", 90)),  # tune(): current position
+            ("TU10", None),
+            ("GPM", struct.pack(">H", 90)),  # current, after the initial 1 s wait
+            ("GPM", struct.pack(">H", 90)),  # stuck-check 1/2: unchanged
+            ("GPM", struct.pack(">H", 90)),  # stuck-check 2/2: unchanged -> retry
+            ("GPM", struct.pack(">H", 100)),  # 2nd attempt: tune(): already there
+            ("TU0", None),
+            ("GPM", struct.pack(">H", 100)),  # current == target -> done
+        ],
+    ) as inst:
+        inst.set_alpha(100)
+
+
+def test_set_alpha_raises_timeout_error_when_stuck(monkeypatch):
+    """Verify that a persistently stuck position raises instead of recursing forever."""
+    monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GPM", struct.pack(">H", 90)),  # tune(): current position
+            ("TU10", None),
+            ("GPM", struct.pack(">H", 90)),  # current, after the initial 1 s wait
+            ("GPM", struct.pack(">H", 90)),  # stuck-check 1/2: unchanged
+            ("GPM", struct.pack(">H", 90)),  # stuck-check 2/2: unchanged -> give up
+        ],
+    ) as inst:
+        with pytest.raises(TimeoutError):
+            inst.set_alpha(100, retries=0)
+
+
+def test_tune():
+    with expected_protocol(
+        PulseCheck,
+        [("TU-5", None)],
+    ) as inst:
+        inst.tune(-5)
+
+
+def test_settings():
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GSY", b"\x01"),
+            ("GG", struct.pack(">H", 250)),
+            ("GSR", b"\x00"),
+            ("GF", b"\x01"),
+            ("GAV", b"\x02"),
+            ("GRE", b"\x02"),
+            ("GPM", struct.pack(">H", 1000)),
+            ("GM", b"\x01"),
+            ("GTF", b"\x00"),
+        ],
+    ) as inst:
+        assert inst.settings == {
+            "sensitivity": 1,
+            "gain": 250,
+            "scan_range": 0,
+            "filter": "low",
+            "averages": 2,
+            "resolution": 4,
+            "alpha": 1000,
+            "math_enabled": True,
+            "trigger_mode": "freerun",
+        }

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -124,20 +124,24 @@ def test_sensitivity():
         inst.sensitivity = 300
 
 
-def test_trigger_mode_get():
+@pytest.mark.parametrize("code, mode", [(0, "freerun"), (1, "trigger"),
+                                        (2, "fringe"), (4, "slow")])
+def test_trigger_mode_get(code, mode):
     with expected_protocol(
         PulseCheck,
-        [("GTF", b"\x02")],
+        [("GTF", bytes([code]))],
     ) as inst:
-        assert inst.trigger_mode == "fringe"
+        assert inst.trigger_mode == mode
 
 
-def test_trigger_mode_set():
+@pytest.mark.parametrize("mode, index", [("freerun", 0), ("trigger", 1),
+                                         ("fringe", 2), ("slow", 3)])
+def test_trigger_mode_set(mode, index):
     with expected_protocol(
         PulseCheck,
-        [("TF1", None)],
+        [(f"TF{index}", None)],
     ) as inst:
-        inst.trigger_mode = "freerun"
+        inst.trigger_mode = mode
 
 
 def test_acf():

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -21,7 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import itertools
 import struct
 
 import pytest
@@ -244,7 +243,7 @@ def test_set_alpha_rejects_negative_retries():
 def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
     """Verify that a position which keeps moving without arriving does not loop forever."""
     monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
-    clock = itertools.count(step=100)
+    clock = iter([0, 10, 100])  # deadline = 60; tripped right after the settling wait
     monkeypatch.setattr(pulsecheck_module.time, "monotonic", lambda: next(clock))
     with expected_protocol(
         PulseCheck,
@@ -260,7 +259,7 @@ def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
 def test_set_alpha_raises_when_target_reached_after_timeout(monkeypatch):
     """Reaching the target after the deadline must report a timeout, not success."""
     monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
-    clock = iter([0, 10, 100])  # deadline = 60; the success check at 100 is past it
+    clock = iter([0, 10, 20, 100])  # deadline = 60; only the success check at 100 is past it
     monkeypatch.setattr(pulsecheck_module.time, "monotonic", lambda: next(clock))
     with expected_protocol(
         PulseCheck,

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -26,8 +26,8 @@ import struct
 
 import pytest
 
-from pymeasure.instruments.ape import pulsecheck as pulsecheck_module
 from pymeasure.instruments.ape import PulseCheck
+from pymeasure.instruments.ape import pulsecheck as pulsecheck_module
 from pymeasure.test import expected_protocol
 
 
@@ -232,15 +232,13 @@ def test_set_alpha_raises_timeout_error_when_stuck(monkeypatch):
             ("GPM", struct.pack(">H", 90)),  # stuck-check 1/2: unchanged
             ("GPM", struct.pack(">H", 90)),  # stuck-check 2/2: unchanged -> give up
         ],
-    ) as inst:
-        with pytest.raises(TimeoutError):
-            inst.set_alpha(100, retries=0)
+    ) as inst, pytest.raises(TimeoutError):
+        inst.set_alpha(100, retries=0)
 
 
 def test_set_alpha_rejects_negative_retries():
-    with expected_protocol(PulseCheck, []) as inst:
-        with pytest.raises(ValueError, match="retries"):
-            inst.set_alpha(100, retries=-1)
+    with expected_protocol(PulseCheck, []) as inst, pytest.raises(ValueError, match="retries"):
+        inst.set_alpha(100, retries=-1)
 
 
 def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
@@ -255,9 +253,8 @@ def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
             ("TU10", None),
             ("GPM", struct.pack(">H", 90)),  # current, after the initial 1 s wait
         ],
-    ) as inst:
-        with pytest.raises(TimeoutError, match="timed out"):
-            inst.set_alpha(100)
+    ) as inst, pytest.raises(TimeoutError, match="timed out"):
+        inst.set_alpha(100)
 
 
 def test_tune():

--- a/tests/instruments/ape/test_pulsecheck.py
+++ b/tests/instruments/ape/test_pulsecheck.py
@@ -257,6 +257,22 @@ def test_set_alpha_raises_timeout_error_when_deadline_passes(monkeypatch):
         inst.set_alpha(100)
 
 
+def test_set_alpha_raises_when_target_reached_after_timeout(monkeypatch):
+    """Reaching the target after the deadline must report a timeout, not success."""
+    monkeypatch.setattr(pulsecheck_module.time, "sleep", lambda seconds: None)
+    clock = iter([0, 10, 100])  # deadline = 60; the success check at 100 is past it
+    monkeypatch.setattr(pulsecheck_module.time, "monotonic", lambda: next(clock))
+    with expected_protocol(
+        PulseCheck,
+        [
+            ("GPM", struct.pack(">H", 90)),  # tune(): current position
+            ("TU10", None),
+            ("GPM", struct.pack(">H", 100)),  # settled on the target, but past the deadline
+        ],
+    ) as inst, pytest.raises(TimeoutError, match="timed out"):
+        inst.set_alpha(100)
+
+
 def test_tune():
     with expected_protocol(
         PulseCheck,

--- a/tests/instruments/ape/test_pulsecheck_usb.py
+++ b/tests/instruments/ape/test_pulsecheck_usb.py
@@ -47,9 +47,18 @@ def block(*values):
 def test_id():
     with expected_protocol(
         PulseCheckUSB,
-        [("*IDN?", "APE GmbH, pulseCheck USB 15, S12345, 1.4.0, 2.1")],
+        [("*IDN?", "APE GmbH;pulseLink S12345;Software 1.9.3.12;Firmware 787")],
     ) as inst:
-        assert inst.id == "APE GmbH, pulseCheck USB 15, S12345, 1.4.0, 2.1"
+        assert inst.id == "APE GmbH;pulseLink S12345;Software 1.9.3.12;Firmware 787"
+
+
+def test_parser_error():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*OPT?", "Parser error")],
+    ) as inst:
+        with pytest.raises(ValueError, match="did not understand"):
+            inst.options
 
 
 def test_read_strips_padding():
@@ -140,17 +149,29 @@ def test_check_errors_empty():
 def test_measurement_running():
     with expected_protocol(
         PulseCheckUSB,
-        [("STATUS:START?", "1")],
+        [("STATUS:START?", "1"), ("STATUS:START=0", None)],
     ) as inst:
         assert inst.measurement_running is True
+        inst.measurement_running = False
 
 
-def test_averages():
+@pytest.mark.parametrize("reply, averages", [
+    ("Off", 1), ("Low (2)", 2), ("Medium (4)", 4), ("High (8)", 8), ("Very high (16)", 16),
+    ("3", 8),  # the index notation documented in the manual
+])
+def test_averages_reply_notations(reply, averages):
     with expected_protocol(
         PulseCheckUSB,
-        [("STATUS:AVERAGE?", "3"), ("STATUS:AVERAGE=4", None)],
+        [("STATUS:AVERAGE?", reply)],
     ) as inst:
-        assert inst.averages == 8
+        assert inst.averages == averages
+
+
+def test_averages_set():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:AVERAGE=4", None)],
+    ) as inst:
         inst.averages = 16
 
 
@@ -275,9 +296,19 @@ def test_displayed_acf():
 def test_acf_without_block():
     with expected_protocol(
         PulseCheckUSB,
-        [("ACF:DATA?", b"E")],
+        [("ACF:DATA?", "Parser error")],
     ) as inst:
-        with pytest.raises(ValueError, match="block"):
+        with pytest.raises(ValueError, match="data block"):
+            inst.acf
+
+
+def test_acf_message_instead_of_data():
+    with expected_protocol(
+        PulseCheckUSB,
+        # the software answers like this while it has no valid autocorrelation
+        [("ACF:DATA?", b"#18Time out")],
+    ) as inst:
+        with pytest.raises(ValueError, match="Time out"):
             inst.acf
 
 
@@ -295,6 +326,23 @@ def test_acf_mean_data():
         }
 
 
+def test_acf_mean_data_as_block():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:MEANDATA?", b"#221" + b"0.4;7.5;-7.5;1.0;0.05")],
+    ) as inst:
+        assert inst.acf_mean_data["delay_max"] == pytest.approx(7.5e-12)
+
+
+def test_acf_mean_data_message():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:MEANDATA?", b"#18Time out")],
+    ) as inst:
+        with pytest.raises(ValueError, match="Time out"):
+            inst.acf_mean_data
+
+
 def test_fwhm():
     with expected_protocol(
         PulseCheckUSB,
@@ -302,6 +350,15 @@ def test_fwhm():
     ) as inst:
         assert inst.fwhm == pytest.approx(0.35e-12)
         assert inst.fit_fwhm == pytest.approx(0.34e-12)
+
+
+def test_fit_fwhm_without_fit():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:FITFWHM?", "No fit data")],
+    ) as inst:
+        with pytest.raises(ValueError, match="No fit data"):
+            inst.fit_fwhm
 
 
 def test_shutters():
@@ -325,9 +382,8 @@ def test_crystal_position():
 def test_crystal_wavelength():
     with expected_protocol(
         PulseCheckUSB,
-        [("XTAL:LAMBDATUNE?", "800"), ("XTAL:LAMBDATUNE=1030", None)],
+        [("XTAL:LAMBDATUNE=1030", None)],
     ) as inst:
-        assert inst.crystal_wavelength == 800
         inst.crystal_wavelength = 1030
 
 

--- a/tests/instruments/ape/test_pulsecheck_usb.py
+++ b/tests/instruments/ape/test_pulsecheck_usb.py
@@ -1,0 +1,340 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import struct
+
+import pytest
+
+from pymeasure.instruments.ape import PulseCheckUSB
+from pymeasure.instruments.ape.pulsecheck_usb import (
+    BusyStatus,
+    DataError,
+    FirmwareError,
+    InitializationStatus,
+    OperationStatus,
+)
+from pymeasure.test import expected_protocol
+
+
+def block(*values):
+    """Pack `values` as the definite length block of doubles the software sends."""
+    payload = struct.pack(f"<{len(values)}d", *values)
+    length = str(len(payload))
+    return f"#{len(length)}{length}".encode() + payload
+
+
+def test_id():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*IDN?", "APE GmbH, pulseCheck USB 15, S12345, 1.4.0, 2.1")],
+    ) as inst:
+        assert inst.id == "APE GmbH, pulseCheck USB 15, S12345, 1.4.0, 2.1"
+
+
+def test_read_strips_padding():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("SYSTEM:DEVICE?", b"\x00pulseCheck USB 15\x00")],
+    ) as inst:
+        assert inst.device_name == "pulseCheck USB 15"
+
+
+def test_serial_number():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("SYSTEM:SNUMBER?", "S12345")],
+    ) as inst:
+        assert inst.serial_number == "S12345"
+
+
+@pytest.mark.parametrize("command, attribute", [
+    ("SYSTEM:SOFTWARE?", "software_version"),
+    ("SYSTEM:HARDWARE?", "hardware_version"),
+    ("SYSTEM:FIRMWARE?", "firmware_version"),
+    ("SYSTEM:MOTOR?", "motor_type"),
+])
+def test_version_properties(command, attribute):
+    with expected_protocol(
+        PulseCheckUSB,
+        [(command, "1.2.3")],
+    ) as inst:
+        assert getattr(inst, attribute) == "1.2.3"
+
+
+def test_operation_status():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*OPER?", "26")],
+    ) as inst:
+        assert inst.operation_status == (
+            OperationStatus.VISA_CONNECTED
+            | OperationStatus.DEVICE_READY
+            | OperationStatus.DEVICE_BUSY
+        )
+
+
+def test_initialization_status():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*INIT?", "252")],
+    ) as inst:
+        # the upper four bits are always set and have to be masked away
+        assert inst.initialization_status == (
+            InitializationStatus.LINK_OK | InitializationStatus.OPTIC_OK
+        )
+
+
+def test_busy_status():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*BUSY?", "6")],
+    ) as inst:
+        assert inst.busy_status == BusyStatus.NEW_DATA | BusyStatus.MEASUREMENT_RUNNING
+
+
+def test_data_errors():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*ERR?", "5")],
+    ) as inst:
+        assert inst.data_errors == DataError.SIGNAL_TOO_LOW | DataError.NO_PEAK_FOUND
+
+
+def test_check_errors():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*FRMW?", "2")],
+    ) as inst:
+        assert inst.check_errors() == [FirmwareError.PARAMETER_ERROR]
+
+
+def test_check_errors_empty():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*FRMW?", "0")],
+    ) as inst:
+        assert inst.check_errors() == []
+
+
+def test_measurement_running():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:START?", "1")],
+    ) as inst:
+        assert inst.measurement_running is True
+
+
+def test_averages():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:AVERAGE?", "3"), ("STATUS:AVERAGE=4", None)],
+    ) as inst:
+        assert inst.averages == 8
+        inst.averages = 16
+
+
+def test_averages_invalid():
+    with expected_protocol(PulseCheckUSB, []) as inst:
+        with pytest.raises(ValueError):
+            inst.averages = 3
+
+
+@pytest.mark.parametrize("reply", ["1", "500", "low", "Low\r"])
+def test_resolution_reply_notations(reply):
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:RESOLUTION?", reply)],
+    ) as inst:
+        assert inst.resolution == 500
+
+
+def test_resolution_set():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:RESOLUTION=4", None)],
+    ) as inst:
+        inst.resolution = 2000
+
+
+def test_fit_type():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:FITTYPE?", "2"), ("STATUS:FITTYPE=1", None)],
+    ) as inst:
+        assert inst.fit_type == "sech2"
+        inst.fit_type = "gaussian"
+
+
+def test_filter_enabled():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("STATUS:FILTER?", "0"), ("STATUS:FILTER=1", None)],
+    ) as inst:
+        assert inst.filter_enabled is False
+        inst.filter_enabled = True
+
+
+def test_scan_range():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("MOTOR:SCANRANGE?", "15000"), ("MOTOR:SCANRANGE=150", None)],
+    ) as inst:
+        assert inst.scan_range == pytest.approx(15e-12)
+        inst.scan_range = 150e-15
+
+
+def test_gain():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("DETECTOR:GAIN?", "450"), ("DETECTOR:GAIN=1000", None)],
+    ) as inst:
+        assert inst.gain == 450
+        inst.gain = 1000
+
+
+def test_gain_out_of_range():
+    with expected_protocol(PulseCheckUSB, []) as inst:
+        with pytest.raises(ValueError):
+            inst.gain = 299
+
+
+def test_autogain_enabled():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("DETECTOR:AUTOGAIN?", "1"), ("DETECTOR:AUTOGAIN=0", None)],
+    ) as inst:
+        assert inst.autogain_enabled is True
+        inst.autogain_enabled = False
+
+
+def test_sensitivity():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("DETECTOR:SENSITIVITY?", "10"), ("DETECTOR:SENSITIVITY=1", None)],
+    ) as inst:
+        assert inst.sensitivity == 10
+        inst.sensitivity = 1
+
+
+def test_trigger_properties():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("TRIGGER:LEVEL?", "1200"),
+         ("TRIGGER:DELAY?", "25"),
+         ("TRIGGER:FREQUENCY?", "80000000"),
+         ("TRIGGER:IMPEDANCE?", "50")],
+    ) as inst:
+        assert inst.trigger_level == pytest.approx(1.2)
+        assert inst.trigger_delay == pytest.approx(25e-6)
+        assert inst.trigger_frequency == pytest.approx(80e6)
+        assert inst.trigger_impedance == pytest.approx(50)
+
+
+def test_acf():
+    with expected_protocol(
+        PulseCheckUSB,
+        # interleaved as [intensity, delay, ...] with the delay in ps
+        [("ACF:DATA?", block(0.25, -1.5, 1.0, 0.0, 0.25, 1.5))],
+    ) as inst:
+        delay, intensity = inst.acf
+        assert delay == pytest.approx([-1.5e-12, 0, 1.5e-12])
+        assert intensity == pytest.approx([0.25, 1.0, 0.25])
+
+
+def test_displayed_acf():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:DISPLAYED_ACF?", block(0.5, -1.0, 0.5, 1.0))],
+    ) as inst:
+        delay, intensity = inst.displayed_acf
+        assert delay == pytest.approx([-1e-12, 1e-12])
+        assert intensity == pytest.approx([0.5, 0.5])
+
+
+def test_acf_without_block():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:DATA?", b"E")],
+    ) as inst:
+        with pytest.raises(ValueError, match="block"):
+            inst.acf
+
+
+def test_acf_mean_data():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:MEANDATA?", "0.4;7.5;-7.5;1.0;0.05")],
+    ) as inst:
+        assert inst.acf_mean_data == {
+            "average": pytest.approx(0.4),
+            "delay_max": pytest.approx(7.5e-12),
+            "delay_min": pytest.approx(-7.5e-12),
+            "intensity_max": pytest.approx(1.0),
+            "intensity_min": pytest.approx(0.05),
+        }
+
+
+def test_fwhm():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:FWHM?", "0.35"), ("ACF:FITFWHM?", "0.34")],
+    ) as inst:
+        assert inst.fwhm == pytest.approx(0.35e-12)
+        assert inst.fit_fwhm == pytest.approx(0.34e-12)
+
+
+def test_shutters():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("SHUTTER:FIX?", "1"), ("SHUTTER:SCAN=0", None)],
+    ) as inst:
+        assert inst.fix_shutter_open is True
+        inst.scan_shutter_open = False
+
+
+def test_crystal_position():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("XTAL:TUNING?", "5000"), ("XTAL:TUNING=6000", None)],
+    ) as inst:
+        assert inst.crystal_position == 5000
+        inst.crystal_position = 6000
+
+
+def test_crystal_wavelength():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("XTAL:LAMBDATUNE?", "800"), ("XTAL:LAMBDATUNE=1030", None)],
+    ) as inst:
+        assert inst.crystal_wavelength == 800
+        inst.crystal_wavelength = 1030
+
+
+def test_crystal_status():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("XTAL:MOVE?", "0"), ("XTAL:SETXTAL?", "BBO")],
+    ) as inst:
+        assert inst.crystal_moving is False
+        assert inst.crystal_type == "BBO"

--- a/tests/instruments/ape/test_pulsecheck_usb.py
+++ b/tests/instruments/ape/test_pulsecheck_usb.py
@@ -33,6 +33,8 @@ from pymeasure.instruments.ape.pulsecheck_usb import (
     FirmwareError,
     InitializationStatus,
     OperationStatus,
+    parse_averages,
+    parse_resolution,
 )
 from pymeasure.test import expected_protocol
 
@@ -42,6 +44,36 @@ def block(*values):
     payload = struct.pack(f"<{len(values)}d", *values)
     length = str(len(payload))
     return f"#{len(length)}{length}".encode() + payload
+
+
+@pytest.mark.parametrize("reply, resolution", [
+    ("very low", 200), ("Low\r", 500), ("very high", 2000),  # the names
+    ("200", 200), ("500", 500), ("2000", 2000),  # the number of samples the software answers
+    ("0", 200), ("1", 500), ("4", 2000),  # the index notation documented in the manual
+])
+def test_parse_resolution(reply, resolution):
+    assert parse_resolution(reply) == resolution
+
+
+@pytest.mark.parametrize("reply", ["-1", "999"])
+def test_parse_resolution_invalid(reply):
+    with pytest.raises(ValueError, match="resolution"):
+        parse_resolution(reply)
+
+
+@pytest.mark.parametrize("reply, averages", [
+    ("Off", 1), ("Low (2)", 2), ("Very high (16)", 16),  # what the software answers
+    ("8", 8), ("16", 16),  # the number of measurements
+    ("0", 1), ("3", 8),  # the index notation documented in the manual
+])
+def test_parse_averages(reply, averages):
+    assert parse_averages(reply) == averages
+
+
+@pytest.mark.parametrize("reply", ["-1", "5", "99"])
+def test_parse_averages_invalid(reply):
+    with pytest.raises(ValueError, match="averages"):
+        parse_averages(reply)
 
 
 def test_id():
@@ -136,6 +168,15 @@ def test_check_errors():
         [("*FRMW?", "2")],
     ) as inst:
         assert inst.check_errors() == [FirmwareError.PARAMETER_ERROR]
+
+
+def test_check_errors_lists_every_error():
+    with expected_protocol(
+        PulseCheckUSB,
+        [("*FRMW?", "3")],
+    ) as inst:
+        assert inst.check_errors() == [FirmwareError.PARSER_ERROR,
+                                       FirmwareError.PARAMETER_ERROR]
 
 
 def test_check_errors_empty():
@@ -281,6 +322,8 @@ def test_acf():
         delay, intensity = inst.acf
         assert delay == pytest.approx([-1.5e-12, 0, 1.5e-12])
         assert intensity == pytest.approx([0.25, 1.0, 0.25])
+        # the reply itself is read-only, the trace handed out must not be
+        assert delay.flags.writeable and intensity.flags.writeable
 
 
 def test_displayed_acf():
@@ -340,6 +383,16 @@ def test_acf_mean_data_message():
         [("ACF:MEANDATA?", b"#18Time out")],
     ) as inst:
         with pytest.raises(ValueError, match="Time out"):
+            inst.acf_mean_data
+
+
+def test_acf_mean_data_parser_error():
+    """The first character is read separately, so read() cannot spot the parser error."""
+    with expected_protocol(
+        PulseCheckUSB,
+        [("ACF:MEANDATA?", "Parser error")],
+    ) as inst:
+        with pytest.raises(ValueError, match="did not understand"):
             inst.acf_mean_data
 
 

--- a/tests/instruments/ape/test_pulsecheck_usb.py
+++ b/tests/instruments/ape/test_pulsecheck_usb.py
@@ -88,9 +88,8 @@ def test_parser_error():
     with expected_protocol(
         PulseCheckUSB,
         [("*OPT?", "Parser error")],
-    ) as inst:
-        with pytest.raises(ValueError, match="did not understand"):
-            inst.options
+    ) as inst, pytest.raises(ValueError, match="did not understand"):
+        inst.options
 
 
 def test_read_strips_padding():
@@ -217,9 +216,8 @@ def test_averages_set():
 
 
 def test_averages_invalid():
-    with expected_protocol(PulseCheckUSB, []) as inst:
-        with pytest.raises(ValueError):
-            inst.averages = 3
+    with expected_protocol(PulseCheckUSB, []) as inst, pytest.raises(ValueError):
+        inst.averages = 3
 
 
 @pytest.mark.parametrize("reply", ["1", "500", "low", "Low\r"])
@@ -276,9 +274,8 @@ def test_gain():
 
 
 def test_gain_out_of_range():
-    with expected_protocol(PulseCheckUSB, []) as inst:
-        with pytest.raises(ValueError):
-            inst.gain = 299
+    with expected_protocol(PulseCheckUSB, []) as inst, pytest.raises(ValueError):
+        inst.gain = 299
 
 
 def test_autogain_enabled():
@@ -340,9 +337,8 @@ def test_acf_without_block():
     with expected_protocol(
         PulseCheckUSB,
         [("ACF:DATA?", "Parser error")],
-    ) as inst:
-        with pytest.raises(ValueError, match="data block"):
-            inst.acf
+    ) as inst, pytest.raises(ValueError, match="data block"):
+        inst.acf
 
 
 def test_acf_message_instead_of_data():
@@ -350,9 +346,8 @@ def test_acf_message_instead_of_data():
         PulseCheckUSB,
         # the software answers like this while it has no valid autocorrelation
         [("ACF:DATA?", b"#18Time out")],
-    ) as inst:
-        with pytest.raises(ValueError, match="Time out"):
-            inst.acf
+    ) as inst, pytest.raises(ValueError, match="Time out"):
+        inst.acf
 
 
 def test_acf_mean_data():
@@ -381,9 +376,8 @@ def test_acf_mean_data_message():
     with expected_protocol(
         PulseCheckUSB,
         [("ACF:MEANDATA?", b"#18Time out")],
-    ) as inst:
-        with pytest.raises(ValueError, match="Time out"):
-            inst.acf_mean_data
+    ) as inst, pytest.raises(ValueError, match="Time out"):
+        inst.acf_mean_data
 
 
 def test_acf_mean_data_parser_error():
@@ -391,9 +385,8 @@ def test_acf_mean_data_parser_error():
     with expected_protocol(
         PulseCheckUSB,
         [("ACF:MEANDATA?", "Parser error")],
-    ) as inst:
-        with pytest.raises(ValueError, match="did not understand"):
-            inst.acf_mean_data
+    ) as inst, pytest.raises(ValueError, match="did not understand"):
+        inst.acf_mean_data
 
 
 def test_fwhm():
@@ -409,9 +402,8 @@ def test_fit_fwhm_without_fit():
     with expected_protocol(
         PulseCheckUSB,
         [("ACF:FITFWHM?", "No fit data")],
-    ) as inst:
-        with pytest.raises(ValueError, match="No fit data"):
-            inst.fit_fwhm
+    ) as inst, pytest.raises(ValueError, match="No fit data"):
+        inst.fit_fwhm
 
 
 def test_shutters():

--- a/tests/instruments/ape/test_pulsecheck_usb.py
+++ b/tests/instruments/ape/test_pulsecheck_usb.py
@@ -89,7 +89,7 @@ def test_parser_error():
         PulseCheckUSB,
         [("*OPT?", "Parser error")],
     ) as inst, pytest.raises(ValueError, match="did not understand"):
-        inst.options
+        _ = inst.options
 
 
 def test_read_strips_padding():
@@ -338,7 +338,7 @@ def test_acf_without_block():
         PulseCheckUSB,
         [("ACF:DATA?", "Parser error")],
     ) as inst, pytest.raises(ValueError, match="data block"):
-        inst.acf
+        _ = inst.acf
 
 
 def test_acf_message_instead_of_data():
@@ -347,7 +347,7 @@ def test_acf_message_instead_of_data():
         # the software answers like this while it has no valid autocorrelation
         [("ACF:DATA?", b"#18Time out")],
     ) as inst, pytest.raises(ValueError, match="Time out"):
-        inst.acf
+        _ = inst.acf
 
 
 def test_acf_mean_data():
@@ -377,7 +377,7 @@ def test_acf_mean_data_message():
         PulseCheckUSB,
         [("ACF:MEANDATA?", b"#18Time out")],
     ) as inst, pytest.raises(ValueError, match="Time out"):
-        inst.acf_mean_data
+        _ = inst.acf_mean_data
 
 
 def test_acf_mean_data_parser_error():
@@ -386,7 +386,7 @@ def test_acf_mean_data_parser_error():
         PulseCheckUSB,
         [("ACF:MEANDATA?", "Parser error")],
     ) as inst, pytest.raises(ValueError, match="did not understand"):
-        inst.acf_mean_data
+        _ = inst.acf_mean_data
 
 
 def test_fwhm():
@@ -403,7 +403,7 @@ def test_fit_fwhm_without_fit():
         PulseCheckUSB,
         [("ACF:FITFWHM?", "No fit data")],
     ) as inst, pytest.raises(ValueError, match="No fit data"):
-        inst.fit_fwhm
+        _ = inst.fit_fwhm
 
 
 def test_shutters():

--- a/tests/instruments/ape/test_pulsecheck_usb_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_usb_with_device.py
@@ -1,0 +1,256 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""Tests requiring a pulseCheck USB attached to a PC running the pulseLink software.
+
+Enable the TCP/IP port in the software under ``Extras`` → ``TCP``, then run::
+
+    pytest tests/instruments/ape/test_pulsecheck_usb_with_device.py \
+        --device-address TCPIP::192.168.0.10::51123::SOCKET
+
+The settings the tests change are read at the start and written back afterwards. The delay
+drive and the crystal motor are only read, never moved. Tests needing a real autocorrelation
+are skipped if no pulse train reaches the detector.
+"""
+
+import time
+
+import numpy as np
+import pytest
+
+from pymeasure.instruments.ape import PulseCheckUSB
+from pymeasure.instruments.ape.pulsecheck_usb import (
+    AVERAGES,
+    RESOLUTIONS,
+    BusyStatus,
+    DataError,
+    FirmwareError,
+    InitializationStatus,
+    OperationStatus,
+)
+
+#: Settings the tests below write, and which are restored when they are done.
+RESTORED_SETTINGS = ("measurement_running", "autogain_enabled", "averages", "resolution",
+                     "fit_type", "filter_enabled", "gain", "sensitivity")
+
+
+@pytest.fixture(scope="module")
+def instrument(connected_device_address):
+    inst = PulseCheckUSB(connected_device_address)
+    settings = {name: getattr(inst, name) for name in RESTORED_SETTINGS}
+    yield inst
+    for name, value in settings.items():
+        assert set_and_read(inst, name, value, timeout=20) == value, f"could not restore {name}"
+
+
+def set_and_read(instrument, name, value, timeout=5):
+    """Write a property and read it back, waiting for the software to apply the setting.
+
+    The detector settings reach the controller only once a further command arrives, so the
+    value is written repeatedly instead of only being polled.
+
+    :param instrument: the instrument to write to.
+    :param name: name of the property.
+    :param value: value to write.
+    :param timeout: how long to wait for the read back to agree, in s.
+    :returns: the value read back.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        setattr(instrument, name, value)
+        time.sleep(0.5)
+        read_back = getattr(instrument, name)
+        if read_back == value or time.monotonic() > deadline:
+            return read_back
+
+
+def running_with_signal(instrument, timeout=10):
+    """Start a measurement and skip the test if the software has no valid autocorrelation.
+
+    :param instrument: the instrument to measure with.
+    :param timeout: how long to wait for valid data, in s.
+    """
+    instrument.measurement_running = True
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            instrument.acf
+            return
+        except ValueError:
+            time.sleep(1)
+    pytest.skip(f"no valid autocorrelation ({instrument.data_errors!r}), is a laser connected?")
+
+
+def test_id(instrument):
+    assert instrument.id.startswith("APE")
+
+
+def test_system_information(instrument):
+    assert instrument.device_name
+    assert instrument.serial_number.startswith("S")
+    assert instrument.software_version
+    assert instrument.hardware_version
+    assert instrument.firmware_version
+    assert instrument.motor_type
+
+
+def test_status_registers(instrument):
+    assert isinstance(instrument.operation_status, OperationStatus)
+    assert isinstance(instrument.initialization_status, InitializationStatus)
+    assert isinstance(instrument.busy_status, BusyStatus)
+    assert isinstance(instrument.data_errors, DataError)
+    assert isinstance(instrument.firmware_errors, FirmwareError)
+
+
+def test_device_initialized(instrument):
+    assert InitializationStatus.LINK_OK in instrument.initialization_status
+    assert OperationStatus.DISCONNECTED not in instrument.operation_status
+
+
+def test_check_errors(instrument):
+    assert isinstance(instrument.check_errors(), list)
+
+
+@pytest.mark.parametrize("averages", AVERAGES)
+def test_averages(instrument, averages):
+    assert set_and_read(instrument, "averages", averages) == averages
+
+
+@pytest.mark.parametrize("resolution", RESOLUTIONS)
+def test_resolution(instrument, resolution):
+    assert set_and_read(instrument, "resolution", resolution) == resolution
+
+
+@pytest.mark.parametrize("fit_type", ["none", "gaussian", "sech2", "lorentz"])
+def test_fit_type(instrument, fit_type):
+    assert set_and_read(instrument, "fit_type", fit_type) == fit_type
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_filter_enabled(instrument, enabled):
+    assert set_and_read(instrument, "filter_enabled", enabled) is enabled
+
+
+@pytest.mark.parametrize("gain", [500, 660])
+def test_gain(instrument, gain):
+    instrument.autogain_enabled = False
+    assert set_and_read(instrument, "gain", gain) == gain
+
+
+def test_gain_out_of_range(instrument):
+    with pytest.raises(ValueError):
+        instrument.gain = 1001
+
+
+@pytest.mark.parametrize("sensitivity", [10, 1])
+def test_sensitivity(instrument, sensitivity):
+    # the software hands a new sensitivity to the detector only while it is measuring,
+    # and takes several seconds to do so
+    instrument.measurement_running = True
+    time.sleep(1)
+    assert set_and_read(instrument, "sensitivity", sensitivity, timeout=20) == sensitivity
+
+
+@pytest.mark.parametrize("running", [True, False])
+def test_measurement_running(instrument, running):
+    assert set_and_read(instrument, "measurement_running", running) is running
+
+
+def test_scan_range(instrument):
+    assert instrument.scan_range in (0, 150e-15, 500e-15, 1.5e-12, 5e-12, 15e-12,
+                                     50e-12, 150e-12)
+
+
+def test_trigger(instrument):
+    assert 0.2 <= instrument.trigger_level <= 5
+    assert 1e-6 <= instrument.trigger_delay <= 50e-6
+    assert instrument.trigger_frequency >= 0
+    assert instrument.trigger_impedance > 0
+
+
+def test_shutters(instrument):
+    assert isinstance(instrument.fix_shutter_open, bool)
+    assert isinstance(instrument.scan_shutter_open, bool)
+
+
+def test_crystal(instrument):
+    assert 500 <= instrument.crystal_position <= 11000
+    assert isinstance(instrument.crystal_moving, bool)
+    assert instrument.crystal_type
+
+
+def test_unsupported_scpi_commands(instrument):
+    """The software answers "Parser error" to the standard commands it does not implement."""
+    with pytest.raises(ValueError):
+        instrument.options
+    with pytest.raises(ValueError):
+        instrument.next_error
+
+
+def test_acf_without_measurement(instrument):
+    instrument.measurement_running = False
+    time.sleep(1)
+    with pytest.raises(ValueError, match="measurement"):
+        instrument.acf
+
+
+def test_acf(instrument):
+    running_with_signal(instrument)
+    delay, intensity = instrument.acf
+
+    assert len(delay) == len(intensity)
+    assert len(delay) == instrument.resolution
+    # the delay axis has to come out sorted, otherwise the two interleaved arrays are swapped
+    assert np.all(np.diff(delay) > 0)
+    assert max(abs(delay)) <= instrument.scan_range
+
+
+def test_displayed_acf(instrument):
+    running_with_signal(instrument)
+    delay, intensity = instrument.displayed_acf
+
+    assert len(delay) == len(intensity)
+    assert np.all(np.diff(delay) > 0)
+
+
+def test_acf_mean_data(instrument):
+    running_with_signal(instrument)
+    mean_data = instrument.acf_mean_data
+
+    assert set(mean_data) == {"average", "delay_max", "delay_min",
+                              "intensity_max", "intensity_min"}
+    assert mean_data["delay_min"] < mean_data["delay_max"]
+    assert mean_data["intensity_min"] <= mean_data["intensity_max"]
+
+
+def test_fwhm(instrument):
+    running_with_signal(instrument)
+    assert 0 < instrument.fwhm < instrument.scan_range
+
+
+def test_fit_fwhm(instrument):
+    running_with_signal(instrument)
+    instrument.fit_type = "gaussian"
+    time.sleep(2)
+    assert 0 < instrument.fit_fwhm < instrument.scan_range

--- a/tests/instruments/ape/test_pulsecheck_usb_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_usb_with_device.py
@@ -95,7 +95,7 @@ def running_with_signal(instrument, timeout=10):
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            instrument.acf
+            _ = instrument.acf
             return
         except ValueError:
             time.sleep(1)
@@ -203,16 +203,16 @@ def test_crystal(instrument):
 def test_unsupported_scpi_commands(instrument):
     """The software answers "Parser error" to the standard commands it does not implement."""
     with pytest.raises(ValueError):
-        instrument.options
+        _ = instrument.options
     with pytest.raises(ValueError):
-        instrument.next_error
+        _ = instrument.next_error
 
 
 def test_acf_without_measurement(instrument):
     instrument.measurement_running = False
     time.sleep(1)
     with pytest.raises(ValueError, match="measurement"):
-        instrument.acf
+        _ = instrument.acf
 
 
 def test_acf(instrument):

--- a/tests/instruments/ape/test_pulsecheck_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_with_device.py
@@ -27,9 +27,9 @@
     pytest tests/instruments/ape/test_pulsecheck_with_device.py \
         --device-address ASRL/dev/ttyUSB0::INSTR
 
-The settings the tests change are read at the start and written back afterwards. The crystal
-is turned by a few steps only and returned to where it started. No pulse train is required;
-the autocorrelation is checked for its shape, not its content.
+The settings the tests change are read at the start and written back afterwards. The turning
+angle is moved by a few steps only and returned to where it started. No pulse train is
+required; the autocorrelation is checked for its shape, not its content.
 """
 
 import time
@@ -44,7 +44,7 @@ from pymeasure.instruments.ape.pulsecheck import TRIGGER_MODES
 #: `filter` comes last, since leaving `trigger_mode` forces it to 'low' (see
 #: `test_trigger_mode_resets_filter`).
 RESTORED_SETTINGS = ("sensitivity", "gain", "scan_range", "averages", "math_enabled",
-                     "running", "trigger_mode", "filter")
+                     "measurement_running", "trigger_mode", "filter")
 
 
 @pytest.fixture(scope="module")
@@ -127,8 +127,8 @@ def test_math_enabled(instrument, value):
 
 
 @pytest.mark.parametrize("value", [False, True])
-def test_running(instrument, value):
-    assert set_and_read(instrument, "running", value) == value
+def test_measurement_running(instrument, value):
+    assert set_and_read(instrument, "measurement_running", value) == value
 
 
 @pytest.mark.parametrize("value", list(TRIGGER_MODES))
@@ -156,30 +156,30 @@ def test_other_trigger_modes_keep_filter(instrument, mode):
     assert instrument.filter == "high"
 
 
-def test_acf(instrument):
-    acf = instrument.acf()
+def test_raw_acf(instrument):
+    acf = instrument.raw_acf()
     assert len(acf) == instrument.resolution
     # the raw 16 bit samples are shifted down by 6 bits
     assert all(0 <= value < 2 ** 10 for value in acf)
 
 
-def test_acf_repeated(instrument):
+def test_raw_acf_repeated(instrument):
     """Consecutive traces must stay in sync, since the reply carries no framing."""
     resolution = instrument.resolution
     for _ in range(5):
-        assert len(instrument.acf()) == resolution
+        assert len(instrument.raw_acf()) == resolution
 
 
-def test_acf_after_other_commands(instrument):
+def test_raw_acf_after_other_commands(instrument):
     """Reading settings in between must not shift the trace's bytes."""
     instrument.settings
-    assert len(instrument.acf()) == instrument.resolution
+    assert len(instrument.raw_acf()) == instrument.resolution
 
 
 @pytest.mark.parametrize("scan_range", [5e-12, 50e-12, 150e-12])
-def test_get_autocorrelation(instrument, scan_range):
+def test_acf(instrument, scan_range):
     assert set_and_read(instrument, "scan_range", scan_range) == scan_range
-    delay, acf = instrument.get_autocorrelation()
+    delay, acf = instrument.acf
     assert len(delay) == len(acf) == instrument.resolution
     assert np.isclose(delay[-1] - delay[0], scan_range)
     assert np.isclose(delay[0], -delay[-1])

--- a/tests/instruments/ape/test_pulsecheck_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_with_device.py
@@ -1,0 +1,206 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2026 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""Tests requiring a pulseCheck connected over RS232, e.g.::
+
+    pytest tests/instruments/ape/test_pulsecheck_with_device.py \
+        --device-address ASRL/dev/ttyUSB0::INSTR
+
+The settings the tests change are read at the start and written back afterwards. The crystal
+is turned by a few steps only and returned to where it started. No pulse train is required;
+the autocorrelation is checked for its shape, not its content.
+"""
+
+import time
+
+import numpy as np
+import pytest
+
+from pymeasure.instruments.ape import PulseCheck
+from pymeasure.instruments.ape.pulsecheck import TRIGGER_MODES
+
+#: Settings the tests below write, and which are restored when they are done.
+#: `filter` comes last, since leaving `trigger_mode` forces it to 'low' (see
+#: `test_trigger_mode_resets_filter`).
+RESTORED_SETTINGS = ("sensitivity", "gain", "scan_range", "averages", "math_enabled",
+                     "running", "trigger_mode", "filter")
+
+
+@pytest.fixture(scope="module")
+def instrument(connected_device_address):
+    inst = PulseCheck(connected_device_address)
+    time.sleep(0.3)
+    settings = {name: getattr(inst, name) for name in RESTORED_SETTINGS}
+    yield inst
+    for name, value in settings.items():
+        assert set_and_read(inst, name, value) == value, f"could not restore {name}"
+
+
+def set_and_read(instrument, name, value, timeout=10):
+    """Write a property and read it back, repeating until the setting arrives.
+
+    The instrument discards a setting if the next command follows too closely, and
+    occasionally even then, so the value is written repeatedly rather than only polled.
+
+    :param instrument: the instrument to write to.
+    :param name: name of the property.
+    :param value: value to write.
+    :param timeout: how long to keep trying, in s.
+    :returns: the value read back.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        setattr(instrument, name, value)
+        time.sleep(0.3)
+        read = getattr(instrument, name)
+        if read == value or time.monotonic() > deadline:
+            return read
+
+
+def test_resolution(instrument):
+    assert instrument.resolution in (4, 8, 16, 32, 64, 128, 256)
+
+
+def test_alpha(instrument):
+    assert isinstance(instrument.alpha, int)
+
+
+def test_tau_register(instrument):
+    assert isinstance(instrument.tau_register, int)
+
+
+def test_settings(instrument):
+    assert set(instrument.settings) == {"sensitivity", "gain", "scan_range", "filter",
+                                        "averages", "resolution", "alpha", "math_enabled",
+                                        "trigger_mode"}
+
+
+@pytest.mark.parametrize("value", [1, 3, 10, 30, 100, 300])
+def test_sensitivity(instrument, value):
+    assert set_and_read(instrument, "sensitivity", value) == value
+
+
+@pytest.mark.parametrize("value", [0, 100, 500, 999])
+def test_gain(instrument, value):
+    assert set_and_read(instrument, "gain", value) == value
+
+
+@pytest.mark.parametrize("value", ["low", "medium", "high"])
+def test_filter(instrument, value):
+    assert set_and_read(instrument, "filter", value) == value
+
+
+@pytest.mark.parametrize("value", [1, 2, 4, 8, 16])
+def test_averages(instrument, value):
+    assert set_and_read(instrument, "averages", value) == value
+
+
+@pytest.mark.parametrize("value", [1.5e-12, 5e-12, 15e-12, 50e-12, 150e-12])
+def test_scan_range(instrument, value):
+    assert set_and_read(instrument, "scan_range", value) == value
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_math_enabled(instrument, value):
+    assert set_and_read(instrument, "math_enabled", value) == value
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_running(instrument, value):
+    assert set_and_read(instrument, "running", value) == value
+
+
+@pytest.mark.parametrize("value", list(TRIGGER_MODES))
+def test_trigger_mode(instrument, value):
+    assert set_and_read(instrument, "trigger_mode", value) == value
+
+
+def test_trigger_mode_resets_filter(instrument):
+    """The 'trigger' mode forces the filter to 'low', and it stays there on the way back."""
+    assert set_and_read(instrument, "trigger_mode", "freerun") == "freerun"
+    assert set_and_read(instrument, "filter", "high") == "high"
+
+    assert set_and_read(instrument, "trigger_mode", "trigger") == "trigger"
+    assert instrument.filter == "low"
+    assert set_and_read(instrument, "trigger_mode", "freerun") == "freerun"
+    assert instrument.filter == "low"
+
+
+@pytest.mark.parametrize("mode", ["fringe", "slow"])
+def test_other_trigger_modes_keep_filter(instrument, mode):
+    assert set_and_read(instrument, "trigger_mode", "freerun") == "freerun"
+    assert set_and_read(instrument, "filter", "high") == "high"
+
+    assert set_and_read(instrument, "trigger_mode", mode) == mode
+    assert instrument.filter == "high"
+
+
+def test_acf(instrument):
+    acf = instrument.acf()
+    assert len(acf) == instrument.resolution
+    # the raw 16 bit samples are shifted down by 6 bits
+    assert all(0 <= value < 2 ** 10 for value in acf)
+
+
+def test_acf_repeated(instrument):
+    """Consecutive traces must stay in sync, since the reply carries no framing."""
+    resolution = instrument.resolution
+    for _ in range(5):
+        assert len(instrument.acf()) == resolution
+
+
+def test_acf_after_other_commands(instrument):
+    """Reading settings in between must not shift the trace's bytes."""
+    instrument.settings
+    assert len(instrument.acf()) == instrument.resolution
+
+
+@pytest.mark.parametrize("scan_range", [5e-12, 50e-12, 150e-12])
+def test_get_autocorrelation(instrument, scan_range):
+    assert set_and_read(instrument, "scan_range", scan_range) == scan_range
+    delay, acf = instrument.get_autocorrelation()
+    assert len(delay) == len(acf) == instrument.resolution
+    assert np.isclose(delay[-1] - delay[0], scan_range)
+    assert np.isclose(delay[0], -delay[-1])
+
+
+def test_tune(instrument):
+    start = instrument.alpha
+    try:
+        instrument.tune(20)
+        time.sleep(2)
+        assert instrument.alpha == start + 20
+    finally:
+        instrument.set_alpha(start)
+    assert instrument.alpha == start
+
+
+def test_set_alpha(instrument):
+    start = instrument.alpha
+    try:
+        instrument.set_alpha(start + 15)
+        assert instrument.alpha == start + 15
+    finally:
+        instrument.set_alpha(start)
+    assert instrument.alpha == start

--- a/tests/instruments/ape/test_pulsecheck_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_with_device.py
@@ -172,7 +172,7 @@ def test_raw_acf_repeated(instrument):
 
 def test_raw_acf_after_other_commands(instrument):
     """Reading settings in between must not shift the trace's bytes."""
-    instrument.settings
+    _ = instrument.settings
     assert len(instrument.raw_acf()) == instrument.resolution
 
 

--- a/tests/instruments/ape/test_pulsecheck_with_device.py
+++ b/tests/instruments/ape/test_pulsecheck_with_device.py
@@ -181,8 +181,8 @@ def test_acf(instrument, scan_range):
     assert set_and_read(instrument, "scan_range", scan_range) == scan_range
     delay, acf = instrument.acf
     assert len(delay) == len(acf) == instrument.resolution
-    assert np.isclose(delay[-1] - delay[0], scan_range)
-    assert np.isclose(delay[0], -delay[-1])
+    assert np.isclose(delay[-1] - delay[0], scan_range, rtol=1e-6, atol=0)
+    assert np.isclose(delay[0], -delay[-1], rtol=1e-6, atol=0)
 
 
 def test_tune(instrument):


### PR DESCRIPTION
## Summary

Adds a new `ape` manufacturer module with drivers for the APE PulseCheck autocorrelator, which comes in two generations with different remote interfaces:

- **`PulseCheck`** — the older models with an RS232 port. A non-SCPI, framed   serial protocol (8N1, CR-terminated). The instrument silently drops a setting if the next command follows too closely, so the driver's properties are meant to be written with a short pause and read back to confirm (documented on the class, with a `set_and_read` helper pattern).
- **`PulseCheckUSB`** (`SCPIMixin`) — the newer USB models, which expose their remote interface through the APE **pulseLink** control software over TCP/IP (enabled in pulseLink under *Extras → TCP*). The driver connects to that socket locally or over the network. pulseLink implements only part of the SCPI standard and applies settings asynchronously, both noted in the docstrings.

```python
from pymeasure.instruments.ape import PulseCheckUSB

pulse_check = PulseCheckUSB("TCPIP::192.168.0.10::51123::SOCKET")
pulse_check.measurement_running = True
delay, intensity = pulse_check.acf
```

## Tests

Protocol tests for both drivers (test_pulsecheck.py, test_pulsecheck_usb.py), plus hardware *_with_device.py suites used during bring-up (skipped without a device). Both drivers were validated on hardware. Docs and CHANGES.rst updated.